### PR TITLE
Don't allow dates prior to 1980-01-01

### DIFF
--- a/wcfsetup/install/files/lib/system/io/ZipWriter.class.php
+++ b/wcfsetup/install/files/lib/system/io/ZipWriter.class.php
@@ -1,8 +1,8 @@
 <?php
 namespace wcf\system\io;
+use wcf\system\exception\SystemException;
 use wcf\util\FileUtil;
 use wcf\util\StringUtil;
-use wcf\system\exception\SystemException;
 
 /**
  * Creates a Zip file archive.


### PR DESCRIPTION
Improve SoftCreatRs version of this fix because Zip doesn't support dates prior to `1980-01-01 00:00 UTC`

See WoltLab/WCF#1443
