### PR TITLE
Remove unnecessary code

### DIFF
--- a/wcfsetup/install/files/lib/system/user/notification/event/UserProfileCommentResponseUserNotificationEvent.class.php
+++ b/wcfsetup/install/files/lib/system/user/notification/event/UserProfileCommentResponseUserNotificationEvent.class.php
@@ -1,11 +1,9 @@
 <?php
 namespace wcf\system\user\notification\event;
-use wcf\system\cache\runtime\CommentRuntimeCache;
 use wcf\system\cache\runtime\UserProfileRuntimeCache;
-use wcf\system\request\LinkHandler;
 
 /**
- * User notification event for profile commment responses.
+ * User notification event for profile comment responses.
  * 
  * @author	Alexander Ebert
  * @copyright	2001-2016 WoltLab GmbH
@@ -24,9 +22,7 @@ class UserProfileCommentResponseUserNotificationEvent extends AbstractSharedUser
 	 * @inheritDoc
 	 */
 	protected function prepare() {
-		CommentRuntimeCache::getInstance()->cacheObjectID($this->userNotificationObject->commentID);
 		UserProfileRuntimeCache::getInstance()->cacheObjectID($this->additionalData['objectID']);
-		UserProfileRuntimeCache::getInstance()->cacheObjectID($this->additionalData['userID']);
 	}
 	
 	/**
@@ -48,8 +44,7 @@ class UserProfileCommentResponseUserNotificationEvent extends AbstractSharedUser
 	 * @inheritDoc
 	 */
 	public function getMessage() {
-		$comment = CommentRuntimeCache::getInstance()->getObject($this->userNotificationObject->commentID);
-		$owner = UserProfileRuntimeCache::getInstance()->getObject($comment->objectID);
+		$owner = UserProfileRuntimeCache::getInstance()->getObject($this->additionalData['objectID']);
 		
 		$authors = $this->getAuthors();
 		if (count($authors) > 1) {
@@ -77,8 +72,7 @@ class UserProfileCommentResponseUserNotificationEvent extends AbstractSharedUser
 	 * @inheritDoc
 	 */
 	public function getEmailMessage($notificationType = 'instant') {
-		$comment = CommentRuntimeCache::getInstance()->getObject($this->userNotificationObject->commentID);
-		$owner = UserProfileRuntimeCache::getInstance()->getObject($comment->objectID);
+		$owner = UserProfileRuntimeCache::getInstance()->getObject($this->additionalData['objectID']);
 		
 		$authors = $this->getAuthors();
 		if (count($authors) > 1) {
@@ -111,10 +105,7 @@ class UserProfileCommentResponseUserNotificationEvent extends AbstractSharedUser
 	 * @inheritDoc
 	 */
 	public function getLink() {
-		$comment = CommentRuntimeCache::getInstance()->getObject($this->userNotificationObject->commentID);
-		$user = UserProfileRuntimeCache::getInstance()->getObject($comment->objectID);
-		
-		return LinkHandler::getInstance()->getLink('User', ['object' => $user], '#wall');
+		return UserProfileRuntimeCache::getInstance()->getObject($this->additionalData['objectID'])->getLink() . '#wall';
 	}
 	
 	/**


### PR DESCRIPTION
Removes unnecessary code in `UserProfileCommentResponseUserNotificationEvent`. The removed code was only used to retrieve the `objectID`, but the `objectID` is also available over `$this->additionalData['objectID']`.