### PR TITLE
Remove obsolete code

### DIFF
--- a/com.woltlab.wcf/templates/user.tpl
+++ b/com.woltlab.wcf/templates/user.tpl
@@ -7,7 +7,6 @@
 	
 	<link rel="canonical" href="{link controller='User' object=$user}{/link}" />
 	
-	<script data-relocate="true" src="{@$__wcf->getPath('wcf')}js/WCF.User{if !ENABLE_DEBUG_MODE}.min{/if}.js?v={@$__wcfVersion}"></script>
 	{event name='javascriptInclude'}
 	<script data-relocate="true">
 		//<![CDATA[


### PR DESCRIPTION
The `user` template loads the WCF.User(.min).js next to the `headInclude` template. This may cause unexpected problems (as i've just experienced).
