### PR TITLE
Add missing 'languagename' attribute in language.xsd file.

### DIFF
--- a/XSD/language.xsd
+++ b/XSD/language.xsd
@@ -11,7 +11,7 @@
 				<xs:element name="category" type="category" maxOccurs="unbounded" />
 			</xs:sequence>
 			<xs:attribute name="languagecode" type="woltlab_varchar" use="required" />
-			<xs:attribute name="languagname" type="woltlab_varchar" use="required" />
+			<xs:attribute name="languagename" type="woltlab_varchar" use="required" />
 		</xs:complexType>
 	</xs:element>
 	


### PR DESCRIPTION
In the language xml files the attribute languagename is used inside the element language. But in the language.xsd this attribute is missing.
The last commit to be pulled is adding this line in the element language in the language.xsd:
<xs:attribute name="languagname" type="woltlab_varchar" use="required" />
This makes the attribute languagename available inside any language xml file.

The first two commits are reversing each other and do not change any file.
