### PR TITLE
add read status for the moderation

### DIFF
--- a/com.woltlab.wcf/templates/userPanel.tpl
+++ b/com.woltlab.wcf/templates/userPanel.tpl
@@ -187,7 +187,7 @@
 			<a href="{link controller='ModerationList'}{/link}">
 				<span class="icon icon16 icon-warning-sign"></span>
 				<span>{lang}wcf.moderation.moderation{/lang}</span>
-				{if $__wcf->getModerationQueueManager()->getOutstandingModerationCount()}<span class="badge badgeInverse">{#$__wcf->getModerationQueueManager()->getOutstandingModerationCount()}</span>{/if}
+				{if $__wcf->getModerationQueueManager()->getOutstandingModerationCount()}<span class="badge{if $__wcf->getModerationQueueManager()->isNew()} badgeInverse{/if}">{#$__wcf->getModerationQueueManager()->getOutstandingModerationCount()}</span>{/if}
 			</a>
 			{if !OFFLINE || $__wcf->session->getPermission('admin.general.canViewPageDuringOfflineMode')}
 				<script data-relocate="true">

--- a/wcfsetup/install/files/lib/data/moderation/queue/ModerationQueueAction.class.php
+++ b/wcfsetup/install/files/lib/data/moderation/queue/ModerationQueueAction.class.php
@@ -110,6 +110,11 @@ class ModerationQueueAction extends AbstractDatabaseObjectAction {
 			}
 		}
 		
+		// set moderation as read
+		if (ModerationQueueManager::getInstance()->isNew()) {
+			UserStorageHandler::getInstance()->update(WCF::getUser()->userID, 'moderationRead', true);
+		}
+		
 		return array(
 			'template' => WCF::getTPL()->fetch('moderationQueueList'),
 			'totalCount' => $totalCount

--- a/wcfsetup/install/files/lib/page/ModerationListPage.class.php
+++ b/wcfsetup/install/files/lib/page/ModerationListPage.class.php
@@ -3,6 +3,7 @@ namespace wcf\page;
 use wcf\data\moderation\queue\ModerationQueue;
 use wcf\system\exception\IllegalLinkException;
 use wcf\system\moderation\queue\ModerationQueueManager;
+use wcf\system\user\storage\UserStorageHandler; 
 use wcf\system\WCF;
 
 /**
@@ -85,6 +86,18 @@ class ModerationListPage extends SortablePage {
 			if ($this->definitionID && !isset($this->availableDefinitions[$this->definitionID])) {
 				throw new IllegalLinkException();
 			}
+		}
+	}
+	
+	/**
+	 * @see	\wcf\page\IPage::readData()
+	 */
+	public function readData() {
+		parent::readData();
+		
+		// set moderation as read
+		if (ModerationQueueManager::getInstance()->isNew()) {
+			UserStorageHandler::getInstance()->update(WCF::getUser()->userID, 'moderationRead', true);
 		}
 	}
 	

--- a/wcfsetup/install/files/lib/system/moderation/queue/ModerationQueueManager.class.php
+++ b/wcfsetup/install/files/lib/system/moderation/queue/ModerationQueueManager.class.php
@@ -352,9 +352,11 @@ class ModerationQueueManager extends SingletonFactory {
 	public function resetModerationCount($userID = null) {
 		if ($userID === null) {
 			UserStorageHandler::getInstance()->resetAll('outstandingModerationCount');
+			UserStorageHandler::getInstance()->resetAll('moderationRead');
 		}
 		else {
 			UserStorageHandler::getInstance()->reset(array($userID), 'outstandingModerationCount');
+			UserStorageHandler::getInstance()->reset(array($userID), 'moderationRead');
 		}
 	}
 	
@@ -408,5 +410,22 @@ class ModerationQueueManager extends SingletonFactory {
 		}
 		
 		$this->resetModerationCount();
+	}
+	
+	/**
+	 * Returns true if the moderation-items are new
+	 * 
+	 * @return	boolean
+	 */
+	public function isNew() {
+		// load storage data
+		UserStorageHandler::getInstance()->loadStorage(array(WCF::getUser()->userID));
+		
+		// get read
+		$data = UserStorageHandler::getInstance()->getStorage(array(WCF::getUser()->userID), 'moderationRead');
+		
+		if ($data[WCF::getUser()->userID] == true) return false; 
+		
+		return true; 
 	}
 }


### PR DESCRIPTION
especially when there is much activate and everything can not always be done immediately and accordingly moderation is almost always full, new items go under in moderation. Also reports. The "Read?" System will help to prevent this by moderation can also be marked as read sporadically.
