### PR TITLE
Removed database password from stack trace

### DIFF
--- a/wcfsetup/install/files/lib/system/WCF.class.php
+++ b/wcfsetup/install/files/lib/system/WCF.class.php
@@ -281,10 +281,10 @@ class WCF {
 			self::handleException(new SystemException($e->getMessage(), $e->getCode(), '', $e));
 		}
 		catch (\Throwable $exception) {
-			die("<pre>WCF::handleException() Unhandled exception: ".$exception->getMessage()."\n\n".$exception->getTraceAsString());
+			die("<pre>WCF::handleException() Unhandled exception: ".$exception->getMessage()."\n\n".preg_replace('/Database->__construct\(.*\)/', 'Database->__construct(...)', $exception->getTraceAsString()));
 		}
 		catch (\Exception $exception) {
-			die("<pre>WCF::handleException() Unhandled exception: ".$exception->getMessage()."\n\n".$exception->getTraceAsString());
+			die("<pre>WCF::handleException() Unhandled exception: ".$exception->getMessage()."\n\n".preg_replace('/Database->__construct\(.*\)/', 'Database->__construct(...)', $exception->getTraceAsString()));
 		}
 	}
 	


### PR DESCRIPTION
Using php7 with the new \Exceptions will return the database login data if there is an error with PDO.
Removing this as done by the LoggedException will prevent unwanted publishing of sensitive Data.