### PR TITLE
Added missing check after visibility in `UserProfileMenu`

### DIFF
--- a/com.woltlab.wcf/templates/user.tpl
+++ b/com.woltlab.wcf/templates/user.tpl
@@ -230,7 +230,7 @@
 		{/hascontent}
 	</div>
 	
-	<section id="profileContent" class="marginTop tabMenuContainer" data-active="{$__wcf->getUserProfileMenu()->getActiveMenuItem()->getIdentifier()}">
+	<section id="profileContent" class="marginTop tabMenuContainer" data-active="{$__wcf->getUserProfileMenu()->getActiveMenuItem($userID)->getIdentifier()}">
 		<nav class="tabMenu">
 			<ul>
 				{foreach from=$__wcf->getUserProfileMenu()->getMenuItems() item=menuItem}
@@ -244,7 +244,7 @@
 		{foreach from=$__wcf->getUserProfileMenu()->getMenuItems() item=menuItem}
 			{if $menuItem->getContentManager()->isVisible($userID)}
 				<div id="{$menuItem->getIdentifier()}" class="container tabMenuContent" data-menu-item="{$menuItem->menuItem}">
-					{if $menuItem === $__wcf->getUserProfileMenu()->getActiveMenuItem()}
+					{if $menuItem === $__wcf->getUserProfileMenu()->getActiveMenuItem($userID)}
 						{@$profileContent}
 					{/if}
 				</div>

--- a/wcfsetup/install/files/lib/page/UserPage.class.php
+++ b/wcfsetup/install/files/lib/page/UserPage.class.php
@@ -122,7 +122,7 @@ class UserPage extends AbstractPage {
 			UserProfileMenu::getInstance()->setActiveMenuItem('about');
 		}
 		
-		$activeMenuItem = UserProfileMenu::getInstance()->getActiveMenuItem();
+		$activeMenuItem = UserProfileMenu::getInstance()->getActiveMenuItem($this->user->userID);
 		$contentManager = $activeMenuItem->getContentManager();
 		$this->profileContent = $contentManager->getContent($this->user->userID);
 		$this->objectType = ObjectTypeCache::getInstance()->getObjectTypeByName('com.woltlab.wcf.user.profileEditableContent', 'com.woltlab.wcf.user.profileAbout');

--- a/wcfsetup/install/files/lib/system/menu/user/profile/UserProfileMenu.class.php
+++ b/wcfsetup/install/files/lib/system/menu/user/profile/UserProfileMenu.class.php
@@ -130,18 +130,28 @@ class UserProfileMenu extends SingletonFactory {
 	}
 	
 	/**
-	 * Returns the first menu item.
-	 * 
+	 * Returns the first visible menu item.
+	 *
+	 * @param 	integer		$userID
 	 * @return	\wcf\data\user\profile\menu\item\UserProfileMenuItem
 	 */
-	public function getActiveMenuItem() {
+	public function getActiveMenuItem($userID = 0) {
 		if (empty($this->menuItems)) {
 			return null;
 		}
 		
 		if ($this->activeMenuItem === null) {
-			reset($this->menuItems);
-			$this->activeMenuItem = current($this->menuItems);
+			if (!empty($userID)) {
+				foreach ($this->menuItems as $menuItem) {
+					if ($menuItem->getContentManager()->isVisible($userID)) {
+						$this->activeMenuItem = $menuItem;
+						break;
+					}
+				}
+			}
+			else {
+				$this->activeMenuItem = reset($this->menuItems);
+			}
 		}
 		
 		return $this->activeMenuItem;


### PR DESCRIPTION
If you move at the moment e.g. the infraction tab to the first position (e.g. with my plugin https://pluginstore.woltlab.com/file/2150-benutzerprofil-menüpunkte-sortieren/ ) and the requested user profile has no infractions than is the menu item hidden but the now active item has no content because the wrong data (in this case the data for the infractions) was loaded.

The same occurs if the requested user profile has infractions but the active user have not the rights to view infractions.

Order of the menu items:
![screenshot_2015 08 17_10h41m24s_002_](https://cloud.githubusercontent.com/assets/7986618/9301152/96d1384e-44cc-11e5-97f3-873e493d59a2.png)

Result:
![screenshot_2015 08 17_10h39m27s_001_](https://cloud.githubusercontent.com/assets/7986618/9301164/ad4eeada-44cc-11e5-9a40-747a2dea7777.png)

With my changes the correct data is always loaded.
![screenshot_2015 08 17_10h44m37s_004_](https://cloud.githubusercontent.com/assets/7986618/9301205/1c72c27e-44cd-11e5-9754-8475dbebec61.png)
