### PR TITLE
Greatly improve guessing of table names (and add guessing of index columns)

### DIFF
--- a/wcfsetup/install/files/lib/data/DatabaseObject.class.php
+++ b/wcfsetup/install/files/lib/data/DatabaseObject.class.php
@@ -186,10 +186,11 @@ abstract class DatabaseObject implements IStorableObject {
 	 */
 	private static final function doTableNameGuessing() {
 		$className = get_called_class();
-		$classParts = explode('\\', $className);
 		if (property_exists($className, 'databaseTableName') && !empty(static::$databaseTableName)) {
 			$tableName = static::$databaseTableName;
-		} else {
+		}
+		else {
+			$classParts = explode('\\', $className);
 			$tableName = strtolower(implode('_', preg_split('/(?=[A-Z])/', array_pop($classParts), -1, PREG_SPLIT_NO_EMPTY)));
 		}
 		return $tableName;
@@ -217,11 +218,11 @@ abstract class DatabaseObject implements IStorableObject {
 	 */
 	public static function getDatabaseTableIndexName() {
 		$className = get_called_class();
-		$classParts = explode('\\', $className);
 		if (property_exists($className, 'databaseTableIndexName') && !empty(static::$databaseTableIndexName)) {
 			$indexName = static::$databaseTableIndexName;
 		}
 		else {
+			$classParts = explode('\\', $className);
 			$classNameParts = preg_split('/(?=[A-Z])/', array_pop($classParts), -1, PREG_SPLIT_NO_EMPTY);
 			$indexName = strtolower(array_pop($classNameParts)) . 'ID';
 		}

--- a/wcfsetup/install/files/lib/data/DatabaseObject.class.php
+++ b/wcfsetup/install/files/lib/data/DatabaseObject.class.php
@@ -5,7 +5,7 @@ use wcf\system\WCF;
 /**
  * Abstract class for all data holder classes.
  * 
- * @author	Marcel Werk
+ * @author	Marcel Werk, Sebastian Teumert
  * @copyright	2001-2014 WoltLab GmbH
  * @license	GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
  * @package	com.woltlab.wcf
@@ -125,18 +125,75 @@ abstract class DatabaseObject implements IStorableObject {
 	}
 	
 	/**
+	 * Returns the database table name of this object.
+	 * 
+	 * If the DBO defines a static, non-empty $databaseTableName property, that property
+	 * is used and prefixed with the application abbreviation and WCF instance number.
+	 *
+	 * If the property is not defined, the table name is guessed. Therefore,
+	 * the class name is split into its CamelCase parts and rejoined with under-
+	 * scores (_). 
+	 * 
+	 * Example:
+	 * wcf\data\event\EventListener would be automatically guessed to
+	 * wcf_<WCF_N>_event_listener
+	 *
 	 * @see	\wcf\data\IStorableObject::getDatabaseTableName()
+	 * @return string <app_abbreviation>_<WCF_N>_<table_name>
 	 */
 	public static function getDatabaseTableName() {
 		$classParts = explode('\\', get_called_class());
-		return $classParts[0].WCF_N.'_'.static::$databaseTableName;
+		$tableName = static::doTableNameGuessing();
+		return $classParts[0].WCF_N.'_'.$tableName;
 	}
 	
 	/**
+	 * Returns the database table alias of the object.
+	 *
+	 * if the DBO defines a static, non-empty $databaseTableName property, 
+	 * that property is used and returned.
+	 *
+	 * Otherwise, the table alias is guessed. Therefore the class name is split
+	 * into its CamelCase parts and rejoined with underscores.
+	 * 
+	 * Example:
+	 * wcf\data\event\EventListener would be automatically guessed to
+	 * event_listener
+	 *
 	 * @see	\wcf\data\IStorableObject::getDatabaseTableAlias()
+	 * @return string
 	 */
 	public static function getDatabaseTableAlias() {
-		return static::$databaseTableName;
+		return static::doTableNameGuessing();
+	}
+	
+	/**
+	 * Guesses the table name. 
+	 *
+	 * This method is private & final because it should
+	 * never be overridden. Developers can override {@link getDatabaseTableAlias()}
+	 * and {@link getDatabaseTableName()} separately when needed, as is done for example
+	 * in {@link wcf\data\user\User}.
+	 * 
+	 * The table name is guessed by splitting the CamelCase class name into it's
+	 * parts and then rejoining them with underscores (_). This works
+	 * well in most cases, but fails for example with {@link wcf\data\acp\ACPSession}
+	 * because of the multiple upper case characters. In those cases, guessing 
+	 * can be prevented by defining a static $databaseTableName property in
+	 * the class.
+	 * 
+	 * @return string
+	 */
+	private static final function doTableNameGuessing() {
+		$className = get_called_class();
+		$classParts = explode('\\', $className);
+		if (property_exists($className, 'databaseTableName') && !empty(static::$databaseTableName)) {
+			$tableName = static::$databaseTableName;
+		} else {
+			$tableName = strtolower(implode('_', preg_split('/(?=\p{Lu})/u', array_pop($classParts), -1, PREG_SPLIT_NO_EMPTY)));
+			// Lu is the unicode character class for capitalized chars
+		}
+		return $tableName;
 	}
 	
 	/**
@@ -147,10 +204,29 @@ abstract class DatabaseObject implements IStorableObject {
 	}
 	
 	/**
+	 * Returns the name of the index column of this DBO.
+	 * 
+	 * If the class defined a static, non-empty $databaseTableIndexName property,
+	 * that property is returned. Otherwise the index is guessed.
+	 *
+	 * The guessed index is the last part of the CamelCase class name followed
+	 * by the literal "ID". 
+	 * For example, wcf\data\event\listener\EventListener would be guessed to "listenerID".
+	 *
 	 * @see	\wcf\data\IStorableObject::getDatabaseTableIndexName()
+	 * @return string
 	 */
 	public static function getDatabaseTableIndexName() {
-		return static::$databaseTableIndexName;
+		$className = get_called_class();
+		$classParts = explode('\\', $className);
+		if (property_exists($className, 'databaseTableIndexName') && !empty(static::$databaseTableIndexName)) {
+			$indexName = static::$databaseTableIndexName;
+		}
+		else {
+			$classNameParts = preg_split('/(?=\p{Lu})/u', array_pop($classParts), -1, PREG_SPLIT_NO_EMPTY);
+			$indexName = strtolower(array_pop($classNameParts)) . 'ID';
+		}
+		return $indexName;
 	}
 	
 	/**

--- a/wcfsetup/install/files/lib/data/DatabaseObject.class.php
+++ b/wcfsetup/install/files/lib/data/DatabaseObject.class.php
@@ -136,10 +136,10 @@ abstract class DatabaseObject implements IStorableObject {
 	 * 
 	 * Example:
 	 * wcf\data\event\EventListener would be automatically guessed to
-	 * wcf_<WCF_N>_event_listener
+	 * wcf<WCF_N>_event_listener
 	 *
 	 * @see	\wcf\data\IStorableObject::getDatabaseTableName()
-	 * @return string <app_abbreviation>_<WCF_N>_<table_name>
+	 * @return string <app_abbreviation><WCF_N>_<table_name>
 	 */
 	public static function getDatabaseTableName() {
 		$classParts = explode('\\', get_called_class());

--- a/wcfsetup/install/files/lib/data/DatabaseObject.class.php
+++ b/wcfsetup/install/files/lib/data/DatabaseObject.class.php
@@ -190,8 +190,7 @@ abstract class DatabaseObject implements IStorableObject {
 		if (property_exists($className, 'databaseTableName') && !empty(static::$databaseTableName)) {
 			$tableName = static::$databaseTableName;
 		} else {
-			$tableName = strtolower(implode('_', preg_split('/(?=\p{Lu})/u', array_pop($classParts), -1, PREG_SPLIT_NO_EMPTY)));
-			// Lu is the unicode character class for capitalized chars
+			$tableName = strtolower(implode('_', preg_split('/(?=[A-Z])/', array_pop($classParts), -1, PREG_SPLIT_NO_EMPTY)));
 		}
 		return $tableName;
 	}
@@ -223,7 +222,7 @@ abstract class DatabaseObject implements IStorableObject {
 			$indexName = static::$databaseTableIndexName;
 		}
 		else {
-			$classNameParts = preg_split('/(?=\p{Lu})/u', array_pop($classParts), -1, PREG_SPLIT_NO_EMPTY);
+			$classNameParts = preg_split('/(?=[A-Z])/', array_pop($classParts), -1, PREG_SPLIT_NO_EMPTY);
 			$indexName = strtolower(array_pop($classNameParts)) . 'ID';
 		}
 		return $indexName;


### PR DESCRIPTION
Table names and index columns can now completely be guessed. Guessing of
the application prefix was added with
94e60f3679791863a1c9f861fabdd3247b231eae, now table names and aliases
can also be guessed.

Therefore, the class name is splitted at capital letters and the those
parts are re-joined with an underscore. This is the default coding
convention that most DBOs adhere to and removes the necessity to specify
the table name & alias explicitly.  Developers can still either define
the table name (and alias) explicitly by setting the property or by
overriding the method.

The index column name can also be guessed. In most cases, it is the last
part of the class name followed by "ID", so that is what is guessed.
The index name can also still be set explicitly either by setting the
property or overriding the method.

A new internal, private & final helper method has been added for the
guessing of the table name / alias.

---

I have tested these changes against the 2.0 branch, they are backwards compatible with all WoltLab products.

These changes allow it to omit many of the necessary properties of a DBO, while still allow to set them to non-standard values if needed. 

I've tested it with the blog, you can make the `blog\data\entry\Entry` object inherit directly from `DatabaseObject` and remove the `databaseTableName` and `databaseTableIndexName` properties and it still works as expected.