### PR TITLE
Add class to dropdown trigger element

### DIFF
--- a/wcfsetup/install/files/js/WCF.js
+++ b/wcfsetup/install/files/js/WCF.js
@@ -1550,6 +1550,7 @@ WCF.Dropdown.Interactive.Instance = Class.extend({
 		WCF.Dropdown._closeAll();
 		
 		this._container.addClass('open');
+		this._triggerElement.addClass('openDropdown');
 		
 		this.render();
 	},
@@ -1559,6 +1560,7 @@ WCF.Dropdown.Interactive.Instance = Class.extend({
 	 */
 	close: function() {
 		this._container.removeClass('open');
+		this._triggerElement.removeClass('openDropdown');
 	},
 	
 	/**


### PR DESCRIPTION
The trigger element of `WCF.Dropdown.Interactive.Instance` will be given/taken the 'dropdownOpen' class when the interface opens/closes.

This allows to style dropdown triggers as active in custom themes without having to manually extend the Dropdown.Interface.Instance

As a comparison, this is what I'm currently doing in my theme:
```js
	WCF.Dropdown.Interactive.Instance = WCF.Dropdown.Interactive.Instance.extend({
		open: function() {
			this._super();
			this._triggerElement.addClass('open');
		},
		
		close: function() {
			this._super();
			this._triggerElement.removeClass('open');
		}
	});
```