### PR TITLE
Fixed installing styles containing templates during WCFSetup

### DIFF
--- a/wcfsetup/install/files/lib/system/cache/builder/ApplicationCacheBuilder.class.php
+++ b/wcfsetup/install/files/lib/system/cache/builder/ApplicationCacheBuilder.class.php
@@ -49,7 +49,7 @@ class ApplicationCacheBuilder extends AbstractCacheBuilder {
 		}
 		
 		// assign wcf pseudo-application
-		if (PACKAGE_ID) {
+		if (isset($data['application'][1])) {
 			$data['wcf'] = $data['application'][1];
 			unset($data['application'][1]);
 		}


### PR DESCRIPTION
The WCF pseudo-application wasn't loaded (even after its creation) during the WCFSetup. That caused an error in `Template::__construct()` [when trying to get the `packageID` of the application](https://github.com/WoltLab/WCF/blob/master/wcfsetup/install/files/lib/data/template/Template.class.php?source=cc#L57). This is called [by `StyleEditor::import()`](https://github.com/WoltLab/WCF/blob/master/wcfsetup/install/files/lib/data/style/StyleEditor.class.php#L438) when creating a template for a style.