### PR TITLE
Don't use .getTagName(), use jQuerys .is() instead

### DIFF
--- a/wcfsetup/install/files/js/WCF.js
+++ b/wcfsetup/install/files/js/WCF.js
@@ -149,9 +149,7 @@ $.fn.extend({
 	 * @returns	string
 	 */
 	getTagName: function() {
-		return (this.length > 0)
-			? this.get(0).tagName.toLowerCase()
-			: '';
+		return (this.length) ? this.get(0).tagName.toLowerCase() : '';
 	},
 	
 	/**


### PR DESCRIPTION
Your custom `.getTagName()` fails on jQuery selectors with multiple or no elements. When you try to `.wcfFadeIn()` on an selector with no elements, a JavaScript error is the result. With an selector containing multiple elements, the effect won't be changed to highlight when one of the elements is an tr, but not the first one. Never ever expect a single element inside an jQuery selector, that's the first thing the jQuery doc tells you. Simply use jQuerys `.is()` instead - it's much more flexible.

As I can see, `WCF.getEffect()` is a "protected method" and only used internally. If this is not the case just say it, I'll make it downward-compatible.
