### PR TITLE
Missing index on wcf1_user.email

### DIFF
--- a/wcfsetup/setup/db/install.sql
+++ b/wcfsetup/setup/db/install.sql
@@ -1124,6 +1124,7 @@ CREATE TABLE wcf1_user (
 	socialNetworkPrivacySettings TEXT,
 	
 	KEY username (username),
+	KEY email (email),
 	KEY registrationDate (registrationDate),
 	KEY styleID (styleID),
 	KEY activationCode (activationCode),


### PR DESCRIPTION
The email column in the wcf1_user table doesn't have an index.

This column is used by User::getUserByEmail() which is used for authentication and lost password.
Like in #1995 a full table scan can lead to massive performance issues on systems with a big number of users.

This PR adds an index to this column.