### PR TITLE
prevent ```Undefined variable: captchaObjectType```

### DIFF
--- a/wcfsetup/install/files/lib/data/comment/CommentAction.class.php
+++ b/wcfsetup/install/files/lib/data/comment/CommentAction.class.php
@@ -595,6 +595,8 @@ class CommentAction extends AbstractDatabaseObjectAction {
 	 * @return	array
 	 */
 	public function getGuestDialog() {
+		$captchaObjectType = null; 
+		
 		if (CAPTCHA_TYPE) {
 			$captchaObjectType = CaptchaHandler::getInstance()->getObjectTypeByName(CAPTCHA_TYPE);
 			if ($captchaObjectType === null) {


### PR DESCRIPTION
If you disable the captcha, you get when creating a commentary the error message: Undefined variable: captchaObjectType on line 610 and 614. This pull request fixes the bug.
