### PR TITLE
Fixes #1269

### DIFF
--- a/wcfsetup/install/files/lib/system/WCF.class.php
+++ b/wcfsetup/install/files/lib/system/WCF.class.php
@@ -377,16 +377,6 @@ class WCF {
 				throw new PermissionDeniedException();
 			}
 		}
-		
-		// handle banned users
-		if (self::getUser()->userID && self::getUser()->banned) {
-			if (isset($_SERVER['HTTP_X_REQUESTED_WITH']) && ($_SERVER['HTTP_X_REQUESTED_WITH'] == 'XMLHttpRequest')) {
-				throw new AJAXException(self::getLanguage()->getDynamicVariable('wcf.user.error.isBanned'), AJAXException::INSUFFICIENT_PERMISSIONS);
-			}
-			else {
-				throw new NamedUserException(self::getLanguage()->getDynamicVariable('wcf.user.error.isBanned'));
-			}
-		}
 	}
 	
 	/**


### PR DESCRIPTION
Pages/Forms/Actions available during offline mode are now also accesible by banned users.
Added `RequestHandler::isAJAXRequest()` and `handleRequest`-event in `RequestHandler::handle()`.
