### PR TITLE
Add RedisCacheSource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,3 +19,4 @@
 * `wcf\system\event\listener\PreParserAtUserListener` removed.
 * `wcf\action\AJAXProxyAction::getData()` removed.
 * Version system removed.
+* `wcf\system\cache\source\RedisCacheSource` added.

--- a/com.woltlab.wcf/option.xml
+++ b/com.woltlab.wcf/option.xml
@@ -89,6 +89,9 @@
 					<category name="general.cache.memcached">
 						<parent>general.cache</parent>
 					</category>
+					<category name="general.cache.redis">
+						<parent>general.cache</parent>
+					</category>
 				<category name="general.payment">
 					<parent>general</parent>
 					<showorder>6</showorder>
@@ -830,14 +833,20 @@ debug:mail_debug_logfile_path,!mail_use_f_param,!mail_smtp_host,!mail_smtp_port,
 				<optiontype>radioButton</optiontype>
 				<defaultvalue><![CDATA[disk]]></defaultvalue>
 				<selectoptions><![CDATA[disk:wcf.acp.option.cache_source_type.disk
-memcached:wcf.acp.option.cache_source_type.memcached]]></selectoptions>
-				<enableoptions><![CDATA[disk:!cache_source_memcached_host
-memcached:cache_source_memcached_host]]></enableoptions>
+memcached:wcf.acp.option.cache_source_type.memcached
+redis:wcf.acp.option.cache_source_type.redis]]></selectoptions>
+				<enableoptions><![CDATA[disk:!cache_source_memcached_host,!cache_source_redis_host
+memcached:cache_source_memcached_host,!cache_source_redis_host
+redis:cache_source_redis_host,!cache_source_memcached_host]]></enableoptions>
 			</option>
 			
 			<option name="cache_source_memcached_host">
 				<categoryname>general.cache.memcached</categoryname>
 				<optiontype>textarea</optiontype>
+			</option>
+			<option name="cache_source_redis_host">
+				<categoryname>general.cache.redis</categoryname>
+				<optiontype>text</optiontype>
 			</option>
 			<!-- /general.cache -->
 			

--- a/wcfsetup/install/files/lib/acp/page/CacheListPage.class.php
+++ b/wcfsetup/install/files/lib/acp/page/CacheListPage.class.php
@@ -82,6 +82,11 @@ class CacheListPage extends AbstractPage {
 				// set version
 				$this->cacheData['version'] = WCF_VERSION;
 			break;
+			
+			case 'wcf\system\cache\source\RedisCacheSource':
+				// set version
+				$this->cacheData['version'] = 'Redis '.CacheHandler::getInstance()->getCacheSource()->getRedisVersion();
+			break;
 		}
 		
 		$this->readCacheFiles('language', FileUtil::unifyDirSeparator(WCF_DIR.'language'));

