### PR TITLE
Added hidden option "language_use_informal_variant" to enable forward-compatibility

### DIFF
--- a/com.woltlab.wcf/option.xml
+++ b/com.woltlab.wcf/option.xml
@@ -422,6 +422,12 @@
 				<optiontype>boolean</optiontype>
 				<defaultvalue>0</defaultvalue>
 			</option>
+			<option name="language_use_informal_variant">
+				<categoryname>general.page</categoryname>
+				<optiontype>boolean</optiontype>
+				<defaultvalue>0</defaultvalue>
+				<hidden>1</hidden>
+			</option>
 			<option name="footer_code">
 				<categoryname>general.page</categoryname>
 				<optiontype>textarea</optiontype>


### PR DESCRIPTION
WSC 3.0 introduces a new option LANGUAGE_USE_INFORMAL_VARIANT to enable informal language variations. However the current implementation raises development effort for third-party developers, i.e. it is not possible to release a plugin that is compatible to WCF 2.1 and WSC 3.0 that uses language variables correctly. There are three possible solutions: 

1.  Release two version of the plugins (higher maintenance effort)
2. Do not support informal variant
3. Check if the option is defined (bloats code)

This pull requests adds the introduced option to WCF 2.1 as hidden one, thus a developer can use the same language files for both framework versions.  This enables forward-compatibility to the new language enhancement. 