### PR TITLE
Implements now IDatabaseObjectProcessor.

### DIFF
--- a/wcfsetup/install/files/lib/data/DatabaseObjectDecorator.class.php
+++ b/wcfsetup/install/files/lib/data/DatabaseObjectDecorator.class.php
@@ -12,7 +12,7 @@ use wcf\system\exception\SystemException;
  * @subpackage	data
  * @category 	Community Framework
  */
-abstract class DatabaseObjectDecorator extends DatabaseObject {
+abstract class DatabaseObjectDecorator extends DatabaseObject implements IDatabaseObjectProcessor {
 	/**
 	 * name of the base class
 	 * @var	string


### PR DESCRIPTION
ProcessibleDatabaseObject checks if the processor implements IDatabaseObjectProcessor. Since the most DatabaseObjectProcessors will extend on DatabaseObjectDecorator it would be an advantage to implement the interface by default. In addition you don't have to change anything since DatabaseObjectDecorator implements all required methods by default.

This would simplify the usage of DatabaseObjectDecorators as processors. That's why I implemented it.
