### PR TITLE
Small .breadcrumbs optimization

### DIFF
--- a/wcfsetup/install/files/style/layout.less
+++ b/wcfsetup/install/files/style/layout.less
@@ -1186,7 +1186,7 @@
 					display: inline-block;
 					font-family: FontAwesome;
 					font-size: 14px;
-					margin: -3px 7px -3px 0;
+					margin: -3px 0;
 					vertical-align: -1px;
 				}
 			}


### PR DESCRIPTION
With this change, the right padding-attribute of the icon in the breadcrumbs area becomes smaller and the icon will appear central.
Testet with all major browsers (IE with 9 and 10)
![breadcrumbs](https://f.cloud.github.com/assets/1836347/774369/57e27892-e956-11e2-9fba-da9baf7df855.png)
