### PR TITLE
Implement DROP PRIMARY KEY statement

### DIFF
--- a/wcfsetup/install/files/lib/system/database/editor/DatabaseEditor.class.php
+++ b/wcfsetup/install/files/lib/system/database/editor/DatabaseEditor.class.php
@@ -111,14 +111,21 @@ abstract class DatabaseEditor {
 	 * @param	array		$indexData
 	 */
 	abstract public function addForeignKey($tableName, $indexName, $indexData);
-	
+
 	/**
 	 * Drops an existing index.
-	 * 
+	 *
 	 * @param	string		$tableName
 	 * @param	string		$indexName
 	 */
 	abstract public function dropIndex($tableName, $indexName);
+
+	/**
+	 * Drops existing primary keys.
+	 *
+	 * @param	string		$tableName
+	 */
+	abstract public function dropPrimaryKey($tableName);
 	
 	/**
 	 * Drops an existing foreign key.

--- a/wcfsetup/install/files/lib/system/database/editor/MySQLDatabaseEditor.class.php
+++ b/wcfsetup/install/files/lib/system/database/editor/MySQLDatabaseEditor.class.php
@@ -181,6 +181,15 @@ class MySQLDatabaseEditor extends DatabaseEditor {
 	}
 	
 	/**
+	 * @see	\wcf\system\database\editor\DatabaseEditor::dropPrimaryKey()
+	 */
+	public function dropPrimaryKey($tableName) {
+		$sql = "ALTER TABLE ".$tableName." DROP PRIMARY KEY";
+		$statement = $this->dbObj->prepareStatement($sql);
+		$statement->execute();
+	}
+	
+	/**
 	 * @see	\wcf\system\database\editor\DatabaseEditor::dropForeignKey()
 	 */
 	public function dropForeignKey($tableName, $indexName) {

--- a/wcfsetup/install/files/lib/system/database/editor/PostgreSQLDatabaseEditor.class.php
+++ b/wcfsetup/install/files/lib/system/database/editor/PostgreSQLDatabaseEditor.class.php
@@ -318,6 +318,15 @@ class PostgreSQLDatabaseEditor extends DatabaseEditor {
 	}
 	
 	/**
+	 * @see	\wcf\system\database\editor\DatabaseEditor::dropPrimaryKey()
+	 */
+	public function dropPrimaryKey($tableName) {
+		$sql = "ALTER TABLE ".$tableName." DROP CONSTRAINT ".$indexName." CASCADE";
+		$statement = $this->dbObj->prepareStatement($sql);
+		$statement->execute();
+	}
+	
+	/**
 	 * @see	\wcf\system\database\editor\DatabaseEditor::dropForeignKey()
 	 */
 	public function dropForeignKey($tableName, $indexName) {

--- a/wcfsetup/install/files/lib/system/database/util/SQLParser.class.php
+++ b/wcfsetup/install/files/lib/system/database/util/SQLParser.class.php
@@ -163,6 +163,10 @@ class SQLParser {
 				else if (preg_match('~^ALTER\s+TABLE\s+(\w+)\s+DROP\s+(?:INDEX|KEY)\s+(\w+)~is', $query, $match)) {
 					$this->executeDropIndexStatement($match[1], $match[2]);
 				}
+				// drop primary key
+				else if (preg_match('~^ALTER\s+TABLE\s+(\w+)\s+DROP\s+PRIMARY\s+KEY~is', $query, $match)) {
+					$this->executeDropPrimaryKeyStatement($match[1]);
+				}
 				// drop foreign key
 				else if (preg_match('~^ALTER\s+TABLE\s+(\w+)\s+DROP\s+FOREIGN KEY\s+(\w+)~is', $query, $match)) {
 					$this->executeDropForeignKeyStatement($match[1], self::getGenericIndexName($match[1], $match[2], 'fk'));
@@ -286,6 +290,16 @@ class SQLParser {
 	 */
 	protected function executeDropIndexStatement($tableName, $indexName) {
 		WCF::getDB()->getEditor()->dropIndex($tableName, $indexName);
+	}
+	
+	/**
+	 * Executes a 'DROP PRIMARY KEY' statement.
+	 * 
+	 * @param	string		$tableName
+	 * @param	string		$primaryKeyName
+	 */
+	protected function executeDropPrimaryKeyStatement($tableName) {
+		WCF::getDB()->getEditor()->dropPrimaryKey($tableName);
 	}
 	
 	/**

--- a/wcfsetup/install/files/lib/system/package/PackageInstallationSQLParser.class.php
+++ b/wcfsetup/install/files/lib/system/package/PackageInstallationSQLParser.class.php
@@ -395,8 +395,8 @@ class PackageInstallationSQLParser extends SQLParser {
 			}
 		}
 		else {
-			// log
-			$this->indexLog[] = array('tableName' => $tableName, 'indexName' => '', 'packageID' => $this->package->packageID, 'action' => 'delete');
+// 			// log
+// 			$this->indexLog[] = array('tableName' => $tableName, 'indexName' => '', 'packageID' => $this->package->packageID, 'action' => 'delete');
 			
 			// execute
 			parent::executeDropPrimaryKeyStatement($tableName);

--- a/wcfsetup/install/files/lib/system/package/PackageInstallationSQLParser.class.php
+++ b/wcfsetup/install/files/lib/system/package/PackageInstallationSQLParser.class.php
@@ -384,6 +384,26 @@ class PackageInstallationSQLParser extends SQLParser {
 	}
 	
 	/**
+	 * @see	\wcf\system\database\util\SQLParser::executeDropPrimaryKeyStatement()
+	 */
+	protected function executeDropPrimaryKeyStatement($tableName) {
+		if ($this->test) {
+			if ($ownerPackageID = $this->getIndexOwnerID($tableName, '')) {
+				if ($ownerPackageID != $this->package->packageID) {
+					throw new SystemException("Cannot drop primary key from '".$tableName."'. A package can only drop own indices.");
+				}
+			}
+		}
+		else {
+			// log
+			$this->indexLog[] = array('tableName' => $tableName, 'indexName' => '', 'packageID' => $this->package->packageID, 'action' => 'delete');
+			
+			// execute
+			parent::executeDropPrimaryKeyStatement($tableName);
+		}
+	}
+	
+	/**
 	 * @see	\wcf\system\database\util\SQLParser::executeDropForeignKeyStatement()
 	 */
 	protected function executeDropForeignKeyStatement($tableName, $indexName) {


### PR DESCRIPTION
implemented the possibility to drop primary keys of a table with "ALTER
TABLE table_name DROP PRIMARY KEY;"

not sure how it works with PostgreSQL, someone might have a look before
merging please