### PR TITLE
Apply multiple changes to PasswordUtil

### DIFF
--- a/wcfsetup/install/files/lib/util/PasswordUtil.class.php
+++ b/wcfsetup/install/files/lib/util/PasswordUtil.class.php
@@ -63,7 +63,7 @@ final class PasswordUtil {
 	 * blowfish encryption type
 	 * @var	string
 	 */
-	const BCRYPT_TYPE = '2a';
+	const BCRYPT_TYPE = '2y';
 	
 	/**
 	 * Returns true if given encryption type is supported.
@@ -90,11 +90,11 @@ final class PasswordUtil {
 	 * @return	boolean
 	 */
 	public static function isBlowfish($hash) {
-		return (Regex::compile('^\$2[afx]\$')->match($hash) ? true : false);
+		return (Regex::compile('^\$2[afxy]\$')->match($hash) ? true : false);
 	}
 	
 	/**
-	 * Returns true if given bcrypt hash uses a different cost factor and should be re-computed.
+	 * Returns true if given bcrypt hash uses a different cost factor or encryption type and should be re-computed.
 	 * 
 	 * @param	string		$hash
 	 * @return	boolean
@@ -103,7 +103,10 @@ final class PasswordUtil {
 		$currentCost = intval(self::BCRYPT_COST);
 		$hashCost = intval(substr($hash, 4, 2));
 		
-		if ($currentCost != $hashCost) {
+		$currentType = self::BCRYPT_TYPE;
+		$hashType = substr($hash, 1, 2);
+		
+		if ($currentCost != $hashCost || $currentType != $hashType) {
 			return true;
 		}
 		


### PR DESCRIPTION
- Update encryption type to `2y` (since `2a` is considered to be
insecure). This is supported since PHP 5.3.7
- Update `isBlowfish()` to detect `2y` as valid blowfish encryption
type
- Improve `isDifferentBlowfish()` to detect encryption type changes as
well (next to cost factor changes)

Oh and i am not sure, what `$2f$` is, since it's not a valid type, but it will be detected as a valid mode.