### PR TITLE
Add default timestamp

### DIFF
--- a/wcfsetup/install/files/lib/system/io/ZipWriter.class.php
+++ b/wcfsetup/install/files/lib/system/io/ZipWriter.class.php
@@ -83,7 +83,7 @@ class ZipWriter {
 	 * @param	string		$name		filename
 	 * @param	integer		$date		file creation time as unix timestamp
 	 */
-	public function addFile($data, $name, $date = 0) {
+	public function addFile($data, $name, $date = TIME_NOW) {
 		// replace backward slashes with forward slashes in the filename
 		$name = StringUtil::replace("\\", "/", $name);
 		


### PR DESCRIPTION
Calling addFile without the (optional) date parameter causes creation of a broken zip file. Setting a valid timestamp as default value fixes it.

See http://beta.woltlab.com/index.php/Thread/2944-ZipWriter-erzeugt-leere-Datei/?postID=25148#post25148
