### PR TITLE
Parse template scripting in 'wcf.ajax.error.*'

### DIFF
--- a/wcfsetup/install/files/lib/action/AJAXInvokeAction.class.php
+++ b/wcfsetup/install/files/lib/action/AJAXInvokeAction.class.php
@@ -174,10 +174,10 @@ class AJAXInvokeAction extends AbstractSecureAction {
 		}
 		
 		if ($e instanceof InvalidSecurityTokenException) {
-			throw new AJAXException(WCF::getLanguage()->get('wcf.ajax.error.sessionExpired'), AJAXException::SESSION_EXPIRED, $e->getTraceAsString());
+			throw new AJAXException(WCF::getLanguage()->getDynamicVariable('wcf.ajax.error.sessionExpired'), AJAXException::SESSION_EXPIRED, $e->getTraceAsString());
 		}
 		else if ($e instanceof PermissionDeniedException) {
-			throw new AJAXException(WCF::getLanguage()->get('wcf.ajax.error.permissionDenied'), AJAXException::INSUFFICIENT_PERMISSIONS, $e->getTraceAsString());
+			throw new AJAXException(WCF::getLanguage()->getDynamicVariable('wcf.ajax.error.permissionDenied'), AJAXException::INSUFFICIENT_PERMISSIONS, $e->getTraceAsString());
 		}
 		else if ($e instanceof IllegalLinkException) {
 			throw new AJAXException(WCF::getLanguage()->get('wcf.ajax.error.illegalLink'), AJAXException::ILLEGAL_LINK, $e->getTraceAsString());

--- a/wcfsetup/install/files/lib/system/WCF.class.php
+++ b/wcfsetup/install/files/lib/system/WCF.class.php
@@ -397,7 +397,7 @@ class WCF {
 		if (defined('BLACKLIST_IP_ADDRESSES') && BLACKLIST_IP_ADDRESSES != '') {
 			if (!StringUtil::executeWordFilter(UserUtil::convertIPv6To4(self::getSession()->ipAddress), BLACKLIST_IP_ADDRESSES)) {
 				if ($isAjax) {
-					throw new AJAXException(self::getLanguage()->get('wcf.ajax.error.permissionDenied'), AJAXException::INSUFFICIENT_PERMISSIONS);
+					throw new AJAXException(self::getLanguage()->getDynamicVariable('wcf.ajax.error.permissionDenied'), AJAXException::INSUFFICIENT_PERMISSIONS);
 				}
 				else {
 					throw new PermissionDeniedException();
@@ -405,7 +405,7 @@ class WCF {
 			}
 			else if (!StringUtil::executeWordFilter(self::getSession()->ipAddress, BLACKLIST_IP_ADDRESSES)) {
 				if ($isAjax) {
-					throw new AJAXException(self::getLanguage()->get('wcf.ajax.error.permissionDenied'), AJAXException::INSUFFICIENT_PERMISSIONS);
+					throw new AJAXException(self::getLanguage()->getDynamicVariable('wcf.ajax.error.permissionDenied'), AJAXException::INSUFFICIENT_PERMISSIONS);
 				}
 				else {
 					throw new PermissionDeniedException();
@@ -415,7 +415,7 @@ class WCF {
 		if (defined('BLACKLIST_USER_AGENTS') && BLACKLIST_USER_AGENTS != '') {
 			if (!StringUtil::executeWordFilter(self::getSession()->userAgent, BLACKLIST_USER_AGENTS)) {
 				if ($isAjax) {
-					throw new AJAXException(self::getLanguage()->get('wcf.ajax.error.permissionDenied'), AJAXException::INSUFFICIENT_PERMISSIONS);
+					throw new AJAXException(self::getLanguage()->getDynamicVariable('wcf.ajax.error.permissionDenied'), AJAXException::INSUFFICIENT_PERMISSIONS);
 				}
 				else {
 					throw new PermissionDeniedException();
@@ -425,7 +425,7 @@ class WCF {
 		if (defined('BLACKLIST_HOSTNAMES') && BLACKLIST_HOSTNAMES != '') {
 			if (!StringUtil::executeWordFilter(@gethostbyaddr(self::getSession()->ipAddress), BLACKLIST_HOSTNAMES)) {
 				if ($isAjax) {
-					throw new AJAXException(self::getLanguage()->get('wcf.ajax.error.permissionDenied'), AJAXException::INSUFFICIENT_PERMISSIONS);
+					throw new AJAXException(self::getLanguage()->getDynamicVariable('wcf.ajax.error.permissionDenied'), AJAXException::INSUFFICIENT_PERMISSIONS);
 				}
 				else {
 					throw new PermissionDeniedException();

--- a/wcfsetup/install/files/lib/system/WCFACP.class.php
+++ b/wcfsetup/install/files/lib/system/WCFACP.class.php
@@ -141,7 +141,7 @@ class WCFACP extends WCF {
 			if (WCF::getUser()->userID == 0) {
 				// work-around for AJAX-requests within ACP
 				if (isset($_SERVER['HTTP_X_REQUESTED_WITH']) && $_SERVER['HTTP_X_REQUESTED_WITH'] == 'XMLHttpRequest') {
-					throw new AJAXException(WCF::getLanguage()->get('wcf.ajax.error.sessionExpired'), AJAXException::SESSION_EXPIRED, '');
+					throw new AJAXException(WCF::getLanguage()->getDynamicVariable('wcf.ajax.error.sessionExpired'), AJAXException::SESSION_EXPIRED, '');
 				}
 				
 				// build redirect path
@@ -165,7 +165,7 @@ class WCFACP extends WCF {
 						WCF::getSession()->checkPermissions(['admin.general.canUseAcp']);
 					}
 					catch (PermissionDeniedException $e) {
-						throw new AJAXException(self::getLanguage()->get('wcf.ajax.error.permissionDenied'), AJAXException::INSUFFICIENT_PERMISSIONS, $e->getTraceAsString());
+						throw new AJAXException(self::getLanguage()->getDynamicVariable('wcf.ajax.error.permissionDenied'), AJAXException::INSUFFICIENT_PERMISSIONS, $e->getTraceAsString());
 					}
 				}
 				else {

--- a/wcfsetup/install/files/lib/system/exception/AJAXException.class.php
+++ b/wcfsetup/install/files/lib/system/exception/AJAXException.class.php
@@ -104,7 +104,7 @@ class AJAXException extends LoggedException {
 				$responseData['code'] = self::INTERNAL_ERROR;
 				$responseData['exceptionID'] = $exceptionID;
 				if (!WCF::debugModeIsEnabled()) {
-					$responseData['message'] = WCF::getLanguage()->get('wcf.ajax.error.internalError');
+					$responseData['message'] = WCF::getLanguage()->getDynamicVariable('wcf.ajax.error.internalError');
 				}
 			break;
 		}

--- a/wcfsetup/install/files/lib/system/exception/InvalidSecurityTokenException.class.php
+++ b/wcfsetup/install/files/lib/system/exception/InvalidSecurityTokenException.class.php
@@ -15,6 +15,6 @@ class InvalidSecurityTokenException extends NamedUserException {
 	 * Creates a new InvalidSecurityTokenException object.
 	 */
 	public function __construct() {
-		parent::__construct(WCF::getLanguage()->get('wcf.ajax.error.sessionExpired'));
+		parent::__construct(WCF::getLanguage()->getDynamicVariable('wcf.ajax.error.sessionExpired'));
 	}
 }

--- a/wcfsetup/install/files/lib/system/request/RequestHandler.class.php
+++ b/wcfsetup/install/files/lib/system/request/RequestHandler.class.php
@@ -73,7 +73,7 @@ class RequestHandler extends SingletonFactory {
 			if (!$isACPRequest && defined('OFFLINE') && OFFLINE) {
 				if (!WCF::getSession()->getPermission('admin.general.canViewPageDuringOfflineMode') && !$this->activeRequest->isAvailableDuringOfflineMode()) {
 					if (isset($_SERVER['HTTP_X_REQUESTED_WITH']) && ($_SERVER['HTTP_X_REQUESTED_WITH'] == 'XMLHttpRequest')) {
-						throw new AJAXException(WCF::getLanguage()->get('wcf.ajax.error.permissionDenied'), AJAXException::INSUFFICIENT_PERMISSIONS);
+						throw new AJAXException(WCF::getLanguage()->getDynamicVariable('wcf.ajax.error.permissionDenied'), AJAXException::INSUFFICIENT_PERMISSIONS);
 					}
 					else {
 						@header('HTTP/1.1 503 Service Unavailable');


### PR DESCRIPTION
[`wcf.ajax.error.(internalError|permissionDenied|sessionExpired)`](https://github.com/WoltLab/WCF/blob/f5ce800a4fd526c6e08845364a6fc37ab118c66a/wcfsetup/install/lang/de.xml#L1860-L1862) containing since cbd5031d7247165176010c85f4cff1bee370c642 template scripting, therefore they must be called with `getDynamicVariable()`.