### PR TITLE
Bug workaround for (undocumented?) autoload change in PHP 5.3.?

### DIFF
--- a/wcfsetup/install/files/lib/system/WCF.class.php
+++ b/wcfsetup/install/files/lib/system/WCF.class.php
@@ -534,7 +534,7 @@ class WCF {
 		$namespaces = explode('\\', $className);
 		if (count($namespaces) > 1) {
 			$applicationPrefix = array_shift($namespaces);
-			if($applicationPrefix === '') {
+			if ($applicationPrefix === '') {
 				$applicationPrefix = array_shift($namespaces);
 			}
 			if (isset(self::$autoloadDirectories[$applicationPrefix])) {


### PR DESCRIPTION
Our local vanilla 5.3.8 always receives classes for autoloading fully-qualified without leading slash (as written in the PHP doc), but a customers 5.3.2-1ubuntu4.18 sometimes receives them with an leading slash. Simple way of handling that, breaks nothing and normally won't affect anything.
