### PR TITLE
Improve http_build_query (fixes reCAPTCHA)

### DIFF
--- a/wcfsetup/install/files/lib/util/HTTPRequest.class.php
+++ b/wcfsetup/install/files/lib/util/HTTPRequest.class.php
@@ -105,7 +105,7 @@ final class HTTPRequest {
 		$this->addHeader('Accept', '*/*');
 		$this->addHeader('Accept-Language', WCF::getLanguage()->getFixedLanguageCode());
 		if ($this->options['method'] !== 'GET') {
-			$this->addHeader('Content-length', strlen(http_build_query($this->postParameters)));
+			$this->addHeader('Content-length', strlen(http_build_query($this->postParameters, '', '&')));
 			$this->addHeader('Content-Type', 'application/x-www-form-urlencoded');
 		}
 		if (isset($this->options['auth'])) {
@@ -153,7 +153,7 @@ final class HTTPRequest {
 		}
 		$request .= "\r\n";
 		// add post parameters
-		if ($this->options['method'] !== 'GET') $request .= http_build_query($this->postParameters)."\r\n\r\n";
+		if ($this->options['method'] !== 'GET') $request .= http_build_query($this->postParameters, '', '&')."\r\n\r\n";
 		$remoteFile->puts($request);
 		
 		$inHeader = true;


### PR DESCRIPTION
As of PHP 5.1.2 (or 5.3?), the default seperator of http_build_query is arg_separator.input, which is "&amp" in some cases. This may cause some unexpected problems i.e. reCAPTCHA doesn't work as intended.
