### PR TITLE
Add use wcf\util\ArrayUtil; and fix Fatal error: Class 'wcf\acp\form\Arra

### DIFF
--- a/wcfsetup/install/files/lib/acp/form/PackageUpdateSearchForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/PackageUpdateSearchForm.class.php
@@ -7,6 +7,7 @@ use wcf\system\exception\UserInputException;
 use wcf\system\package\PackageUpdateDispatcher;
 use wcf\system\WCF;
 use wcf\system\WCFACP;
+use wcf\util\ArrayUtil;
 use wcf\util\HeaderUtil;
 use wcf\util\StringUtil;
 


### PR DESCRIPTION
Add use wcf\util\ArrayUtil; and fix Fatal error: Class 'wcf\acp\form\ArrayUtil' not found in...
