### PR TITLE
remove superfluous interface treatment

### DIFF
--- a/wcfsetup/install/files/lib/acp/action/WorkerProxyAction.class.php
+++ b/wcfsetup/install/files/lib/acp/action/WorkerProxyAction.class.php
@@ -4,7 +4,6 @@ use wcf\action\AbstractSecureAction;
 use wcf\action\AJAXInvokeAction;
 use wcf\system\exception\SystemException;
 use wcf\system\WCF;
-use wcf\util\ClassUtil;
 use wcf\util\JSON;
 
 /**
@@ -64,7 +63,7 @@ class WorkerProxyAction extends AJAXInvokeAction {
 			throw new SystemException("class name cannot be empty.");
 		}
 		
-		if (!ClassUtil::isInstanceOf($this->className, 'wcf\system\worker\IWorker')) {
+		if (!is_subclass_of($this->className, 'wcf\system\worker\IWorker')) {
 			throw new SystemException("'".$this->className."' does not implement 'wcf\system\worker\IWorker'");
 		}
 	}

--- a/wcfsetup/install/files/lib/action/AJAXInvokeAction.class.php
+++ b/wcfsetup/install/files/lib/action/AJAXInvokeAction.class.php
@@ -10,7 +10,6 @@ use wcf\system\exception\SystemException;
 use wcf\system\exception\UserInputException;
 use wcf\system\exception\ValidateActionException;
 use wcf\system\WCF;
-use wcf\util\ClassUtil;
 use wcf\util\JSON;
 use wcf\util\StringUtil;
 
@@ -111,10 +110,10 @@ class AJAXInvokeAction extends AbstractSecureAction {
 	 */
 	protected function invoke() {
 		// check for interface and inheritance of SingletonFactory
-		if (!ClassUtil::isInstanceOf($this->className, 'wcf\system\IAJAXInvokeAction')) {
+		if (!is_subclass_of($this->className, 'wcf\system\IAJAXInvokeAction')) {
 			throw new SystemException("'".$this->className."' does not implement 'wcf\system\IAJAXInvokeAction'");
 		}
-		else if (!ClassUtil::isInstanceOf($this->className, 'wcf\system\SingletonFactory')) {
+		else if (!is_subclass_of($this->className, 'wcf\system\SingletonFactory')) {
 			throw new SystemException("'".$this->className."' does not extend 'wcf\system\SingletonFactory'");
 		}
 		

--- a/wcfsetup/install/files/lib/action/AJAXProxyAction.class.php
+++ b/wcfsetup/install/files/lib/action/AJAXProxyAction.class.php
@@ -4,7 +4,6 @@ use wcf\data\IStorableObject;
 use wcf\system\exception\SystemException;
 use wcf\system\WCF;
 use wcf\util\ArrayUtil;
-use wcf\util\ClassUtil;
 use wcf\util\StringUtil;
 
 /**
@@ -57,12 +56,12 @@ class AJAXProxyAction extends AJAXInvokeAction {
 	 * @see	\wcf\action\IAction::execute()
 	 */
 	protected function invoke() {
-		if (!ClassUtil::isInstanceOf($this->className, 'wcf\data\IDatabaseObjectAction')) {
+		if (!is_subclass_of($this->className, 'wcf\data\IDatabaseObjectAction')) {
 			throw new SystemException("'".$this->className."' does not implement 'wcf\data\IDatabaseObjectAction'");
 		}
 		
 		if (!empty($this->interfaceName)) {
-			if (!ClassUtil::isInstanceOf($this->className, $this->interfaceName)) {
+			if (!is_subclass_of($this->className, $this->interfaceName)) {
 				throw new SystemException("'".$this->className."' does not implement '".$this->interfaceName."'");
 			}
 		}

--- a/wcfsetup/install/files/lib/data/AbstractDatabaseObjectAction.class.php
+++ b/wcfsetup/install/files/lib/data/AbstractDatabaseObjectAction.class.php
@@ -7,7 +7,6 @@ use wcf\system\exception\UserInputException;
 use wcf\system\request\RequestHandler;
 use wcf\system\WCF;
 use wcf\util\ArrayUtil;
-use wcf\util\ClassUtil;
 use wcf\util\JSON;
 use wcf\util\StringUtil;
 
@@ -214,7 +213,7 @@ abstract class AbstractDatabaseObjectAction implements IDatabaseObjectAction, ID
 	 * Resets cache of database object.
 	 */
 	protected function resetCache() {
-		if (ClassUtil::isInstanceOf($this->className, 'wcf\data\IEditableCachedObject')) {
+		if (is_subclass_of($this->className, 'wcf\data\IEditableCachedObject')) {
 			call_user_func(array($this->className, 'resetCache'));
 		}
 	}

--- a/wcfsetup/install/files/lib/data/DatabaseObjectList.class.php
+++ b/wcfsetup/install/files/lib/data/DatabaseObjectList.class.php
@@ -4,7 +4,6 @@ use wcf\system\database\util\PreparedStatementConditionBuilder;
 use wcf\system\event\EventHandler;
 use wcf\system\exception\SystemException;
 use wcf\system\WCF;
-use wcf\util\ClassUtil;
 
 /**
  * Abstract class for a list of database objects.
@@ -122,13 +121,13 @@ abstract class DatabaseObjectList implements \Countable, ITraversableObject {
 		
 		if (!empty($this->decoratorClassName)) {
 			// validate decorator class name
-			if (!ClassUtil::isInstanceOf($this->decoratorClassName, 'wcf\data\DatabaseObjectDecorator')) {
+			if (!is_subclass_of($this->decoratorClassName, 'wcf\data\DatabaseObjectDecorator')) {
 				throw new SystemException("'".$this->decoratorClassName."' should extend 'wcf\data\DatabaseObjectDecorator'");
 			}
 			
 			$objectClassName = $this->objectClassName ?: $this->className;
 			$baseClassName = call_user_func(array($this->decoratorClassName, 'getBaseClass'));
-			if ($objectClassName != $baseClassName && !ClassUtil::isInstanceOf($baseClassName, $objectClassName)) {
+			if ($objectClassName != $baseClassName && !is_subclass_of($baseClassName, $objectClassName)) {
 				throw new SystemException("'".$this->decoratorClassName."' can't decorate objects of class '".$objectClassName."'");
 			}
 		}

--- a/wcfsetup/install/files/lib/data/ProcessibleDatabaseObject.class.php
+++ b/wcfsetup/install/files/lib/data/ProcessibleDatabaseObject.class.php
@@ -1,7 +1,6 @@
 <?php
 namespace wcf\data;
 use wcf\system\exception\SystemException;
-use wcf\util\ClassUtil;
 
 /**
  * Abstract class for all processible data holder classes.
@@ -37,15 +36,15 @@ class ProcessibleDatabaseObject extends DatabaseObject {
 				if (!class_exists($this->className)) {
 					throw new SystemException("Unable to find class '".$this->className."'");
 				}
-				if (!ClassUtil::isInstanceOf($this->className, static::$processorInterface)) {
+				if (!is_subclass_of($this->className, static::$processorInterface)) {
 					throw new SystemException("'".$this->className."' does not implement '".static::$processorInterface."'");
 				}
 				
-				if (ClassUtil::isInstanceOf($this->className, 'wcf\system\SingletonFactory')) {
+				if (is_subclass_of($this->className, 'wcf\system\SingletonFactory')) {
 					$this->processor = call_user_func(array($this->className, 'getInstance'));
 				}
 				else {
-					if (!ClassUtil::isInstanceOf($this->className, 'wcf\data\IDatabaseObjectProcessor')) {
+					if (!is_subclass_of($this->className, 'wcf\data\IDatabaseObjectProcessor')) {
 						throw new SystemException("'".$this->className."' does not implement 'wcf\data\IDatabaseObjectProcessor'");
 					}
 					

--- a/wcfsetup/install/files/lib/data/object/type/ObjectType.class.php
+++ b/wcfsetup/install/files/lib/data/object/type/ObjectType.class.php
@@ -4,7 +4,6 @@ use wcf\data\ProcessibleDatabaseObject;
 use wcf\data\TDatabaseObjectOptions;
 use wcf\data\TDatabaseObjectPermissions;
 use wcf\system\exception\SystemException;
-use wcf\util\ClassUtil;
 
 /**
  * Represents an object type.
@@ -78,11 +77,11 @@ class ObjectType extends ProcessibleDatabaseObject {
 				if (!class_exists($this->className)) {
 					throw new SystemException("Unable to find class '".$this->className."'");
 				}
-				if (($definitionInterface = ObjectTypeCache::getInstance()->getDefinition($this->definitionID)->interfaceName) && !ClassUtil::isInstanceOf($this->className, $definitionInterface)) {
+				if (($definitionInterface = ObjectTypeCache::getInstance()->getDefinition($this->definitionID)->interfaceName) && !is_subclass_of($this->className, $definitionInterface)) {
 					throw new SystemException("'".$this->className."' does not implement '".$definitionInterface."'");
 				}
 				
-				if (ClassUtil::isInstanceOf($this->className, 'wcf\system\SingletonFactory')) {
+				if (is_subclass_of($this->className, 'wcf\system\SingletonFactory')) {
 					$this->processor = call_user_func(array($this->className, 'getInstance'));
 				}
 				else {

--- a/wcfsetup/install/files/lib/data/sitemap/Sitemap.class.php
+++ b/wcfsetup/install/files/lib/data/sitemap/Sitemap.class.php
@@ -5,7 +5,6 @@ use wcf\data\TDatabaseObjectOptions;
 use wcf\data\TDatabaseObjectPermissions;
 use wcf\system\exception\SystemException;
 use wcf\system\WCF;
-use wcf\util\ClassUtil;
 
 /**
  * Represents a sitemap entry.
@@ -49,7 +48,7 @@ class Sitemap extends DatabaseObject {
 				throw new SystemException("Unable to find class '".$this->className."' for sitemap '".$this->sitemapName."'");
 			}
 			
-			if (!ClassUtil::isInstanceOf($this->className, 'wcf\system\sitemap\ISitemapProvider')) {
+			if (!is_subclass_of($this->className, 'wcf\system\sitemap\ISitemapProvider')) {
 				throw new SystemException("'".$this->className."' does not implement 'wcf\system\sitemap\ISitemapProvider'");
 			}
 			

--- a/wcfsetup/install/files/lib/data/user/option/ViewableUserOption.class.php
+++ b/wcfsetup/install/files/lib/data/user/option/ViewableUserOption.class.php
@@ -4,7 +4,6 @@ use wcf\data\user\User;
 use wcf\data\DatabaseObjectDecorator;
 use wcf\system\cache\builder\UserOptionCacheBuilder;
 use wcf\system\exception\SystemException;
-use wcf\util\ClassUtil;
 use wcf\util\StringUtil;
 
 /**
@@ -73,7 +72,7 @@ class ViewableUserOption extends DatabaseObjectDecorator {
 			}
 			
 			// validate interface
-			if (!ClassUtil::isInstanceOf($this->outputClass, 'wcf\system\option\user\IUserOptionOutput')) {
+			if (!is_subclass_of($this->outputClass, 'wcf\system\option\user\IUserOptionOutput')) {
 				throw new SystemException("'".$this->outputClass."' does not implement 'wcf\system\option\user\IUserOptionOutput'");
 			}
 			

--- a/wcfsetup/install/files/lib/data/user/profile/menu/item/UserProfileMenuItem.class.php
+++ b/wcfsetup/install/files/lib/data/user/profile/menu/item/UserProfileMenuItem.class.php
@@ -4,7 +4,6 @@ use wcf\data\DatabaseObject;
 use wcf\data\TDatabaseObjectOptions;
 use wcf\data\TDatabaseObjectPermissions;
 use wcf\system\exception\SystemException;
-use wcf\util\ClassUtil;
 
 /**
  * Represents an user profile menu item.
@@ -56,11 +55,11 @@ class UserProfileMenuItem extends DatabaseObject {
 				throw new SystemException("Unable to find class '".$this->className."'");
 			}
 			
-			if (!ClassUtil::isInstanceOf($this->className, 'wcf\system\SingletonFactory')) {
+			if (!is_subclass_of($this->className, 'wcf\system\SingletonFactory')) {
 				throw new SystemException("'".$this->className."' does not extend 'wcf\system\SingletonFactory'");
 			}
 			
-			if (!ClassUtil::isInstanceOf($this->className, 'wcf\system\menu\user\profile\content\IUserProfileMenuContent')) {
+			if (!is_subclass_of($this->className, 'wcf\system\menu\user\profile\content\IUserProfileMenuContent')) {
 				throw new SystemException("'".$this->className."' does not implement 'wcf\system\menu\user\profile\content\IUserProfileMenuContent'");
 			}
 			

--- a/wcfsetup/install/files/lib/page/MultipleLinkPage.class.php
+++ b/wcfsetup/install/files/lib/page/MultipleLinkPage.class.php
@@ -3,7 +3,6 @@ namespace wcf\page;
 use wcf\system\event\EventHandler;
 use wcf\system\exception\SystemException;
 use wcf\system\WCF;
-use wcf\util\ClassUtil;
 
 /**
  * Provides default implementations for a multiple link page.
@@ -131,7 +130,7 @@ abstract class MultipleLinkPage extends AbstractPage {
 			throw new SystemException('DatabaseObjectList class name not specified.');
 		}
 		
-		if (!ClassUtil::isInstanceOf($this->objectListClassName, 'wcf\data\DatabaseObjectList')) {
+		if (!is_subclass_of($this->objectListClassName, 'wcf\data\DatabaseObjectList')) {
 			throw new SystemException("'".$this->objectListClassName."' does not extend 'wcf\data\DatabaseObjectList'");
 		}
 		

--- a/wcfsetup/install/files/lib/system/WCF.class.php
+++ b/wcfsetup/install/files/lib/system/WCF.class.php
@@ -23,7 +23,6 @@ use wcf\system\session\SessionHandler;
 use wcf\system\style\StyleHandler;
 use wcf\system\template\TemplateEngine;
 use wcf\system\user\storage\UserStorageHandler;
-use wcf\util\ClassUtil;
 use wcf\util\FileUtil;
 use wcf\util\StringUtil;
 use wcf\util\UserUtil;
@@ -476,7 +475,7 @@ class WCF {
 		self::$autoloadDirectories[$abbreviation] = $packageDir . 'lib/';
 		
 		$className = $abbreviation.'\system\\'.strtoupper($abbreviation).'Core';
-		if (class_exists($className) && ClassUtil::isInstanceOf($className, 'wcf\system\application\IApplication')) {
+		if (class_exists($className) && is_subclass_of($className, 'wcf\system\application\IApplication')) {
 			// include config file
 			$configPath = $packageDir . PackageInstallationDispatcher::CONFIG_FILE;
 			if (file_exists($configPath)) {
@@ -649,7 +648,7 @@ class WCF {
 		}
 		
 		if (class_exists($objectName)) {
-			if (!(ClassUtil::isInstanceOf($objectName, 'wcf\system\SingletonFactory'))) {
+			if (!(is_subclass_of($objectName, 'wcf\system\SingletonFactory'))) {
 				throw new SystemException("class '".$objectName."' does not implement the interface 'SingletonFactory'");
 			}
 			

--- a/wcfsetup/install/files/lib/system/cache/builder/UserGroupPermissionCacheBuilder.class.php
+++ b/wcfsetup/install/files/lib/system/cache/builder/UserGroupPermissionCacheBuilder.class.php
@@ -3,7 +3,6 @@ namespace wcf\system\cache\builder;
 use wcf\system\database\util\PreparedStatementConditionBuilder;
 use wcf\system\exception\SystemException;
 use wcf\system\WCF;
-use wcf\util\ClassUtil;
 use wcf\util\StringUtil;
 
 /**
@@ -96,7 +95,7 @@ class UserGroupPermissionCacheBuilder extends AbstractCacheBuilder {
 			if (!class_exists($className)) {
 				throw new SystemException("unable to find class '".$className."'");
 			}
-			if (!ClassUtil::isInstanceOf($className, 'wcf\system\option\user\group\IUserGroupOptionType')) {
+			if (!is_subclass_of($className, 'wcf\system\option\user\group\IUserGroupOptionType')) {
 				throw new SystemException("'".$className."' does not implement 'wcf\system\option\user\group\IUserGroupOptionType'");
 			}
 			

--- a/wcfsetup/install/files/lib/system/cli/command/WorkerCLICommand.class.php
+++ b/wcfsetup/install/files/lib/system/cli/command/WorkerCLICommand.class.php
@@ -3,7 +3,6 @@ namespace wcf\system\cli\command;
 use phpline\internal\Log;
 use wcf\system\CLIWCF;
 use wcf\system\Regex;
-use wcf\util\ClassUtil;
 use wcf\util\CLIUtil;
 use wcf\util\DirectoryUtil;
 use wcf\util\StringUtil;
@@ -78,7 +77,7 @@ class WorkerCLICommand implements IArgumentedCLICommand {
 			if (!$reflection->isInstantiable()) {
 				$invalid = true;
 			}
-			else if (!ClassUtil::isInstanceOf($class, 'wcf\system\worker\IWorker')) {
+			else if (!is_subclass_of($class, 'wcf\system\worker\IWorker')) {
 				$invalid = true;
 			}
 		}
@@ -155,7 +154,7 @@ class WorkerCLICommand implements IArgumentedCLICommand {
 			$reflection = new \ReflectionClass($class);
 			if (!$reflection->isInstantiable()) continue;
 			
-			if (!ClassUtil::isInstanceOf($class, 'wcf\system\worker\IWorker')) {
+			if (!is_subclass_of($class, 'wcf\system\worker\IWorker')) {
 				Log::info('Invalid worker file: ', $worker);
 				continue;
 			}

--- a/wcfsetup/install/files/lib/system/clipboard/ClipboardHandler.class.php
+++ b/wcfsetup/install/files/lib/system/clipboard/ClipboardHandler.class.php
@@ -7,7 +7,6 @@ use wcf\system\database\util\PreparedStatementConditionBuilder;
 use wcf\system\exception\SystemException;
 use wcf\system\SingletonFactory;
 use wcf\system\WCF;
-use wcf\util\ClassUtil;
 
 /**
  * Handles clipboard-related actions.
@@ -320,7 +319,7 @@ class ClipboardHandler extends SingletonFactory {
 			$actionClassName = $actionObject->actionClassName;
 			if (!isset($actions[$actionClassName])) {
 				// validate class
-				if (!ClassUtil::isInstanceOf($actionClassName, 'wcf\system\clipboard\action\IClipboardAction')) {
+				if (!is_subclass_of($actionClassName, 'wcf\system\clipboard\action\IClipboardAction')) {
 					throw new SystemException("'".$actionClassName."' does not implement 'wcf\system\clipboard\action\IClipboardAction'");
 				}
 				

--- a/wcfsetup/install/files/lib/system/cronjob/CronjobScheduler.class.php
+++ b/wcfsetup/install/files/lib/system/cronjob/CronjobScheduler.class.php
@@ -7,7 +7,6 @@ use wcf\system\cache\builder\CronjobCacheBuilder;
 use wcf\system\exception\SystemException;
 use wcf\system\SingletonFactory;
 use wcf\system\WCF;
-use wcf\util\ClassUtil;
 
 /**
  * Provides functions to execute cronjobs.
@@ -173,7 +172,7 @@ class CronjobScheduler extends SingletonFactory {
 		}
 		
 		// verify class signature
-		if (!(ClassUtil::isInstanceOf($className, 'wcf\system\cronjob\ICronjob'))) {
+		if (!(is_subclass_of($className, 'wcf\system\cronjob\ICronjob'))) {
 			throw new SystemException("'".$className."' does not implement 'wcf\system\cronjob\ICronjob'");
 		}
 		

--- a/wcfsetup/install/files/lib/system/dashboard/DashboardHandler.class.php
+++ b/wcfsetup/install/files/lib/system/dashboard/DashboardHandler.class.php
@@ -8,7 +8,6 @@ use wcf\system\database\util\PreparedStatementConditionBuilder;
 use wcf\system\exception\SystemException;
 use wcf\system\SingletonFactory;
 use wcf\system\WCF;
-use wcf\util\ClassUtil;
 
 /**
  * Handles dashboard boxes.
@@ -67,7 +66,7 @@ class DashboardHandler extends SingletonFactory {
 		);
 		foreach ($boxIDs as $boxID) {
 			$className = $this->boxCache[$boxID]->className;
-			if (!ClassUtil::isInstanceOf($className, 'wcf\system\dashboard\box\IDashboardBox')) {
+			if (!is_subclass_of($className, 'wcf\system\dashboard\box\IDashboardBox')) {
 				throw new SystemException("'".$className."' does not implement 'wcf\system\dashboard\box\IDashboardBox'");
 			}
 			

--- a/wcfsetup/install/files/lib/system/event/EventHandler.class.php
+++ b/wcfsetup/install/files/lib/system/event/EventHandler.class.php
@@ -5,7 +5,6 @@ use wcf\system\event\listener\IParameterizedEventListener;
 use wcf\system\event\IEventListener as ILegacyEventListener;
 use wcf\system\exception\SystemException;
 use wcf\system\SingletonFactory;
-use wcf\util\ClassUtil;
 
 /**
  * EventHandler executes all registered actions for a specific event.
@@ -111,9 +110,9 @@ class EventHandler extends SingletonFactory {
 									if (!class_exists($eventListener->listenerClassName)) {
 										throw new SystemException("Unable to find class '".$eventListener->listenerClassName."'");
 									}
-									if (!ClassUtil::isInstanceOf($eventListener->listenerClassName, 'wcf\system\event\listener\IParameterizedEventListener')) {
+									if (!is_subclass_of($eventListener->listenerClassName, 'wcf\system\event\listener\IParameterizedEventListener')) {
 										// legacy event listeners
-										if (!ClassUtil::isInstanceOf($eventListener->listenerClassName, 'wcf\system\event\IEventListener')) {
+										if (!is_subclass_of($eventListener->listenerClassName, 'wcf\system\event\IEventListener')) {
 											throw new SystemException("'".$eventListener->listenerClassName."' does not implement 'wcf\system\event\listener\IParameterizedEventListener'");
 										}
 									}
@@ -196,9 +195,9 @@ class EventHandler extends SingletonFactory {
 						if (!class_exists($eventListener->listenerClassName)) {
 							throw new SystemException("Unable to find class '".$eventListener->listenerClassName."'");
 						}
-						if (!ClassUtil::isInstanceOf($eventListener->listenerClassName, 'wcf\system\event\listener\IParameterizedEventListener')) {
+						if (!is_subclass_of($eventListener->listenerClassName, 'wcf\system\event\listener\IParameterizedEventListener')) {
 							// legacy event listeners
-							if (!ClassUtil::isInstanceOf($eventListener->listenerClassName, 'wcf\system\event\IEventListener')) {
+							if (!is_subclass_of($eventListener->listenerClassName, 'wcf\system\event\IEventListener')) {
 								throw new SystemException("'".$eventListener->listenerClassName."' does not implement 'wcf\system\event\listener\IParameterizedEventListener'");
 							}
 						}

--- a/wcfsetup/install/files/lib/system/message/QuickReplyManager.class.php
+++ b/wcfsetup/install/files/lib/system/message/QuickReplyManager.class.php
@@ -11,7 +11,6 @@ use wcf\system\exception\UserInputException;
 use wcf\system\SingletonFactory;
 use wcf\system\WCF;
 use wcf\util\ArrayUtil;
-use wcf\util\ClassUtil;
 use wcf\util\MessageUtil;
 use wcf\util\StringUtil;
 
@@ -134,7 +133,7 @@ class QuickReplyManager extends SingletonFactory {
 		
 		$this->container = new $containerClassName($parameters['objectID']);
 		if (!empty($containerDecoratorClassName)) {
-			if (!ClassUtil::isInstanceOf($containerDecoratorClassName, 'wcf\data\DatabaseObjectDecorator')) {
+			if (!is_subclass_of($containerDecoratorClassName, 'wcf\data\DatabaseObjectDecorator')) {
 				throw new SystemException("'".$containerDecoratorClassName."' does not extend 'wcf\data\DatabaseObjectDecorator'");
 			}
 			
@@ -233,7 +232,7 @@ class QuickReplyManager extends SingletonFactory {
 			}
 			
 			// update visit time (messages shouldn't occur as new upon next visit)
-			if (ClassUtil::isInstanceOf($containerActionClassName, 'wcf\data\IVisitableObjectAction')) {
+			if (is_subclass_of($containerActionClassName, 'wcf\data\IVisitableObjectAction')) {
 				$containerAction = new $containerActionClassName(array(($this->container instanceof DatabaseObjectDecorator ? $this->container->getDecoratedObject() : $this->container)), 'markAsRead');
 				$containerAction->executeAction();
 			}

--- a/wcfsetup/install/files/lib/system/moderation/queue/AbstractModerationQueueHandler.class.php
+++ b/wcfsetup/install/files/lib/system/moderation/queue/AbstractModerationQueueHandler.class.php
@@ -7,7 +7,6 @@ use wcf\data\user\UserProfile;
 use wcf\system\database\util\PreparedStatementConditionBuilder;
 use wcf\system\exception\SystemException;
 use wcf\system\WCF;
-use wcf\util\ClassUtil;
 
 /**
  * Default implementation for moderation queue handlers.
@@ -48,7 +47,7 @@ abstract class AbstractModerationQueueHandler implements IModerationQueueHandler
 	 * @see	\wcf\system\moderation\queue\IModerationQueueHandler::identifyOrphans()
 	 */
 	public function identifyOrphans(array $queues) {
-		if (empty($this->className) || !class_exists($this->className) || !ClassUtil::isInstanceOf($this->className, 'wcf\data\DatabaseObject')) {
+		if (empty($this->className) || !class_exists($this->className) || !is_subclass_of($this->className, 'wcf\data\DatabaseObject')) {
 			throw new SystemException("DatabaseObject class name '" . $this->className . "' is missing or invalid");
 		}
 		

--- a/wcfsetup/install/files/lib/system/option/OptionHandler.class.php
+++ b/wcfsetup/install/files/lib/system/option/OptionHandler.class.php
@@ -7,7 +7,6 @@ use wcf\system\event\EventHandler;
 use wcf\system\exception\SystemException;
 use wcf\system\exception\UserInputException;
 use wcf\system\language\I18nHandler;
-use wcf\util\ClassUtil;
 use wcf\util\StringUtil;
 
 /**
@@ -376,7 +375,7 @@ class OptionHandler implements IOptionHandler {
 			return null;
 		}
 		
-		if (!ClassUtil::isInstanceOf($className, 'wcf\system\option\IOptionType')) {
+		if (!is_subclass_of($className, 'wcf\system\option\IOptionType')) {
 			throw new SystemException("'".$className."' does not implement 'wcf\system\option\IOptionType'");
 		}
 		

--- a/wcfsetup/install/files/lib/system/option/user/group/UserGroupOptionHandler.class.php
+++ b/wcfsetup/install/files/lib/system/option/user/group/UserGroupOptionHandler.class.php
@@ -5,7 +5,6 @@ use wcf\data\user\group\UserGroup;
 use wcf\system\exception\SystemException;
 use wcf\system\exception\UserInputException;
 use wcf\system\option\OptionHandler;
-use wcf\util\ClassUtil;
 use wcf\system\WCF;
 
 /**
@@ -84,7 +83,7 @@ class UserGroupOptionHandler extends OptionHandler {
 		if (!class_exists($className)) {
 			return null;
 		}
-		if (!ClassUtil::isInstanceOf($className, 'wcf\system\option\user\group\IUserGroupOptionType')) {
+		if (!is_subclass_of($className, 'wcf\system\option\user\group\IUserGroupOptionType')) {
 			throw new SystemException("'".$className."' does not implement 'wcf\system\option\user\group\IUserGroupOptionType'");
 		}
 		

--- a/wcfsetup/install/files/lib/system/poll/PollManager.class.php
+++ b/wcfsetup/install/files/lib/system/poll/PollManager.class.php
@@ -10,7 +10,6 @@ use wcf\system\exception\SystemException;
 use wcf\system\exception\UserInputException;
 use wcf\system\SingletonFactory;
 use wcf\system\WCF;
-use wcf\util\ClassUtil;
 use wcf\util\StringUtil;
 
 /**
@@ -418,10 +417,10 @@ class PollManager extends SingletonFactory {
 		
 		// validates against object type's class
 		$className = $this->cache[$objectType]->className;
-		if (!ClassUtil::isInstanceOf($className, 'wcf\system\poll\IPollHandler')) {
+		if (!is_subclass_of($className, 'wcf\system\poll\IPollHandler')) {
 			throw new SystemException("'".$className."' does not implement 'wcf\system\poll\IPollHandler'");
 		}
-		else if (!ClassUtil::isInstanceOf($className, 'wcf\system\SingletonFactory')) {
+		else if (!is_subclass_of($className, 'wcf\system\SingletonFactory')) {
 			throw new SystemException("'".$className."' does not extend 'wcf\system\SingletonFactory'");
 		}
 		

--- a/wcfsetup/install/files/lib/system/search/acp/ACPSearchHandler.class.php
+++ b/wcfsetup/install/files/lib/system/search/acp/ACPSearchHandler.class.php
@@ -4,7 +4,6 @@ use wcf\system\application\ApplicationHandler;
 use wcf\system\cache\builder\ACPSearchProviderCacheBuilder;
 use wcf\system\exception\SystemException;
 use wcf\system\SingletonFactory;
-use wcf\util\ClassUtil;
 
 /**
  * Handles ACP Search.
@@ -50,7 +49,7 @@ class ACPSearchHandler extends SingletonFactory {
 		
 		foreach ($this->cache as $acpSearchProvider) {
 			$className = $acpSearchProvider->className;
-			if (!ClassUtil::isInstanceOf($className, 'wcf\system\search\acp\IACPSearchResultProvider')) {
+			if (!is_subclass_of($className, 'wcf\system\search\acp\IACPSearchResultProvider')) {
 				throw new SystemException("'".$className."' does not implement 'wcf\system\search\acp\IACPSearchResultProvider'");
 			}
 			

--- a/wcfsetup/install/files/lib/system/search/acp/AbstractCategorizedACPSearchResultProvider.class.php
+++ b/wcfsetup/install/files/lib/system/search/acp/AbstractCategorizedACPSearchResultProvider.class.php
@@ -1,7 +1,6 @@
 <?php
 namespace wcf\system\search\acp;
 use wcf\system\exception\SystemException;
-use wcf\util\ClassUtil;
 
 /**
  * Abstract implementation of a ACP search result provider with nested categories.
@@ -88,7 +87,7 @@ abstract class AbstractCategorizedACPSearchResultProvider extends AbstractACPSea
 	 */
 	protected function loadCategories() {
 		// validate list class name
-		if (empty($this->listClassName) || !ClassUtil::isInstanceOf($this->listClassName, 'wcf\data\DatabaseObjectList')) {
+		if (empty($this->listClassName) || !is_subclass_of($this->listClassName, 'wcf\data\DatabaseObjectList')) {
 			throw new SystemException("Given class '".$this->listClassName."' is empty or invalid");
 		}
 		

--- a/wcfsetup/install/files/lib/system/user/authentication/UserAuthenticationFactory.class.php
+++ b/wcfsetup/install/files/lib/system/user/authentication/UserAuthenticationFactory.class.php
@@ -3,7 +3,6 @@ namespace wcf\system\user\authentication;
 use wcf\system\event\EventHandler;
 use wcf\system\exception\SystemException;
 use wcf\system\SingletonFactory;
-use wcf\util\ClassUtil;
 
 /**
  * Gets the user authentication instance.
@@ -35,7 +34,7 @@ class UserAuthenticationFactory extends SingletonFactory {
 		// call loadInstance event
 		EventHandler::getInstance()->fireAction($this, 'init');
 		
-		if (!ClassUtil::isInstanceOf($this->className, 'wcf\system\user\authentication\IUserAuthentication')) {
+		if (!is_subclass_of($this->className, 'wcf\system\user\authentication\IUserAuthentication')) {
 			throw new SystemException("'" . $this->className . "' does not implement 'wcf\system\user\authentication\IUserAuthentication'");
 		}
 		

--- a/wcfsetup/install/files/lib/system/worker/AbstractRebuildDataWorker.class.php
+++ b/wcfsetup/install/files/lib/system/worker/AbstractRebuildDataWorker.class.php
@@ -5,7 +5,6 @@ use wcf\system\exception\SystemException;
 use wcf\system\request\LinkHandler;
 use wcf\system\search\SearchIndexManager;
 use wcf\system\WCF;
-use wcf\util\ClassUtil;
 
 /**
  * Abstract implementation of rebuild data worker.
@@ -92,7 +91,7 @@ abstract class AbstractRebuildDataWorker extends AbstractWorker implements IRebu
 			throw new SystemException('DatabaseObjectList class name not specified.');
 		}
 		
-		if (!ClassUtil::isInstanceOf($this->objectListClassName, 'wcf\data\DatabaseObjectList')) {
+		if (!is_subclass_of($this->objectListClassName, 'wcf\data\DatabaseObjectList')) {
 			throw new SystemException("'".$this->objectListClassName."' does not extend 'wcf\data\DatabaseObjectList'");
 		}
 		

--- a/wcfsetup/install/files/lib/util/ClassUtil.class.php
+++ b/wcfsetup/install/files/lib/util/ClassUtil.class.php
@@ -47,14 +47,7 @@ final class ClassUtil {
 			throw new SystemException("Cannot determine class inheritance, reference class '".$targetClass."' does not exist");
 		}
 		
-		// check for simple inheritance
-		if (class_exists($targetClass)) {
-			return is_subclass_of($className, $targetClass);
-		}
-		
-		// check for interface
-		$reflectionClass = new \ReflectionClass($className);
-		return $reflectionClass->implementsInterface($targetClass);
+		return is_subclass_of($className, $targetClass);
 	}
 	
 	private function __construct() { }

--- a/wcfsetup/install/files/lib/util/ClassUtil.class.php
+++ b/wcfsetup/install/files/lib/util/ClassUtil.class.php
@@ -34,6 +34,8 @@ final class ClassUtil {
 	 * @param	string		$className
 	 * @param	string		$targetClass
 	 * @return	boolean
+	 * 
+	 * @deprecated	use is_subclass_of() instead
 	 */
 	public static function isInstanceOf($className, $targetClass) {
 		// validate parameters


### PR DESCRIPTION
Since PHP 5.3.9, `is_subclass_of` supports checks against interfaces as
well. Therefore, the special interface treatment with `ReflectionClass`
is obsolete.