### PR TITLE
reread objects

### DIFF
--- a/wcfsetup/install/files/lib/data/user/UserAction.class.php
+++ b/wcfsetup/install/files/lib/data/user/UserAction.class.php
@@ -3,6 +3,7 @@ namespace wcf\data\user;
 use wcf\data\object\type\ObjectTypeCache;
 use wcf\data\user\avatar\UserAvatarAction;
 use wcf\data\user\group\UserGroup;
+use wcf\data\user\UserEditor;
 use wcf\data\AbstractDatabaseObjectAction;
 use wcf\data\IClipboardAction;
 use wcf\data\ISearchAction;
@@ -344,6 +345,11 @@ class UserAction extends AbstractDatabaseObjectAction implements IClipboardActio
 		foreach ($this->objects as $userEditor) {
 			$userEditor->addToGroups($groupIDs, $deleteOldGroups, $addDefaultGroups);
 		}
+		
+		//reread objects
+		$this->objects = array();
+		UserEditor::resetCache();
+		$this->readObjects();
 		
 		if (MODULE_USER_RANK) {
 			$action = new UserProfileAction($this->objects, 'updateUserRank');


### PR DESCRIPTION
Currently you have, if you add a user to a group in a plugin, update the online marking and online rank again, because an object which has not yet been updated, is passed for the update. This pull request make that the function clears the cache of the UserEditor and re-reads the objects.
