### PR TITLE
Date Picker now supports min/max dates and RTL mode

### DIFF
--- a/com.woltlab.wcf/template/headInclude.tpl
+++ b/com.woltlab.wcf/template/headInclude.tpl
@@ -75,6 +75,7 @@
 			'wcf.global.page.pageNavigation': '{lang}wcf.global.page.pageNavigation{/lang}',
 			'wcf.global.page.next': '{capture assign=pageNext}{lang}wcf.global.page.next{/lang}{/capture}{@$pageNext|encodeJS}',
 			'wcf.global.page.previous': '{capture assign=pagePrevious}{lang}wcf.global.page.previous{/lang}{/capture}{@$pagePrevious|encodeJS}',
+			'wcf.global.pageDirection': '{lang}wcf.global.pageDirection{/lang}',
 			'wcf.global.thousandsSeparator': '{capture assign=thousandsSeparator}{lang}wcf.global.thousandsSeparator{/lang}{/capture}{@$thousandsSeparator|encodeJS}',
 			'wcf.sitemap.title': '{lang}wcf.sitemap.title{/lang}',
 			'wcf.style.changeStyle': '{lang}wcf.style.changeStyle{/lang}'

--- a/wcfsetup/install/files/js/WCF.js
+++ b/wcfsetup/install/files/js/WCF.js
@@ -2114,6 +2114,17 @@ WCF.Date.Picker = {
 			$input.removeAttr('name');
 			$input.before('<input type="hidden" id="' + $input.wcfIdentify() + 'DatePicker" name="' + $inputName + '" value="' + $inputValue + '" />');
 			
+			// get min- and maxdate
+			var minDate = ($input.data('min-date') != null)
+				? new Date($input.data('min-date'))
+				: null;
+			var maxDate = ($input.data('max-date') != null)
+				? new Date($input.data('max-date'))
+				: null;
+			
+			// page direction
+			var isRTL = (WCF.Language.get('wcf.global.pageDirection') == 'rtl');
+			
 			// init date picker
 			$input.datepicker({
 				altField: '#' + $input.wcfIdentify() + 'DatePicker',
@@ -2124,6 +2135,10 @@ WCF.Date.Picker = {
 				dayNames: WCF.Language.get('__days'),
 				dayNamesMin: WCF.Language.get('__daysShort'),
 				dayNamesShort: WCF.Language.get('__daysShort'),
+				firstDay: 1,
+				isRTL: isRTL,
+				maxDate: maxDate,
+				minDate: minDate,
 				monthNames: WCF.Language.get('__months'),
 				monthNamesShort: WCF.Language.get('__monthsShort'),
 				showOtherMonths: true,


### PR DESCRIPTION
I haven't found a var in the WCF indicating the first day of the week. Maybe you want to add a new language var for this, but it's not that easy: Most countries and ISO 8601 say it's monday (new default), the US says it's sunday (old default). But: UK says monday, too - so it's not really language-specific. Maybe according to the time zone? Do what ever you prefer...
