### PR TITLE
Adding the ability to bind objects to callbacks

### DIFF
--- a/wcfsetup/install/files/lib/system/Callback.class.php
+++ b/wcfsetup/install/files/lib/system/Callback.class.php
@@ -17,19 +17,33 @@ final class Callback {
 	 * encapsulated callback
 	 * @var	callback
 	 */
-	private $callback = null;
+	private $callback;
+	
+	/**
+	 * the object the closure is bound to
+	 * @var	object
+	 */
+	private $boundObject;
 	
 	/**
 	 * Creates new instance of Callback.
 	 * 
 	 * @param	callback	$callback
+	 * @param	object		$boundObject
 	 */
-	public function __construct($callback) {
+	public function __construct($callback, $boundObject = null) {
 		if (!is_callable($callback)) {
 			throw new SystemException('Given callback is not callable.');
 		}
 		
+		if (!is_null($boundObject) && !is_object($boundObject)) {
+			throw new SystemException("Can't bind the callback to a non-object (".gettype($boundObject)." given).");
+		}
+		
+		// TODO: When upgrading to PHP 5.4, use $callback->bindTo($boundObject) instead
+		// Meanwhile the bound object is passed as first argument to the callback
 		$this->callback = $callback;
+		$this->boundObject = $boundObject;
 	}
 	
 	/**
@@ -38,6 +52,19 @@ final class Callback {
 	 * @return	mixed
 	 */
 	public function __invoke() {
-		return call_user_func_array($this->callback, func_get_args());
+		$arguments = func_get_args();
+		if (!is_null($this->boundObject)) {
+			array_unshift($arguments, $this->boundObject);
+		}
+		return call_user_func_array($this->callback, $arguments);
+	}
+	
+	/**
+	 * Returns the object this callback is bound to.
+	 * 
+	 * @return	object
+	 */
+	public function getBoundObject() {
+		return $this->boundObject;
 	}
 }


### PR DESCRIPTION
Unfortunately the "real" support of this was added in PHP 5.4, so we can't use it. This is a way to work around that pitfall. Please note that `function() use ($this) {}` doesn't work in PHP 5.3. This suggestion is the same as doing

``` php
$callback = function($self) { return $self->someProperty; };
$callback($this);
```

but I think this is a nicer way of doing that - and that's actually the only reason for this `Callback` class, isn't it? Naturally you mustn't pass a object, so it's 100% downward-compatible.

Simple usage example:

``` php
$callback = new Callback(function($self) { return $self->someProperty; }, $this);
$callback();
```
