### PR TITLE
Unify dir separator in exception view

### DIFF
--- a/wcfsetup/install/files/lib/core.functions.php
+++ b/wcfsetup/install/files/lib/core.functions.php
@@ -123,7 +123,7 @@ namespace wcf\functions\exception {
 <p class="exceptionText">&nbsp;</p> <!-- required to ensure spacing after copy & paste -->
 <p class="exceptionText">
 	The error code can be used by an administrator to lookup the full error message in the Administration Control Panel via “Logs » Errors”.
-	In addition the error has been writen to the log file located at <span class="exceptionInlineCodeWrapper"><span class="exceptionInlineCode">{$logFile}</span></span> and can be accessed with a FTP program or similar.
+	In addition the error has been written to the log file located at <span class="exceptionInlineCodeWrapper"><span class="exceptionInlineCode">{$logFile}</span></span> and can be accessed with a FTP program or similar.
 </p>
 <p class="exceptionText">&nbsp;</p> <!-- required to ensure spacing after copy & paste -->
 <p class="exceptionText">Notice: The error code was randomly generated and has no use beyond looking up the full message.</p>
@@ -521,7 +521,7 @@ EXPLANATION;
 
 	function sanitizePath($path) {
 		if (WCF::debugModeIsEnabled() && defined('EXCEPTION_PRIVACY') && EXCEPTION_PRIVACY === 'public') {
-			return $path;
+			return FileUtil::unifyDirSeparator($path);
 		}
 
 		return '*/'.FileUtil::removeTrailingSlash(FileUtil::getRelativePath(WCF_DIR, $path));

--- a/wcfsetup/install/lang/en.xml
+++ b/wcfsetup/install/lang/en.xml
@@ -2231,7 +2231,7 @@ Errors are:
 <p class="exceptionText">&nbsp;</p> <!-- required to ensure spacing after copy & paste -->
 <p class="exceptionText">
 	The error code can be used by an administrator to lookup the full error message in the Administration Control Panel via “Logs » Errors”.
-	In addition the error has been writen to the log file located at <span class="exceptionInlineCodeWrapper"><span class="exceptionInlineCode">{$logFile}</span></span> and can be accessed with a FTP program or similar.
+	In addition the error has been written to the log file located at <span class="exceptionInlineCodeWrapper"><span class="exceptionInlineCode">{$logFile}</span></span> and can be accessed with a FTP program or similar.
 </p>
 <p class="exceptionText">&nbsp;</p> <!-- required to ensure spacing after copy & paste -->
 <p class="exceptionText">Notice: The error code was randomly generated and has no use beyond looking up the full message.</p>]]></item>


### PR DESCRIPTION
Unifies the dir separators for the path to the log file in the exception view. `C:\inetpub\wwwroot\test\wcf22/log/2016-02-28.txt` -> `C:/inetpub/wwwroot/test/wcf22/log/2016-02-28.txt`