### PR TITLE
Removes 'final' modifier from wcf\util\XML

### DIFF
--- a/wcfsetup/install/files/lib/util/XML.class.php
+++ b/wcfsetup/install/files/lib/util/XML.class.php
@@ -12,7 +12,7 @@ use wcf\system\exception\SystemException;
  * @subpackage	util
  * @category 	Community Framework
  */
-final class XML {
+class XML {
 	/**
 	 * DOMDocument object
 	 * @var	\DOMDocument


### PR DESCRIPTION
As discussed here:
https://github.com/WoltLab/WCF/commit/1828478932594ab7abf42c9873bc52f98e49b56a#commitcomment-1278404