--- a/wcfsetup/install/files/lib/system/cache/source/RedisCacheSource.class.php
+++ b/wcfsetup/install/files/lib/system/cache/source/RedisCacheSource.class.php
@@ -99,7 +99,28 @@ class RedisCacheSource implements ICacheSource {
 	 * @see	\wcf\system\cache\source\ICacheSource::get()
 	 */
 	public function get($cacheName, $maxLifetime) {
+		$parts = explode('-', $cacheName, 2);
 		
+		if (isset($parts[1])) {
+			$value = $this->redis->hget($this->getCacheName($parts[0]), $parts[1]);
+		}
+		else {
+			$value = $this->redis->get($this->getCacheName($cacheName));
+		}
+		
+		// check if the key exist
+		if ($value === false) {
+			return null;
+		}
+		
+		$value = @unserialize($value);
+		
+		// check if value is valid
+		if ($value === false) {
+			return null;
+		}
+		
+		return $value;
 	}
 	
 	/**

--- a/wcfsetup/install/files/lib/system/cache/source/RedisCacheSource.class.php
+++ b/wcfsetup/install/files/lib/system/cache/source/RedisCacheSource.class.php
@@ -73,7 +73,11 @@ class RedisCacheSource implements ICacheSource {
 	 * @see	\wcf\system\cache\source\ICacheSource::flushAll()
 	 */
 	public function flushAll() {
+		// set flush key to current time if it does not exist yet (this prevents falling back to 0 if the key gets deleted)
+		$this->redis->setnx('_flush', TIME_NOW);
 		
+		// atomic increment of flush count
+		$this->redis->incr('_flush');
 	}
 	
 	/**

--- a/wcfsetup/install/files/lib/system/cache/source/RedisCacheSource.class.php
+++ b/wcfsetup/install/files/lib/system/cache/source/RedisCacheSource.class.php
@@ -66,7 +66,22 @@ class RedisCacheSource implements ICacheSource {
 	 * @see	\wcf\system\cache\source\ICacheSource::flush()
 	 */
 	public function flush($cacheName, $useWildcard) {
+		$parts = explode('-', $cacheName, 2);
 		
+		// check if the key is saved in a hashset
+		if (isset($parts[1])) {
+			if ($useWildcard) {
+				// delete the complete hashset
+				$this->redis->del($this->getCacheName($parts[0]));
+			}
+			else {
+				// delete the specified key from the hashset
+				$this->redis->hdel($this->getCacheName($parts[0]), $parts[1]);
+			}
+		}
+		else {
+			$this->redis->del($this->getCacheName($cacheName));
+		}
 	}
 	
 	/**

--- a/wcfsetup/install/files/lib/system/cache/source/RedisCacheSource.class.php
+++ b/wcfsetup/install/files/lib/system/cache/source/RedisCacheSource.class.php
@@ -1,0 +1,44 @@
+<?php
+namespace wcf\system\cache\source;
+use wcf\system\exception\SystemException;
+use wcf\system\WCF;
+
+/**
+ * RedisCacheSource is an implementation of CacheSource that uses a Redis server to store cached variables.
+ * 
+ * @author	Maximilian Mader
+ * @copyright	2001-2015 WoltLab GmbH
+ * @license	GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @package	com.woltlab.wcf
+ * @subpackage	system.cache.source
+ * @category	Community Framework
+ */
+class RedisCacheSource implements ICacheSource {
+	/**
+	 * @see	\wcf\system\cache\source\ICacheSource::flush()
+	 */
+	public function flush($cacheName, $useWildcard) {
+		
+	}
+	
+	/**
+	 * @see	\wcf\system\cache\source\ICacheSource::flushAll()
+	 */
+	public function flushAll() {
+		
+	}
+	
+	/**
+	 * @see	\wcf\system\cache\source\ICacheSource::get()
+	 */
+	public function get($cacheName, $maxLifetime) {
+		
+	}
+	
+	/**
+	 * @see	\wcf\system\cache\source\ICacheSource::set()
+	 */
+	public function set($cacheName, $value, $maxLifetime) {
+		
+	}
+}

--- a/wcfsetup/install/files/lib/system/cache/source/RedisCacheSource.class.php
+++ b/wcfsetup/install/files/lib/system/cache/source/RedisCacheSource.class.php
@@ -113,4 +113,24 @@ class RedisCacheSource implements ICacheSource {
 			$this->redis->setex($cacheName, $this->getTTL($maxLifetime), serialize($value));
 		}
 	}
+	
+	/**
+	 * Returns the name for the given cache name in respect to flush count.
+	 * 
+	 * @param	string		$cacheName
+	 * @return	string
+	 */
+	protected function getCacheName($cacheName) {
+		$flush = $this->redis->get('_flush');
+		
+		// create flush counter if it does not exist
+		if ($flush === false) {
+			$this->redis->setnx('_flush', TIME_NOW);
+			$this->redis->incr('_flush');
+			
+			$flush = $this->redis->get('_flush');
+		}
+		
+		return $flush.':'.$cacheName;
+	}
 }

--- a/wcfsetup/install/files/lib/system/cache/source/RedisCacheSource.class.php
+++ b/wcfsetup/install/files/lib/system/cache/source/RedisCacheSource.class.php
@@ -184,4 +184,15 @@ class RedisCacheSource implements ICacheSource {
 		
 		return $flush.':'.$cacheName;
 	}
