### PR TITLE
Fixed detection of an installed wcf during the installation

### DIFF
--- a/wcfsetup/install/files/lib/system/WCFSetup.class.php
+++ b/wcfsetup/install/files/lib/system/WCFSetup.class.php
@@ -382,6 +382,11 @@ class WCFSetup extends WCF {
 		else {
 			if ($foundDirectory = FileUtil::scanFolder(INSTALL_SCRIPT_DIR, "WCF.class.php", true)) {
 				$foundDirectory = $wcfDir = FileUtil::unifyDirSeperator(dirname(dirname(dirname($foundDirectory))).'/');
+				
+				if (dirname(dirname($wcfDir)).'/' == TMP_DIR) {
+					$foundDirectory = false;
+					$wcfDir = FileUtil::unifyDirSeperator(INSTALL_SCRIPT_DIR).'wcf/';
+				}
 			}
 			else {
 				$wcfDir = FileUtil::unifyDirSeperator(INSTALL_SCRIPT_DIR).'wcf/';


### PR DESCRIPTION
Fixed a bug that recognized the installation files in a nested
tmp-directory as an already installed WCF instance at the "choose
folder" page.
