### PR TITLE
add a copyright-div

### DIFF
--- a/com.woltlab.wcf/templates/footer.tpl
+++ b/com.woltlab.wcf/templates/footer.tpl
@@ -34,7 +34,13 @@
 			
 			{if ENABLE_BENCHMARK}{include file='benchmark'}{/if}
 			
-			{event name='copyright'}
+			{hascontent}
+				<div class="marginTop">
+					{content}
+						{event name='copyright'}
+					{/content}
+				</div>
+			{/hascontent}
 		</div>
 	</div>
 </footer>


### PR DESCRIPTION
I want to add a copyright in my plugin. The problem now is that I can not assume that even a copyright has been added with the copyright Event. Even so I do not know if a distance has already been added to the top (`marginTop`), because only the first Copyright should have a distance to the top. So if I suspect that my plugin has been installed in the dummy app without copyright, I have to add the class `marginTop`. But if I suspect that my plugin is installed together with the board, I can not add a the class. The element (the div) solves the problem.
