### PR TITLE
shows an icon for the comment-expansion (and makes it bold)

### DIFF
--- a/wcfsetup/install/files/js/WCF.Comment.js
+++ b/wcfsetup/install/files/js/WCF.Comment.js
@@ -144,7 +144,7 @@ WCF.Comment.Handler = Class.extend({
 		if ($comment.data('displayedResponses') < $comment.data('responses')) {
 			if (this._loadNextResponses[commentID] === undefined) {
 				var $difference = $comment.data('responses') - $comment.data('displayedResponses');
-				this._loadNextResponses[commentID] = $('<li class="jsCommentLoadNextResponses"><a>' + WCF.Language.get('wcf.comment.response.more', { count: $difference }) + '</a></li>').appendTo(this._commentButtonList[commentID]);
+				this._loadNextResponses[commentID] = $('<li class="jsCommentLoadNextResponses"><a><span class="icon icon16 icon-comment"></span> ' + WCF.Language.get('wcf.comment.response.more', { count: $difference }) + '</a></li>').appendTo(this._commentButtonList[commentID]);
 				this._loadNextResponses[commentID].children('a').data('commentID', commentID).click($.proxy(this._loadResponses, this));
 				this._commentButtonList[commentID].parent().show();
 			}

--- a/wcfsetup/install/files/style/comment.less
+++ b/wcfsetup/install/files/style/comment.less
@@ -62,6 +62,13 @@
 			font-size: @wcfSmallFontSize;
 			padding-right: 3px;
 		}
+		> .jsCommentLoadNextResponses > a {
+			.icon {
+				color: inherit;
+			}
+			
+			font-weight: bold;
+		}
 	}
 }
 


### PR DESCRIPTION
before: http://picul.de/NTV
after: http://picul.de/NT4

the reason for that is, i never see this link…
in my board ive added this icon, maybe you like it, too.
i would prefer icon-comment**s**, but its taken by the conversations.
