### PR TITLE
easy way to disable WCF's branding via AbstractPage

### DIFF
--- a/com.woltlab.wcf/templates/pageFooterCopyright.tpl
+++ b/com.woltlab.wcf/templates/pageFooterCopyright.tpl
@@ -1,3 +1,3 @@
 {event name='copyright'}
 
-{if !'WOLTLAB_BRANDING'|defined || WOLTLAB_BRANDING}<div class="copyright">{lang}wcf.page.copyright{/lang}</div>{/if}
+{if (!'WOLTLAB_BRANDING'|defined || WOLTLAB_BRANDING) && (!$showWoltLabBranding|isset || $showWoltLabBranding)}<div class="copyright">{lang}wcf.page.copyright{/lang}</div>{/if}

--- a/wcfsetup/install/files/lib/page/AbstractPage.class.php
+++ b/wcfsetup/install/files/lib/page/AbstractPage.class.php
@@ -84,6 +84,12 @@ abstract class AbstractPage implements IPage {
 	public $useTemplate = true;
 	
 	/**
+	 * enables the branding of WoltLab GmbH within the footer
+	 * @var	boolean
+	 */
+	public $showWoltLabBranding = true;
+	
+	/**
 	 * @inheritDoc
 	 */
 	public final function __construct() { }
@@ -128,7 +134,8 @@ abstract class AbstractPage implements IPage {
 			'action' => $this->action,
 			'templateName' => $this->templateName,
 			'templateNameApplication' => $this->templateNameApplication,
-			'canonicalURL' => $this->canonicalURL
+			'canonicalURL' => $this->canonicalURL,
+			'showWoltLabBranding' => $this->showWoltLabBranding
 		]);
 	}
 	


### PR DESCRIPTION
implemented the boolean `\wcf\page\AbstractPage::$showWoltLabBranding`.

This change is needed to provide an easy way (for 3rdparty-developers)
to hide WoltLab's copyright notice within the footer on specific pages
by setting it to `false`.
This gives every developer the possibility to show a specific copyright
without showing the general one. So far so good we could also do this by
setting `WOLTLAB_BRANDING` to `false`. But setting this option would
disable WoltLab's copyright at all which is not the wanted effect in
most cases and would cause much trouble in case WoltLab's products are
installed and no copyright-free-license has been purchased.
Maybe it would even more senseful to remove `WOLTLAB_BRANDING` at all
and use `AbstractPage::$showWoltLabBranding` only.

In a nutshell: Without such a solution there is no easy way to disably
only WoltLab's copyright on only a few pages.