### PR TITLE
Set dummy relevance if not sorting by relevance

### DIFF
--- a/wcfsetup/install/files/lib/system/search/mysql/MysqlSearchEngine.class.php
+++ b/wcfsetup/install/files/lib/system/search/mysql/MysqlSearchEngine.class.php
@@ -114,7 +114,7 @@ class MysqlSearchEngine extends AbstractSearchEngine {
 		$sql = "SELECT		objectID
 					".($relevanceCalc ? ','.$relevanceCalc : '')."
 			FROM		".SearchIndexManager::getTableName($objectTypeName)."
-			WHERE		".($fulltextCondition !== null ? $fulltextCondition : '')."
+			WHERE		".($fulltextCondition !== null ? $fulltextCondition : ", '0' AS relevance")."
 					".(($searchIndexCondition !== null && $searchIndexCondition->__toString()) ? ($fulltextCondition !== null ? "AND " : '').$searchIndexCondition : '')."
 			".(!empty($orderBy) && $fulltextCondition === null ? 'ORDER BY '.$orderBy : '')."
 			LIMIT		".($limit == 1000 ? SearchEngine::INNER_SEARCH_LIMIT : $limit);

--- a/wcfsetup/install/files/lib/system/search/mysql/MysqlSearchEngine.class.php
+++ b/wcfsetup/install/files/lib/system/search/mysql/MysqlSearchEngine.class.php
@@ -112,9 +112,9 @@ class MysqlSearchEngine extends AbstractSearchEngine {
 		}
 		
 		$sql = "SELECT		objectID
-					".($relevanceCalc ? ','.$relevanceCalc : '')."
+					".($relevanceCalc ? ','.$relevanceCalc : ", '0' AS relevance")."
 			FROM		".SearchIndexManager::getTableName($objectTypeName)."
-			WHERE		".($fulltextCondition !== null ? $fulltextCondition : ", '0' AS relevance")."
+			WHERE		".($fulltextCondition !== null ? $fulltextCondition : '')."
 					".(($searchIndexCondition !== null && $searchIndexCondition->__toString()) ? ($fulltextCondition !== null ? "AND " : '').$searchIndexCondition : '')."
 			".(!empty($orderBy) && $fulltextCondition === null ? 'ORDER BY '.$orderBy : '')."
 			LIMIT		".($limit == 1000 ? SearchEngine::INNER_SEARCH_LIMIT : $limit);


### PR DESCRIPTION
Using a custom outer SQL query isn't possible because you have no access to the sort order, so you cant skip select of the relevance like the default query does.
So selecting a dummy relevance for compatibility is necessary.
This makes also sens because the elasticsearch searchengine will always Select a relevance.