### PR TITLE
Improved FileReader class and fixed issue in AttachmentPage

### DIFF
--- a/wcfsetup/install/files/lib/page/AttachmentPage.class.php
+++ b/wcfsetup/install/files/lib/page/AttachmentPage.class.php
@@ -135,7 +135,7 @@ class AttachmentPage extends AbstractPage {
 		
 		// add etag for non-thumbnail
 		if (!$this->thumbnail && !$this->tiny) {
-			$this->fileReader->addHeader('ETag', '"'.$this->attachmentID."'");
+			$this->fileReader->addHeader('ETag', '"'.$this->attachmentID.'"');
 		}
 	}
 	


### PR DESCRIPTION
This pull request fixes an issue in `AttachmentPage` (`'` vs. `"`).

It also improves the `FileReader` class. To comply with util classes like `XML` and `XMLWriter` I
- removed the `final` tag of the class
- changed the access level of the attributes and methods from `private` to `protected`
- moved some stuff into own methods which can be overwritten in possible sub classes (`sendHeaders` and `sendFile`)
