### PR TITLE
Change XSD namespace protocols

### DIFF
--- a/XSD/aclOption.xsd
+++ b/XSD/aclOption.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- This file is used for xml files which install, update or delete acl options. -->
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.woltlab.com" targetNamespace="http://www.woltlab.com" elementFormDefault="qualified">
+<xs:schema xmlns:xs="https://www.w3.org/2001/XMLSchema" xmlns="https://www.woltlab.com" targetNamespace="https://www.woltlab.com" elementFormDefault="qualified">
 	<!-- include types -->
 	<xs:include schemaLocation="types.xsd" />
 	

--- a/XSD/acpMenu.xsd
+++ b/XSD/acpMenu.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- This file is used for xml files which install, update or delete acp menu items. -->
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.woltlab.com" targetNamespace="http://www.woltlab.com" elementFormDefault="qualified">
+<xs:schema xmlns:xs="https://www.w3.org/2001/XMLSchema" xmlns="https://www.woltlab.com" targetNamespace="https://www.woltlab.com" elementFormDefault="qualified">
 	<!-- include types -->
 	<xs:include schemaLocation="types.xsd" />
 	

--- a/XSD/acpSearchProvider.xsd
+++ b/XSD/acpSearchProvider.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- This file is used for xml-files which install, update or delete page menu items. -->
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.woltlab.com" targetNamespace="http://www.woltlab.com" elementFormDefault="qualified">
+<xs:schema xmlns:xs="https://www.w3.org/2001/XMLSchema" xmlns="https://www.woltlab.com" targetNamespace="https://www.woltlab.com" elementFormDefault="qualified">
 	<!-- include types -->
 	<xs:include schemaLocation="types.xsd" />
 	

--- a/XSD/bbcode.xsd
+++ b/XSD/bbcode.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- This file is used for xml-files which install, update or delete page menu items. -->
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.woltlab.com" targetNamespace="http://www.woltlab.com" elementFormDefault="qualified">
+<xs:schema xmlns:xs="https://www.w3.org/2001/XMLSchema" xmlns="https://www.woltlab.com" targetNamespace="https://www.woltlab.com" elementFormDefault="qualified">
 	<!-- include types -->
 	<xs:include schemaLocation="types.xsd" />
 	

--- a/XSD/clipboardAction.xsd
+++ b/XSD/clipboardAction.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- This file is used for xml files which install, update or delete clip board actions. -->
-<xs:schema id="data" targetNamespace="http://www.woltlab.com" xmlns="http://www.woltlab.com" xmlns:xs="http://www.w3.org/2001/XMLSchema" attributeFormDefault="qualified" elementFormDefault="qualified">
+<xs:schema id="data" targetNamespace="https://www.woltlab.com" xmlns="https://www.woltlab.com" xmlns:xs="https://www.w3.org/2001/XMLSchema" attributeFormDefault="qualified" elementFormDefault="qualified">
 	<!-- action element -->
 	<xs:element name="action">
 		<xs:complexType>

--- a/XSD/coreObject.xsd
+++ b/XSD/coreObject.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!-- This file is used for xml files which install or delete core objects. -->
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.woltlab.com" targetNamespace="http://www.woltlab.com" elementFormDefault="qualified">
+<xs:schema xmlns:xs="https://www.w3.org/2001/XMLSchema" xmlns="https://www.woltlab.com" targetNamespace="https://www.woltlab.com" elementFormDefault="qualified">
 	<!-- include types -->
 	<xs:include schemaLocation="types.xsd" />
 	

--- a/XSD/cronjob.xsd
+++ b/XSD/cronjob.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!-- The file "cronjobs.xsd" is used for xml-files which installs, updates or deletes searchable cronjobs. -->
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.woltlab.com" targetNamespace="http://www.woltlab.com" elementFormDefault="qualified">
+<xs:schema xmlns:xs="https://www.w3.org/2001/XMLSchema" xmlns="https://www.woltlab.com" targetNamespace="https://www.woltlab.com" elementFormDefault="qualified">
 	<!-- include types -->
 	<xs:include schemaLocation="types.xsd" />
 

