### PR TITLE
Fixed possible issue in UserStorageHandler::update()

### DIFF
--- a/wcfsetup/install/files/lib/system/user/storage/UserStorageHandler.class.php
+++ b/wcfsetup/install/files/lib/system/user/storage/UserStorageHandler.class.php
@@ -97,11 +97,9 @@ class UserStorageHandler extends SingletonFactory {
 		$this->updateFields[$userID][$field] = $fieldValue;
 		
 		// update data cache for given user
-		if (!isset($this->cache[$userID])) {
-			$this->cache[$userID] = array();
+		if (isset($this->cache[$userID])) {
+			$this->cache[$userID][$field] = $fieldValue;
 		}
-		
-		$this->cache[$userID][$field] = $fieldValue;
 	}
 	
 	/**


### PR DESCRIPTION
Creating the cache of not loaded users will cause the UserStorageHandler not never load their data from the database.
