### PR TITLE
Catch error on empty logfiles

### DIFF
--- a/wcfsetup/install/files/lib/acp/page/ExceptionLogViewPage.class.php
+++ b/wcfsetup/install/files/lib/acp/page/ExceptionLogViewPage.class.php
@@ -4,6 +4,7 @@ use wcf\page\AbstractPage;
 use wcf\page\MultipleLinkPage;
 use wcf\system\event\EventHandler;
 use wcf\system\exception\IllegalLinkException;
+use wcf\system\exception\NamedUserException;
 use wcf\system\Regex;
 use wcf\system\WCF;
 use wcf\util\DirectoryUtil;
@@ -115,6 +116,8 @@ class ExceptionLogViewPage extends MultipleLinkPage {
 		// split contents
 		$split = new Regex('(?:^|\n<<<<\n\n)(?:<<<<<<<<([a-f0-9]{40})<<<<\n|$)');
 		$contents = $split->split($contents, Regex::SPLIT_NON_EMPTY_ONLY | Regex::CAPTURE_SPLIT_DELIMITER);
+		
+		if (empty($contents)) throw new NamedUserException(WCF::getLanguage()->get('wcf.acp.exceptionLog.logEmpty', array('logFile' => $this->logFile)));
 		
 		// even items become keys, odd items become values
 		$this->exceptions = call_user_func_array('array_merge', array_map(

--- a/wcfsetup/install/lang/de.xml
+++ b/wcfsetup/install/lang/de.xml
@@ -218,6 +218,7 @@
 		<item name="wcf.acp.exceptionLog.exception.stacktrace"><![CDATA[Stacktrace]]></item>
 		<item name="wcf.acp.exceptionLog.exception.copy"><![CDATA[Fehlermeldung kopieren]]></item>
 		<item name="wcf.acp.exceptionLog.exceptionNotFound"><![CDATA[Es wurde kein Fehler mit der ID „{$exceptionID}“ gefunden.]]></item>
+		<item name="wcf.acp.exceptionLog.logEmpty"><![CDATA[Die Datei „{$logFile}“ ist leer.]]></item>
 		<item name="wcf.acp.exceptionLog.search"><![CDATA[Suche]]></item>
 		<item name="wcf.acp.exceptionLog.search.exceptionID"><![CDATA[Fehler-ID]]></item>
 		<item name="wcf.acp.exceptionLog.search.logFile"><![CDATA[Datei]]></item>

--- a/wcfsetup/install/lang/en.xml
+++ b/wcfsetup/install/lang/en.xml
@@ -217,6 +217,7 @@ Examples for medium ID detection:
 		<item name="wcf.acp.exceptionLog.exception.stacktrace"><![CDATA[Stacktrace]]></item>
 		<item name="wcf.acp.exceptionLog.exception.copy"><![CDATA[Copy error message]]></item>
 		<item name="wcf.acp.exceptionLog.exceptionNotFound"><![CDATA[No error with the ID “{$exceptionID}” was found.]]></item>
+		<item name="wcf.acp.exceptionLog.logEmpty"><![CDATA[The file „{$logFile}“ is empty.]]></item>
 		<item name="wcf.acp.exceptionLog.search"><![CDATA[Search]]></item>
 		<item name="wcf.acp.exceptionLog.search.exceptionID"><![CDATA[Error-ID]]></item>
 		<item name="wcf.acp.exceptionLog.search.logFile"><![CDATA[Logfile]]></item>


### PR DESCRIPTION
Currently, trying to view empty logfiles throws an error:

> wcf/lib/acp/page/ExceptionLogViewPage.class.php (125): array_merge() expects at least 1 parameter, 0 given"

See also http://www.woltlab.com/forum/index.php/Thread/227703-Fehlermeldung-ACP-Error-Log
