### PR TITLE
add init event

### DIFF
--- a/wcfsetup/install/files/lib/data/DatabaseObjectList.class.php
+++ b/wcfsetup/install/files/lib/data/DatabaseObjectList.class.php
@@ -1,6 +1,7 @@
 <?php
 namespace wcf\data;
 use wcf\system\database\util\PreparedStatementConditionBuilder;
+use wcf\system\event\EventHandler;
 use wcf\system\exception\SystemException;
 use wcf\system\WCF;
 use wcf\util\ClassUtil;
@@ -133,6 +134,8 @@ abstract class DatabaseObjectList implements \Countable, ITraversableObject {
 		}
 		
 		$this->conditionBuilder = new PreparedStatementConditionBuilder();
+		
+		EventHandler::getInstance()->fireAction($this, 'init');
 	}
 	
 	/**


### PR DESCRIPTION
For many reasons is important to add conditions to a DatabaseObjectList. e.g. for a plugin like this: https://community.woltlab.com/thread/235327-weil-s-so-sch%C3%B6n-war-benutzergruppe-darf-nur-eigene-themen-sehen-lesen/?pageNo=1

With this PR plugins are able to modify lists in 3rd party plugins too.