### PR TITLE
Set this._badge to null in WCF.User.Panel.Abstract.updateBadge on removal

### DIFF
--- a/wcfsetup/install/files/js/WCF.User.js
+++ b/wcfsetup/install/files/js/WCF.User.js
@@ -390,6 +390,7 @@ WCF.User.Panel.Abstract = Class.extend({
 		}
 		else if (this._badge !== null) {
 			this._badge.remove();
+			this._badge = null;
 		}
 		
 		if (this._options.enableMarkAsRead) {
@@ -527,7 +528,7 @@ WCF.User.Panel.Notification = WCF.User.Panel.Abstract.extend({
 		}
 		
 		this.updateBadge(count);
-	}	
+	}
 });
 
 /**


### PR DESCRIPTION
When not explicitly set to `null` the variable will still contain a reference, thus a badge update will not create a new badge when it was removed earlier.