### PR TITLE
Fix calculation of maximum width in WCF.ImageViewer._checkImageSize()

### DIFF
--- a/wcfsetup/install/files/js/WCF.ImageViewer.js
+++ b/wcfsetup/install/files/js/WCF.ImageViewer.js
@@ -92,7 +92,7 @@ WCF.ImageViewer = Class.extend({
 		
 		$image.removeClass('jsResizeImage');
 		var $dimensions = $image.getDimensions();
-		var $maxWidth = $image.parents('div').innerWidth();
+		var $maxWidth = $image.parents('div').width();
 		
 		if ($dimensions.width > $maxWidth) {
 			$image.css({


### PR DESCRIPTION
jQuery’s `.innerWidth()` returns the width of the element, including left and right padding, in pixels but the maximum width of an image should be the content width of its container.
