### PR TITLE
Do not inherit from DatabaseObject

### DIFF
--- a/wcfsetup/install/files/lib/data/DatabaseObjectDecorator.class.php
+++ b/wcfsetup/install/files/lib/data/DatabaseObjectDecorator.class.php
@@ -12,7 +12,7 @@ use wcf\system\exception\SystemException;
  * @subpackage	data
  * @category	Community Framework
  */
-abstract class DatabaseObjectDecorator extends DatabaseObject {
+abstract class DatabaseObjectDecorator {
 	/**
 	 * name of the base class
 	 * @var	string


### PR DESCRIPTION
Inheriting from the DatabaseObject means, that the DatabaseObjectDecorator is also implementing the IStorableObject.
The ObjectDecorator it self is not storable and does not use any methods from the DatabaseObject (overrides most of them).
