### PR TITLE
Fixed a bug with the deletion of the temp files

### DIFF
--- a/wcfsetup/install/files/lib/system/WCFSetup.class.php
+++ b/wcfsetup/install/files/lib/system/WCFSetup.class.php
@@ -1038,8 +1038,7 @@ class WCFSetup extends WCF {
 		WCF::getTPL()->display('stepInstallPackages');
 		
 		// delete tmp files
-		$directory = TMP_DIR.TMP_FILE_PREFIX.'/';
-		$it = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($directory));
+		$it = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator(TMP_DIR));
 		while ($it->valid()) {
 			// delete all files except directories and packages (required for post-wcfsetup installation)
 			if (!$it->isDot() && !$it->isDir() && !preg_match('~\.tar(\.gz)?$~', $it->getSubPathName())) {


### PR DESCRIPTION
TMP_DIR already includes the TMP_FILE_PREFIX during the installation, so
it is not necessary to add it to the TMP_DIR. There was also an
exception thrown caused by this and the files in the temp-filder
weren't deleted.
