### PR TITLE
Improved categoryAdd template

### DIFF
--- a/wcfsetup/install/files/acp/templates/categoryAdd.tpl
+++ b/wcfsetup/install/files/acp/templates/categoryAdd.tpl
@@ -45,27 +45,10 @@
 
 <form method="post" action="{if $action == 'add'}{link controller=$addController application=$objectType->getProcessor()->getApplication()}{/link}{else}{link controller=$editController application=$objectType->getProcessor()->getApplication() object=$category}{/link}{/if}">
 	<div class="container containerPadding marginTop">
+		{event name='beforeFieldsets'}
+		
 		<fieldset>
 			<legend>{lang}wcf.global.form.data{/lang}</legend>
-			
-			{if $categoryNodeList->hasChildren() && $objectType->getProcessor()->getMaximumNestingLevel()}
-				<dl{if $errorField == 'parentCategoryID'} class="formError"{/if}>
-					<dt><label for="parentCategoryID">{@$objectType->getProcessor()->getLanguageVariable('parentCategoryID')}</label></dt>
-					<dd>
-						<select id="parentCategoryID" name="parentCategoryID">
-							<option value="0"></option>
-							{include file='categoryOptionList' categoryID=$parentCategoryID maximumNestingLevel=$objectType->getProcessor()->getMaximumNestingLevel()}
-						</select>
-						{if $errorField == 'parentCategoryID'}
-							<small class="innerError">
-								{assign var=__languageVariable value='parentCategoryID.error.'|concat:$errorType}
-								{@$objectType->getProcessor()->getLanguageVariable($__languageVariable)}
-							</small>
-						{/if}
-						{hascontent}<small>{content}{@$objectType->getProcessor()->getLanguageVariable('parentCategoryID.description', true)}{/content}</small>{/hascontent}
-					</dd>
-				</dl>
-			{/if}
 			
 			<dl{if $errorField == 'title'} class="formError"{/if}>
 				<dt><label for="title">{@$objectType->getProcessor()->getLanguageVariable('title')}</label></dt>
@@ -113,6 +96,31 @@
 				</dd>
 			</dl>
 			
+			{event name='dataFields'}
+		</fieldset>
+		
+		<fieldset>
+			<legend>{@$objectType->getProcessor()->getLanguageVariable('position')}</legend>
+			
+			{if $categoryNodeList->hasChildren() && $objectType->getProcessor()->getMaximumNestingLevel()}
+				<dl{if $errorField == 'parentCategoryID'} class="formError"{/if}>
+					<dt><label for="parentCategoryID">{@$objectType->getProcessor()->getLanguageVariable('parentCategoryID')}</label></dt>
+					<dd>
+						<select id="parentCategoryID" name="parentCategoryID">
+							<option value="0"></option>
+							{include file='categoryOptionList' categoryID=$parentCategoryID maximumNestingLevel=$objectType->getProcessor()->getMaximumNestingLevel()}
+						</select>
+						{if $errorField == 'parentCategoryID'}
+							<small class="innerError">
+								{assign var=__languageVariable value='parentCategoryID.error.'|concat:$errorType}
+								{@$objectType->getProcessor()->getLanguageVariable($__languageVariable)}
+							</small>
+						{/if}
+						{hascontent}<small>{content}{@$objectType->getProcessor()->getLanguageVariable('parentCategoryID.description', true)}{/content}</small>{/hascontent}
+					</dd>
+				</dl>
+			{/if}
+			
 			<dl{if $errorField == 'showOrder'} class="formError"{/if}>
 				<dt><label for="showOrder">{@$objectType->getProcessor()->getLanguageVariable('showOrder')}</label></dt>
 				<dd>
@@ -127,7 +135,7 @@
 				</dd>
 			</dl>
 			
-			{event name='dataFields'}
+			{event name='positionFields'}
 		</fieldset>
 		
 		{if $aclObjectTypeID}
@@ -143,7 +151,7 @@
 			</fieldset>
 		{/if}
 		
-		{event name='fieldsets'}
+		{event name='afterFieldsets'}
 	</div>
 	
 	<div class="formSubmit">

--- a/wcfsetup/install/lang/de.xml
+++ b/wcfsetup/install/lang/de.xml
@@ -1368,6 +1368,7 @@ Erlaubte Dateiendungen: {', '|implode:$attachmentHandler->getAllowedExtensions()
 		<item name="wcf.category.noneAvailable"><![CDATA[Es wurde noch keine Kategorie hinzugefügt.]]></item>
 		<item name="wcf.category.parentCategoryID"><![CDATA[Übergeordnete Kategorie]]></item>
 		<item name="wcf.category.parentCategoryID.error.notValid"><![CDATA[Die ausgewählte Kategorie existiert nicht.]]></item>
+		<item name="wcf.category.position"><![CDATA[Position]]></item>
 		<item name="wcf.category.showOrder"><![CDATA[Position]]></item>
 		<item name="wcf.category.description"><![CDATA[Beschreibung]]></item>
 		<item name="wcf.category.title"><![CDATA[Titel]]></item>

--- a/wcfsetup/install/lang/en.xml
+++ b/wcfsetup/install/lang/en.xml
@@ -1366,6 +1366,7 @@ Allowed extensions: {', '|implode:$attachmentHandler->getAllowedExtensions()}]]>
 		<item name="wcf.category.noneAvailable"><![CDATA[No category has been added yet.]]></item>
 		<item name="wcf.category.parentCategoryID"><![CDATA[Parent Category]]></item>
 		<item name="wcf.category.parentCategoryID.error.notValid"><![CDATA[Chosen category does not exist.]]></item>
+		<item name="wcf.category.position"><![CDATA[Position]]></item>
 		<item name="wcf.category.showOrder"><![CDATA[Position]]></item>
 		<item name="wcf.category.description"><![CDATA[Description]]></item>
 		<item name="wcf.category.title"><![CDATA[Title]]></item>


### PR DESCRIPTION
This pull request improves the `categoryAdd` template to comply with the appearance of the `boardAdd` template.

The following changes were made:
- Moved `parentCategoryID` and `showOrder` fields into own fieldset
- Added `beforeFieldsets` and `afterFieldsets` template event
- Removed`fieldsets` template event
