### PR TITLE
Fix marking styles as tainted

### DIFF
--- a/wcfsetup/install/files/acp/templates/styleAdd.tpl
+++ b/wcfsetup/install/files/acp/templates/styleAdd.tpl
@@ -62,7 +62,9 @@
 	</nav>
 </header>
 
-<p class="info">{lang}wcf.acp.style.protected{/lang}</p>
+{if !$isTainted}
+	<p class="info">{lang}wcf.acp.style.protected{/lang}</p>
+{/if}
 
 {include file='formError'}
 
@@ -934,7 +936,7 @@
 	</dl>
 	
 	<div class="formSubmit">
-		<button id="styleDisableProtectionSubmit" disabled>{lang}wcf.global.button.submit{/lang}</button>
+		<button id="styleDisableProtectionSubmit" class="buttonPrimary" disabled>{lang}wcf.global.button.submit{/lang}</button>
 	</div>
 </div>
 

--- a/wcfsetup/install/files/js/WoltLab/WCF/Acp/Ui/Style/Editor.js
+++ b/wcfsetup/install/files/js/WoltLab/WCF/Acp/Ui/Style/Editor.js
@@ -1,10 +1,10 @@
 /**
- * Provides the basic core functionality.
+ * Provides the style editor.
  * 
  * @author	Alexander Ebert
- * @copyright	2001-2015 WoltLab GmbH
+ * @copyright	2001-2016 WoltLab GmbH
  * @license	GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
- * @module	WoltLab/WCF/Core
+ * @module	WoltLab/WCF/Acp/Ui/Style/Editor
  */
 define(['Ajax', 'Dictionary', 'Dom/Util', 'EventHandler'], function(Ajax, Dictionary, DomUtil, EventHandler) {
 	"use strict";
@@ -21,7 +21,7 @@ define(['Ajax', 'Dictionary', 'Dom/Util', 'EventHandler'], function(Ajax, Dictio
 		 */
 		setup: function(options) {
 			this._handleLayoutWidth();
-			this._handleLess(options.isTainted);
+			this._handleScss(options.isTainted);
 			
 			if (!options.isTainted) {
 				this._handleProtection(options.styleId);
@@ -53,11 +53,11 @@ define(['Ajax', 'Dictionary', 'Dom/Util', 'EventHandler'], function(Ajax, Dictio
 		},
 		
 		/**
-		 * Handles LESS input fields.
+		 * Handles SCSS input fields.
 		 * 
 		 * @param	{boolean}	isTainted	false if style is in protected mode
 		 */
-		_handleLess: function(isTainted) {
+		_handleScss: function(isTainted) {
 			var individualScss = elById('individualScss');
 			var overrideScss = elById('overrideScss');
 			

--- a/wcfsetup/install/files/js/WoltLab/WCF/Ajax.js
+++ b/wcfsetup/install/files/js/WoltLab/WCF/Ajax.js
@@ -77,6 +77,9 @@ define(['AjaxRequest', 'Core', 'ObjectMap'], function(AjaxRequest, Core, ObjectM
 		 * @param	{object<string, *>}	options		request options
 		 */
 		apiOnce: function(options) {
+			// Fetch AjaxRequest, as it cannot be provided because of a circular dependency
+			if (AjaxRequest === undefined) AjaxRequest = require('AjaxRequest');
+			
 			options.pinData = false;
 			options.callbackObject = null;
 			if (!options.url) options.url = 'index.php/AJAXProxy/?t=' + SECURITY_TOKEN;


### PR DESCRIPTION
Fixes `Uncaught TypeError: AjaxRequest is not a constructor` when trying to mark a style as tainted.