### PR TITLE
Fixed a bug in MemcacheAdapter that made it unusable

### DIFF
--- a/wcfsetup/install/files/lib/system/cache/source/MemcacheAdapter.class.php
+++ b/wcfsetup/install/files/lib/system/cache/source/MemcacheAdapter.class.php
@@ -23,9 +23,9 @@ class MemcacheAdapter extends SingletonFactory {
 	private $memcache = null;
 	
 	/**
-	 * Creates a new MemcacheAdapter object.
+	 * @see	wcf\system\SingletonFactory::init()
 	 */
-	protected function __construct() {
+	protected function init() {
 		if (!class_exists('Memcache')) {
 			throw new SystemException('memcache support is not enabled.');
 		}


### PR DESCRIPTION
wcf\system\SingletonFactory::__construct can't be overriden, use init() instead
