### PR TITLE
Update global.less

### DIFF
--- a/wcfsetup/install/files/style/global.less
+++ b/wcfsetup/install/files/style/global.less
@@ -453,6 +453,6 @@ a.badge:hover {
 	html.iOS,
 	html.iOS > body {
 		width: 100%;
-		overflow: hidden;
+		overflow: auto;
 	}
 }


### PR DESCRIPTION
Overflow: hidden causes incompatibility with latest Chrome for Android version (v40.0.2214.89).

Details: https://community.woltlab.com/thread/234872-4-x-scrollen-in-chrome-f%C3%BCr-android-nicht-mehr-m%C3%B6glich/