### PR TITLE
Allow icons to be framed

### DIFF
--- a/wcfsetup/install/files/style/global.less
+++ b/wcfsetup/install/files/style/global.less
@@ -136,7 +136,8 @@ body > iframe[src="about:blank"] {
 
 .framed {
 	> canvas,
-	> img {
+	> img,
+	> .icon {
 		background-color: @wcfContentBackgroundColor;
 		border: 1px solid @wcfContainerBorderColor;
 		padding: 1px;


### PR DESCRIPTION
Since icons are images too it should be possible to use them with the `.framed` class.
