### PR TITLE
DBOEditor->update() now also updates the array that represents the objects data

### DIFF
--- a/wcfsetup/install/files/lib/data/DatabaseObjectEditor.class.php
+++ b/wcfsetup/install/files/lib/data/DatabaseObjectEditor.class.php
@@ -59,6 +59,8 @@ abstract class DatabaseObjectEditor extends DatabaseObjectDecorator implements I
 			if (!empty($updateSQL)) $updateSQL .= ', ';
 			$updateSQL .= $key . ' = ?';
 			$statementParameters[] = $value;
+			// update object data
+			$this->getDecoratedObject()->data[$key] = $value;
 		}
 		$statementParameters[] = $this->__get(static::getDatabaseTableIndexName());
 		
@@ -81,6 +83,8 @@ abstract class DatabaseObjectEditor extends DatabaseObjectDecorator implements I
 			if (!empty($updateSQL)) $updateSQL .= ', ';
 			$updateSQL .= $key . ' = ' . $key . ' + ?';
 			$statementParameters[] = $value;
+			// update object data
+			$this->getDecoratedObject()->data[$key] += $value;
 		}
 		$statementParameters[] = $this->__get(static::getDatabaseTableIndexName());
 		


### PR DESCRIPTION
Consider the following test case:

```
<?php
require_once('./global.php');    
@header("Content-type: text/plain");
$dbo = new wcf\data\smiley\Smiley(1);
$dboEditor = new wcf\data\smiley\SmileyEditor($dbo);
echo "Path: " . $dboEditor->smileyPath; 
// at this point, some plugin might call $dboEditor->update(...);
echo "\r";
if(strpos($dboEditor->smileyPath, ".svg") === false)
    $dboEditor->update(array("smileyPath" => str_replace(".png", ".svg", $dboEditor->smileyPath)));
else
    $dboEditor->update(array("smileyPath" => str_replace(".svg", ".png", $dboEditor->smileyPath)));
echo "Path new: " . $dboEditor->smileyPath;
    // another plugin, that uses a later event, will now get the old values, not the updated ones
```

This will print the following output:
Path: images/smilies/smileySmiling.svg
Path new: images/smilies/smileySmiling.svg
That is not exactly what one might expect to happen when he updates an object ;)
The real problem lies in the event system: when one event listener updates an object, and another event listener uses a value that is affected by the beforementioned event listener, the behavior might become irradic due to the latter event listener now using obsolete data.

My pull request changes that behavior, the output is now as expected:
Path: images/smilies/smileySmiling.svg
Path new: images/smilies/smileySmiling.png

Tested it in a live installation of the latest WCF with the wbbaddons dummy app, seems not to affect any existing code ;)
