### PR TITLE
Speed up parseSmilies in MessageParser

### DIFF
--- a/wcfsetup/install/files/lib/system/bbcode/MessageParser.class.php
+++ b/wcfsetup/install/files/lib/system/bbcode/MessageParser.class.php
@@ -133,8 +133,10 @@ class MessageParser extends BBCodeParser {
 	 */
 	protected function parseSmilies($text, $enableHtml = false) {
 		foreach ($this->smilies as $code => $html) {
-			//$text = preg_replace('~(?<!&\w{2}|&\w{3}|&\w{4}|&\w{5}|&\w{6}|&#\d{2}|&#\d{3}|&#\d{4}|&#\d{5})'.preg_quote((!$enableHtml ? StringUtil::encodeHTML($code) : $code), '~').'(?![^<]*>)~', $html, $text);
-			$text = preg_replace('~(?<=^|\s|<li>)'.preg_quote((!$enableHtml ? StringUtil::encodeHTML($code) : $code), '~').'(?=$|\s|</li>'.(!$enableHtml ? '|<br />' : '').')~', $html, $text);
+			if (strpos($text, (!$enableHtml ? StringUtil::encodeHTML($code) : $code)) !== FALSE) {
+				//$text = preg_replace('~(?<!&\w{2}|&\w{3}|&\w{4}|&\w{5}|&\w{6}|&#\d{2}|&#\d{3}|&#\d{4}|&#\d{5})'.preg_quote((!$enableHtml ? StringUtil::encodeHTML($code) : $code), '~').'(?![^<]*>)~', $html, $text);
+				$text = preg_replace('~(?<=^|\s|<li>)'.preg_quote((!$enableHtml ? StringUtil::encodeHTML($code) : $code), '~').'(?=$|\s|</li>'.(!$enableHtml ? '|<br />' : '').')~', $html, $text);
+			}
 		}
 		
 		return $text;


### PR DESCRIPTION
If the WCF holds many smilies (thousands, e.g. due to the emoji plugin by SoftCreatR), the loop in the parseSmilies function needs a significant amount of time. Checking beforehand with strpos and only calling preg_replace, if the smiley was found at least one time, leads to an improved performance.