### PR TITLE
Add Safari Mobile Browser Detection

### DIFF
--- a/wcfsetup/install/files/lib/data/user/online/UserOnline.class.php
+++ b/wcfsetup/install/files/lib/data/user/online/UserOnline.class.php
@@ -225,6 +225,11 @@ class UserOnline extends UserProfile {
 			return 'Android Browser '.$match[1];
 		}
 		
+		// safari mobile
+		if (preg_match('~([\d\.]+) Mobile/\w+ safari~i', $this->userAgent, $match)) {
+			return 'Safari Mobile '.$match[1];
+		}
+		
 		// safari
 		if (preg_match('~([\d\.]+) safari~i', $this->userAgent, $match)) {
 			return 'Safari '.$match[1];


### PR DESCRIPTION
Currently, Safari Mobile will be detected wrong. `Mozilla/5.0 (iPad; CPU OS 8_0_2 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12A405 Safari/600.1.4` will be detected as `Safari 405` for example, but it should be detected as `Safari Mobile 8.0`.
