### PR TITLE
Allow admin to set default gravatar type

### DIFF
--- a/com.woltlab.wcf/option.xml
+++ b/com.woltlab.wcf/option.xml
@@ -829,6 +829,17 @@ no:!cache_source_memcached_host]]></enableoptions>
 				<defaultvalue>192</defaultvalue>
 				<minvalue>48</minvalue>
 			</option>
+			<option name="gravatar_default_type">
+				<categoryname>user.avatar</categoryname>
+				<optiontype>select</optiontype>
+				<defaultvalue><![CDATA[404]]></defaultvalue>
+				<selectoptions><![CDATA[404:wcf.user.avatar.404
+identicon:wcf.user.avatar.gravatarType.identicon
+wavatar:wcf.user.avatar.gravatarType.wavatar
+monsterid:wcf.user.avatar.gravatarType.monsterid
+retro:wcf.user.avatar.gravatarType.retro]]></selectoptions>
+				<options>module_gravatar</options>
+			</option>
 			<!-- /user.avatar -->
 			
 			<!-- user.signature -->

--- a/com.woltlab.wcf/template/avatarEdit.tpl
+++ b/com.woltlab.wcf/template/avatarEdit.tpl
@@ -85,7 +85,7 @@
 			
 			{if MODULE_GRAVATAR}
 				<dl{if $errorField == 'gravatar'} class="formError"{/if}>
-					<dt class="framed"><img src="http://www.gravatar.com/avatar/{@$__wcf->user->email|strtolower|md5}?s=96" alt="" class="icon96" /></dt>
+					<dt class="framed"><img src="http://www.gravatar.com/avatar/{@$__wcf->user->email|strtolower|md5}?s=96{if GRAVATAR_DEFAULT_TYPE != '404'}&d={GRAVATAR_DEFAULT_TYPE}{/if}" alt="" class="icon96" /></dt>
 					<dd>
 						<label><input type="radio" name="avatarType" value="gravatar" {if $avatarType == 'gravatar'}checked="checked" {/if}/> {lang}wcf.user.avatar.type.gravatar{/lang}</label>
 						{if $errorField == 'gravatar'}

--- a/wcfsetup/install/files/lib/action/GravatarDownloadAction.class.php
+++ b/wcfsetup/install/files/lib/action/GravatarDownloadAction.class.php
@@ -68,7 +68,7 @@ class GravatarDownloadAction extends AbstractAction {
 			}
 			
 			// try to download new version
