### PR TITLE
Added attribute 'languagename' for element 'language'

### DIFF
--- a/XSD/language.xsd
+++ b/XSD/language.xsd
@@ -11,6 +11,7 @@
 				<xs:element name="category" type="category" maxOccurs="unbounded" />
 			</xs:sequence>
 			<xs:attribute name="languagecode" type="woltlab_varchar" use="required" />
+			<xs:attribute name="languagename" type="woltlab_varchar" use="required" />
 		</xs:complexType>
 	</xs:element>
 	


### PR DESCRIPTION
The attribute languagename is used inside the language xml files although it isn't written in the language xsd file. This pull request offers a change of the language.xsd which adds the missing attribute.
