### PR TITLE
One-File installation

### DIFF
--- a/wcfsetup/install.php
+++ b/wcfsetup/install.php
@@ -755,10 +755,7 @@ if (isset($_GET['showCSS'])) {
 // check whether setup files are already unzipped
 if (!file_exists(TMP_DIR . 'install/files/lib/system/WCFSetup.class.php')) {
 	// extract the tar-ball at the end of install.php
-	$fp = fopen(__FILE__, 'r');
-	fseek($fp, __COMPILER_HALT_OFFSET__);
-	file_put_contents(SETUP_FILE, stream_get_contents($fp));
-	fclose($fp);
+	file_put_contents(SETUP_FILE, file_get_contents(__FILE__, false, null, __COMPILER_HALT_OFFSET__));
 	
 	// try to unzip all setup files into temp folder
 	$tar = new Tar(SETUP_FILE);


### PR DESCRIPTION
The installation now consists of only one file, the WCFSetup.tar.gz can be appended to install.php, because we are using __halt_compiler() now

Creating the finished install.php is easy, under Unix based OSes at least: cat WCFSetup.tar.gz >> install.php
