### PR TITLE
Fix ReCaptcha in RegisterForm

### DIFF
--- a/wcfsetup/install/files/lib/form/RegisterForm.class.php
+++ b/wcfsetup/install/files/lib/form/RegisterForm.class.php
@@ -73,7 +73,7 @@ class RegisterForm extends UserAddForm {
 	 * enable recaptcha
 	 * @var	boolean
 	 */
-	public $useCaptcha = true;
+	public $useCaptcha = REGISTER_USE_CAPTCHA;
 	
 	/**
 	 * field names
@@ -109,7 +109,7 @@ class RegisterForm extends UserAddForm {
 			exit;
 		}
 		
-		if (!REGISTER_USE_CAPTCHA || WCF::getSession()->getVar('recaptchaDone')) {
+		if (!MODULE_SYSTEM_RECAPTCHA || WCF::getSession()->getVar('recaptchaDone')) {
 			$this->useCaptcha = false;
 		}
 		


### PR DESCRIPTION
Because of the fact, that RegisterForm does not extend RecaptchaForm, a check is missing. When disabling the whole module while reCAPTCHA protection during registration is enabled, the reCAPTCHA is still enabled in the registration form.

To be short: MODULE_SYSTEM_RECAPTCHA is ignored in RegisterForm.
