### PR TITLE
Small template optimization

### DIFF
--- a/wcfsetup/install/files/acp/templates/index.tpl
+++ b/wcfsetup/install/files/acp/templates/index.tpl
@@ -19,7 +19,7 @@
 </header>
 
 {if $inRescueMode}
-	<p style="background-color: rgb(255, 153, 153); border: 2px solid rgb(255, 0, 0); padding: 1em;">{lang}wcf.acp.index.inRescueMode{/lang}</p>
+	<p class="error">{lang}wcf.acp.index.inRescueMode{/lang}</p>
 {/if}
 
 {if $usersAwaitingApproval}


### PR DESCRIPTION
Uses the default <code>.error</code>-class instead inline css.
