### PR TITLE
Fix phrase

### DIFF
--- a/wcfsetup/install/lang/de.xml
+++ b/wcfsetup/install/lang/de.xml
@@ -2224,7 +2224,7 @@ Fehler sind beispielsweise:
 		<item name="wcf.global.error.exception"><![CDATA[<h2>Was ist passiert?</h2>
 		<p>Ein nicht zu korrigierender Fehler ist bei der Verarbeitung Ihrer Anfrage aufgetreten. Der interne Fehlercode lautet: <code>{$exceptionID}</code></p>
 		<p>Leiten Sie diesen Code an den Administrator weiter, um ihm bei der Behebung zu helfen.</p>
-		<p>Wenn Sie der Administrator sind können Sie die vollständige Fehlermeldung bei „ACP » Protokoll » Fehler“ einsehen. Der Fehlercode selbst ist für den Support wertlos!</p>]]></item>
+		<p>Wenn Sie der Administrator sind, können Sie die vollständige Fehlermeldung im Administrationsbereich unter „Protokoll » Fehler“ einsehen. Der Fehlercode selbst ist für den Support wertlos!</p>]]></item>
 		<item name="wcf.global.error.permissionDenied"><![CDATA[Der Zutritt zu dieser Seite ist Ihnen leider verwehrt. Sie besitzen nicht die notwendigen Zugriffsrechte, um diese Seite aufrufen zu können.]]></item>
 		<item name="wcf.global.error.permissionDenied.title"><![CDATA[Der Zutritt zu dieser Seite ist Ihnen leider verwehrt.]]></item>
 		<item name="wcf.global.error.timeout"><![CDATA[Keine Antwort vom Server erhalten, Anfrage wurde abgebrochen.]]></item>


### PR DESCRIPTION
In `wcf.global.error.exception`, a colon is missing. Furthermore (despite the bad grammar) i would recommend not to abbreviate „Administrationsbereich“ because not everyone knows, what „ACP“ means.

This PR replaces #1970 