### PR TITLE
Fix display of PHPInfoPage

### DIFF
--- a/wcfsetup/install/files/lib/acp/page/PHPInfoPage.class.php
+++ b/wcfsetup/install/files/lib/acp/page/PHPInfoPage.class.php
@@ -41,7 +41,7 @@ class PHPInfoPage extends AbstractPage {
 		
 		// style fixes
 		// remove first table
-		$info = preg_replace('%<table.*?</table><(<br />)?%s', '', $info, 1);
+		$info = preg_replace('%<table.*?</table>(<br />)?%s', '', $info, 1);
 		// float logos
 		$info = preg_replace('%<img([^>]*)>%s', '<img style="float:right" \\1>', $info, 1);
 		


### PR DESCRIPTION
PHP 5.6 comes with a slightly modified `phpinfo`, which completely breaks the PHPInfoPage, because `<table border="0" cellpadding="3" width="600">` no longer exists. These tables have been replaced by simple `<table>`-tags without attributes. It also doesn't use `<br />`-tags after tables anymore. There might also be some rows, which have just one column. The result looks a little bit ugly.

Furthermore, IE behaves different and produces weird stuff. But that's nothing new... However, fixing it by adding a `table-layout` also affects the display in other browsers. But that's fine, from what i've seen.

And while working on a proper display, we could also float images as in the original phpinfo, which looks much better than currently.
