### PR TITLE
Added stylesheetInclude template event.

### DIFF
--- a/com.woltlab.wcf/template/headInclude.tpl
+++ b/com.woltlab.wcf/template/headInclude.tpl
@@ -25,6 +25,7 @@
 
 <!-- Stylesheets -->
 <link rel="stylesheet/less" type="text/css" href="{@$__wcf->getPath()}style/bootstrap.less" />
+{event name='stylesheetInclude'}
 <script type="text/javascript">
 	//<![CDATA[
 	var less = { env: 'development' };

--- a/wcfsetup/install/files/acp/templates/header.tpl
+++ b/wcfsetup/install/files/acp/templates/header.tpl
@@ -29,6 +29,7 @@
 	
 	<!-- Stylesheets -->
 	<link rel="stylesheet/less" type="text/css" href="{@$__wcf->getPath()}style/bootstrap.less" />
+	{event name='stylesheetInclude'}
 	<script type="text/javascript">
 		//<![CDATA[
 		var less = { env: 'development' };


### PR DESCRIPTION
So far you have an event for javascriptInclude, javascriptLanguageInclude, javascriptIconInclude and javascriptInit. What is missing is a stylesheetInclude event. This commit provides exactly that. It is placed after the bootstrap.less, so that you can add your own less files or css files without being an application.
