### PR TITLE
throw SystemException if the objectTypeID is invalid

### DIFF
--- a/wcfsetup/install/files/lib/data/like/object/LikeObject.class.php
+++ b/wcfsetup/install/files/lib/data/like/object/LikeObject.class.php
@@ -3,6 +3,7 @@ namespace wcf\data\like\object;
 use wcf\data\object\type\ObjectTypeCache;
 use wcf\data\user\User;
 use wcf\data\DatabaseObject;
+use wcf\system\exception\SystemException;
 use wcf\system\WCF;
 
 /**
@@ -73,7 +74,14 @@ class LikeObject extends DatabaseObject {
 	 */
 	public function getLikedObject() {
 		if ($this->likedObject === null) {
-			$this->likedObject = ObjectTypeCache::getInstance()->getObjectType($this->objectTypeID)->getProcessor()->getObjectByID($this->objectID);
+			$objectType = ObjectTypeCache::getInstance()->getObjectType($this->objectTypeID); 
+			
+			if ($objectType === null) {
+				// if the objectTypeID is e.g. null, because the object is invalid
+				throw new SystemException('Can not fetch likedObject, because objectType is invalid.');
+			}
+			
+			$this->likedObject = $objectType->getProcessor()->getObjectByID($this->objectID);
 		}
 		
 		return $this->likedObject;


### PR DESCRIPTION
If the objectTypeID is null, a PHP Fatal Error is thrown, because getObjectType() returns null. Instead of the fatal error, now a system exception is thrown with the (optional) stack trace. This is much nicer, especially for developers
