### PR TITLE
Disabled serializing of Singletons

### DIFF
--- a/wcfsetup/install/files/lib/system/SingletonFactory.class.php
+++ b/wcfsetup/install/files/lib/system/SingletonFactory.class.php
@@ -1,5 +1,6 @@
 <?php
 namespace wcf\system;
+use wcf\system\exception\SystemException;
 
 /**
  * Basis class for singleton classes.
@@ -35,6 +36,14 @@ abstract class SingletonFactory {
 	 * Object cloning is disallowed.
 	 */
 	protected final function __clone() { }
+	
+	/**
+	 * Object serializing is disallowed.
+	 */
+	public final function __sleep() {
+		throw new SystemException('Serializing of Singletons is not allowed');
+		// Turret: I'm different
+	}
 	
 	/**
 	 * Returns an unique instance of current child class.


### PR DESCRIPTION
```
$a = Test::getInstance();
$b = Test::getInstance();
echo 'A: '.$a->foo."\n"; // A: bar
echo 'B: '.$b->foo."\n"; // B: bar
$a->foo = 'a';
echo 'A: '.$a->foo."\n"; // A: a
echo 'B: '.$b->foo."\n"; // B: a
$b = unserialize(serialize($b)); // -> With this change SystemException
$a->foo = 'b';
echo 'A: '.$a->foo."\n"; // A: b
echo 'B: '.$b->foo."\n"; // B: a
```
