### PR TITLE
use require instead of require once in WCF::initDB()

### DIFF
--- a/wcfsetup/install/files/lib/system/WCF.class.php
+++ b/wcfsetup/install/files/lib/system/WCF.class.php
@@ -280,7 +280,7 @@ class WCF {
 		$dbHost = $dbUser = $dbPassword = $dbName = '';
 		$dbPort = 0;
 		$dbClass = 'wcf\system\database\MySQLDatabase';
-		require_once(WCF_DIR.'config.inc.php');
+		require(WCF_DIR.'config.inc.php');
 		
 		// create database connection
 		self::$dbObj = new $dbClass($dbHost, $dbUser, $dbPassword, $dbName, $dbPort);


### PR DESCRIPTION
We just stumbled around a bug when the 'config.inc.php' was already included via a third party script before the WCF got loaded. In this special case the DB vars will remain blank ('').

I know this is not an intended way to use the WCF, but in our EA we're using Doctrine as ORM Manager besides the WCF DB Connection.
