### PR TITLE
prevent infinte loop

### DIFF
--- a/wcfsetup/install/files/lib/data/VersionableDatabaseObjectEditor.class.php
+++ b/wcfsetup/install/files/lib/data/VersionableDatabaseObjectEditor.class.php
@@ -53,7 +53,7 @@ abstract class VersionableDatabaseObjectEditor extends DatabaseObjectEditor {
 	 * @see	\wcf\data\IEditableObject::deleteAll()
 	 */
 	public static function deleteAll(array $objectIDs = array()) {
-		$affectedCount = static::deleteAll($objectIDs);
+		$affectedCount = parent::deleteAll($objectIDs);
 		
 		// delete versions
 		$sql = "DELETE FROM	".static::getDatabaseVersionTableName()."


### PR DESCRIPTION
Using parent::deleteAll() to prevent an infinte loop. 
