### PR TITLE
Always surround user mentions by a prime character

### DIFF
--- a/wcfsetup/install/files/js/WCF.Message.js
+++ b/wcfsetup/install/files/js/WCF.Message.js
@@ -3335,11 +3335,8 @@ WCF.Message.UserMention = Class.extend({
 		// insert username
 		if (username.indexOf("'") !== -1) {
 			username = username.replace(/'/g, "''");
-			username = "'" + username + "'";
 		}
-		else if (username.indexOf(' ') !== -1) {
-			username = "'" + username + "'";
-		}
+		username = "'" + username + "'";
 		var $usernameNode = new CKEDITOR.dom.text('@' + username);
 		$range.insertNode($usernameNode);
 		$range.selectNodeContents($usernameNode);


### PR DESCRIPTION
Whenever you pick a username from the dropdown, it should be surrounded by the prime character to provide a better usability.
