### PR TITLE
Fix vimeo embed

### DIFF
--- a/wcfsetup/setup/db/install.sql
+++ b/wcfsetup/setup/db/install.sql
@@ -1877,7 +1877,7 @@ INSERT INTO wcf1_style_variable (variableName, defaultValue) VALUES ('messageSid
 	-- Youtube
 	INSERT INTO wcf1_bbcode_media_provider (title, regex, html) VALUES ('YouTube', 'https?://(?:.+?\\.)?youtu(?:\\.be/|be\\.com/(?:#/)?watch\\?(?:.*?&)?v=)(?P<ID>[a-zA-Z0-9_-]+)(?P<start>(?:#a?t=(?:\\d+|(?:\\d+h(?:\\d+m)?(?:\\d+s)?)|(?:\\d+m(?:\\d+s)?)|(?:\\d+s))$)?)', '<iframe style="max-width:100%;" width="560" height="315" src="https://www.youtube-nocookie.com/embed/{$ID}?wmode=transparent{$start}" allowfullscreen></iframe>');
 	-- Vimeo
-	INSERT INTO wcf1_bbcode_media_provider (title, regex, html) VALUES ('Vimeo', 'http://vimeo\\.com/(?P<ID>\\d+)', '<iframe src="http://player.vimeo.com/video/{$ID}" width="400" height="225" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe>');
+	INSERT INTO wcf1_bbcode_media_provider (title, regex, html) VALUES ('Vimeo', 'https?://vimeo\\.com/(?P<ID>\\d+)', '<iframe src="https://player.vimeo.com/video/{$ID}" width="400" height="225" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe>');
 	-- MyVideo
 	INSERT INTO wcf1_bbcode_media_provider (title, regex, html) VALUES ('MyVideo', 'http://(?:www\\.)?myvideo\\.de/watch/(?P<ID>\\d+)', '<object width="611" height="383" type="application/x-shockwave-flash" data="http://www.myvideo.de/movie/{$ID}"><param name="movie" value="http://www.myvideo.de/movie/{$ID}" /><param name="AllowFullscreen" value="true" /><param name="AllowScriptAccess" value="always" /><param name="wmode" value="transparent" /></object>');
 	-- Clipfish


### PR DESCRIPTION
Currently, the media provider "Vimeo" doesn't include HTTPs in the regular expression and it does not use HTTPs to embed media.