### PR TITLE
Add method setMaxLifetime()

### DIFF
--- a/wcfsetup/install/files/lib/system/cache/builder/AbstractCacheBuilder.class.php
+++ b/wcfsetup/install/files/lib/system/cache/builder/AbstractCacheBuilder.class.php
@@ -56,6 +56,13 @@ abstract class AbstractCacheBuilder extends SingletonFactory implements ICacheBu
 	}
 	
 	/**
+	 * @see	wcf\system\cache\builder\ICacheBuilder::setMaxLifetime()
+	 */
+	public function setMaxLifetime($maxLifetime = 0) {
+		$this->maxLifetime = $maxLifetime;
+	}
+	
+	/**
 	 * @see	wcf\system\cache\builder\ICacheBuilder::getMaxLifetime()
 	 */
 	public function getMaxLifetime() {

--- a/wcfsetup/install/files/lib/system/cache/builder/ICacheBuilder.class.php
+++ b/wcfsetup/install/files/lib/system/cache/builder/ICacheBuilder.class.php
@@ -22,6 +22,13 @@ interface ICacheBuilder {
 	public function getData(array $parameters = array(), $arrayIndex = '');
 	
 	/**
+	 * Sets maximum lifetime for cache resource.
+	 * 
+	 * @param	int		$maxLifetime
+	 */
+	public function setMaxLifetime($maxLifetime = 0);
+	
+	/**
 	 * Returns maximum lifetime for cache resource.
 	 * 
 	 * @return	integer


### PR DESCRIPTION
Currently, we can overwrite $maxLifetime within a cache builder. However, it may be necessary in some cases to define the maximum age of a single resource instead of the whole cache.

Example: I have a cache builder to call an external API. The cache builder creates a resource for every (different) call. Now, i would like to reset the resource of a specific call. Atm, i can just reset all resources, created by the cache builder.
