### PR TITLE
Correcting filename of dropdowns in CSS

### DIFF
--- a/wcfsetup/install/files/acp/style/style.css
+++ b/wcfsetup/install/files/acp/style/style.css
@@ -391,7 +391,7 @@ nav.topMenu > div > ul > li > span:not(.badge) {
 
 nav.topMenu ul li .dropdownCaption {
 	cursor: pointer;
-	background-image: url('../../icon/dropdown2.svg');
+	background-image: url('../../icon/dropDown2.svg');
 	background-position: 97% center;
 	background-repeat: no-repeat;
 	padding-right: 15px !important;
@@ -3202,7 +3202,7 @@ img[src*='enable'] {
 }
 
 .clipboardEditor > ul > li > span {
-	background-image: url('../../icon/dropdown1.svg');
+	background-image: url('../../icon/dropDown1.svg');
 	background-position: right center;
 	background-repeat: no-repeat;
 	padding-right: 12px;


### PR DESCRIPTION
dropdown1.svg -> dropDown1.svg
dropdown2.svg -> dropDown2.svg

We poor users of Unix based OSs didn't saw the icons :(
