### PR TITLE
Add the constant TIMEZONE to the Options.inc.php-File

### DIFF
--- a/wcfsetup/install/files/options.inc.php
+++ b/wcfsetup/install/files/options.inc.php
@@ -23,3 +23,4 @@ define('SESSION_TIMEOUT', 3600);
 define('CACHE_SOURCE_TYPE', 'disk');
 define('ENABLE_SESSION_DATA_CACHE', 0);
 define('MODULE_MASTER_PASSWORD', 1);
+define('TIMEZONE', 'Europe/Berlin');


### PR DESCRIPTION
After the install comes a FATAL ERROR. 

With this commit, the Constant "TIMEZONE" will be defined.
