### PR TITLE
Remove SearchKeywordManager::simplifyKeyword()

### DIFF
--- a/wcfsetup/install/files/lib/system/search/SearchKeywordManager.class.php
+++ b/wcfsetup/install/files/lib/system/search/SearchKeywordManager.class.php
@@ -22,8 +22,6 @@ class SearchKeywordManager extends SingletonFactory {
 	 * @param	string		$keyword
 	 */
 	public function add($keyword) {
-		$keyword = static::simplifyKeyword($keyword);
-		
 		// search existing entry
 		$sql = "SELECT	*
 			FROM	wcf".WCF_N."_search_keyword
@@ -45,17 +43,5 @@ class SearchKeywordManager extends SingletonFactory {
 			]]);
 			$action->executeAction();
 		}
-	}
-	
-	/**
-	 * Returns simplified version of the given keyword.
-	 * 
-	 * @param	string		$keyword
-	 * @return	string
-	 */
-	public static function simplifyKeyword($keyword) {
-		// TODO: do something useful
-		
-		return $keyword;
 	}
 }


### PR DESCRIPTION
This method exists since 2013 and was never really in use.

Because this method is only used inside `SearchKeywordManager` and does nothing else as returning the input it should be removed. 