### PR TITLE
Fix informal language variant in condition error messages

### DIFF
--- a/wcfsetup/install/files/lib/system/condition/AbstractSingleFieldCondition.class.php
+++ b/wcfsetup/install/files/lib/system/condition/AbstractSingleFieldCondition.class.php
@@ -62,7 +62,7 @@ abstract class AbstractSingleFieldCondition extends AbstractCondition {
 	 */
 	protected function getErrorMessageElement() {
 		if ($this->errorMessage) {
-			return '<small class="innerError">'.WCF::getLanguage()->get($this->errorMessage).'</small>';
+			return '<small class="innerError">'.WCF::getLanguage()->getDynamicVariable($this->errorMessage).'</small>';
 		}
 		
 		return '';


### PR DESCRIPTION
 `wcf.global.form.error.noValidSelection` uses template scripting and is used [here](https://github.com/WoltLab/WCF/blob/master/wcfsetup/install/files/lib/system/condition/AbstractMultiSelectCondition.class.php#L87) as a condition error message.