### PR TITLE
Importing SystemException in OptionPackageInstallationPlugin

### DIFF
--- a/wcfsetup/install/files/lib/system/package/plugin/OptionPackageInstallationPlugin.class.php
+++ b/wcfsetup/install/files/lib/system/package/plugin/OptionPackageInstallationPlugin.class.php
@@ -2,6 +2,7 @@
 namespace wcf\system\package\plugin;
 use wcf\data\option\Option;
 use wcf\data\option\OptionEditor;
+use wcf\system\exception\SystemException;
 use wcf\system\WCF;
 use wcf\util\StringUtil;
 


### PR DESCRIPTION
<br />
<b>Fatal error</b>:  Class 'wcf\system\package\plugin\SystemException' not found in <b>/var/www/wbb3.1/wcf1.2/lib/system/package/plugin/OptionPackageInstallationPlugin.class.php</b> on line <b>52</b><br />
