### PR TITLE
Fix getLink()-Methode in UserProfileCommentUserNotificationEvent

### DIFF
--- a/wcfsetup/install/files/lib/system/user/notification/event/UserProfileCommentUserNotificationEvent.class.php
+++ b/wcfsetup/install/files/lib/system/user/notification/event/UserProfileCommentUserNotificationEvent.class.php
@@ -97,7 +97,7 @@ class UserProfileCommentUserNotificationEvent extends AbstractUserNotificationEv
 	 * @see	\wcf\system\user\notification\event\IUserNotificationEvent::getLink()
 	 */
 	public function getLink() {
-		return LinkHandler::getInstance()->getLink('User', array('object' => WCF::getUser()), '#wall');
+		return LinkHandler::getInstance()->getLink('User', array('id' => $this->userNotificationObject->objectID), '#wall');
 	}
 	
 	/**


### PR DESCRIPTION
The getLink()-Methode returns now the correct link. I don't want to load a user object for the link, so I use only the userID.