### PR TITLE
Move 3rdpartyFields to a better position

### DIFF
--- a/com.woltlab.wcf/templates/accountManagement.tpl
+++ b/com.woltlab.wcf/templates/accountManagement.tpl
@@ -276,9 +276,9 @@
 								</dd>
 							</dl>
 						{/if}
+						
+						{event name='3rdpartyFields'}
 					{/if}
-					
-					{event name='3rdpartyFields'}
 				{/content}
 			</fieldset>
 		{/hascontent}


### PR DESCRIPTION
Placing the event `3rdpartyFields` into the if statement makes more sense. Otherwise, you have to check `$__wcf->getUser()->hasAdministrativeAccess()` twice.
