### PR TITLE
fixed assign-error overriding templateNameApplication

### DIFF
--- a/wcfsetup/install/files/lib/page/AbstractPage.class.php
+++ b/wcfsetup/install/files/lib/page/AbstractPage.class.php
@@ -127,6 +127,7 @@ abstract class AbstractPage implements IPage {
 		WCF::getTPL()->assign([
 			'action' => $this->action,
 			'templateName' => $this->templateName,
+			'templateNameApplication' => $this->templateNameApplication,
 			'canonicalURL' => $this->canonicalURL
 		]);
 	}


### PR DESCRIPTION
templateNameApplication didn't get assigned to the template which will cause an error if a developer sets a custom value