### PR TITLE
Use WCF.Template for WCF.Language

### DIFF
--- a/wcfsetup/install/files/js/WCF.js
+++ b/wcfsetup/install/files/js/WCF.js
@@ -1672,8 +1672,23 @@ WCF.Language = {
 	 * @param	string		key
 	 * @return	mixed
 	 */
-	get: function(key) {
-		return this._variables.get(key);
+	get: function(key, parameters) {
+		// initialize parameters with an empty object
+		if (typeof parameters === 'undefined') var parameters = {};
+		
+		var value = this._variables.get(key);
+		
+		if (typeof value === 'string') {
+			// transform strings into template and try to refetch
+			this.add(key, new WCF.Template(value));
+			return this.get(key, parameters);
+		}
+		else if (value !== null && typeof value === 'object' && typeof value.fetch !== 'undefined') {
+			// evaluate templates
+			value = value.fetch(parameters);
+		}
+		
+		return value;
 	}
 };
 


### PR DESCRIPTION
``` js
WCF.Language.add('language.item', '{$var}');
WCF.Language.get('language.item'); // {$var}
WCF.Language.get('language.item', { var: test }); // test
```

This won't break any existing code.
