### PR TITLE
Add table name guessing

### DIFF
--- a/wcfsetup/install/files/lib/data/DatabaseObject.class.php
+++ b/wcfsetup/install/files/lib/data/DatabaseObject.class.php
@@ -128,7 +128,8 @@ abstract class DatabaseObject implements IStorableObject {
 	 * @see	\wcf\data\IStorableObject::getDatabaseTableName()
 	 */
 	public static function getDatabaseTableName() {
-		return 'wcf'.WCF_N.'_'.static::$databaseTableName;
+		$classParts = explode('\\', get_called_class());
+		return $classParts[0].WCF_N.'_'.static::$databaseTableName;
 	}
 	
 	/**


### PR DESCRIPTION
This commit adds guessing of the table name prefix to DBOs. It is backwards compatible with all WoltLab products.

With this change it is not longer required to add a dedicated abstract DBO to each application just to set the proper table name prefix. Instead, the first part of the namespace (the app abbreviation) is used as prefix.

This change is fully backwards compatible _if you adhered to the coding standards_ set forth by WCf. If you used the `wcf` table prefix for tables of your standalone applications, this will break things. But as far as i know every application in the plugin store should use it's own prefix.
