### PR TITLE
Implements IEditableCachedObject.

### DIFF
--- a/wcfsetup/install/files/lib/data/DatabaseObjectEditor.class.php
+++ b/wcfsetup/install/files/lib/data/DatabaseObjectEditor.class.php
@@ -116,7 +116,7 @@ abstract class DatabaseObjectEditor extends DatabaseObjectDecorator implements I
 	}
 	
 	/**
-	 * @see wcf\data\IEditableCachedObject::$resetCache()
+	 * @see wcf\data\IEditableCachedObject::resetCache()
 	 */
 	public static function resetCache() {
 		


### PR DESCRIPTION
Why not directly implementing the IEditableCachedObject interface? Most of the editors are used for change database tables which are read later by the CacheBuilders. With the resetCache method directly inheriting from DatabaseObjectEditor it is much more easier to use this method.

Because of that I added the method to the DatabaseObjectEditor class with an empty method body, so that only the subclasses have to use it which are cached.
