### PR TITLE
Added Tarballz to gitignore as they are useless in most cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ nbactions.xml
 
 # SVN
 .svn/ # svn folders
+
+# Community Framework
+*.tar 
+*.tar.gz # Ignore packages build directly in the workspace. They can however, if wanted, added manually via git add


### PR DESCRIPTION
The Tarballs can however explicitly added to Git via git add. But they won't appear in commands like git status -> Git won't tell you that they exist.
