### PR TITLE
fix tabMenu newContent hidden

### DIFF
--- a/wcfsetup/install/files/js/WoltLab/WCF/Ui/TabMenu/Simple.js
+++ b/wcfsetup/install/files/js/WoltLab/WCF/Ui/TabMenu/Simple.js
@@ -224,11 +224,11 @@ define(['Dictionary', 'Dom/Traverse', 'Dom/Util', 'EventHandler'], function(Dict
 			tab.classList.add('active');
 			var newContent = this._containers.get(name);
 			newContent.classList.add('active');
+			newContent.classList.remove('hidden');
 			
 			if (this._isLegacy) {
 				tab.classList.add('ui-state-active');
 				newContent.classList.add('ui-state-active');
-				newContent.classList.remove('hidden');
 			}
 			
 			var menu = tab.parentNode.parentNode;


### PR DESCRIPTION
TabMenu with li[data-name="foo"] after selection of the tab continue still hidden.