--- a/XSD/dashboardBox.xsd
+++ b/XSD/dashboardBox.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!-- This file is used for xml files which install, update or delete user group options. -->
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.woltlab.com" targetNamespace="http://www.woltlab.com" elementFormDefault="qualified">
+<xs:schema xmlns:xs="https://www.w3.org/2001/XMLSchema" xmlns="https://www.woltlab.com" targetNamespace="https://www.woltlab.com" elementFormDefault="qualified">
 	<!-- include types -->
 	<xs:include schemaLocation="types.xsd" />
 

--- a/XSD/eventListener.xsd
+++ b/XSD/eventListener.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!-- This file is used for xml files which install, update or delete event listeners. -->
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.woltlab.com" targetNamespace="http://www.woltlab.com" elementFormDefault="qualified">
+<xs:schema xmlns:xs="https://www.w3.org/2001/XMLSchema" xmlns="https://www.woltlab.com" targetNamespace="https://www.woltlab.com" elementFormDefault="qualified">
 	<!-- include types -->
 	<xs:include schemaLocation="types.xsd" />
 	

--- a/XSD/language.xsd
+++ b/XSD/language.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!-- This file is used for xml files which install or update language items. -->
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.woltlab.com" targetNamespace="http://www.woltlab.com" elementFormDefault="qualified">
+<xs:schema xmlns:xs="https://www.w3.org/2001/XMLSchema" xmlns="https://www.woltlab.com" targetNamespace="https://www.woltlab.com" elementFormDefault="qualified">
 	<!-- include types -->
 	<xs:include schemaLocation="types.xsd" />
 	

--- a/XSD/objectType.xsd
+++ b/XSD/objectType.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!-- This file is used for xml files which install, update or delete user group options. -->
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.woltlab.com" targetNamespace="http://www.woltlab.com" elementFormDefault="qualified">
+<xs:schema xmlns:xs="https://www.w3.org/2001/XMLSchema" xmlns="https://www.woltlab.com" targetNamespace="https://www.woltlab.com" elementFormDefault="qualified">
 	<!-- include types -->
 	<xs:include schemaLocation="types.xsd" />
 

--- a/XSD/objectTypeDefinition.xsd
+++ b/XSD/objectTypeDefinition.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- This file is used for xml-files which install, update or delete page menu items. -->
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.woltlab.com" targetNamespace="http://www.woltlab.com" elementFormDefault="qualified">
+<xs:schema xmlns:xs="https://www.w3.org/2001/XMLSchema" xmlns="https://www.woltlab.com" targetNamespace="https://www.woltlab.com" elementFormDefault="qualified">
 	<!-- include types -->
 	<xs:include schemaLocation="types.xsd" />
 	

--- a/XSD/option.xsd
+++ b/XSD/option.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- The file "option.xsd" is used for xml-files which installs, updates or deletes options. -->
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.woltlab.com" targetNamespace="http://www.woltlab.com" elementFormDefault="qualified">
+<xs:schema xmlns:xs="https://www.w3.org/2001/XMLSchema" xmlns="https://www.woltlab.com" targetNamespace="https://www.woltlab.com" elementFormDefault="qualified">
 	<!-- include types -->
 	<xs:include schemaLocation="types.xsd" />
 	

--- a/XSD/optionTypes.xsd
+++ b/XSD/optionTypes.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.woltlab.com" targetNamespace="http://www.woltlab.com" elementFormDefault="qualified">
+<xs:schema xmlns:xs="https://www.w3.org/2001/XMLSchema" xmlns="https://www.woltlab.com" targetNamespace="https://www.woltlab.com" elementFormDefault="qualified">
 	<!-- include types -->
 	<xs:include schemaLocation="types.xsd" />
 	

--- a/XSD/package.xsd
+++ b/XSD/package.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.woltlab.com" targetNamespace="http://www.woltlab.com" elementFormDefault="qualified">
+<xs:schema xmlns:xs="https://www.w3.org/2001/XMLSchema" xmlns="https://www.woltlab.com" targetNamespace="https://www.woltlab.com" elementFormDefault="qualified">
 	<!-- include types -->
 	<xs:include schemaLocation="types.xsd" />
 	

