### PR TITLE
Set Path to root when being undefined

### DIFF
--- a/wcfsetup/install/files/lib/util/FileUtil.class.php
+++ b/wcfsetup/install/files/lib/util/FileUtil.class.php
@@ -368,7 +368,7 @@ class FileUtil {
 			$port = 80;
 			$parsedUrl = parse_url($httpUrl);
 			$host = $parsedUrl['host'];
-			$path = $parsedUrl['path'];
+			$path = (isset($parsedUrl['path']) ? $parsedUrl['path'] : '/');
 			
 			$remoteFile = new RemoteFile($host, $port, 30, $options); // the file to read.
 			if (!isset($remoteFile)) {


### PR DESCRIPTION
Error occurs for example when using: http://woltlab.com instead of http://woltlab.com/
