### PR TITLE
Adds template event for header logo

### DIFF
--- a/com.woltlab.wcf/template/header.tpl
+++ b/com.woltlab.wcf/template/header.tpl
@@ -18,7 +18,7 @@
 		<div id="logo" class="wcf-logo">
 			<!-- clickable area -->
 			<a href="{link controller='Index'}{/link}">
-				<!-- *** insert header logo here -->
+				{event name='headerLogo'}
 			</a>
 			<!-- /clickable area -->
 			


### PR DESCRIPTION
Currently, you have to copy the whole header template and ship a new one with a standalone application, just to include a header logo. I replaced the placeholder - comment with an template event, so that a standalone application simply can use a template listener to include it's header logo.
