### PR TITLE
Fix email comparison on user edit

### DIFF
--- a/wcfsetup/install/files/lib/acp/form/UserEditForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/UserEditForm.class.php
@@ -386,6 +386,11 @@ class UserEditForm extends UserAddForm {
 	 * @see	\wcf\acp\form\UserAddForm::validateEmail()
 	 */
 	protected function validateEmail($email, $confirmEmail) {
+		// check confirm input
+		if (mb_strtolower($email) != mb_strtolower($confirmEmail)) {
+			throw new UserInputException('confirmEmail', 'notEqual');
+		}
+		
 		if (mb_strtolower($this->user->email) != mb_strtolower($email)) {
 			parent::validateEmail($email, $this->confirmEmail);
 		}


### PR DESCRIPTION
See https://community.woltlab.com/thread/243853-acp-email-confirmation-field-doesn-t-work-correctly