### PR TITLE
Add missing call to UserOptionAddForm::setDefaultOutputClass()

### DIFF
--- a/wcfsetup/install/files/lib/acp/form/UserOptionAddForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/UserOptionAddForm.class.php
@@ -212,6 +212,8 @@ class UserOptionAddForm extends AbstractForm {
 		if ($this->optionType == 'float') {
 			$this->defaultValue = floatval($this->defaultValue);
 		}
+
+		$this->setDefaultOutputClass();
 	}
 	
 	/**


### PR DESCRIPTION
See 85fc3b968cda8216caad32b2f42bdf2d1b7ce15d `setDefaultOutputClass()` is never called.