-			$gravatarURL = sprintf(Gravatar::GRAVATAR_BASE, md5(StringUtil::toLowerCase($this->user->email)), $this->size, '404');
+			$gravatarURL = sprintf(Gravatar::GRAVATAR_BASE, md5(StringUtil::toLowerCase($this->user->email)), $this->size, GRAVATAR_DEFAULT_TYPE);
 			try {
 				$tmpFile = FileUtil::downloadFileFromHttp($gravatarURL, 'gravatar');
 				copy($tmpFile, WCF_DIR.$cachedFilename);

--- a/wcfsetup/install/files/lib/data/user/avatar/Gravatar.class.php
+++ b/wcfsetup/install/files/lib/data/user/avatar/Gravatar.class.php
@@ -94,7 +94,7 @@ class Gravatar extends DefaultAvatar {
 	 * @return	boolean
 	 */
 	public static function test($email) {
-		$gravatarURL = sprintf(self::GRAVATAR_BASE, md5(StringUtil::toLowerCase($email)), 80, '404');
+		$gravatarURL = sprintf(self::GRAVATAR_BASE, md5(StringUtil::toLowerCase($email)), 80, GRAVATAR_DEFAULT_TYPE);
 		try {
 			$tmpFile = FileUtil::downloadFileFromHttp($gravatarURL, 'gravatar');
 			@unlink($tmpFile);

--- a/wcfsetup/install/lang/de.xml
+++ b/wcfsetup/install/lang/de.xml
@@ -691,6 +691,8 @@
 		<item name="wcf.acp.option.category.user.3rdPartyAuth"><![CDATA[Authentifizierung über Drittanbieter]]></item>
 		<item name="wcf.acp.option.max_avatar_height"><![CDATA[Maximale Avatar-Höhe]]></item>
 		<item name="wcf.acp.option.max_avatar_width"><![CDATA[Maximale Avatar-Breite]]></item>
+		<item name="wcf.acp.option.gravatar_default_type"><![CDATA[Standard Gravatar-Typ]]></item>
+		<item name="wcf.acp.option.gravatar_default_type.description"><![CDATA[Der <a href="{@$__wcf->getPath()}acp/dereferrer.php?url=https://de.gravatar.com/site/implement/images/#default-image">Standard-Gravatar-Typ</a>, wenn einer E-Mail kein Gravatar zugeordnet werden kann.]]></item>
 		<item name="wcf.acp.option.module_gravatar"><![CDATA[Gravatare]]></item>
 		<item name="wcf.acp.option.module_gravatar.description"><![CDATA[Aktiviert die Unterstützung für Gravatare („Global Recognized Avatar“).]]></item>
 		<item name="wcf.acp.option.module_users_online"><![CDATA[„Benutzer online“-Anzeige]]></item>
@@ -2186,6 +2188,11 @@ Sollten Sie sich nicht auf der Website: {@PAGE_TITLE|language} angemeldet haben,
 		<item name="wcf.user.avatar.alt"><![CDATA[Benutzer-Avatarbild]]></item>
 		<item name="wcf.user.avatar.edit"><![CDATA[Avatar verwalten]]></item>
 		<item name="wcf.user.avatar.error.disabled"><![CDATA[Der Administrator hat{if $__wcf->user->avatarID || $__wcf->user->enableGravatar} Ihren derzeitigen Avatar gesperrt und{/if} Ihnen die weitere Nutzungsberechtigung der Avatar-Funktion {if !$__wcf->user->disableAvatarReason}entzogen.{else} aus folgenden Gründen entzogen: {$__wcf->user->disableAvatarReason}{/if}]]></item>
+		<item name="wcf.user.avatar.gravatarType.404"><![CDATA[Kein Standard-Gravatar]]></item>
+		<item name="wcf.user.avatar.gravatarType.identicon"><![CDATA[Identicon]]></item>
+		<item name="wcf.user.avatar.gravatarType.wavatar"><![CDATA[Wavatar]]></item>
+		<item name="wcf.user.avatar.gravatarType.monsterid"><![CDATA[Monster-ID]]></item>
+		<item name="wcf.user.avatar.gravatarType.retro"><![CDATA[Retro]]></item>
 		<item name="wcf.user.avatar.type.custom"><![CDATA[Eigenen Avatar hochladen]]></item>
 		<item name="wcf.user.avatar.type.custom.crop"><![CDATA[Avatar zuschneiden]]></item>
 		<item name="wcf.user.avatar.type.custom.crop.description"><![CDATA[Die verkleinerten Darstellungen Ihres Avatars verwenden einen quadratischen Ausschnitt. Sie können den gewünschten Ausschnitt individuell festlegen, in dem Sie den hervorgehobenen Bereich mit gedrückter Maustaste an die gewünschte Position verschieben.]]></item>

--- a/wcfsetup/install/lang/en.xml
+++ b/wcfsetup/install/lang/en.xml
@@ -690,6 +690,8 @@ Examples for medium ID detection:
 		<item name="wcf.acp.option.category.user.3rdPartyAuth"><![CDATA[Third-Party Authentication]]></item>
 		<item name="wcf.acp.option.max_avatar_height"><![CDATA[Maximum Avatar Height]]></item>
 		<item name="wcf.acp.option.max_avatar_width"><![CDATA[Maximum Avatar Width]]></item>
+		<item name="wcf.acp.option.gravatar_default_type"><![CDATA[Default Gravatar Type]]></item>
+		<item name="wcf.acp.option.gravatar_default_type.description"><![CDATA[The <a href="{@$__wcf->getPath()}acp/dereferrer.php?url=https://de.gravatar.com/site/implement/images/#default-image">default Gravatar type</a> used if no matching Gravatar was found.]]></item>
 		<item name="wcf.acp.option.module_gravatar"><![CDATA[Gravatars]]></item>
 		<item name="wcf.acp.option.module_gravatar.description"><![CDATA[Enables support for Gravatars (“Global Recognized Avatar”).]]></item>
 		<item name="wcf.acp.option.module_users_online"><![CDATA[“Users Online” List]]></item>
@@ -2142,6 +2144,11 @@ You can safely ignore this email if you did not register with the website: {@PAG
 		<item name="wcf.user.avatar.alt"><![CDATA[User Avatar]]></item>
 		<item name="wcf.user.avatar.edit"><![CDATA[Avatar Management]]></item>
 		<item name="wcf.user.avatar.error.disabled"><![CDATA[The administrators {if $__wcf->user->avatarID || $__wcf->user->enableGravatar}have banned your avatar and {/if}disallowed you from using an avatar{if $__wcf->user->disableAvatarReason}: {$__wcf->user->disableAvatarReason}{/if}.]]></item>
+		<item name="wcf.user.avatar.gravatarType.404"><![CDATA[No default Gravatar]]></item>
+		<item name="wcf.user.avatar.gravatarType.identicon"><![CDATA[Identicon]]></item>
+		<item name="wcf.user.avatar.gravatarType.wavatar"><![CDATA[Wavatar]]></item>
+		<item name="wcf.user.avatar.gravatarType.monsterid"><![CDATA[Monster id]]></item>
+		<item name="wcf.user.avatar.gravatarType.retro"><![CDATA[Retro]]></item>
 		<item name="wcf.user.avatar.type.custom"><![CDATA[Upload Own Avatar]]></item>
 		<item name="wcf.user.avatar.type.custom.crop"><![CDATA[Crop Avatar]]></item>
 		<item name="wcf.user.avatar.type.custom.crop.description"><![CDATA[The scaled versions of your avatar are based on a square cutout. You may specify an individual cutout by holding down your mouse button and moving the highlighted area to the desired position.]]></item>


### PR DESCRIPTION
This change allows administrators to select the default Gravatar type used if a Gravatar was not found for an e-mail.
If the setting is set to "No default Gravatar" the avatar-default.svg will be used instead.

Here's an example of those Gravatar types (destinee.larsons gravatar was updated before I changed the setting to monsterid):
![2013-06-01_2143](https://f.cloud.github.com/assets/642457/595537/9ba2c8b8-cb09-11e2-93a8-867f6f1cf5e7.png)
