### PR TITLE
Separating checkModules() and checkPermissions() in AbstractAction

### DIFF
--- a/wcfsetup/install/files/lib/action/AbstractAction.class.php
+++ b/wcfsetup/install/files/lib/action/AbstractAction.class.php
@@ -58,6 +58,34 @@ abstract class AbstractAction implements IAction {
 	}
 	
 	/**
+	 * @see	wcf\action\IAction::checkModules()
+	 */
+	public function checkModules() {
+		// call checkModules event
+		EventHandler::getInstance()->fireAction($this, 'checkModules');
+		
+		// check modules
+		foreach ($this->neededModules as $module) {
+			if (!defined($module) || !constant($module)) {
+				throw new IllegalLinkException();
+			}
+		}
+	}
+	
+	/**
+	 * @see	wcf\action\IAction::checkPermissions()
+	 */
+	public function checkPermissions() {
+		// call checkPermissions event
+		EventHandler::getInstance()->fireAction($this, 'checkPermissions');
+		
+		// check permission
+		if (!empty($this->neededPermissions)) {
+			WCF::getSession()->checkPermissions($this->neededPermissions);
+		}
+	}
+	
+	/**
 	 * @see	wcf\action\IAction::execute()
 	 */
 	public function execute() {
@@ -67,16 +95,10 @@ abstract class AbstractAction implements IAction {
 		}
 		
 		// check modules
-		if (!empty($this->neededModules)) {
-			foreach ($this->neededModules as $module) {
-				if (!defined($module) || !constant($module)) throw new IllegalLinkException();
-			}
-		}
+		$this->checkModules();
 		
-		// check permission
-		if (!empty($this->neededPermissions)) {
-			WCF::getSession()->checkPermissions($this->neededPermissions);
-		}
+		// check permissions
+		$this->checkPermissions();
 		
 		// call execute event
 		EventHandler::getInstance()->fireAction($this, 'execute');

--- a/wcfsetup/install/files/lib/action/IAction.class.php
+++ b/wcfsetup/install/files/lib/action/IAction.class.php
@@ -24,6 +24,16 @@ interface IAction {
 	public function readParameters();
 	
 	/**
+	 * Checks the modules of this action.
+	 */
+	public function checkModules();
+	
+	/**
+	 * Checks the permissions of this action.
+	 */
+	public function checkPermissions();
+	
+	/**
 	 * Executes this action.
 	 */
 	public function execute();


### PR DESCRIPTION
Actually nothing was changed, just separating the code into own methods to make them overridable, just like in AbstractPage.

See discussion result of #1115
