### PR TITLE
x-font-woff worked better for me

### DIFF
--- a/wcfsetup/install/files/font/getFont.php
+++ b/wcfsetup/install/files/font/getFont.php
@@ -14,7 +14,7 @@
 // list of known font types
 $types = array(
 	'eot' => 'application/vnd.ms-fontobject',
-	'woff' => 'application/x-woff', // best supported, but this is not the right one according to http://www.w3.org/TR/WOFF/#appendix-b
+	'woff' => 'application/x-font-woff', // best supported, but this is not the right one according to http://www.w3.org/TR/WOFF/#appendix-b
 	'ttf' => 'application/octet-stream'
 );
 


### PR DESCRIPTION
chrome gave me following warning before: _http://picul.de/view/NTA_
i’ve tested this change with chrome and firefox and got no warnings.
