### PR TITLE
add required to required optiontypes

### DIFF
--- a/com.woltlab.wcf/templates/integerOptionType.tpl
+++ b/com.woltlab.wcf/templates/integerOptionType.tpl
@@ -1,1 +1,1 @@
-<input type="number" id="{$option->optionName}" name="values[{$option->optionName}]" value="{$value}"{if $option->minvalue !== null} min="{$option->minvalue}"{/if}{if $option->maxvalue !== null} max="{$option->maxvalue}"{/if}{if $inputClass} class="{@$inputClass}"{/if}>
+<input type="number" id="{$option->optionName}" name="values[{$option->optionName}]" value="{$value}"{if $option->minvalue !== null} min="{$option->minvalue}"{/if}{if $option->maxvalue !== null} max="{$option->maxvalue}"{/if}{if $inputClass} class="{@$inputClass}"{/if}{if $option->required} required{/if}>

--- a/com.woltlab.wcf/templates/messageOptionType.tpl
+++ b/com.woltlab.wcf/templates/messageOptionType.tpl
@@ -1,4 +1,4 @@
-<textarea id="{$option->optionName}" name="values[{$option->optionName}]" cols="40" rows="10">{$value}</textarea>
+<textarea id="{$option->optionName}" name="values[{$option->optionName}]" cols="40" rows="10"{if $option->required} required{/if}>{$value}</textarea>
 {include file='wysiwyg' wysiwygSelector=$option->optionName}
 
 <script data-relocate="true">

--- a/com.woltlab.wcf/templates/multiSelectOptionType.tpl
+++ b/com.woltlab.wcf/templates/multiSelectOptionType.tpl
@@ -1,4 +1,4 @@
-<select id="{$option->optionName}" name="values[{$option->optionName}][]" multiple size="{if $selectOptions|count > 10}10{else}{@$selectOptions|count}{/if}">
+<select id="{$option->optionName}" name="values[{$option->optionName}][]" multiple size="{if $selectOptions|count > 10}10{else}{@$selectOptions|count}{/if}"{if $option->required} required{/if}>
 {foreach from=$selectOptions key=key item=selectOption}
 	<option value="{$key}"{if $key|in_array:$value} selected{/if}>{lang}{@$selectOption}{/lang}</option>
 {/foreach}

--- a/com.woltlab.wcf/templates/multiSelectSearchableOptionType.tpl
+++ b/com.woltlab.wcf/templates/multiSelectSearchableOptionType.tpl
@@ -1,5 +1,5 @@
 <label><input type="checkbox" id="search_{$option->optionName}" name="searchOptions[{$option->optionName}]"{if $searchOption} checked{/if}> {lang}wcf.user.option.searchRadioButtonOption{/lang}</label>
-<select id="{$option->optionName}" name="values[{$option->optionName}][]" multiple size="{if $selectOptions|count > 10}10{else}{@$selectOptions|count}{/if}"{if !$searchOption} disabled{/if}>
+<select id="{$option->optionName}" name="values[{$option->optionName}][]" multiple size="{if $selectOptions|count > 10}10{else}{@$selectOptions|count}{/if}"{if !$searchOption} disabled{/if}{if $option->required} required{/if}>
 	{foreach from=$selectOptions key=key item=selectOption}
 		<option value="{$key}"{if $key|in_array:$value} selected{/if}>{lang}{@$selectOption}{/lang}</option>
 	{/foreach}

--- a/com.woltlab.wcf/templates/selectOptionType.tpl
+++ b/com.woltlab.wcf/templates/selectOptionType.tpl
@@ -1,5 +1,5 @@
 <label class="selectDropdown">
-	<select id="{$option->optionName}" name="values[{$option->optionName}]">
+	<select id="{$option->optionName}" name="values[{$option->optionName}]"{if $option->required} required{/if}>
 		{if !$allowEmptyValue|empty}<option value="">{lang}wcf.global.noSelection{/lang}</option>{/if}
 		{foreach from=$selectOptions key=key item=selectOption}
 			<option value="{$key}"{if $value == $key} selected{/if}>{lang}{@$selectOption}{/lang}</option>

--- a/com.woltlab.wcf/templates/selectSearchableOptionType.tpl
+++ b/com.woltlab.wcf/templates/selectSearchableOptionType.tpl
@@ -1,6 +1,6 @@
 <label><input type="checkbox" id="search_{$option->optionName}" name="searchOptions[{$option->optionName}]"{if $searchOption} checked{/if}> {lang}wcf.user.option.searchRadioButtonOption{/lang}</label>
 <label class="selectDropdown">
-	<select id="{$option->optionName}" name="values[{$option->optionName}]"{if !$searchOption} disabled{/if}>
+	<select id="{$option->optionName}" name="values[{$option->optionName}]"{if !$searchOption} disabled{/if}{if $option->required} required{/if}>
 		{if !$allowEmptyValue|empty}<option value="">{lang}wcf.global.noSelection{/lang}</option>{/if}
 		{foreach from=$selectOptions key=key item=selectOption}
 			<option value="{$key}"{if $value == $key} selected{/if}>{lang}{@$selectOption}{/lang}</option>

