### PR TITLE
Fixes DateUtil::validateDate()

### DIFF
--- a/wcfsetup/install/files/lib/util/DateUtil.class.php
+++ b/wcfsetup/install/files/lib/util/DateUtil.class.php
@@ -363,7 +363,7 @@ final class DateUtil {
 		}
 		
 		// try to convert $date into a UNIX timestamp
-		$time = @strtotime($date);
+		$time = @strtotime($date." GMT");
 		if ($time === false) {
 			throw new SystemException("date '".$date."' is invalid");
 		}


### PR DESCRIPTION
Fixes WoltLab/WCF#1283 as gmdate returns a date in GMT but strtotime doesn't if input isn't specified as GMT.

> Each parameter of this function uses the default time zone unless a time zone is specified in that parameter.

See http://www.php.net/manual/en/function.strtotime.php
