### PR TITLE
Fixes tag replacement in wcf\system\MetaTagHandler

### DIFF
--- a/wcfsetup/install/files/lib/system/MetaTagHandler.class.php
+++ b/wcfsetup/install/files/lib/system/MetaTagHandler.class.php
@@ -62,6 +62,10 @@ class MetaTagHandler extends SingletonFactory implements \Countable, \Iterator {
 			$value = StringUtil::encodeHTML($value);
 		}
 		
+		if (!isset($this->objects[$identifier])) {
+			$this->indexToObject[] = $identifier;
+		}
+		
 		$this->objects[$identifier] = array(
 			'isProperty' => $isProperty,
 			'name' => $name,
@@ -71,9 +75,7 @@ class MetaTagHandler extends SingletonFactory implements \Countable, \Iterator {
 		// replace description if Open Graph Protocol tag was given
 		if ($name == 'og:description') {
 			$this->objects['description']['value'] = $value;
-		}
-		
-		$this->indexToObject[] = $identifier;
+		}		
 	}
 	
 	/**
@@ -136,3 +138,4 @@ class MetaTagHandler extends SingletonFactory implements \Countable, \Iterator {
 		return isset($this->indexToObject[$this->index]);
 	}
 }
+


### PR DESCRIPTION
cf. #1198

If you try to replace a tag, a new index is added to the indexToObject array, which later returns the same tag (same identifier!) twice during iteration.

Test case:

```
<?php
require_once('./global.php');    
@header("Content-type: text/plain");

$tagHandler = wcf\system\MetaTagHandler::getInstance();

foreach($tagHandler as $tag)
    echo $tag.PHP_EOL;

echo '+++' . PHP_EOL;

$tagHandler->addTag('description', 'description', 'fuuu!');

foreach($tagHandler as $tag)
    echo $tag.PHP_EOL;
```

Output:

```
<meta name="description" content="" />
<meta name="keywords" content="" />
<meta property="og:site_name" content="" />
+++
<meta name="description" content="fuuu!" />
<meta name="keywords" content="" />
<meta property="og:site_name" content="" />
<meta name="description" content="fuuu!" />
```

It should be clear, that if you replace the tag with the same identifier, it should not be displayed twice. The proposed pull request fixes the issue by only creating a new index in the indexToObject array, if and only if the identifier was not used before.
