### PR TITLE
Added setTransparentColor to ImageAdapter classes

### DIFF
--- a/wcfsetup/install/files/lib/system/image/adapter/GDImageAdapter.class.php
+++ b/wcfsetup/install/files/lib/system/image/adapter/GDImageAdapter.class.php
@@ -205,6 +205,16 @@ class GDImageAdapter implements IImageAdapter {
 	}
 	
 	/**
+	 * @see wcf\system\image\adapter\IImageAdapter::setTransparentColor()
+	 */
+	public function setTransparentColor($red, $green, $blue) {
+		if ($this->type == IMAGETYPE_PNG) {
+			$color = imagecolorallocate($this->image, $red, $green, $blue);
+			imageColorTransparent($this->image, $color);
+		}
+	}
+	
+	/**
 	 * @see	wcf\system\image\adapter\IImageAdapter::writeImage()
 	 */
 	public function writeImage($image, $filename) {

--- a/wcfsetup/install/files/lib/system/image/adapter/IImageAdapter.class.php
+++ b/wcfsetup/install/files/lib/system/image/adapter/IImageAdapter.class.php
@@ -111,6 +111,15 @@ interface IImageAdapter {
 	public function hasColor();
 	
 	/**
+	 * Sets a color to be transparent with alpha 0.
+	 *
+	 * @param	integer		$red
+	 * @param	integer		$green
+	 * @param	integer		$blue
+	 */
+	public function setTransparentColor($red, $green, $blue);
+	
+	/**
 	 * Writes an image to disk.
 	 * 
 	 * @param	mixed		$image

--- a/wcfsetup/install/files/lib/system/image/adapter/ImageAdapter.class.php
+++ b/wcfsetup/install/files/lib/system/image/adapter/ImageAdapter.class.php
@@ -135,6 +135,13 @@ class ImageAdapter implements IImageAdapter {
 	}
 	
 	/**
+	 * @see	wcf\system\image\adapter\IImageAdapter::setTransparentColor()
+	 */
+	public function setTransparentColor($red, $green, $blue) {
+		$this->adapter->setTransparentColor($red, $green, $blue);
+	}
+	
+	/**
 	 * @see	wcf\system\image\adapter\IImageAdapter::writeImage()
 	 */
 	public function writeImage($image, $filename = null) {

--- a/wcfsetup/install/files/lib/system/image/adapter/ImagickImageAdapter.class.php
+++ b/wcfsetup/install/files/lib/system/image/adapter/ImagickImageAdapter.class.php
@@ -134,7 +134,6 @@ class ImagickImageAdapter implements IImageAdapter {
 	public function setColor($red, $green, $blue) {
 		$this->color = new \ImagickPixel();
 		$this->color->setColor('rgb('.$red.','.$green.','.$blue.')');
-		
 	}
 	
 	/**
@@ -146,6 +145,14 @@ class ImagickImageAdapter implements IImageAdapter {
 		}
 		
 		return false;
+	}
+	
+	/**
+	 * @see wcf\system\image\adapter\IImageAdapter::setTransparentColor()
+	 */
+	public function setTransparentColor($red, $green, $blue) {
+		$color = 'rgb(' . $red . ',' . $green . ',' . $blue . ')';
+		$this->imagick->paintTransparentImage($color, 0.0, 0);
 	}
 	
 	/**


### PR DESCRIPTION
This function set a specific Color on a Image to be transparent.
Tested by creating Images on
Imagick 3.1.0RC1 (ImageMagick 6.7.7-10)
GD 2.0
PHP 5.4.14-1~quantal+1
