### PR TITLE
add getRoutes()-methode

### DIFF
--- a/wcfsetup/install/files/lib/system/request/RouteHandler.class.php
+++ b/wcfsetup/install/files/lib/system/request/RouteHandler.class.php
@@ -104,6 +104,15 @@ class RouteHandler extends SingletonFactory {
 	}
 	
 	/**
+	 * Returns all registered routes. 
+	 * 
+	 * @return	array<\wcf\system\request\Route>
+	 **/
+	public function getRoutes() {
+		return $this->routes; 
+	}
+	
+	/**
 	 * Returns true if a route matches. Please bear in mind, that the
 	 * first route which is able to consume all path components is used,
 	 * even if other routes may fit better. Route order is crucial!


### PR DESCRIPTION
For a WCF2.1 plugin I need all the routes, which are registered. Since it's not possible to directly access the routes as a plugin, I would propose, for introducing a method.
