### PR TITLE
Adjust bcrypt cost

### DIFF
--- a/wcfsetup/install/files/lib/util/PasswordUtil.class.php
+++ b/wcfsetup/install/files/lib/util/PasswordUtil.class.php
@@ -48,7 +48,7 @@ final class PasswordUtil {
 	 * blowfish cost factor
 	 * @var	string
 	 */
-	const BCRYPT_COST = '08';
+	const BCRYPT_COST = '14';
 	
 	/**
 	 * blowfish encryption type


### PR DESCRIPTION
Adjust bcrypt cost to prevent future password hash attacks from "08" to "14".

Benchmark with one Thread: Intel(R) Core(TM) i7-4770 CPU @ 3.40GHz
##### 

0cef6ce24cc4d3bdb553754f6ea95c765fd3a0bb23313b Cost 01 took 0.00sec
6444b8c9a0769c32a66e7eec17a4687d9491341fbaea1a Cost 02 took 0.00sec
b574c9c72eece2b9b850684ec32c944ebbb7f23e913492 Cost 03 took 0.00sec
05d1da6d77aef3f839e1637ebfe86bfc9ce0f26e7adf10 Cost 04 took 0.00sec
1712b9f8a394fe2bdd87df4bccea1674603645f004b322 Cost 05 took 0.00sec
9b273724b2e0cd9a1261f5aa717ff1f3ca0706549729e0 Cost 06 took 0.00sec
d613a9cb3373b3aaa2c3aa76eef452221ebfc54b6dc8fc Cost 07 took 0.01sec
4b5c602328abd9ebd98a624bbe31b60047782a659cf9c0 Cost 08 took 0.01sec
2eafabe1b068ce00a1a9d0b8a06063114e9b9cfcc72ce4 Cost 09 took 0.03sec
23d90b4016cc6ce3612fb6941a232bc463b3a4b49d7dd6 Cost 10 took 0.05sec
88f90f11bd655883543edd6858e724ce22fee202153026 Cost 11 took 0.11sec
3f36104c464b98678c2aa085dadca258699bd4c94c51bc Cost 12 took 0.22sec
3c739aa56523f1779bdbdd51a975efdb2f186cd2a52e09 Cost 13 took 0.44sec
b004d1fce96e04be39bd1066f0ff8fba5281531387305c Cost 14 took 0.88sec
713abbcd3572169159f46ffabd9ca59421a827a847dade Cost 15 took 1.76sec
3f2cf30e4689c77934d60c47004d64868d98c40b5342ed Cost 16 took 3.52sec
ba8d410333a168cd1f015f54e6b845a26d25b6701775a3 Cost 17 took 7.05sec
12d75ee1670461b46ebc8c102a90d4b66c479055a9a942 Cost 18 took 14.09sec
1322956f61ec11c58d3c58f3b910fbe09fe8885404769e Cost 19 took 28.20sec
a66a7040d20b1cb1c259b23f9e63b443b69cb875920616 Cost 20 took 56.46sec
