### PR TITLE
Add missing parent::execute();

### DIFF
--- a/wcfsetup/install/files/lib/system/cronjob/GetUpdateInfoCronjob.class.php
+++ b/wcfsetup/install/files/lib/system/cronjob/GetUpdateInfoCronjob.class.php
@@ -18,6 +18,8 @@ class GetUpdateInfoCronjob implements ICronjob {
 	 * @see	\wcf\system\ICronjob::execute()
 	 */
 	public function execute(Cronjob $cronjob) {
+		parent::execute($cronjob);
+		
 		PackageUpdateDispatcher::getInstance()->refreshPackageDatabase();
 	}
 }

--- a/wcfsetup/install/files/lib/system/cronjob/RefreshSearchRobotsCronjob.class.php
+++ b/wcfsetup/install/files/lib/system/cronjob/RefreshSearchRobotsCronjob.class.php
@@ -21,6 +21,8 @@ class RefreshSearchRobotsCronjob implements ICronjob {
 	 * @see	\wcf\system\ICronjob::execute()
 	 */
 	public function execute(Cronjob $cronjob) {
+		parent::execute($cronjob);
+		
 		$filename = FileUtil::downloadFileFromHttp('http://assets.woltlab.com/spiderlist/typhoon/list.xml', 'spiders');
 		$xml = new XML();
 		$xml->load($filename);


### PR DESCRIPTION
Cannot attach event listeners to `GetUpdateInfoCronjob` and `RefreshSearchRobotsCronjob` because of missing `parent::execute($cronjob);`