### PR TITLE
Corrected parent call

### DIFF
--- a/wcfsetup/install/files/lib/acp/form/StyleEditForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/StyleEditForm.class.php
@@ -89,7 +89,7 @@ class StyleEditForm extends StyleAddForm {
 	 * @see	wcf\form\IForm::save()
 	 */
 	public function save() {
-		AbstractForm::saved();
+		AbstractForm::save();
 		
 		$this->objectAction = new StyleAction(array($this->style), 'update', array(
 			'data' => array(


### PR DESCRIPTION
Now events are properly fired - first save, then later saved
