### PR TITLE
Improve display of Facebook shares

### DIFF
--- a/wcfsetup/install/files/js/WCF.Message.js
+++ b/wcfsetup/install/files/js/WCF.Message.js
@@ -3421,9 +3421,9 @@ WCF.Message.Share.Page = Class.extend({
 	 * Fetches number of Facebook likes.
 	 */
 	_fetchFacebook: function() {
-		this._fetchCount('https://graph.facebook.com/?id={pageURL}', $.proxy(function(data) {
-			if (data.shares) {
-				this._provider.facebook.link.children('span.badge').show().text(data.shares);
+		this._fetchCount('https://graph.facebook.com/fql?q=SELECT%20share_count%20FROM%20link_stat%20WHERE%20url=%27{pageURL}%27', $.proxy(function(data) {
+			if (data.data.share_count) {
+				this._provider.facebook.link.children('span.badge').show().text(data.data.share_count);
 			}
 		}, this));
 	},

--- a/wcfsetup/install/files/js/WCF.Message.js
+++ b/wcfsetup/install/files/js/WCF.Message.js
@@ -3418,7 +3418,7 @@ WCF.Message.Share.Page = Class.extend({
 	},
 	
 	/**
-	 * Fetches number of Facebook likes.
+	 * Fetches number of Facebook shares.
 	 */
 	_fetchFacebook: function() {
 		this._fetchCount('https://graph.facebook.com/fql?q=SELECT%20share_count%20FROM%20link_stat%20WHERE%20url=%27{pageURL}%27', $.proxy(function(data) {

--- a/wcfsetup/install/files/js/WCF.Message.js
+++ b/wcfsetup/install/files/js/WCF.Message.js
@@ -3422,8 +3422,8 @@ WCF.Message.Share.Page = Class.extend({
 	 */
 	_fetchFacebook: function() {
 		this._fetchCount('https://graph.facebook.com/fql?q=SELECT%20share_count%20FROM%20link_stat%20WHERE%20url=%27{pageURL}%27', $.proxy(function(data) {
-			if (data.data.share_count) {
-				this._provider.facebook.link.children('span.badge').show().text(data.data.share_count);
+			if (data.data[0].share_count) {
+				this._provider.facebook.link.children('span.badge').show().text(data.data[0].share_count);
 			}
 		}, this));
 	},


### PR DESCRIPTION
As of April '15, `shares` includes both, likes and shares. By using an FQL query, you can get the exact number of shares without likes or other factors, which are counted in.