+	
+	/**
+	 * Returns the Redis server version
+	 * 
+	 * @return	string
+	 */
+	public function getRedisVersion() {
+		$info = $this->redis->info('server');
+		
+		return $info['redis_version'];
+	}
 }

--- a/wcfsetup/install/lang/de.xml
+++ b/wcfsetup/install/lang/de.xml
@@ -134,6 +134,7 @@
 		<item name="wcf.acp.cache.list.size"><![CDATA[Größe]]></item>
 		<item name="wcf.acp.cache.source.type.DiskCacheSource"><![CDATA[Dateisystem]]></item>
 		<item name="wcf.acp.cache.source.type.MemcachedCacheSource"><![CDATA[Memcached]]></item>
+		<item name="wcf.acp.cache.source.type.RedisCacheSource"><![CDATA[Redis]]></item>
 		<item name="wcf.acp.cache.type.data"><![CDATA[Daten]]></item>
 		<item name="wcf.acp.cache.type.language"><![CDATA[Sprachen]]></item>
 		<item name="wcf.acp.cache.type.style"><![CDATA[Stile]]></item>
@@ -692,15 +693,20 @@
 		<item name="wcf.acp.option.blacklist_user_agents.description"><![CDATA[Eine Browser-Kennung (User-Agent) pro Zeile]]></item>
 		<item name="wcf.acp.option.cache_source_memcached_host"><![CDATA[Memcached-Server]]></item>
 		<item name="wcf.acp.option.cache_source_memcached_host.description"><![CDATA[Mehrere Server können zeilenweise angegeben und die Gewichtung als dritter Parameter angegeben werden, zum Beispiel „localhost:11211:67“ oder „10.0.13.37:31337:33“.]]></item>
+		<item name="wcf.acp.option.cache_source_redis_host"><![CDATA[Redis-Server]]></item>
+		<item name="wcf.acp.option.cache_source_redis_host.description"><![CDATA[Die Adresse des Servers, zum Beispiel „localhost“ oder „10.0.13.37:1337“.]]></item>
 		<item name="wcf.acp.option.cache_source_type"><![CDATA[Cache-Methode]]></item>
 		<item name="wcf.acp.option.cache_source_type.description"><![CDATA[Beachten Sie, dass einige Methoden spezielle Anforderungen an das Server-System stellen und nicht auf jedem Server zur Verfügung stehen.]]></item>
 		<item name="wcf.acp.option.cache_source_type.disk"><![CDATA[Dateisystem (Standard)]]></item>
 		<item name="wcf.acp.option.cache_source_type.memcached"><![CDATA[Memcached]]></item>
+		<item name="wcf.acp.option.cache_source_type.redis"><![CDATA[Redis]]></item>
 		<item name="wcf.acp.option.category.general"><![CDATA[Allgemein]]></item>
 		<item name="wcf.acp.option.category.general.cache"><![CDATA[Cache]]></item>
 		<item name="wcf.acp.option.category.general.cache.general"><![CDATA[Allgemein]]></item>
 		<item name="wcf.acp.option.category.general.cache.memcached"><![CDATA[Memcached]]></item>
 		<item name="wcf.acp.option.category.general.cache.memcached.description"><![CDATA[Memcached speichert häufig benötigte Daten im Arbeitsspeicher zwischen. Dies kann die Last auf die Datenbank und das Dateisystem drastisch reduzieren. Lesen Sie mehr über dieses Thema auf der folgenden Seite: <a href="http://memcached.org/" class="externalURL">memcached.org</a>.]]></item>
+		<item name="wcf.acp.option.category.general.cache.redis"><![CDATA[Redis]]></item>
+		<item name="wcf.acp.option.category.general.cache.redis.description"><![CDATA[Redis speichert häufig benötigte Daten im Arbeitsspeicher zwischen. Dies kann die Last auf die Datenbank und das Dateisystem drastisch reduzieren. Lesen Sie mehr über dieses Thema auf der folgenden Seite: <a href="http://redis.io/" class="externalURL">redis.io</a>.]]></item>
 		<item name="wcf.acp.option.category.general.system.date"><![CDATA[Datum &amp; Zeit]]></item>
 		<item name="wcf.acp.option.category.general.system.image"><![CDATA[Grafik]]></item>
 		<item name="wcf.acp.option.category.general.system"><![CDATA[System]]></item>

