### PR TITLE
Extend support for G+ vanity urls

### DIFF
--- a/com.woltlab.wcf/userOption.xml
+++ b/com.woltlab.wcf/userOption.xml
@@ -170,7 +170,7 @@
 				<categoryname>profile.contact</categoryname>
 				<optiontype>text</optiontype>
 				<outputclass>wcf\system\option\user\GooglePlusUserOptionOutput</outputclass>
-				<validationpattern>^$|^\d{21}$|^\+[A-Za-z\d%öÖäÄüÜß]+$</validationpattern>
+				<validationpattern>^$|^\d{21}$|^\+\S[^/]+$</validationpattern>
 				<contentpattern>^https?://(?:plus|www).google(?:apis)?.com(?:/\w+/\w+(?:/\w)?)?/(\d{21}|\+\S[^/]+)$</contentpattern>
 				<searchable>1</searchable>
 				<visible>15</visible>


### PR DESCRIPTION
- Allow googleapis.com
- Allow ~~umlauts~~ special characters in names (even if urlencoded)
- Allow different URL structures e.g.

https://plus.google.com/+SaschaGreuel
https://plus.google.com/u/0/108464746210444165938
https://plus.googleapis.com/wm/4/+SaschaGreuel
...
