### PR TITLE
Fixing Zip to properly extract empty folders.

### DIFF
--- a/wcfsetup/install/files/lib/system/io/IArchive.class.php
+++ b/wcfsetup/install/files/lib/system/io/IArchive.class.php
@@ -12,6 +12,13 @@ namespace wcf\system\io;
  * @category 	Community Framework
  */
 interface IArchive {
+	/** 
+	 * Returns the table of contents (TOC) list for this tar archive.
+	 * 
+	 * @return 	array 		list of content
+	 */
+	public function getContentList();
+	
 	/**
 	 * Returns an associative array with information
 	 * about a specific file in the archive.

--- a/wcfsetup/install/files/lib/system/io/Tar.class.php
+++ b/wcfsetup/install/files/lib/system/io/Tar.class.php
@@ -218,9 +218,10 @@ class Tar implements IArchive {
 		}
 		$header = $this->getFileInfo($index);
 		
-		// can not extract a folder
-		if ($header['type'] != 'file') {
-			return false;
+		FileUtil::makePath(dirname($destination));
+		if ($header['type'] === 'folder') {
+			FileUtil::makePath($destination);
+			return;
 		}
 		
 		// seek to offset


### PR DESCRIPTION
Additionally adding getContentList to IArchive and implementing it for Zip.
Furthermore the API of Tar and Zip now also matches in the data-arrays.

Fixes WoltLab/WCF#591
Closes WoltLab/WCF#592
