### PR TITLE
Parse report message with 'SimpleMessageParser'

### DIFF
--- a/wcfsetup/install/files/lib/data/moderation/queue/ViewableModerationQueue.class.php
+++ b/wcfsetup/install/files/lib/data/moderation/queue/ViewableModerationQueue.class.php
@@ -154,7 +154,7 @@ class ViewableModerationQueue extends DatabaseObjectDecorator {
 	 * @return	string
 	 */
 	public function getFormattedMessage() {
-		return SimpleMessageParser::getInstance()->parse($this->message);
+		return SimpleMessageParser::getInstance()->parse($this->message, true, false);
 	}
 	
 	/**

--- a/wcfsetup/install/files/lib/data/moderation/queue/ViewableModerationQueue.class.php
+++ b/wcfsetup/install/files/lib/data/moderation/queue/ViewableModerationQueue.class.php
@@ -6,6 +6,7 @@ use wcf\data\user\UserProfile;
 use wcf\data\user\UserProfileCache;
 use wcf\data\DatabaseObjectDecorator;
 use wcf\data\IUserContent;
+use wcf\system\bbcode\SimpleMessageParser;
 use wcf\system\moderation\queue\ModerationQueueManager;
 use wcf\system\visitTracker\VisitTracker;
 
@@ -153,7 +154,7 @@ class ViewableModerationQueue extends DatabaseObjectDecorator {
 	 * @return	string
 	 */
 	public function getFormattedMessage() {
-		return nl2br(htmlspecialchars($this->message));
+		return SimpleMessageParser::getInstance()->parse($this->message);
 	}
 	
 	/**


### PR DESCRIPTION
This change makes it possible to click on links that are submitted with the report message.

This is useful if the user reports a double thread and send the link to the other thread within the report message.