### PR TITLE
Adding array comparison methods

### DIFF
--- a/wcfsetup/install/files/lib/util/ArrayUtil.class.php
+++ b/wcfsetup/install/files/lib/util/ArrayUtil.class.php
@@ -1,7 +1,7 @@
 <?php
 namespace wcf\util;
-use wcf\system\Callback;
 use wcf\system\exception\SystemException;
+use wcf\system\Callback;
 
 /**
  * Contains Array-related functions.
@@ -203,7 +203,7 @@ final class ArrayUtil {
 	 * @param	callable	$callback
 	 * @return	boolean
 	 */
-	protected static function compareHelper($method, array $array1, array $array2, Callback $callback) {
+	protected static function compareHelper($method, array $array1, array $array2, Callback $callback = null) {
 		// get function name
 		$function = null;
 		if ($method === 'value') {


### PR DESCRIPTION
Allows comparison of two arrays (just values, just keys or keys and values) while ignoring the item order. You can use callbacks, too.
