### PR TITLE
Add missing info box in acp template boxList.tpl

### DIFF
--- a/wcfsetup/install/files/acp/templates/boxList.tpl
+++ b/wcfsetup/install/files/acp/templates/boxList.tpl
@@ -76,6 +76,8 @@
 			</ul>
 		</nav>
 	</div>
+{else}
+	<p class="info">{lang}wcf.global.noItems{/lang}</p>
 {/if}
 
 {include file='footer'}


### PR DESCRIPTION
Add in the `boxList.tpl` the `info` box, if there are no items available