### PR TITLE
Update wcfsetup/install/files/js/WCF.js

### DIFF
--- a/wcfsetup/install/files/js/WCF.js
+++ b/wcfsetup/install/files/js/WCF.js
@@ -5418,20 +5418,8 @@ WCF.Popover = Class.extend({
 				};
 				
 				$element.hover($.proxy(this._overElement, this), $.proxy(this._out, this));
-				
-				if ($element.getTagName() === 'a') {
-					$element.click($.proxy(this._cancel, this));
-				}
 			}
 		}, this));
-	},
-	
-	/**
-	 * Cancels popovers if link is being clicked
-	 */
-	_cancel: function(event) {
-		this._cancelPopover = true;
-		this._hide(true);
 	},
 	
 	/**


### PR DESCRIPTION
This commit (re)adds? possibility to use popovers on links that don't redirect to another page. If you get redirected while a popover is loading no error will occur - I tested it without this check multiple times in multiple browsers ;)
