### PR TITLE
Added FileReader class

### DIFF
--- a/wcfsetup/install/files/lib/util/FileReader.class.php
+++ b/wcfsetup/install/files/lib/util/FileReader.class.php
@@ -1,0 +1,227 @@
+<?php
+namespace wcf\util;
+use wcf\system\io\File;
+use wcf\system\Regex;
+
+/**
+ * Provides functions to send files to the client via PHP.
+ * 
+ * @author	Sebastian Oettl, Marcel Werk
+ * @copyright	2001-2013 WoltLab GmbH
+ * @license	GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @package	com.woltlab.wcf
+ * @subpackage	util
+ * @category	Community Framework
+ */
+final class FileReader {
+	/**
+	 * http options
+	 * @var	array
+	 */
+	private $options = array(
+		'filename' => '',
+		'mimeType' => 'application/octet-stream',
+		'filesize' => 0,
+		'showInline' => false,
+		'enableRangeSupport' => true,
+		'lastModificationTime' => 0,
+		'expirationDate' => 0,
+		'maxAge' => 0
+	);
+	
+	/**
+	 * list of header items
+	 * @var	array
+	 */
+	private $headers = array();
+	
+	/**
+	 * start byte
+	 * @var	integer
+	 */
+	private $startByte = 0;
+	
+	/**
+	 * end byte
+	 * @var	integer
+	 */
+	private $endByte = 0;
+	
+	/**
+	 * True if http range is invalid.
+	 * @var	boolean
+	 */
+	private $invalidRange = false;
+	
+	/**
+	 * Creates a new instance of the HTTPFileReader class.
+	 * 
+	 * @param	string		$location
+	 * @param	array		$options
+	 */
+	public function __construct($location, array $options) {
+		$this->location = $location;
+		
+		// check location
+		if (empty($this->location) || !file_exists($this->location)) {
+			throw new SystemException('Location of file is not set or invalid');
+		}
+		
+		// set options
+		$this->setOptions($options);
+	}
+	
+	/**
+	 * Sends the file to the client.
+	 */
+	public function send() {
+		// set filename if necessary
+		if (empty($this->options['filename'])) {
+			$this->options['filename'] = basename($this->location);
+		}
+		
+		// detect filesize if necessary
+		if (empty($this->options['filesize'])) {
+			$this->options['filesize'] = @filesize($this->location);
+		}
+			
+		// handle range
+		$this->handleRange();
+		
+		// handle headers
+		$this->handleHeaders();
+		
+		// show headers
+		foreach ($this->headers as $name => $value) {
+			if (empty($name)) {
+				@header($value);
+			}
+			else {
+				@header($name.': '.$value);
+			}
+		}
+		
+		// show file
+		if (!$this->invalidRange) {
+			if ($this->startByte > 0 || $this->endByte < $this->options['filesize'] - 1) {
+				$file = new File($this->location, 'rb');
+				if ($this->startByte > 0) $file->seek($this->startByte);
+				while ($this->startByte <= $this->endByte) {
+					$remainingBytes = $this->endByte - $this->startByte;
+					$readBytes = ($remainingBytes > 1048576 ? 1048576 : $remainingBytes + 1);
+					echo $file->read($readBytes);
+					$this->startByte += $readBytes;
+				}
+				$file->close();
+			}
+			else {
+				readfile($this->location);
+			}
+		}
+	}
+	
+	/**
+	 * Handles the given range options.
+	 */
+	private function handleRange() {
+		$this->startByte = 0;
+		$this->endByte = $this->options['filesize'] - 1;
+		if ($this->options['enableRangeSupport']) {
+			if (!empty($_SERVER['HTTP_RANGE'])) {
+				$regex = new Regex('^bytes=(-?\d+)(?:-(\d+))?$');
+				if ($regex->match($_SERVER['HTTP_RANGE'])) {
+					$matches = $regex->getMatches();
+					$first = intval($matches[1]);
+					$last = (isset($matches[2]) ? intval($matches[2]) : 0);
+					
+					if ($first < 0) {
+						// negative value; subtract from filesize
+						$this->startByte = $this->options['filesize'] + $first;
+					}
+					else {
+						$this->startByte = $first;
+						if ($last > 0) {
+							$this->endByte = $last;
+						}
+					}
+				}
+			}
+		}
+	}
+	
+	/**
+	 * Handles the given header items.
+	 */
+	private function handleHeaders() {
+		if ($this->startByte < 0 || $this->startByte >= $this->options['filesize'] || $this->endByte >= $this->options['filesize']) {
+			// invalid range given
+			$this->addHeader('', 'HTTP/1.1 416 Requested Range Not Satisfiable');
+			$this->addHeader('Accept-Ranges', 'bytes');
+			$this->addHeader('Content-Range', 'bytes */'.$this->options['filesize']);
+			$this->invalidRange = true;
+		}
+		else {
+			// file type
+			$this->addHeader('Content-Type', $this->options['mimeType']);
+			
+			// file name
+			$this->addHeader('Content-disposition', ($this->options['showInline'] ? 'inline' : 'attachment').'; filename="'.$this->options['filename'].'"');
+			
+			// range
+			if ($this->startByte > 0 || $this->endByte < $this->options['filesize'] - 1) {
+				$this->addHeader('', 'HTTP/1.1 206 Partial Content');
+				$this->addHeader('Content-Range', 'bytes '.$this->startByte.'-'.$this->endByte.'/'.$this->options['filesize']);
+			}
+			if ($this->options['enableRangeSupport']) {
+				$this->addHeader('Accept-Ranges', 'bytes');
+			}
+			
+			// send file size
+			$this->addHeader('Content-Length', ($this->endByte + 1 - $this->startByte));
+			
+			// cache headers
+			if ($this->options['maxAge']) {
+				$this->addHeader('Cache-control', 'max-age='.$this->options['maxAge'].', private');
+			}
+			if ($this->options['expirationDate']) {
+				$this->addHeader('Expires', gmdate('D, d M Y H:i:s', $this->options['expirationDate']).' GMT');
+			}
+			if ($this->options['lastModificationTime']) {
+				$this->addHeader('Last-Modified', gmdate('D, d M Y H:i:s', $this->options['lastModificationTime']).' GMT');
+			}
+		}
+	}
+	
+	/**
+	 * Sets the options for the http response.
+	 * 
+	 * @param	array		$options
+	 */
+	public function setOptions(array $options) {
+		if (isset($options['mimeType']) && $options['mimeType'] == 'image/x-png') {
+			$options['mimeType'] = 'image/png';
+		}
+		
+		$this->options = array_merge($this->options, $options);
+	}
+	
+	/**
+	 * Adds the header with the given name and value.
+	 * 
+	 * @param	string		$name
+	 * @param	string		$value
+	 */	
+	public function addHeader($name, $value) {
+		$this->headers[$name] = $value;
+	}
+	
+	/**
+	 * Removes the header with the given name.
+	 * 
+	 * @param	string		$name
+	 */
+	public function removeHeader($name) {
+		unset($this->headers[$name]);
+		return;
+	}
+}


### PR DESCRIPTION
This commit adds the util class `FileReader`. With this class you can easily add the support for downloading files to pages and other classes - without the need to copy code.

Options are holding the data needed to provide the download (or the inline view for images,..).

I have already adapted the `AttachmentPage`. As this pull request only affects this mentioned page, I would really appreciate it if you merge this pull request into the WCF 2.0 series. It makes it a lot easier to create extensions which provide the functionality to download files.

Of course I have tested my changes - and I noticed no negative effects.
