### PR TITLE
Add path2x element to smiley XSD

### DIFF
--- a/XSD/smiley.xsd
+++ b/XSD/smiley.xsd
@@ -40,6 +40,7 @@
 				<xs:all>
 					<xs:element name="title" type="woltlab_varchar_nullable" minOccurs="0" />
 					<xs:element name="path" type="woltlab_varchar_nullable" minOccurs="0" />
+					<xs:element name="path2x" type="woltlab_varchar_nullable" minOccurs="0" />
 					<xs:element name="aliases" type="woltlab_varchar_nullable" minOccurs="0" />
 				</xs:all>
 			</xs:extension>


### PR DESCRIPTION
According to d4da0d92d193f6586681f8470a4632e1bb3fabf3, the smiley XML PIPs should support the new element `<path2x>`.