### PR TITLE
Update Tooltip if title changes

### DIFF
--- a/wcfsetup/install/files/js/WCF.js
+++ b/wcfsetup/install/files/js/WCF.js
@@ -2456,6 +2456,11 @@ WCF.Effect.BalloonTooltip.prototype = {
 	 * Moves tooltip to cursor position.
 	 */
 	_mouseMoveHandler: function(event) {
+		var $element = $(event.currentTarget);
+		if ($element.attr('title')) {
+			this._mouseEnterHandler(event);
+		}
+		
 		if ($(document).width() - event.pageX < this.tooltip.getDimensions().width) {
 			this.tooltip.css({
 				top: (event.pageY) + "px",


### PR DESCRIPTION
Problems occured for example when disabling cronjobs.
Currently it only updates if the mouse moves, maybe we can get it to update instantly?
