### PR TITLE
Fixed ZipWriter getDosDatetime on NaN value

### DIFF
--- a/wcfsetup/install/files/lib/system/io/ZipWriter.class.php
+++ b/wcfsetup/install/files/lib/system/io/ZipWriter.class.php
@@ -5,7 +5,7 @@ use wcf\util\StringUtil;
 
 /**
  * Creates a Zip file archive.
- *
+ * 
  * @author	Marcel Werk
  * @copyright	2001-2012 WoltLab GmbH
  * @license	GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
@@ -177,7 +177,7 @@ class ZipWriter {
 	
 	/**
 	 * Converts an unix timestamp to Zip file time.
-	 *
+	 * 
 	 * @param	integer		$date		unix timestamp
 	 * @return	string
 	 */


### PR DESCRIPTION
Fixes the Zip creation when the timestamp, passed through addFile, is not a number.
Otherwise getDosDatetime will add 11 Bytes instead of a double word which makes the whole file corrupt.
