### PR TITLE
Add callback param to WCF.ToggleOptions

### DIFF
--- a/wcfsetup/install/files/js/WCF.js
+++ b/wcfsetup/install/files/js/WCF.js
@@ -3404,7 +3404,7 @@ WCF.ToggleOptions = Class.extend({
 		}
 		
 		if (this._callback !== null) {
-			$.proxy(this._callback, this)();
+			this._callback();
 		}
 	}
 });


### PR DESCRIPTION
as usual: 100% downward-compatible
It would be great if you add callbacks on spec when creating new classes, there are always cases in which they can be very helpful :smiley:
