### PR TITLE
CKEditor style optimization

### DIFF
--- a/wcfsetup/install/files/style/message.less
+++ b/wcfsetup/install/files/style/message.less
@@ -861,6 +861,10 @@ li:nth-child(2n+1) .message {
 	width: auto !important;
 }
 
+.cke_dialog_background_cover {
+	background-color: #000 !important;
+}
+
 @media only screen and (max-width: 800px) {
 	.message.messageSidebarOrientationLeft,
 	.message.messageSidebarOrientationRight {


### PR DESCRIPTION
With this change, the CKEditor and WCF popover has the same background-color.
see http://beta.woltlab.com/index.php/Thread/1289-Konsistentes-Hintergrund-Dimmen/
