### PR TITLE
Allow breadcrumbs without an link

### DIFF
--- a/com.woltlab.wcf/template/breadcrumbs.tpl
+++ b/com.woltlab.wcf/template/breadcrumbs.tpl
@@ -4,7 +4,12 @@
 	<ul>
 		{foreach from=$__wcf->getBreadcrumbs() item=$breadcrumb}
 			<li title="{$breadcrumb->getLabel()}"{if $__microdata} itemscope="itemscope" itemtype="http://data-vocabulary.org/Breadcrumb"{/if}>
-				<a href="{$breadcrumb->getURL()}"{if $__microdata} itemprop="url"{/if}><span{if $__microdata} itemprop="title"{/if}>{$breadcrumb->getLabel()}</span></a> <span class="pointer"><span>&raquo;</span></span>
+				{if $breadcrumb->getURL()}
+					<a href="{$breadcrumb->getURL()}"{if $__microdata} itemprop="url"{/if}><span{if $__microdata} itemprop="title"{/if}>{$breadcrumb->getLabel()}</span></a>
+				{else}
+					<span{if $__microdata} itemprop="title"{/if}>{$breadcrumb->getLabel()}</span>
+				{/if}
+				<span class="pointer"><span>&raquo;</span></span>
 			</li>
 		{/foreach}
 	</ul>

--- a/wcfsetup/install/files/style/layout.less
+++ b/wcfsetup/install/files/style/layout.less
@@ -737,7 +737,7 @@
 				}
 			}
 			
-			> a {
+			> *:not(.pointer) {
 				color: @wcfColor;
 				display: block;
 				overflow: hidden;
@@ -745,6 +745,7 @@
 				text-decoration: none;
 				text-overflow: ellipsis;
 				white-space: nowrap;
+				cursor: pointer;
 				
 				.textShadow(@wcfContentBackgroundColor);
 			}


### PR DESCRIPTION
This should be avoided wherever possible, but sometimes there are good reasons for a breadcrumb without an link. For example, when using sidebars, you probably have a navigation like
- Category
  - Item 1
  - Item 2

Usually "Category" doesn't represent a page, it's just a logical container for its containing items. Adding the category to the breadcrumbs navigation results in a much better user experience. When the user navigates deeper, the resulting breadcrumbs navigation would be
Homepage > Category > Item 1
Homepage > Category > Item 2

instead of just
Homepage > Item 1
Homepage > Item 2

This makes the user easier to understand that "Item 1" and "Item 2" are of the same kind.
