### PR TITLE
Escape delimiter in validationPattern

### DIFF
--- a/wcfsetup/install/files/lib/system/bbcode/BBCodeParser.class.php
+++ b/wcfsetup/install/files/lib/system/bbcode/BBCodeParser.class.php
@@ -235,7 +235,7 @@ class BBCodeParser extends SingletonFactory {
 	protected function isValidTagAttribute(array $tagAttributes, BBCodeAttribute $definedTagAttribute) {
 		if ($definedTagAttribute->validationPattern && isset($tagAttributes[$definedTagAttribute->attributeNo])) {
 			// validate attribute
-			if (!preg_match('~'.$definedTagAttribute->validationPattern.'~i', $tagAttributes[$definedTagAttribute->attributeNo])) {
+			if (!preg_match('~'.preg_quote($definedTagAttribute->validationPattern, '~').'~i', $tagAttributes[$definedTagAttribute->attributeNo])) {
 				return false;
 			}
 		}

--- a/wcfsetup/install/files/lib/system/option/OptionHandler.class.php
+++ b/wcfsetup/install/files/lib/system/option/OptionHandler.class.php
@@ -302,7 +302,7 @@ class OptionHandler implements IOptionHandler {
 		
 		// validate with pattern
 		if ($option->validationPattern) {
-			if (!preg_match('~'.$option->validationPattern.'~', $this->optionValues[$option->optionName])) {
+			if (!preg_match('~'.preg_quote($option->validationPattern, '~').'~', $this->optionValues[$option->optionName])) {
 				throw new UserInputException($option->optionName, 'validationFailed');
 			}
 		}


### PR DESCRIPTION
Using the tilde sign in validation patterns may cause PHP errors, because it's used as delimiter but won't be escaped.