### PR TITLE
Fixed inconsistent usage of elseif

### DIFF
--- a/com.woltlab.wcf/template/headInclude.tpl
+++ b/com.woltlab.wcf/template/headInclude.tpl
@@ -18,7 +18,7 @@
 {if JQUERY_SOURCE == 'google'}
 <script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/2.0.0/jquery.min.js"></script>
 <script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jqueryui/1.10.2/jquery-ui.min.js"></script>
-{else if JQUERY_SOURCE == 'microsoft'}
+{elseif JQUERY_SOURCE == 'microsoft'}
 <script type="text/javascript" src="//ajax.aspnetcdn.com/ajax/jQuery/jquery-2.0.0.min.js"></script>
 <script type="text/javascript" src="//ajax.aspnetcdn.com/ajax/jquery.ui/1.10.2/jquery-ui.min.js"></script>
 {else}


### PR DESCRIPTION
In the past, elseif was used within templates. Now, you've mixed up the
usage of else if and elseif.