--- a/wcfsetup/install/lang/en.xml
+++ b/wcfsetup/install/lang/en.xml
@@ -133,6 +133,7 @@ Examples for medium ID detection:
 		<item name="wcf.acp.cache.list.size"><![CDATA[Size]]></item>
 		<item name="wcf.acp.cache.source.type.DiskCacheSource"><![CDATA[Filesystem]]></item>
 		<item name="wcf.acp.cache.source.type.MemcachedCacheSource"><![CDATA[Memcached]]></item>
+		<item name="wcf.acp.cache.source.type.RedisCacheSource"><![CDATA[Redis]]></item>
 		<item name="wcf.acp.cache.type.data"><![CDATA[Data]]></item>
 		<item name="wcf.acp.cache.type.language"><![CDATA[Languages]]></item>
 		<item name="wcf.acp.cache.type.style"><![CDATA[Styles]]></item>
@@ -691,15 +692,20 @@ Examples for medium ID detection:
 		<item name="wcf.acp.option.blacklist_user_agents.description"><![CDATA[One user-agent per line]]></item>
 		<item name="wcf.acp.option.cache_source_memcached_host"><![CDATA[Memcached-Server]]></item>
 		<item name="wcf.acp.option.cache_source_memcached_host.description"><![CDATA[One server per line, you can additionally specify a weight factor to allow load balancing, for example “localhost:11211:67” or “10.0.13.37:31337:33”.]]></item>
+		<item name="wcf.acp.option.cache_source_redis_host"><![CDATA[Redis-Server]]></item>
+		<item name="wcf.acp.option.cache_source_redis_host.description"><![CDATA[The server’s address, for example “localhost” or “10.0.13.37:1337”.]]></item>
 		<item name="wcf.acp.option.cache_source_type"><![CDATA[Caching Method]]></item>
 		<item name="wcf.acp.option.cache_source_type.description"><![CDATA[Caching methods different from “Filesystem” require special extensions or services running on your machine.]]></item>
 		<item name="wcf.acp.option.cache_source_type.disk"><![CDATA[Filesystem (default)]]></item>
 		<item name="wcf.acp.option.cache_source_type.memcached"><![CDATA[Memcached]]></item>
+		<item name="wcf.acp.option.cache_source_type.redis"><![CDATA[Redis]]></item>
 		<item name="wcf.acp.option.category.general"><![CDATA[General]]></item>
 		<item name="wcf.acp.option.category.general.cache"><![CDATA[Cache]]></item>
 		<item name="wcf.acp.option.category.general.cache.general"><![CDATA[General]]></item>
 		<item name="wcf.acp.option.category.general.cache.memcached"><![CDATA[Memcached]]></item>
 		<item name="wcf.acp.option.category.general.cache.memcached.description"><![CDATA[Memcached uses the machine’s memory to store frequently accessed data, reducing database and filesystem load. Read more about Memcached on <a href="http://memcached.org/" class="externalURL">memcached.org</a>.]]></item>
+		<item name="wcf.acp.option.category.general.cache.redis"><![CDATA[Redis]]></item>
+		<item name="wcf.acp.option.category.general.cache.redis.description"><![CDATA[Redis uses the machine’s memory to store frequently accessed data, reducing database and filesystem load. Read more about Redis on <a href="http://redis.io/" class="externalURL">redis.io</a>.]]></item>
 		<item name="wcf.acp.option.category.general.system.date"><![CDATA[Date &amp; Time]]></item>
 		<item name="wcf.acp.option.category.general.system.image"><![CDATA[Graphics]]></item>
 		<item name="wcf.acp.option.category.general.system"><![CDATA[System]]></item>


### PR DESCRIPTION
This adds a new `RedisCacheSource` to the core.

Please have another look at the language variable `wcf.acp.option.category.general.cache.redis.description`, it is nearly the same as the `memcached` one as both `Redis`and `memcached` are quite similar in function.