### PR TITLE
Add beforePageHeader to the header.tpl

### DIFF
--- a/com.woltlab.wcf/templates/header.tpl
+++ b/com.woltlab.wcf/templates/header.tpl
@@ -1,6 +1,6 @@
-{event name='beforePageHeader'}
-
 <a id="top"></a>
+
+{event name='beforePageHeader'}
 
 <header id="pageHeader" class="{if $__wcf->getStyleHandler()->getStyle()->getVariable('useFluidLayout')}layoutFluid{else}layoutFixed{/if}{if $sidebarOrientation|isset && $sidebar|isset} sidebarOrientation{@$sidebarOrientation|ucfirst}{if $sidebarOrientation == 'right' && $sidebarCollapsed} sidebarCollapsed{/if}{/if}">
 	<div>


### PR DESCRIPTION
Sometimes you need to add html before the header (like GTM code odd a custom header across multiple websites).
A beforePageHeader event in the header template can be used for such code.
(Previous pull request was to the wrong branch)
