### PR TITLE
WCF.Language.get returns the key when the language item is not found

### DIFF
--- a/wcfsetup/install/files/js/WCF.js
+++ b/wcfsetup/install/files/js/WCF.js
@@ -1683,6 +1683,10 @@ WCF.Language = {
 			// evaluate templates
 			value = value.fetch(parameters);
 		}
+		else if (value === null) {
+			// return key again
+			return key;
+		}
 		
 		return value;
 	}


### PR DESCRIPTION
This is a consistent behaviour to the PHP code
