### PR TITLE
Add afterInit event

### DIFF
--- a/com.woltlab.wcf/templates/wysiwyg.tpl
+++ b/com.woltlab.wcf/templates/wysiwyg.tpl
@@ -71,6 +71,8 @@ $(function() {
 		if ($editor) $editor.destroy(true);
 		
 		$('#' + $editorName).ckeditor($config);
+		
+		{event name='afterInit'}
 	});
 
 	head.load([


### PR DESCRIPTION
You are able to define own options for CKE in the wysiwyg template. However, you are not able to work with the CKE instance, because it's created later. This prevents you from working with CKE's internal events.
