### PR TITLE
removed double class attribute from section tag on update overview

### DIFF
--- a/wcfsetup/install/files/acp/templates/packageUpdate.tpl
+++ b/wcfsetup/install/files/acp/templates/packageUpdate.tpl
@@ -17,7 +17,7 @@
 </header>
 
 {foreach from=$availableUpdates item=update}
-	<section class="section" class="jsPackageUpdate" data-package="{$update[package]}">
+	<section class="section jsPackageUpdate" data-package="{$update[package]}">
 		<header class="sectionHeader">
 			<h2 class="sectionTitle"><label>
 				<input type="checkbox" value="1" checked>


### PR DESCRIPTION
The `section` got two `class="x"` attributes which makes it impossible to run any update from the PackageUpdatePage because the second gets ignored and `WCF.ACP.Package.Update.Manager` won't find any `.jsPackageUpdate`.