### PR TITLE
Popover fix

### DIFF
--- a/wcfsetup/install/files/style/global.less
+++ b/wcfsetup/install/files/style/global.less
@@ -189,7 +189,6 @@ body > iframe[src="about:blank"] {
 	padding: @wcfGapSmall;
 	position: absolute;
 	vertical-align: middle;
-	width: 400px !important;
 	z-index: 500;
 	
 	.borderRadius(6px);
@@ -211,6 +210,7 @@ body > iframe[src="about:blank"] {
 		color: @wcfColor;
 		max-height: 300px;
 		min-height: 32px;
+		width: 400px;
 		opacity: 0;
 		overflow: hidden;
 		padding: @wcfGapSmall @wcfGapMedium;


### PR DESCRIPTION
This request fixes the dynamic re sizing of popover elements.
The width: 400px !Important on .popover prevents that .popoverContent is able to resize over 400px even if the content is wider.

To check that Problem you just need to add a width larger than 400px to a element inside .popoverContent