--- a/XSD/packageInstallationPlugin.xsd
+++ b/XSD/packageInstallationPlugin.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- This file is used for xml files which install or update package installation plugins. -->
-<xs:schema id="data" targetNamespace="http://www.woltlab.com" xmlns="http://www.woltlab.com" xmlns:xs="http://www.w3.org/2001/XMLSchema" attributeFormDefault="qualified" elementFormDefault="qualified">
+<xs:schema id="data" targetNamespace="https://www.woltlab.com" xmlns="https://www.woltlab.com" xmlns:xs="https://www.w3.org/2001/XMLSchema" attributeFormDefault="qualified" elementFormDefault="qualified">
 	<xs:element name="data">
 		<xs:complexType>
 			<xs:choice minOccurs="0" maxOccurs="unbounded">

--- a/XSD/packageUpdateServer.xsd
+++ b/XSD/packageUpdateServer.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- This file is used for package server xml files. -->
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.woltlab.com" targetNamespace="http://www.woltlab.com" elementFormDefault="qualified">
+<xs:schema xmlns:xs="https://www.w3.org/2001/XMLSchema" xmlns="https://www.woltlab.com" targetNamespace="https://www.woltlab.com" elementFormDefault="qualified">
 	<!-- include types -->
 	<xs:include schemaLocation="types.xsd" />
 	

--- a/XSD/pageLocation.xsd
+++ b/XSD/pageLocation.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!-- This file is used for xml files which install, update or delete page locations. -->
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.woltlab.com" targetNamespace="http://www.woltlab.com" elementFormDefault="qualified">
+<xs:schema xmlns:xs="https://www.w3.org/2001/XMLSchema" xmlns="https://www.woltlab.com" targetNamespace="https://www.woltlab.com" elementFormDefault="qualified">
 	<!-- include types -->
 	<xs:include schemaLocation="types.xsd" />
 	

--- a/XSD/pageMenu.xsd
+++ b/XSD/pageMenu.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- This file is used for xml-files which install, update or delete page menu items. -->
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.woltlab.com" targetNamespace="http://www.woltlab.com" elementFormDefault="qualified">
+<xs:schema xmlns:xs="https://www.w3.org/2001/XMLSchema" xmlns="https://www.woltlab.com" targetNamespace="https://www.woltlab.com" elementFormDefault="qualified">
 	<!-- include types -->
 	<xs:include schemaLocation="types.xsd" />
 	

--- a/XSD/sitemap.xsd
+++ b/XSD/sitemap.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- This file is used for xml-files which install, update or delete templatelisteners. -->
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.woltlab.com" targetNamespace="http://www.woltlab.com" elementFormDefault="qualified">
+<xs:schema xmlns:xs="https://www.w3.org/2001/XMLSchema" xmlns="https://www.woltlab.com" targetNamespace="https://www.woltlab.com" elementFormDefault="qualified">
 	<!-- include types -->
 	<xs:include schemaLocation="types.xsd" />
 	

--- a/XSD/smiley.xsd
+++ b/XSD/smiley.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- This file is used for xml-files which install, update or delete page menu items. -->
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.woltlab.com" targetNamespace="http://www.woltlab.com" elementFormDefault="qualified">
+<xs:schema xmlns:xs="https://www.w3.org/2001/XMLSchema" xmlns="https://www.woltlab.com" targetNamespace="https://www.woltlab.com" elementFormDefault="qualified">
 	<!-- include types -->
 	<xs:include schemaLocation="types.xsd" />
 	

--- a/XSD/styleattributes.xsd
+++ b/XSD/styleattributes.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!-- The file "styleattributes.xsd" is used for xml-files which installs, updates or deletes style attributes.  -->
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.woltlab.com" targetNamespace="http://www.woltlab.com" elementFormDefault="qualified">
+<xs:schema xmlns:xs="https://www.w3.org/2001/XMLSchema" xmlns="https://www.woltlab.com" targetNamespace="https://www.woltlab.com" elementFormDefault="qualified">
         
         <!-- include types -->
         <xs:include schemaLocation="types.xsd" />

