### PR TITLE
Set php limit to database field length

### DIFF
--- a/wcfsetup/install/files/lib/system/search/SearchKeywordManager.class.php
+++ b/wcfsetup/install/files/lib/system/search/SearchKeywordManager.class.php
@@ -35,7 +35,7 @@ class SearchKeywordManager extends SingletonFactory {
 		}
 		else {
 			$action = new SearchKeywordAction([], 'create', ['data' => [
-				'keyword' => mb_substr($keyword, 0, 255),
+				'keyword' => mb_substr($keyword, 0, 191),
 				'searches' => 1,
 				'lastSearchTime' => TIME_NOW
 			]]);


### PR DESCRIPTION
This prevents a fatal error because the field length of `keyword` is since a2bdc5f8a98c596955d86121017d33bab93740c9 191.