### PR TITLE
Fix application support in AbstractOptionPackageInstallationPlugin

### DIFF
--- a/wcfsetup/install/files/lib/system/package/plugin/AbstractOptionPackageInstallationPlugin.class.php
+++ b/wcfsetup/install/files/lib/system/package/plugin/AbstractOptionPackageInstallationPlugin.class.php
@@ -293,7 +293,7 @@ abstract class AbstractOptionPackageInstallationPlugin extends AbstractXMLPackag
 		
 		// check if option already exists
 		$sql = "SELECT	*
-			FROM	wcf".WCF_N."_".$this->tableName."
+			FROM	".$this->application.WCF_N."_".$this->tableName."
 			WHERE	optionName = ?";
 		$statement = WCF::getDB()->prepareStatement($sql);
 		$statement->execute([


### PR DESCRIPTION
This commit https://github.com/WoltLab/WCF/commit/b372ca966151915c149fb23f2a25e4680c7d1e0b#diff-b3f6157d2488454dd566e9f19360fa8cR286 breaks the possibility to install options for applications by hardcoding `wcf`.