### PR TITLE
Added WCF.DelayedExecuter

### DIFF
--- a/wcfsetup/install/files/js/WCF.js
+++ b/wcfsetup/install/files/js/WCF.js
@@ -1235,7 +1235,6 @@ WCF.DelayedExecuter = function(callback, delay) {
 		return;
 	}
 
-	this._callback = callback;
 	setTimeout(callback, delay); 
 };
 


### PR DESCRIPTION
This can be used to avoid creating a WCF.PeriodicalExecuter wich is always stopped at the first execution. If wanted, I could make use of it.
