### PR TITLE
Receive Github email fails

### DIFF
--- a/wcfsetup/install/files/lib/action/GithubAuthAction.class.php
+++ b/wcfsetup/install/files/lib/action/GithubAuthAction.class.php
@@ -118,7 +118,7 @@ class GithubAuthAction extends AbstractAction {
 					WCF::getSession()->register('__username', $userData['login']);
 					
 					// check whether user has entered a public email
-					if (isset($userData) && isset($userData['email']) && $userData['email'] !== null) {
+					if (isset($userData) && isset($userData['email']) && $userData['email'] != null) {
 						WCF::getSession()->register('__email', $userData['email']);
 					}
 					// fetch emails via api


### PR DESCRIPTION
Github returns an empty string instead of `null`, if there's no public email. The `else`-statement will never reached.
