### PR TITLE
Removing exit in exception handler

### DIFF
--- a/wcfsetup/install/files/lib/system/WCF.class.php
+++ b/wcfsetup/install/files/lib/system/WCF.class.php
@@ -271,11 +271,11 @@ class WCF {
 		try {
 			if ($e instanceof IPrintableException) {
 				$e->show();
-				exit;
 			}
-			
-			// repack Exception
-			self::handleException(new SystemException($e->getMessage(), $e->getCode(), '', $e));
+			else {
+				// repack Exception
+				self::handleException(new SystemException($e->getMessage(), $e->getCode(), '', $e));
+			}
 		}
 		catch (\Exception $exception) {
 			die("<pre>WCF::handleException() Unhandled exception: ".$exception->getMessage()."\n\n".$exception->getTraceAsString());


### PR DESCRIPTION
Php is automatically exit the current Script after an Exception is thrown.
Because of this, it is not necessary to manually exit the Script inside the exception handler.
While this won't change anything with normal php, it will break hhvm to use the default exception handler