### PR TITLE
Fix inconsistency

### DIFF
--- a/com.woltlab.wcf/templates/wysiwyg.tpl
+++ b/com.woltlab.wcf/templates/wysiwyg.tpl
@@ -111,7 +111,7 @@ $(function() {
 		'{@$__wcf->getPath()}js/3rdParty/redactor/redactor{if !ENABLE_DEBUG_MODE}.min{/if}.js?v={@LAST_UPDATE_TIME}',
 		{if $__wcf->getLanguage()->getFixedLanguageCode() != 'en'}'{@$__wcf->getPath()}js/3rdParty/redactor/languages/{@$__wcf->getLanguage()->getFixedLanguageCode()}.js?v={@LAST_UPDATE_TIME}',{/if}
 		{if !ENABLE_DEBUG_MODE}
-			'{@$__wcf->getPath()}js/3rdParty/redactor/plugins/wcombined.min.js?v={@LAST_UPDATE_TIME}',
+			'{@$__wcf->getPath()}js/3rdParty/redactor/plugins/wcombined.min.js?v={@LAST_UPDATE_TIME}'
 		{else}
 			{* official *}
 			'{@$__wcf->getPath()}js/3rdParty/redactor/plugins/table.js?v={@LAST_UPDATE_TIME}',


### PR DESCRIPTION
When loading `wcombined` in the `wysiwyg` template, there's an additional comma at the end of the line while there isn't any if debug mode is enabled. So loading additional scripts might not be impossible, but way more complicated than neccessary, because you have to check if debug mode is enabled or not.