### PR TITLE
Trim URL in StringUtil::getAnchorTag()

### DIFF
--- a/wcfsetup/install/files/lib/util/StringUtil.class.php
+++ b/wcfsetup/install/files/lib/util/StringUtil.class.php
@@ -740,6 +740,8 @@ final class StringUtil {
 	 * @return	string		anchor tag
 	 */
 	public static function getAnchorTag($url, $title = '', $encodeTitle = true) {
+		$url = self::trim($url);
+		
 		$external = true;
 		if (ApplicationHandler::getInstance()->isInternalURL($url)) {
 			$external = false;


### PR DESCRIPTION
The regular expressions won’t match with a space in front of the URL, this, for example, allows circumvention of the external URL check.
Moreover a space in front of the URL doesn’t make sense anyway and should be encoded as `%20`.

This can easily be tested with the URLBBCode, for example: `[url=' https://test.example.com/']PAGE_TITLE[/url]` will be shown as internal URL.

*Note*: In 2.0 the link detection must be disabled, else the generated BBCode will look like this: `[url=' [url]https://test.example.com/[/url]']PAGE_TITLE[/url]`