### PR TITLE
Honor option "module_attachment"

### DIFF
--- a/com.woltlab.wcf/userGroupOption.xml
+++ b/com.woltlab.wcf/userGroupOption.xml
@@ -287,6 +287,7 @@
 				<categoryname>user.message.attachment</categoryname>
 				<optiontype>fileSize</optiontype>
 				<defaultvalue>1000000</defaultvalue>
+				<options>module_attachment</options>
 			</option>
 			<option name="user.attachment.allowedExtensions">
 				<categoryname>user.message.attachment</categoryname>
@@ -300,11 +301,13 @@ zip
 txt
 pdf]]></defaultvalue>
 				<wildcard><![CDATA[*]]></wildcard>
+				<options>module_attachment</options>
 			</option>
 			<option name="user.attachment.maxCount">
 				<categoryname>user.message.attachment</categoryname>
 				<optiontype>integer</optiontype>
 				<defaultvalue>10</defaultvalue>
+				<options>module_attachment</options>
 			</option>
 			
 			<option name="admin.attachment.canManageAttachment">
@@ -312,6 +315,7 @@ pdf]]></defaultvalue>
 				<optiontype>boolean</optiontype>
 				<defaultvalue>0</defaultvalue>
 				<admindefaultvalue>1</admindefaultvalue>
+				<options>module_attachment</options>
 			</option>
 			
 			<option name="admin.content.bbcode.canManageBBCode">


### PR DESCRIPTION
Currently, the option "module_attachment" is honored everywhere but not within the WCF itself.
