### PR TITLE
Fix tab menu

### DIFF
--- a/wcfsetup/install/files/js/WoltLab/WCF/Ui/TabMenu/Simple.js
+++ b/wcfsetup/install/files/js/WoltLab/WCF/Ui/TabMenu/Simple.js
@@ -224,11 +224,11 @@ define(['Dictionary', 'EventHandler', 'Dom/Traverse', 'Dom/Util'], function(Dict
 			tab.classList.add('active');
 			var newContent = this._containers.get(name);
 			newContent.classList.add('active');
+			newContent.classList.remove('hidden');
 			
 			if (this._isLegacy) {
 				tab.classList.add('ui-state-active');
 				newContent.classList.add('ui-state-active');
-				newContent.classList.remove('hidden');
 			}
 			
 			var menu = tab.parentNode.parentNode;


### PR DESCRIPTION
The class `hidden` is [added](https://github.com/WoltLab/WCF/blob/next/wcfsetup/install/files/js/WoltLab/WCF/Ui/TabMenu/Simple.js#L216) to the old tab regardless if we are in legacy mode or not, so this class needs to be removed regardless of the legacy mode. Otherwise all tab contents will be hidden.