### PR TITLE
Fix issue when uninstalling applications

### DIFF
--- a/wcfsetup/install/files/lib/system/request/Route.class.php
+++ b/wcfsetup/install/files/lib/system/request/Route.class.php
@@ -361,7 +361,14 @@ class Route {
 			self::$defaultControllers = array();
 			
 			foreach (ApplicationHandler::getInstance()->getApplications() as $application) {
-				$controller = WCF::getApplicationObject($application)->getPrimaryController();
+				$app = WCF::getApplicationObject($application);
+				
+				if (!$app) {
+					continue;
+				}
+				
+				$controller = $app->getPrimaryController();
+				
 				if (!$controller) {
 					continue;
 				}


### PR DESCRIPTION
This prevents a call to a member function `getPrimaryController()` on a non-object in `Route.class.php` and allows uninstallation of applications again.
