### PR TITLE
Fix: Bug in package revert(from invalid package file) in WCFSetup

### DIFF
--- a/wcfsetup/install/files/lib/system/WCFSetup.class.php
+++ b/wcfsetup/install/files/lib/system/WCFSetup.class.php
@@ -1074,7 +1074,7 @@ class WCFSetup extends WCF {
 				while ($queueID) {
 					$queueIDs[] = $queueID;
 					
-					$queueID = (isset($queues[$queueID])) ?: 0;
+					$queueID = (isset($queues[$queueID])) ? $queues[$queueID] : 0;
 				}
 				
 				// remove previously created queues


### PR DESCRIPTION
This is just a minor fix for the WCFSetup. 
Further functional checks should be done in this code section.
As this is a bug leaving the setup in an unusable state I tried a quick fix.
It seems that you meant to do this, and added the 'isset' later on and well that caused this bug.
