### PR TITLE
Adds the ability to run custom initialization in derived DBOActions.

### DIFF
--- a/wcfsetup/install/files/lib/data/AbstractDatabaseObjectAction.class.php
+++ b/wcfsetup/install/files/lib/data/AbstractDatabaseObjectAction.class.php
@@ -141,9 +141,18 @@ abstract class AbstractDatabaseObjectAction implements IDatabaseObjectAction, ID
 		$this->action = $action;
 		$this->parameters = $parameters;
 		
+		// initialize further settings
+		$this->__init($baseClass, $indexName);
+		
 		// fire event action
 		EventHandler::getInstance()->fireAction($this, 'initializeAction');
 	}
+	
+	/**
+	 * This function can be overridden in children to perform custom initialization
+	 * of a DBOAction before the 'initializeAction' event is fired.
+	 */
+	protected function __init($baseClass, $indexName) { }
 	
 	/**
 	 * @see	\wcf\data\IDatabaseObjectAction::validateAction()


### PR DESCRIPTION
 Currently, you have to use an event listener with proper nice value to ensure your initialization runs before evrything else. This change allows derived classes to use the initialized values from the constructor but on the same time runs before any 3rd party event listeners. This greatly enhances the flexibility and extensibily of DBOActions.
