### PR TITLE
Fix error in temlate engine

### DIFF
--- a/wcfsetup/install/files/lib/system/template/TemplateScriptingCompiler.class.php
+++ b/wcfsetup/install/files/lib/system/template/TemplateScriptingCompiler.class.php
@@ -798,8 +798,8 @@ class TemplateScriptingCompiler {
 			}
 			if (!empty($phpCode)) $phpCode = "<?php\n".$phpCode."\n?>";
 			
-			$sourceFilename = WCF::getTPL()->getSourceFilename($templateName, $application);
-			$metaDataFilename = WCF::getTPL()->getMetaDataFilename($templateName);
+			$sourceFilename = $this->template->getSourceFilename($templateName, $application);
+			$metaDataFilename = $this->template->getMetaDataFilename($templateName);
 			
 			$data = $this->compileString($templateName, file_get_contents($sourceFilename), array(
 				'application' => $application,


### PR DESCRIPTION
This patch fixes an error in the TemplateScriptingCompiler. Instead of
using `WCF::getTPL()` now the engine which is passed during
initialization is used. This allows one to compile e.g. frontend
templates in the ACP and generally removes an unecessary coupling from
the engine.

This fix is needed for my plugin (https://pluginstore.woltlab.com/file/1494-custom-template-listeners/), as I want to compile the templates in the ACP to make sure they actually compile before a user can ruin his frontend. Without these changes, the `{include}` template tag will most likely not compile in most situations as `WCF::getTPL()` returns an `ACPTemplateEngine` in this instance which doesn't know about frontend templates. By using the template engine specified in the constructor one can pass a template engine for the frontend and compile the template sucessfully.

I have tested these changes and found no negative effect so far.