### PR TITLE
Hyphen vs Minus

### DIFF
--- a/wcfsetup/install/files/js/WCF.js
+++ b/wcfsetup/install/files/js/WCF.js
@@ -2934,16 +2934,16 @@ WCF.MultipleLanguageInput = Class.extend({
  */
 WCF.Number = {
 	/**
-	 * Rounds a number to a given number of floating points digits. Defaults to 0.
+	 * Rounds a number to a given number of decimal places. Defaults to 0.
 	 * 
 	 * @param	number		number
-	 * @param	floatingPoint	number of digits
+	 * @param	decimalPlaces	number of decimal places
 	 * @return	number
 	 */
-	round: function (number, floatingPoint) {
-		floatingPoint = Math.pow(10, (floatingPoint || 0));
+	round: function (number, decimalPlaces) {
+		decimalPlaces = Math.pow(10, (decimalPlaces || 0));
 		
-		return Math.round(number * floatingPoint) / floatingPoint;
+		return Math.round(number * decimalPlaces) / decimalPlaces;
 	}
 };
 
@@ -2988,11 +2988,14 @@ WCF.String = {
 	 * @param	mixed	number
 	 * @return	string
 	 */
-	formatNumeric: function(number, floatingPoint) {
-		number = String(WCF.Number.round(number, floatingPoint || 2));
+	formatNumeric: function(number, decimalPlaces) {
+		number = String(WCF.Number.round(number, decimalPlaces || 2));
 		number = number.replace('.', WCF.Language.get('wcf.global.decimalPoint'));
 		
-		return this.addThousandsSeparator(number);
+		number = this.addThousandsSeparator(number);
+		number = number.replace('-', '\u2212');
+		
+		return number;
 	},
 	
 	/**

--- a/wcfsetup/install/files/lib/util/StringUtil.class.php
+++ b/wcfsetup/install/files/lib/util/StringUtil.class.php
@@ -21,10 +21,16 @@ final class StringUtil {
 	const HTML_COMMENT_PATTERN = '~<!--(.*?)-->~';
 	
 	/**
-	 * utf8 bytes of the horizontal ellipsis char
+	 * utf8 bytes of the HORIZONTAL ELLIPSIS (U+2026)
 	 * @var	string
 	 */
 	const HELLIP = "\xE2\x80\xA6";
+	
+	/**
+	 * utf8 bytes of the MINUS SIGN (U+2212)
+	 * @var	string
+	 */
+	const MINUS = "\xE2\x88\x92";
 	
 	/**
 	 * Alias to php sha1() function.
@@ -141,17 +147,19 @@ final class StringUtil {
 	 * @return	string
 	 */
 	public static function formatNumeric($numeric) {
-		if (is_int($numeric)) 
+		if (is_int($numeric)) {
 			return self::formatInteger($numeric);
-			
-		else if (is_float($numeric))
+		}
+		else if (is_float($numeric)) {
 			return self::formatDouble($numeric);
-			
+		}
 		else {
-			if (floatval($numeric) - (float) intval($numeric))
+			if (floatval($numeric) - (float) intval($numeric)) {
 				return self::formatDouble($numeric);
-			else 
+			}
+			else {
 				return self::formatInteger(intval($numeric));
+			}
 		}
 	}
 	
@@ -163,6 +171,9 @@ final class StringUtil {
 	 */
 	public static function formatInteger($integer) {
 		$integer = self::addThousandsSeparator($integer);
+		
+		// format minus
+		$integer = self::formatNegative($integer);
 		
 		return $integer;
 	}
@@ -192,6 +203,9 @@ final class StringUtil {
 		// add thousands separator
 		$double = self::addThousandsSeparator($double);
 		
+		// format minus
+		$double = self::formatNegative($double);
+		
 		return $double;
 	}
 	
@@ -207,6 +221,16 @@ final class StringUtil {
 		}
 		
 		return $number;
+	}
+	
+	/**
+	 * Replaces the MINUS-HYPHEN with the MINUS SIGN
+	 * 
+	 * @param	mixed		$number
+	 * @return	string
+	 */
+	public static function formatNegative($number) {
+		return self::replace('-', self::MINUS, $number);
 	}
 	
 	/**


### PR DESCRIPTION
As we are in many cases already using the typographical correct character (`„“”` vs. `"`) I propose using the correct minus character instead of the hyphen.

`-` <- this is a hyphen (the one next to the full stop on a German keyboard)
`−` <- this is a minus

Note the difference:
`+-` <- the hyphen is lower than the horizontal bar of the plus
`+−` <- the minus is at the same vertical position and it has got the same width (if it does not show correctly try copying it into your comment box)
