### PR TITLE
Fixes balloon tooltips

### DIFF
--- a/wcfsetup/install/files/js/WCF.js
+++ b/wcfsetup/install/files/js/WCF.js
@@ -4230,7 +4230,16 @@ WCF.Effect.BalloonTooltip = Class.extend({
 		}
 		
 		// calculate top offset
-		var $top = $elementOffsets.top + $elementDimensions.height + 7;
+		if ($elementOffsets.top + $elementDimensions.height + $tooltipDimensions.height - $(document).scrollTop() < $(window).height()) {
+			var $top = $elementOffsets.top + $elementDimensions.height + 7;
+			this._tooltip.removeClass('inverse');
+			$arrow.css('top', -5);
+		}
+		else {
+			var $top = $elementOffsets.top - $elementDimensions.height - 7;
+			this._tooltip.addClass('inverse');
+			$arrow.css('top', $tooltipDimensions.height);
+		}
 		
 		// calculate left offset
 		switch ($alignment) {

--- a/wcfsetup/install/files/style/global.less
+++ b/wcfsetup/install/files/style/global.less
@@ -164,8 +164,6 @@ body > iframe[src="about:blank"] {
 	z-index: 800;
 	
 	.borderRadius(6px);
-	.boxShadow(0, 3px, rgba(0, 0, 0, .3), 7px);
-	
 	.pointer {
 		border-color: @wcfTooltipBackgroundColor transparent;
 		border-style: solid;
@@ -173,6 +171,15 @@ body > iframe[src="about:blank"] {
 		left: 50%;
 		position: absolute;
 		top: -5px;
+	}
+	
+	.boxShadow(0, 3px, rgba(0, 0, 0, .3), 7px);
+	
+	&.inverse {
+		.boxShadow(0, -3px, rgba(0, 0, 0, .3), 7px);
+		.pointer {
+			border-width: 5px 5px 0;
+		}
 	}
 }
 


### PR DESCRIPTION
Balloon tooltips will show up above the hovered element if necessary.

Tooltips will be displayed below an element if they would be on screen (standard behavior).
![Standard](http://i1278.photobucket.com/albums/y519/InsertRandmNick/2013-04-09_2012_zps10669807.png)

But if they would be offscreen they will be displayed above.
![Anti-offscreen](http://i1278.photobucket.com/albums/y519/InsertRandmNick/2013-04-09_2012_001_zps839f00a0.png)
