### PR TITLE
Force lowercase for cookie domain and domain name

### DIFF
--- a/wcfsetup/install/files/lib/acp/form/ApplicationEditForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/ApplicationEditForm.class.php
@@ -169,8 +169,8 @@ class ApplicationEditForm extends AbstractForm {
 		
 		// save application
 		$this->objectAction = new ApplicationAction(array($this->application->getDecoratedObject()), 'update', array('data' => array_merge($this->additionalFields, array(
-			'cookieDomain' => $this->cookieDomain,
-			'domainName' => $this->domainName,
+			'cookieDomain' => mb_strtolower($this->cookieDomain),
+			'domainName' => mb_strtolower($this->domainName),
 			'domainPath' => $this->domainPath
 		))));
 		$this->objectAction->executeAction();


### PR DESCRIPTION
Entering a non-lowercase domain name may result in an infinite loop and a non-lowercase cookie domain might result in some unexpected behavior.