### PR TITLE
Improvements to DirectoryUtil

### DIFF
--- a/wcfsetup/install/files/lib/util/DirectoryUtil.class.php
+++ b/wcfsetup/install/files/lib/util/DirectoryUtil.class.php
@@ -14,7 +14,7 @@ use wcf\system\exception\SystemException;
 */
 class DirectoryUtil {
 	/**
-	 * @var \DirectoryIterator | \RecursiveDirectoryIterator
+	 * @var \DirectoryIterator
 	 */
 	protected $obj = null;
 	


### PR DESCRIPTION
- Adding missing namespaces to documentation
- Moving FileUtil::unifyDirSeperator() into scanning to avoid duplicate work when fetching more than one list of file
- Fixing indentation -> Now matching code guidelines
- Some method moving -> More logical order
- Removed destroy() in favor of clearCaches()
