### PR TITLE
Bugfix UserEdit-Funktion --> FATAL ERROR

### DIFF
--- a/wcfsetup/install/files/lib/data/user/UserAction.class.php
+++ b/wcfsetup/install/files/lib/data/user/UserAction.class.php
@@ -128,7 +128,7 @@ class UserAction extends AbstractDatabaseObjectAction {
 		
 		foreach ($this->objects as $userEditor) {
 			if (count($groupIDs)) {
-				$userEditor->addToGroups($groupIDs, true, true);
+				$userEditor->addToGroups($groupIDs);
 			}
 			
 			if (count($removeGroups)) {


### PR DESCRIPTION
In UserEdit.class.php one MySQL-Query modified.

Fatal error: Could not execute prepared statement: SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry '2-1' for key 'userID'

Information:

error message: Could not execute prepared statement: SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry '2-1' for key 'userID'
error code: 23000
sql type: wcf\system\database\MySQLDatabase
sql error: Duplicate entry '2-1' for key 'userID'
sql error number: 23000
sql version: 5.1.43-nmm4-log
file: /www/htdocs/w00e542b/wcf/lib/system/database/statement/PreparedStatement.class.php (77)
php version: 5.3.6-nmm1
wcf version: 2.0.0 Alpha 1 (Maelstrom)
date: Sun, 28 Aug 2011 18:55:01 +0000
request: /wcf/acp/index.php?form=UserEdit
referer: http://maelstrom.devxs.de/wcf/acp/index.php?form=UserEdit&userID=2&
Stacktrace:
#0 /www/htdocs/w00e542b/wcf/lib/data/user/UserEditor.class.php(148): wcf\system\database\statement\PreparedStatement->execute(Array)
#1 /www/htdocs/w00e542b/wcf/lib/data/user/UserAction.class.php(131): wcf\data\user\UserEditor->addToGroups(Array, false, false)
#2 [internal function]: wcf\data\user\UserAction->update(Array, Array, Array, Array)
#3 /www/htdocs/w00e542b/wcf/lib/data/AbstractDatabaseObjectAction.class.php(124): call_user_func_array(Array, Array)
#4 /www/htdocs/w00e542b/wcf/lib/acp/form/UserEditForm.class.php(163): wcf\data\AbstractDatabaseObjectAction->executeAction()
#5 /www/htdocs/w00e542b/wcf/lib/form/AbstractForm.class.php(44): wcf\acp\form\UserEditForm->save()
#6 /www/htdocs/w00e542b/wcf/lib/form/AbstractForm.class.php(89): wcf\form\AbstractForm->submit()
#7 /www/htdocs/w00e542b/wcf/lib/acp/form/UserAddForm.class.php(287): wcf\form\AbstractForm->readData()
#8 /www/htdocs/w00e542b/wcf/lib/acp/form/UserEditForm.class.php(88): wcf\acp\form\UserAddForm->readData()
#9 /www/htdocs/w00e542b/wcf/lib/page/AbstractPage.class.php(126): wcf\acp\form\UserEditForm->readData()
#10 /www/htdocs/w00e542b/wcf/lib/acp/form/UserAddForm.class.php(329): wcf\page\AbstractPage->show()
#11 /www/htdocs/w00e542b/wcf/lib/page/AbstractPage.class.php(49): wcf\acp\form\UserAddForm->show()
#12 /www/htdocs/w00e542b/wcf/lib/system/request/Request.class.php(58): wcf\page\AbstractPage->__construct()
#13 /www/htdocs/w00e542b/wcf/lib/system/request/RequestHandler.class.php(51): wcf\system\request\Request->execute()
#14 /www/htdocs/w00e542b/wcf/acp/index.php(10): wcf\system\request\RequestHandler->handle('wcf', true)
#15 {main}

Change INSERT INTO to REPLACE INTO in MySQL-Query.