--- a/com.woltlab.wcf/templates/textI18nOptionType.tpl
+++ b/com.woltlab.wcf/templates/textI18nOptionType.tpl
@@ -1,2 +1,2 @@
-<input type="{@$inputType}" id="{$option->optionName}" name="{$option->optionName}" value="{$i18nPlainValues[$option->optionName]}" class="long">
+<input type="{@$inputType}" id="{$option->optionName}" name="{$option->optionName}" value="{$i18nPlainValues[$option->optionName]}"{if $option->required} required{/if} class="long">
 {include file='multipleLanguageInputJavascript' elementIdentifier=$option->optionName forceSelection=false}

--- a/com.woltlab.wcf/templates/textOptionType.tpl
+++ b/com.woltlab.wcf/templates/textOptionType.tpl
@@ -1,1 +1,1 @@
-<input type="{@$inputType}" id="{$option->optionName}" name="values[{$option->optionName}]" value="{$value}"{if $option->minlength > 0} required{/if}{if $option->maxlength} maxlength="{$option->maxlength}"{/if}{if $inputClass} class="{@$inputClass}"{/if}>
+<input type="{@$inputType}" id="{$option->optionName}" name="values[{$option->optionName}]" value="{$value}"{if $option->minlength > 0 || $option->required} required{/if}{if $option->maxlength} maxlength="{$option->maxlength}"{/if}{if $inputClass} class="{@$inputClass}"{/if}>

--- a/com.woltlab.wcf/templates/textSearchableOptionType.tpl
+++ b/com.woltlab.wcf/templates/textSearchableOptionType.tpl
@@ -1,5 +1,5 @@
 <label><input type="checkbox" id="search_{$option->optionName}" name="searchOptions[{$option->optionName}]"{if $searchOption} checked{/if}> {lang}wcf.user.option.searchTextOption{/lang}</label>
-<input type="{@$inputType}" id="{$option->optionName}" name="values[{$option->optionName}]" value="{$value}"{if $inputClass} class="{@$inputClass}"{/if}{if !$searchOption} disabled{/if}>
+<input type="{@$inputType}" id="{$option->optionName}" name="values[{$option->optionName}]" value="{$value}"{if $inputClass} class="{@$inputClass}"{/if}{if !$searchOption} disabled{/if}{if $option->required} required{/if}>
 
 <script data-relocate="true">
 //<![CDATA[

--- a/com.woltlab.wcf/templates/textareaI18nOptionType.tpl
+++ b/com.woltlab.wcf/templates/textareaI18nOptionType.tpl
@@ -1,2 +1,2 @@
-<textarea id="{$option->optionName}" name="{$option->optionName}" cols="40" rows="10">{$i18nPlainValues[$option->optionName]}</textarea>
+<textarea id="{$option->optionName}" name="{$option->optionName}" cols="40" rows="10"{if $option->required} required{/if}>{$i18nPlainValues[$option->optionName]}</textarea>
 {include file='multipleLanguageInputJavascript' elementIdentifier=$option->optionName forceSelection=false}

--- a/com.woltlab.wcf/templates/textareaOptionType.tpl
+++ b/com.woltlab.wcf/templates/textareaOptionType.tpl
@@ -1,1 +1,1 @@
-<textarea id="{$option->optionName}" name="values[{$option->optionName}]" cols="40" rows="10">{$value}</textarea>
+<textarea id="{$option->optionName}" name="values[{$option->optionName}]" cols="40" rows="10"{if $option->required} required{/if}>{$value}</textarea>

--- a/com.woltlab.wcf/templates/textareaSearchableOptionType.tpl
+++ b/com.woltlab.wcf/templates/textareaSearchableOptionType.tpl
@@ -1,5 +1,5 @@
 <label><input type="checkbox" id="search_{$option->optionName}" name="searchOptions[{$option->optionName}]"{if $searchOption} checked{/if}> {lang}wcf.user.option.searchTextOption{/lang}</label>
-<textarea id="{$option->optionName}" name="values[{$option->optionName}]"{if !$searchOption} disabled{/if} cols="40" rows="10">{$value}</textarea>
+<textarea id="{$option->optionName}" name="values[{$option->optionName}]"{if !$searchOption} disabled{/if} cols="40" rows="10"{if $option->required} required{/if}>{$value}</textarea>
 
 <script data-relocate="true">
 //<![CDATA[


### PR DESCRIPTION
see also: https://community.woltlab.com/thread/245055/?postID=1533283#post1533283

Required optiontypes don't get marked as required at the moment which makes it impossible to highlight them via JS/CSS and allows the user sending the form with empty fields which produces unnecessary loss of time and traffic because validate will return an exception if empty.
I might have forgotten to change some optiontypes like radios or checkboxes.

compare #2060