### PR TITLE
Update MultipleLinkPage.class.php

### DIFF
--- a/wcfsetup/install/files/lib/page/MultipleLinkPage.class.php
+++ b/wcfsetup/install/files/lib/page/MultipleLinkPage.class.php
@@ -144,7 +144,7 @@ abstract class MultipleLinkPage extends AbstractPage {
 	protected function readObjects() {
 		$this->objectList->sqlLimit = $this->sqlLimit;
 		$this->objectList->sqlOffset = $this->sqlOffset;
-		if ($this->sqlOrderBy) $this->objectList->sqlOrderBy = $this->sqlOrderBy;
+		if ($this->sqlOrderBy) $this->objectList->sqlOrderBy = $this->objectList->getDatabaseTableAlias().".".$this->sqlOrderBy;
 		
 		EventHandler::getInstance()->fireAction($this, 'beforeReadObjects');
 		


### PR DESCRIPTION
When joining a table in a *List class which has a column with the same name like a column in the primary table, a fatal error is raised: Fatal error: Could not execute prepared statement: SQLSTATE[23000]: Integrity constraint violation: 1052 Column '' in order clause is ambiguous
