### PR TITLE
fix PHP error in file wcf/lib/acp/form/UsersMassProcessingForm.class.php (

### DIFF
--- a/wcfsetup/install/files/lib/acp/form/UsersMassProcessingForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/UsersMassProcessingForm.class.php
@@ -3,6 +3,7 @@ namespace wcf\acp\form;
 use wcf\system\menu\acp\ACPMenu;
 use wcf\data\user\UserEditor;
 use wcf\data\user\group\UserGroup;
+use wcf\data\option\Option;
 use wcf\form\AbstractForm;
 use wcf\system\WCF;
 use wcf\system\WCFACP;
@@ -62,6 +63,13 @@ class UsersMassProcessingForm extends UserOptionListForm {
 	 * @var	wcf\system\database\condition\PreparedStatementConditionBuilder
 	 */
 	public $conditions = null;
+
+        /**
+	 * Options of the active category.
+	 * 
+	 * @var array
+	 */
+	public $activeOptions = array();
 	
 	/**
 	 * @see wcf\form\Form::readFormParameters()


### PR DESCRIPTION
fix PHP error in file wcf/lib/acp/form/UsersMassProcessingForm.class.php (398): Argument 1 passed to wcf\acp\form\UsersMassProcessingForm::checkOption() must be an instance of wcf\acp\form\Option, instance of wcf\data\option\Option given, called in wcf/lib/acp/form/AbstractOptionListForm.class.php on line 203 and defined

and PHP notice in file wcf/lib/acp/form/UsersMassProcessingForm.class.php (333): Undefined property: wcf\acp\form\UsersMassProcessingForm::$activeOptions
