### PR TITLE
Added sandbox support for TemplateEngine

### DIFF
--- a/wcfsetup/install/files/lib/data/language/Language.class.php
+++ b/wcfsetup/install/files/lib/data/language/Language.class.php
@@ -112,8 +112,7 @@ class Language extends DatabaseObject {
 		$staticItem = $this->get($item);
 		
 		if (isset($this->dynamicItems[$this->languageID][$item])) {
-			if (count($variables)) WCF::getTPL()->assign($variables);
-			return WCF::getTPL()->fetchString($this->dynamicItems[$this->languageID][$item]);
+			return WCF::getTPL()->fetchString($this->dynamicItems[$this->languageID][$item], $variables);
 		}
 		
 		return $staticItem;


### PR DESCRIPTION
Added two methods to TemplateEngine:
- enableSandbox (enables execution in sandbox)
- disableSandbox (disables execution in sandbox)

Added new parameters to two methods (fetch, fetchString) of TemplateEngine:
- variables (array)
- sandbox (boolean)

Dynamic language variables are executed in sandbox now.
