### PR TITLE
Remove 'share_buttons_show_count' relict

### DIFF
--- a/com.woltlab.wcf/option.xml
+++ b/com.woltlab.wcf/option.xml
@@ -1003,7 +1003,6 @@ redis:cache_source_redis_host,!cache_source_memcached_host]]></enableoptions>
 				<categoryname>message.general.share</categoryname>
 				<optiontype>boolean</optiontype>
 				<defaultvalue>1</defaultvalue>
-				<enableoptions><![CDATA[share_buttons_show_count]]></enableoptions>
 			</option>
 			<option name="share_buttons_providers">
 				<categoryname>message.general.share</categoryname>
@@ -1024,7 +1023,6 @@ WhatsApp
 LinkedIn
 Pinterest
 XING</defaultvalue>
-				<enableoptions><![CDATA[share_buttons_show_count]]></enableoptions>
 			</option>
 			
 			<!-- /message.general.share -->


### PR DESCRIPTION
The option `share_buttons_show_count` was removed with this commit: bdc6630a23e6d9888674bf41361532a036e746ce