### PR TITLE
Added a class for unconfirmed notifications

### DIFF
--- a/com.woltlab.wcf/templates/notificationList.tpl
+++ b/com.woltlab.wcf/templates/notificationList.tpl
@@ -63,7 +63,7 @@
 			<div class="container marginTop">
 				<ul class="containerList userNotificationItemList">
 		{/if}
-				<li class="jsNotificationItem notificationItem{if $notification[authors] > 1} groupedNotificationItem{/if}" data-notification-id="{@$notification[notificationID]}" data-link="{$notification[event]->getLink()}" data-is-grouped="{if $notification[authors] > 1}true{else}false{/if}" data-is-confirmed="{if $notification[event]->isConfirmed()}true{else}false{/if}">
+				<li class="jsNotificationItem notificationItem{if $notification[authors] > 1} groupedNotificationItem{/if}{if !$notification[event]->isConfirmed()} notificationUnconfirmed{/if}" data-notification-id="{@$notification[notificationID]}" data-link="{$notification[event]->getLink()}" data-is-grouped="{if $notification[authors] > 1}true{else}false{/if}" data-is-confirmed="{if $notification[event]->isConfirmed()}true{else}false{/if}">
 					<div class="box24">
 						{if $notification[authors] < 2}
 							<div class="framed">

--- a/com.woltlab.wcf/templates/notificationListOustanding.tpl
+++ b/com.woltlab.wcf/templates/notificationListOustanding.tpl
@@ -1,5 +1,5 @@
 {foreach from=$notifications[notifications] item=notification}
-	<li class="jsNotificationItem notificationItem{if $notification[event]->getAuthors()|count > 1} groupedNotificationItem{/if}" data-link="{$notification[event]->getLink()}" data-notification-id="{@$notification[notificationID]}" data-is-confirmed="{if $notification[event]->isConfirmed()}true{else}false{/if}">
+	<li class="jsNotificationItem notificationItem{if $notification[event]->getAuthors()|count > 1} groupedNotificationItem{/if}{if !$notification[event]->isConfirmed()} notificationUnconfirmed{/if}" data-link="{$notification[event]->getLink()}" data-notification-id="{@$notification[notificationID]}" data-is-confirmed="{if $notification[event]->isConfirmed()}true{else}false{/if}">
 		<span class="box24">
 			<div class="framed">
 				{if $notification[event]->getAuthors()|count < 2}

--- a/wcfsetup/install/files/js/WCF.User.js
+++ b/wcfsetup/install/files/js/WCF.User.js
@@ -1338,6 +1338,7 @@ WCF.Notification.List = Class.extend({
 		$item.data('isConfirmed', true);
 		$item.find('.notificationItemMarkAsConfirmed').remove();
 		$item.find('.newContentBadge').remove();
+		$item.removeClass('notificationUnconfirmed');
 	}
 });
 
@@ -1518,6 +1519,7 @@ WCF.Notification.UserPanel = WCF.UserPanel.extend({
 						$item.data('isConfirmed', true);
 						$item.find('.notificationItemMarkAsConfirmed').remove();
 						$item.find('.newContentBadge').remove();
+						$item.removeClass('notificationUnconfirmed');
 						
 						return false;
 					}


### PR DESCRIPTION
CSS attributes set via `.dropdownMenu li.notificationItem[data-is-confirmed="false"]` will not be removed after confirming a notification as read.
