### PR TITLE
fix error handling in guest-wcf dialog

### DIFF
--- a/wcfsetup/install/files/js/WCF.Comment.js
+++ b/wcfsetup/install/files/js/WCF.Comment.js
@@ -568,10 +568,10 @@ WCF.Comment.Handler = Class.extend({
 					var $responseList = $comment.find('ul.commentResponseList');
 					if (!$responseList.length) $responseList = $('<ul class="commentResponseList" />').insertBefore($comment.find('.commentOptionContainer'));
 					$(data.returnValues.template).appendTo($responseList).wcfFadeIn();
-				}
-				
-				if (!WCF.User.userID) {
-					this._guestDialog.wcfDialog('close');
+					
+					if (!WCF.User.userID) {
+						this._guestDialog.wcfDialog('close');
+					}
 				}
 			break;
 			


### PR DESCRIPTION
Is currently writing as a guest a response to a comment and choose for example an blocked name, the dialog is closed anyway, instead of displaying the error message.
