### PR TITLE
Improving FileUtil::downloadFileFromHTTP()

### DIFF
--- a/wcfsetup/install/files/lib/system/io/File.class.php
+++ b/wcfsetup/install/files/lib/system/io/File.class.php
@@ -58,6 +58,15 @@ class File {
 	}
 	
 	/**
+	 * Closes the file descriptor.
+	 */
+	public function __destruct() {
+		if (is_resource($this->resource)) {
+			fclose($this->resource);
+		}
+	}
+	
+	/**
 	 * Calls the specified function on the open file.
 	 * Do not call this function directly. Use $file->write('') instead.
 	 * 
@@ -67,11 +76,11 @@ class File {
 	public function __call($function, $arguments) {
 		if (function_exists('f' . $function)) {
 			array_unshift($arguments, $this->resource);
-	       		return call_user_func_array('f' . $function, $arguments);
+			return call_user_func_array('f' . $function, $arguments);
 		}
 		else if (function_exists($function)) {
 			array_unshift($arguments, $this->filename);
-	       		return call_user_func_array($function, $arguments);
+			return call_user_func_array($function, $arguments);
 		}
 		else {
 			throw new SystemException('Can not call file method ' . $function);


### PR DESCRIPTION
- Adding $options to specify method and Timeout of our HTTP-Request
- Adding $postParameters to specify the body of our request (data will automatically be urlencoded)
- Adding $headers to fetch the response header (will be available as a key => value array)

Everything was successfully tested with GET, HEAD, POST-Requests on SSL and non-SSL URLs.
Implements https://www.woltlab.com/bugtracker/index.php?page=Bug&bugID=1493