--- a/XSD/templateListener.xsd
+++ b/XSD/templateListener.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- This file is used for xml-files which install, update or delete templatelisteners. -->
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.woltlab.com" targetNamespace="http://www.woltlab.com" elementFormDefault="qualified">
+<xs:schema xmlns:xs="https://www.w3.org/2001/XMLSchema" xmlns="https://www.woltlab.com" targetNamespace="https://www.woltlab.com" elementFormDefault="qualified">
 	<!-- include types -->
 	<xs:include schemaLocation="types.xsd" />
 	

--- a/XSD/types.xsd
+++ b/XSD/types.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.woltlab.com" targetNamespace="http://www.woltlab.com" elementFormDefault="qualified">
+<xs:schema xmlns:xs="https://www.w3.org/2001/XMLSchema" xmlns="https://www.woltlab.com" targetNamespace="https://www.woltlab.com" elementFormDefault="qualified">
 	<!-- string type with a minimum length of 1 and a maximum length of 255 characters -->
 	<xs:simpleType name="woltlab_varchar">
 		<xs:restriction base="xs:string">

--- a/XSD/userGroupOption.xsd
+++ b/XSD/userGroupOption.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!-- This file is used for xml files which install, update or delete user group options. -->
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.woltlab.com" targetNamespace="http://www.woltlab.com" elementFormDefault="qualified">
+<xs:schema xmlns:xs="https://www.w3.org/2001/XMLSchema" xmlns="https://www.woltlab.com" targetNamespace="https://www.woltlab.com" elementFormDefault="qualified">
 	<!-- include types -->
 	<xs:include schemaLocation="types.xsd" />
 	

--- a/XSD/userMenu.xsd
+++ b/XSD/userMenu.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- This file is used for xml-files which install, update or delete page menu items. -->
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.woltlab.com" targetNamespace="http://www.woltlab.com" elementFormDefault="qualified">
+<xs:schema xmlns:xs="https://www.w3.org/2001/XMLSchema" xmlns="https://www.woltlab.com" targetNamespace="https://www.woltlab.com" elementFormDefault="qualified">
 	<!-- include types -->
 	<xs:include schemaLocation="types.xsd" />
 	

--- a/XSD/userNotificationEvent.xsd
+++ b/XSD/userNotificationEvent.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!-- This file is used for xml files which install, update or delete event listeners. -->
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.woltlab.com" targetNamespace="http://www.woltlab.com" elementFormDefault="qualified">
+<xs:schema xmlns:xs="https://www.w3.org/2001/XMLSchema" xmlns="https://www.woltlab.com" targetNamespace="https://www.woltlab.com" elementFormDefault="qualified">
 	<!-- include types -->
 	<xs:include schemaLocation="types.xsd" />
 	

--- a/XSD/userOption.xsd
+++ b/XSD/userOption.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!-- This file is used for xml files which install, update or delete user options. -->
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.woltlab.com" targetNamespace="http://www.woltlab.com" elementFormDefault="qualified">
+<xs:schema xmlns:xs="https://www.w3.org/2001/XMLSchema" xmlns="https://www.woltlab.com" targetNamespace="https://www.woltlab.com" elementFormDefault="qualified">
 	<!-- include types -->
 	<xs:include schemaLocation="types.xsd" />
 	

--- a/XSD/userProfileMenu.xsd
+++ b/XSD/userProfileMenu.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- This file is used for xml-files which install, update or delete page menu items. -->
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.woltlab.com" targetNamespace="http://www.woltlab.com" elementFormDefault="qualified">
+<xs:schema xmlns:xs="https://www.w3.org/2001/XMLSchema" xmlns="https://www.woltlab.com" targetNamespace="https://www.woltlab.com" elementFormDefault="qualified">
 	<!-- include types -->
 	<xs:include schemaLocation="types.xsd" />
 	


### PR DESCRIPTION
The protocol for `xmlns:xs`, `xmlns` and `targetNamespace` should be changed from http to https due to possible problems with some XML validators and also, to save a roundtrip while validating.