### PR TITLE
Make Message Data accessible

### DIFF
--- a/wcfsetup/install/files/lib/system/message/embedded/object/MessageEmbeddedObjectManager.class.php
+++ b/wcfsetup/install/files/lib/system/message/embedded/object/MessageEmbeddedObjectManager.class.php
@@ -42,6 +42,12 @@ class MessageEmbeddedObjectManager extends SingletonFactory {
 	protected $activeMessageID = null;
 	
 	/**
+	 * objectType of the active message
+	 * @var	string
+	 */
+	protected $activeMessageObjectType = '';
+	
+	/**
 	 * list of embedded object handlers
 	 * @var	array
 	 */
@@ -158,6 +164,7 @@ class MessageEmbeddedObjectManager extends SingletonFactory {
 	public function setActiveMessage($messageObjectType, $messageID) {
 		$this->activeMessageObjectTypeID = ObjectTypeCache::getInstance()->getObjectTypeIDByName('com.woltlab.wcf.message', $messageObjectType);
 		$this->activeMessageID = $messageID;
+		$this->activeMessageObjectType = $messageObjectType;
 	}
 	
 	/**
@@ -254,5 +261,32 @@ class MessageEmbeddedObjectManager extends SingletonFactory {
 		$this->getEmbeddedObjectHandlers();
 		
 		return $this->embeddedObjectHandlers[$objectTypeID];
+	}
+	
+	/**
+	 * Returns active message id.
+	 * 
+	 * @return	integer
+	 */
+	public function getActiveMessageID() {
+		return $this->activeMessageID;
+	}
+	
+	/**
+	 * Returns active message object type.
+	 * 
+	 * @return	string
+	 */
+	public function getActiveMessageObjectType() {
+		return $this->activeMessageObjectType;
+	}
+	
+	/**
+	 * Returns active message object type id.
+	 * 
+	 * @return	integer
+	 */
+	public function getActiveMessageObjectTypeID() {
+		return $this->activeMessageObjectTypeID;
 	}
 }


### PR DESCRIPTION
With WCF2.1 there was a change of the bbcode system, so that there is currently no way to get data about the currently parsed message.
As i suggested previously there should be a way for other bbcodes than only the attachment bbcode:
https://community.woltlab.com/thread/228918-objectid-in-abstractbbcode-einf%C3%BCgen/
With the MessageEmbeddedObjectManager the basis for this is done, but there is no way to access this data.
I'll hope this will be changed before Relase.