### PR TITLE
Automatically insert constants into database queries

### DIFF
--- a/wcfsetup/install/files/lib/system/WCF.class.php
+++ b/wcfsetup/install/files/lib/system/WCF.class.php
@@ -42,6 +42,12 @@ if (!defined('NO_IMPORTS')) {
  */
 class WCF {
 	/**
+	 * list of active applications
+	 * @var array<wcf\system\application\IApplication
+	 */
+	protected static $applications = array();
+	
+	/**
 	 * list of autoload directories
 	 * @var array
 	 */
@@ -225,6 +231,15 @@ class WCF {
 	 */
 	public static final function getTPL() {
 		return self::$tplObj;
+	}
+	
+	/**
+	 * Returns array of applications
+	 *
+	 * @return	array<wcf\system\application\IApplication>
+	 */
+	public static final function getApplications() {
+		return self::$applications;
 	}
 	
 	/**
@@ -427,8 +442,10 @@ class WCF {
 			
 			// start application if not within ACP
 			if (!class_exists('wcf\system\WCFACP', false)) {
-				new $className();
+				self::$applications[$abbreviation] = new $className();
 			}
+			
+			self::$applications[$abbreviation] = null;
 		}
 		else {
 			unset(self::$autoloadDirectories[$abbreviation]);

--- a/wcfsetup/install/files/lib/system/database/Database.class.php
+++ b/wcfsetup/install/files/lib/system/database/Database.class.php
@@ -182,7 +182,10 @@ abstract class Database {
 	 */
 	public function prepareStatement($statement, $limit = 0, $offset = 0) {
 		$statement = $this->handleLimitParameter($statement, $limit, $offset);
-		
+		$statement = str_replace('wcf1_', 'wcf'.WCF_N.'_', $statement);
+		foreach (\wcf\system\WCF::getApplications() as $key => $val) {
+			$statement = str_replace($key.'1_1_', $key.constant(strtoupper($key.'_N')).'_', $statement);
+		}
 		try {
 			$pdoStatement = $this->pdo->prepare($statement);
 			if ($pdoStatement instanceof \PDOStatement) {


### PR DESCRIPTION
Now one can simply use `wcf1_` and `wbb1_1_` in their database queries.
