### PR TITLE
Let WCF.MultipleLanguageInput differ between element ID and name

### DIFF
--- a/com.woltlab.wcf/template/multipleLanguageInputJavascript.tpl
+++ b/com.woltlab.wcf/template/multipleLanguageInputJavascript.tpl
@@ -1,9 +1,10 @@
 {if !$forceSelection|isset}{assign var=forceSelection value=false}{/if}
+{if !$elementName|isset}{assign var=elementName value=$elementIdentifier}{/if}
 <script type="text/javascript">
 	//<![CDATA[
 	$(function() {
 		var $availableLanguages = { {implode from=$availableLanguages key=languageID item=languageName}{@$languageID}: '{$languageName}'{/implode} };
-		var $values = { {implode from=$i18nValues[$elementIdentifier] key=languageID item=value}'{@$languageID}': '{$value}'{/implode} };
+		var $values = { {implode from=$i18nValues[$elementName] key=languageID item=value}'{@$languageID}': '{$value}'{/implode} };
 		new WCF.MultipleLanguageInput('{@$elementIdentifier}', {if $forceSelection}true{else}false{/if}, $values, $availableLanguages);
 	});
 	//]]>

--- a/wcfsetup/install/files/js/WCF.js
+++ b/wcfsetup/install/files/js/WCF.js
@@ -2585,7 +2585,7 @@ WCF.MultipleLanguageInput = Class.extend({
 	/**
 	 * Initializes multiple language ability for given element id.
 	 * 
-	 * @param	integer		elementID
+	 * @param	string		elementID
 	 * @param	boolean		forceSelection
 	 * @param	boolean		isEnabled
 	 * @param	object		values
@@ -2822,14 +2822,14 @@ WCF.MultipleLanguageInput = Class.extend({
 		}
 		
 		var $form = $(this._element.parents('form')[0]);
-		var $elementID = this._element.wcfIdentify();
+		var $elementName = this._element.prop('name');
 		
 		for (var $languageID in this._availableLanguages) {
 			if (this._values[$languageID] === undefined) {
 				this._values[$languageID] = '';
 			}
 			
-			$('<input type="hidden" name="' + $elementID + '_i18n[' + $languageID + ']" value="' + this._values[$languageID] + '" />').appendTo($form);
+			$('<input type="hidden" name="' + $elementName + '_i18n[' + $languageID + ']" value="' + this._values[$languageID] + '" />').appendTo($form);
 		}
 		
 		// remove name attribute to prevent conflict with i18n values


### PR DESCRIPTION
see [#1107](https://github.com/WoltLab/WCF/issues/1107#issuecomment-13608927)

When sending an form inside an dialog with AJAX, you probably must change the element ID to avoid conflicts with the underlying page. That's the reason why HTML differs between ID and name. Let WCF.MultipleLanguageInput do the same. 100% downward-compatible
