### PR TITLE
Trim wordfilter

### DIFF
--- a/wcfsetup/install/files/lib/util/StringUtil.class.php
+++ b/wcfsetup/install/files/lib/util/StringUtil.class.php
@@ -593,7 +593,7 @@ final class StringUtil {
 		$word = mb_strtolower($word);
 		
 		if ($filter != '') {
-			$forbiddenNames = explode("\n", mb_strtolower(self::unifyNewlines($filter)));
+			$forbiddenNames = ArrayUtil::trim(explode("\n", mb_strtolower(self::unifyNewlines($filter))));
 			foreach ($forbiddenNames as $forbiddenName) {
 				if (mb_strpos($forbiddenName, '*') !== false) {
 					$forbiddenName = str_replace('\*', '.*', preg_quote($forbiddenName, '/'));


### PR DESCRIPTION
Actions like registering may fail, if a wordfilter contains empty lines or if a line ends with a space. Instead, an asterisk should be used.
