### PR TITLE
Fix display of PHPInfoPage in PHP 5.6

### DIFF
--- a/wcfsetup/install/files/lib/acp/page/PHPInfoPage.class.php
+++ b/wcfsetup/install/files/lib/acp/page/PHPInfoPage.class.php
@@ -41,11 +41,13 @@ class PHPInfoPage extends AbstractPage {
 		
 		// style fixes
 		// remove first table
-		$info = preg_replace('%<table.*?</table><br />%s', '', $info, 1);
+		$info = preg_replace('%<table.*?</table><(<br />)?%s', '', $info, 1);
+		// float logos
+		$info = preg_replace('%<img([^>]*)>%s', '<img style="float:right" \\1>', $info, 1);
 		
 		// fix tables
-		$info = preg_replace('%<h2>(.*?)</h2>\s*<table( border="0" cellpadding="3" width="600")?>%', '<div class="tabularBox tabularBoxTitle marginTop"><header><h2>\\1</h2></header><table class="table">', $info);
-		$info = preg_replace('%<table( border="0" cellpadding="3" width="600")?>%', '<div class="tabularBox marginTop"><table class="table">', $info);
+		$info = preg_replace('%<h2>(.*?)</h2>\s*<table( border="0" cellpadding="3" width="600")?>%', '<div class="tabularBox tabularBoxTitle marginTop"><header><h2>\\1</h2></header><table class="table" style="table-layout:fixed;">', $info);
+		$info = preg_replace('%<table( border="0" cellpadding="3" width="600")?>%', '<div class="tabularBox marginTop"><table class="table" style="table-layout:fixed;">', $info);
 		$info = str_replace('</table>', '</table></div>', $info);
 		
 		// fix display of disable_functions & disable_classes


### PR DESCRIPTION
PHP 5.6 comes with a slightly modified `phpinfo`, which completely breaks the PHPInfoPage, because `<table border="0" cellpadding="3" width="600">` no longer exists. These tables have been replaced by simple `<table>`-tags without attributes. It also doesn't use `<br />`-tags after tables anymore.

Furthermore, IE behaves different (o'rly...) and produces weird stuff.
