### PR TITLE
Add footerCoypright.tpl

### DIFF
--- a/com.woltlab.wcf/templates/footer.tpl
+++ b/com.woltlab.wcf/templates/footer.tpl
@@ -35,6 +35,8 @@
 			{if ENABLE_BENCHMARK}{include file='benchmark'}{/if}
 			
 			{event name='copyright'}
+			
+			{event name='footerCopyright'}
 		</div>
 	</div>
 </footer>

--- a/com.woltlab.wcf/templates/footerCopyright.tpl
+++ b/com.woltlab.wcf/templates/footerCopyright.tpl
@@ -1,0 +1,1 @@
+{* Styles may override this file within their own template group to display a custom copyright notice *}


### PR DESCRIPTION
Makes adding copyrights to styles easier.

While adding a copyright for your own standalone application is easy using the provided template event (and also for plugins, even if that requires slightly more work), adding your own copyright to styles if more troublesome.

Current established practice seems to be to ship an own template group with the style and to ovverride the whole `footer.tpl`. I don't think that is is a really good practice, but for most style designers it seems to be the way to go.

Providing a dedicated file that is deliberately empty and included in the footer by default allows style creators to only override this single file to add their own copyright, without the need to ship the whole footer again and having to  keep track of changes to it, and update and redeploy their styles when parts of the footer change.
