### PR TITLE
Fix CSS ID selector for 3rdParty

### DIFF
--- a/com.woltlab.wcf/templates/accountManagement.tpl
+++ b/com.woltlab.wcf/templates/accountManagement.tpl
@@ -213,7 +213,7 @@
 		{/if}
 		
 		{hascontent}
-			<fieldset id="3rdParty">
+			<fieldset id="thirdParty">
 				<legend>{lang}wcf.user.3rdparty{/lang}</legend>
 				
 				{content}


### PR DESCRIPTION
CSS selectors will not work if the ID starts with a number.

This pull request fixes the 3rdParty HTML tag ID.