### PR TITLE
Apply further changes to ZipWriter

### DIFF
--- a/wcfsetup/install/files/lib/system/io/ZipWriter.class.php
+++ b/wcfsetup/install/files/lib/system/io/ZipWriter.class.php
@@ -186,7 +186,7 @@ class ZipWriter {
 		// Ensure we have a numeric value
 		$date = intval($date);
 		
-		if($date < 315532800) {
+		if ($date < 315532800) {
 			return "\x00\x00\x00\x00";
 		}
 		


### PR DESCRIPTION
Instead of throwing an exception, you better set the date to zero, so a date prior 1980-01-01 00:00 UTC will also be possible.
