### PR TITLE
Fix typo in privacy policy text

### DIFF
--- a/com.woltlab.wcf/page.xml
+++ b/com.woltlab.wcf/page.xml
@@ -720,7 +720,7 @@
 				<title>Datenschutzerklärung</title>
 				<content><![CDATA[<h2>Datenschutz</h2>
     <p>Die Nutzung unserer Website ist in der Regel ohne Angabe personenbezogener Daten möglich. Soweit auf unseren Seiten personenbezogene Daten (beispielsweise Name, 
-      Anschrift oder eMail-Adressen) erhoben werden, erfolgt dies, soweit möglich, stets auf freiwilliger Basis. Diese Daten werden ohne Ihre ausdrückliche Zustimmung nicht an Dritte weitergegeben.   
+      Anschrift oder E-Mail-Adressen) erhoben werden, erfolgt dies, soweit möglich, stets auf freiwilliger Basis. Diese Daten werden ohne Ihre ausdrückliche Zustimmung nicht an Dritte weitergegeben.   
     </p>
     <p><br></p>
     <p>Wir weisen darauf hin, dass die Datenübertragung im Internet (z.B. 


### PR DESCRIPTION
It is always written as "E-Mail" in the text and on the other language items for german, this fix the typo.