### PR TITLE
Type casting for \Exception::__construct()

### DIFF
--- a/wcfsetup/install/files/lib/system/exception/SystemException.class.php
+++ b/wcfsetup/install/files/lib/system/exception/SystemException.class.php
@@ -41,7 +41,7 @@ class SystemException extends LoggedException implements IPrintableException {
 	 * @param	\Exception	$previous	repacked Exception
 	 */
 	public function __construct($message = '', $code = 0, $description = '', \Exception $previous = null) {
-		parent::__construct((string)$message, (int)$code, $previous);
+		parent::__construct((string) $message, (int) $code, $previous);
 		$this->description = $description;
 	}
 	


### PR DESCRIPTION
Sometimes I get a fatal error because \Exception::__construct() requires the first parameter to be a string an the second one to be a int.
