### PR TITLE
[2.1] fixed smiley bottleneck, major performance improvement

### DIFF
--- a/wcfsetup/install/files/lib/system/bbcode/MessageParser.class.php
+++ b/wcfsetup/install/files/lib/system/bbcode/MessageParser.class.php
@@ -132,9 +132,15 @@ class MessageParser extends BBCodeParser {
 	 * @return	string		text
 	 */
 	protected function parseSmilies($text, $enableHtml = false) {
-		foreach ($this->smilies as $code => $html) {
-			//$text = preg_replace('~(?<!&\w{2}|&\w{3}|&\w{4}|&\w{5}|&\w{6}|&#\d{2}|&#\d{3}|&#\d{4}|&#\d{5})'.preg_quote((!$enableHtml ? StringUtil::encodeHTML($code) : $code), '~').'(?![^<]*>)~', $html, $text);
-			$text = preg_replace('~(?<=^|\s|<li>)'.preg_quote((!$enableHtml ? StringUtil::encodeHTML($code) : $code), '~').'(?=$|\s|</li>'.(!$enableHtml ? '|<br />' : '').')~', $html, $text);
+		$codes = array_keys($this->smilies);
+		$pattern = '~(?<=^|\s|<li>)'.str_replace('@', '|', preg_quote((!$enableHtml ? StringUtil::encodeHTML(implode('@', $codes)) : implode('|', $codes)), '~')).'(?=$|\s|</li>'.(!$enableHtml ? '|<br />' : '').')~';
+		$matches = array();
+		preg_match_all($pattern, $text, $matches);
+		if (isset($matches[0])) {
+			foreach ($matches[0] as $key => $value) {
+				$value = StringUtil::decodeHTML($value);
+				$text = preg_replace('~(?<=^|\s|<li>)'.preg_quote((!$enableHtml ? StringUtil::encodeHTML($value) : $value), '~').'(?=$|\s|</li>'.(!$enableHtml ? '|<br />' : '').')~', $this->smilies[$value], $text);
+			}
 		}
 		
 		return $text;


### PR DESCRIPTION
## Disclaimer

> Please keep in mind that these are production profilings and there are addons installed which decrease the performance drastically already e.g. lexicon. If we calculate these out of the results, the performance improvement is way bigger than it looks like at the beginning.

> The profiling for these results happened during rush hour (~load of 5 with 8 logical core CPU). While writing the performance improvement and benchmarking it I got even better results, due to being at 8 AM with a load of 0.8. 

**Pre**
![image](https://cloud.githubusercontent.com/assets/3914677/19493262/38ba934a-957a-11e6-9411-f3294be11024.png)
**Post**
![image](https://cloud.githubusercontent.com/assets/3914677/19493267/40acb65a-957a-11e6-8d34-9cfe7d4e2db5.png)


> I'm not a php expert and I'm sure that there is a better way to implement such improvement and even improve it further. The goal is to limit the encodeHTML calls as much as possible as it is by far the most resource hungry part. On top the regex query can be limited to run only once and another time for every smiley found instead of once for every smiley in the database. At this point the current preg_match_all result could be filtered by duplicates to reduce further iterations.

# +1k Smileys
## Board
### Pre-Improvement:
**WoltLab Benchmark:** `Execution time: 5.1334s (98,34% PHP, 1,66% SQL) | SQL queries: 61 | Memory-Usage: 24,06 MB`
**XDebug:** `1358 different functions called in 5152 milliseconds (1 runs, 23 shown)`

![image](https://cloud.githubusercontent.com/assets/3914677/19491558/b102f43e-9573-11e6-888b-7ae1a5328678.png)

### Post-Improvement:
**WoltLab Benchmark:** `Execution time: 2.3657s (98,54% PHP, 1,46% SQL) | SQL queries: 60 | Memory-Usage: 24,06 MB`
**XDebug:** `1334 different functions called in 2384 milliseconds (1 runs, 48 shown)`

![image](https://cloud.githubusercontent.com/assets/3914677/19491655/099b71f2-9574-11e6-9b02-8ce400f324a8.png)

## Thread
### Pre-Improvement:
**WoltLab Benchmark:** `Execution time: 1.0229s (98,9% PHP, 1,09% SQL) | SQL queries: 24 | Memory-Usage: 16,4 MB`
**XDebug:** `1275 different functions called in 1044 milliseconds (1 runs, 63 shown)`

![image](https://cloud.githubusercontent.com/assets/3914677/19491976/40638444-9575-11e6-9599-a0b92e0721fc.png)

### Post-Improvement:
**WoltLab Benchmark:** `Execution time: 0.7464s (97,9% PHP, 2,09% SQL) | SQL queries: 24 | Memory-Usage: 16,27 MB`
**XDebug:** `1272 different functions called in 767 milliseconds (1 runs, 96 shown)`

![image](https://cloud.githubusercontent.com/assets/3914677/19491934/16c6265a-9575-11e6-856c-ee245364d6c8.png)



# Default Smileys
## Board
### Pre-Improvement:
**WoltLab Benchmark:** `Execution time: 0.5504s (88,65% PHP, 11,33% SQL) | SQL queries: 37 | Memory-Usage: 11,61 MB`
**XDebug:** `1162 different functions called in 523 milliseconds (1 runs, 130 shown)`

![image](https://cloud.githubusercontent.com/assets/3914677/19492456/05c6d316-9577-11e6-9809-2f64e86fa30b.png)


### Post-Improvement:
**WoltLab Benchmark:** `Execution time: 0.4693s (97,42% PHP, 2,56% SQL) | SQL queries: 37 | Memory-Usage: 11,63 MB`
**XDebug:** `1162 different functions called in 472 milliseconds (1 runs, 139 shown)`

![image](https://cloud.githubusercontent.com/assets/3914677/19492511/3e872368-9577-11e6-8e80-fdbd90e703a9.png)


## Thread
### Pre-Improvement:
**WoltLab Benchmark:** `Execution time: 0.3511s (95,5% PHP, 4,47% SQL) | SQL queries: 26 | Memory-Usage: 16,05 MB`
**XDebug:** `1170 different functions called in 368 milliseconds (1 runs, 126 shown)`

![image](https://cloud.githubusercontent.com/assets/3914677/19492614/abb51f26-9577-11e6-9f31-d2d6ee29de57.png)

### Post-Improvement:
**WoltLab Benchmark:** `Execution time: 0.3042s (91,65% PHP, 8,31% SQL) | SQL queries: 26 | Memory-Usage: 16,08 MB`
**XDebug:** `1170 different functions called in 330 milliseconds (1 runs, 146 shown)`

![image](https://cloud.githubusercontent.com/assets/3914677/19492550/66c829da-9577-11e6-92f8-22df843e09e2.png)


