### PR TITLE
WCF plugins which have other requirements than the WCF will stop install...

### DIFF
--- a/wcfsetup/install/files/lib/system/package/PackageInstallationDispatcher.class.php
+++ b/wcfsetup/install/files/lib/system/package/PackageInstallationDispatcher.class.php
@@ -233,6 +233,15 @@ class PackageInstallationDispatcher {
 				}
 			}
 			
+			// if package is plugin to com.woltlab.wcf it must not have any other requirement
+			$requirements = $this->getArchive()->getRequirements();
+			if ($package->parentPackageID == 1 && count($requirements)) {
+			    foreach ($requirements as $package => $data) {
+			    	if ($package == 'com.woltlab.wcf') continue;
+			    	throw new SystemException('Package '.$package->package.' is plugin of com.woltlab.wcf (WCF) but has more than one requirement.');
+			    }
+			}
+			
 			// insert requirements and dependencies
 			$requirements = $this->getArchive()->getAllExistingRequirements();
 			if (count($requirements) > 0) {


### PR DESCRIPTION
...ation immediately.

This implements a kind of last resort to stop installations which would add dependencies to every package by adding requirements to the WCF.
