### PR TITLE
Fixed check for empty polls

### DIFF
--- a/com.woltlab.wcf/templates/__messageFormPoll.tpl
+++ b/com.woltlab.wcf/templates/__messageFormPoll.tpl
@@ -14,13 +14,20 @@
 	
 	<div id="poll" class="jsOnly tabMenuContent container containerPadding">
 		<fieldset>
-			<dl{if $errorField == 'pollOptions'} class="formError"{/if}>
+			<dl{if $errorField == 'pollQuestion'} class="formError"{/if}>
 				<dt>
 					<label for="pollQuestion">{lang}wcf.poll.question{/lang}</label>
 				</dt>
 				<dd>
 					<input type="text" name="pollQuestion" id="pollQuestion" value="{$pollQuestion}" class="long" maxlength="255" />
+					{if $errorField == 'pollQuestion'}
+						<small class="innerError">
+							{lang}wcf.global.form.error.empty{/lang}
+						</small>
+					{/if}
 				</dd>
+			</dl>
+			<dl{if $errorField == 'pollOptions'} class="formError"{/if}>
 				<dt>
 					<label>{lang}wcf.poll.options{/lang}</label>
 				</dt>

--- a/wcfsetup/install/files/lib/system/poll/PollManager.class.php
+++ b/wcfsetup/install/files/lib/system/poll/PollManager.class.php
@@ -197,9 +197,16 @@ class PollManager extends SingletonFactory {
 	 * Validates poll parameters.
 	 */
 	public function validate() {
-		// if no question is given, ignore poll completely
-		if (empty($this->pollData['question'])) {
+		$count = count($this->pollOptions);
+
+		// if no question and no options are given, ignore poll completely
+		if (empty($this->pollData['question']) && !$count) {
 			return;
+		}
+
+		// no question given
+		if (empty($this->pollData['question'])) {
+			throw new UserInputException('pollQuestion');
 		}
 		
 		if ($this->pollData['endTime'] && $this->pollData['endTime'] <= TIME_NOW) {
@@ -210,7 +217,6 @@ class PollManager extends SingletonFactory {
 		}
 		
 		// no options given
-		$count = count($this->pollOptions);
 		if (!$count) {
 			throw new UserInputException('pollOptions');
 		}


### PR DESCRIPTION
If the question was empty, the poll was discarded, even when the user gave options. This could lead to frustation as all options had to be typed again. I added an error message for that case.