### PR TITLE
Add WCF.Template

### DIFF
--- a/wcfsetup/install/files/js/WCF.js
+++ b/wcfsetup/install/files/js/WCF.js
@@ -1,7 +1,7 @@
 /**
  * Class and function collection for WCF
  * 
- * @author	Alexander Ebert
+ * @author	Tim Düsterhus, Alexander Ebert
  * @copyright	2001-2011 WoltLab GmbH
  * @license	GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
  */


### PR DESCRIPTION
Added WCF.Template class, based upon ideas from prototype.js

Usage is like this:

``` js
var myTemplate = new WCF.Template('{$hello} World');
myTemplate.fetch({ hello: 'Hi' }); // Hi World
myTemplate.fetch({ hello: 'Hello' }); // Hello World

my2ndTemplate = new WCF.Template('{@$html}{$html}');
my2ndTemplate.fetch({ html: '<b>Test</b>' }); // <b>Test</b>&lt;b&gt;Test&lt;/b&gt;

var my3rdTemplate = new WCF.Template('You can use {literal}{$variable}{/literal}-Tags here');
my3rdTemplate.fetch({ variable: 'Not shown' }); // You can use {$variable}-Tags here
```

It currently provides the following functions from the Template-System of the WCF:
Automatic escaping of HTML-Code: {$html}, can be disabled with an @: {@$html}
Literal-Tags that won't be parsed: {literal}[$notParsed}{/literal}
And outputting of delimiter tags: {ldelim} and {rdelim}

The templates can be optionally compiled into javascript-code, that will be eval'd.
