### PR TITLE
Add events to UserProfile::isAccessible, UserProfile::isProtected and UsersOnlineList::isVisible

### DIFF
--- a/wcfsetup/install/files/lib/data/user/UserProfile.class.php
+++ b/wcfsetup/install/files/lib/data/user/UserProfile.class.php
@@ -12,6 +12,7 @@ use wcf\data\DatabaseObjectDecorator;
 use wcf\data\ITitledLinkObject;
 use wcf\system\cache\builder\UserGroupPermissionCacheBuilder;
 use wcf\system\cache\runtime\UserProfileRuntimeCache;
+use wcf\system\event\EventHandler;
 use wcf\system\user\signature\SignatureCache;
 use wcf\system\user\storage\UserStorageHandler;
 use wcf\system\WCF;
@@ -20,12 +21,12 @@ use wcf\util\StringUtil;
 
 /**
  * Decorates the user object and provides functions to retrieve data for user profiles.
- * 
+ *
  * @author	Marcel Werk
  * @copyright	2001-2016 WoltLab GmbH
  * @license	GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
  * @package	WoltLabSuite\Core\Data\User
- * 
+ *
  * @method	User	getDecoratedObject()
  * @mixin	User
  */
@@ -34,89 +35,89 @@ class UserProfile extends DatabaseObjectDecorator implements ITitledLinkObject {
 	 * @inheritDoc
 	 */
 	protected static $baseClass = User::class;
-	
+
 	/**
 	 * cached list of user profiles
 	 * @var	UserProfile[]
 	 */
 	protected static $userProfiles = [];
-	
+
 	/**
 	 * list of ignored user ids
 	 * @var	integer[]
 	 */
 	protected $ignoredUserIDs = null;
-	
+
 	/**
 	 * list of follower user ids
 	 * @var	integer[]
 	 */
 	protected $followerUserIDs = null;
-	
+
 	/**
 	 * list of following user ids
 	 * @var	integer[]
 	 */
 	protected $followingUserIDs = null;
-	
+
 	/**
 	 * user avatar
 	 * @var	IUserAvatar
 	 */
 	protected $avatar = null;
-	
+
 	/**
 	 * user rank object
 	 * @var	UserRank
 	 */
 	protected $rank = null;
-	
+
 	/**
 	 * age of this user
 	 * @var	integer
 	 */
 	protected $__age = null;
-	
+
 	/**
 	 * group data and permissions
 	 * @var	mixed[][]
 	 */
 	protected $groupData = null;
-	
+
 	/**
 	 * current location of this user.
 	 * @var	string
 	 */
 	protected $currentLocation = null;
-	
+
 	const GENDER_MALE = 1;
 	const GENDER_FEMALE = 2;
-	
+
 	const ACCESS_EVERYONE = 0;
 	const ACCESS_REGISTERED = 1;
 	const ACCESS_FOLLOWING = 2;
 	const ACCESS_NOBODY = 3;
-	
+
 	/**
 	 * @inheritDoc
 	 */
 	public function __toString() {
 		return $this->getDecoratedObject()->__toString();
 	}
-	
+
 	/**
 	 * Returns a list of all user ids being followed by current user.
-	 * 
+	 *
 	 * @return	integer[]
 	 */
 	public function getFollowingUsers() {
 		if ($this->followingUserIDs === null) {
 			$this->followingUserIDs = [];
-			
+
 			if ($this->userID) {
 				// get ids
 				$data = UserStorageHandler::getInstance()->getField('followingUserIDs', $this->userID);
-				
+
 				// cache does not exist or is outdated
 				if ($data === null) {
 					$sql = "SELECT	followUserID
@@ -125,7 +126,7 @@ class UserProfile extends DatabaseObjectDecorator implements ITitledLinkObject {
 					$statement = WCF::getDB()->prepareStatement($sql);
 					$statement->execute([$this->userID]);
 					$this->followingUserIDs = $statement->fetchAll(\PDO::FETCH_COLUMN);
-					
+
 					// update storage data
 					UserStorageHandler::getInstance()->update($this->userID, 'followingUserIDs', serialize($this->followingUserIDs));
 				}
@@ -134,23 +135,23 @@ class UserProfile extends DatabaseObjectDecorator implements ITitledLinkObject {
 				}
 			}
 		}
-		
+
 		return $this->followingUserIDs;
 	}
-	
+
 	/**
 	 * Returns a list of user ids following current user.
-	 * 
+	 *
 	 * @return	integer[]
 	 */
 	public function getFollowers() {
 		if ($this->followerUserIDs === null) {
 			$this->followerUserIDs = [];
-			
+
 			if ($this->userID) {
 				// get ids
 				$data = UserStorageHandler::getInstance()->getField('followerUserIDs', $this->userID);
-				
+
 				// cache does not exist or is outdated
 				if ($data === null) {
 					$sql = "SELECT	userID
@@ -159,7 +160,7 @@ class UserProfile extends DatabaseObjectDecorator implements ITitledLinkObject {
 					$statement = WCF::getDB()->prepareStatement($sql);
 					$statement->execute([$this->userID]);
 					$this->followerUserIDs = $statement->fetchAll(\PDO::FETCH_COLUMN);
-					
+
 					// update storage data
 					UserStorageHandler::getInstance()->update($this->userID, 'followerUserIDs', serialize($this->followerUserIDs));
 				}
@@ -168,23 +169,23 @@ class UserProfile extends DatabaseObjectDecorator implements ITitledLinkObject {
 				}
 			}
 		}
-		
+
 		return $this->followerUserIDs;
 	}
-	
+
 	/**
 	 * Returns a list of ignored user ids.
-	 * 
+	 *
 	 * @return	integer[]
 	 */
 	public function getIgnoredUsers() {
 		if ($this->ignoredUserIDs === null) {
 			$this->ignoredUserIDs = [];
-			
+
 			if ($this->userID) {
 				// get ids
 				$data = UserStorageHandler::getInstance()->getField('ignoredUserIDs', $this->userID);
-				
+
 				// cache does not exist or is outdated
 				if ($data === null) {
 					$sql = "SELECT	ignoreUserID
@@ -193,7 +194,7 @@ class UserProfile extends DatabaseObjectDecorator implements ITitledLinkObject {
 					$statement = WCF::getDB()->prepareStatement($sql);
 					$statement->execute([$this->userID]);
 					$this->ignoredUserIDs = $statement->fetchAll(\PDO::FETCH_COLUMN);
-					
+
 					// update storage data
 					UserStorageHandler::getInstance()->update($this->userID, 'ignoredUserIDs', serialize($this->ignoredUserIDs));
 				}
@@ -202,43 +203,43 @@ class UserProfile extends DatabaseObjectDecorator implements ITitledLinkObject {
 				}
 			}
 		}
-		
+
 		return $this->ignoredUserIDs;
 	}
-	
+
 	/**
 	 * Returns true if current user is following given user id.
-	 * 
+	 *
 	 * @param	integer		$userID
 	 * @return	boolean
 	 */
 	public function isFollowing($userID) {
 		return in_array($userID, $this->getFollowingUsers());
 	}
-	
+
 	/**
 	 * Returns true if given user ids follows current user.
-	 * 
+	 *
 	 * @param	integer		$userID
 	 * @return	boolean
 	 */
 	public function isFollower($userID) {
 		return in_array($userID, $this->getFollowers());
 	}
-	
+
 	/**
 	 * Returns true if given user is ignored.
-	 * 
+	 *
 	 * @param	integer		$userID
 	 * @return	boolean
 	 */
 	public function isIgnoredUser($userID) {
 		return in_array($userID, $this->getIgnoredUsers());
 	}
-	
+
 	/**
 	 * Returns the user's avatar.
-	 * 
+	 *
 	 * @return	IUserAvatar
 	 */
 	public function getAvatar() {
@@ -265,28 +266,28 @@ class UserProfile extends DatabaseObjectDecorator implements ITitledLinkObject {
 					}
 				}
 			}
-			
+
 			// use default avatar
 			if ($this->avatar === null) {
 				$this->avatar = new DefaultAvatar();
 			}
 		}
-		
+
 		return $this->avatar;
 	}
-	
+
 	/**
 	 * Returns true if the active user can view the avatar of this user.
-	 * 
+	 *
 	 * @return	boolean
 	 */
 	public function canSeeAvatar() {
 		return (WCF::getUser()->userID == $this->userID || WCF::getSession()->getPermission('user.profile.avatar.canSeeAvatars'));
 	}
-	
+
 	/**
 	 * Returns true if this user is currently online.
-	 * 
+	 *
 	 * @return	boolean
 	 */
 	public function isOnline() {
@@ -295,44 +296,44 @@ class UserProfile extends DatabaseObjectDecorator implements ITitledLinkObject {
 		}
 		return false;
 	}
-	
+
 	/**
 	 * Returns true if the active user can view the online status of this user.
-	 * 
+	 *
 	 * @return	boolean
 	 */
 	public function canViewOnlineStatus() {
 		return (WCF::getUser()->userID == $this->userID || WCF::getSession()->getPermission('admin.user.canViewInvisible') || $this->isAccessible('canViewOnlineStatus'));
 	}
-	
+
 	/**
 	 * Returns the current location of this user.
-	 * 
+	 *
 	 * @return	string
 	 */
 	public function getCurrentLocation() {
 		if ($this->currentLocation === null) {
 			$userOnline = new UserOnline($this->getDecoratedObject());
 			$userOnline->setLocation();
-			
+
 			$this->currentLocation = $userOnline->getLocation();
 		}
-		
+
 		return $this->currentLocation;
 	}
-	
+
 	/**
 	 * Returns the last activity time.
-	 * 
+	 *
 	 * @return	integer
 	 */
 	public function getLastActivityTime() {
 		return max($this->lastActivityTime, $this->sessionLastActivityTime);
 	}
-	
+
 	/**
 	 * Returns a new user profile object.
-	 * 
+	 *
 	 * @param	integer				$userID
 	 * @return	UserProfile
 	 * @deprecated	3.0, use UserProfileRuntimeCache::getObject()
@@ -340,48 +341,48 @@ class UserProfile extends DatabaseObjectDecorator implements ITitledLinkObject {
 	public static function getUserProfile($userID) {
 		return UserProfileRuntimeCache::getInstance()->getObject($userID);
 	}
-	
+
 	/**
 	 * Returns a list of user profiles.
-	 * 
+	 *
 	 * @param	integer[]		$userIDs
 	 * @return	UserProfile[]
 	 * @deprecated	3.0, use UserProfileRuntimeCache::getObjects()
 	 */
 	public static function getUserProfiles(array $userIDs) {
 		$users = UserProfileRuntimeCache::getInstance()->getObjects($userIDs);
-		
+
 		// this method does not return null for non-existing user profiles
 		foreach ($users as $userID => $user) {
 			if ($user === null) {
 				unset($users[$userID]);
 			}
 		}
-		
+
 		return $users;
 	}
-	
+
 	/**
 	 * Returns the user profile of the user with the given name.
-	 * 
+	 *
 	 * @param	string		$username
 	 * @return	UserProfile
 	 */
 	public static function getUserProfileByUsername($username) {
 		$users = self::getUserProfilesByUsername([$username]);
-		
+
 		return $users[$username];
 	}
-	
+
 	/**
 	 * Returns the user profiles of the users with the given names.
-	 * 
+	 *
 	 * @param	string[]	$usernames
 	 * @return	UserProfile[]
 	 */
 	public static function getUserProfilesByUsername(array $usernames) {
 		$users = [];
-		
+
 		// save case sensitive usernames
 		$caseSensitiveUsernames = [];
 		foreach ($usernames as &$username) {
@@ -390,7 +391,7 @@ class UserProfile extends DatabaseObjectDecorator implements ITitledLinkObject {
 			$username = $tmp;
 		}
 		unset($username);
-		
+
 		// check cache
 		$userProfiles = UserProfileRuntimeCache::getInstance()->getCachedObjects();
 		foreach ($usernames as $index => $username) {
@@ -401,24 +402,24 @@ class UserProfile extends DatabaseObjectDecorator implements ITitledLinkObject {
 				}
 			}
 		}
-		
+
 		if (!empty($usernames)) {
 			$userList = new UserProfileList();
 			$userList->getConditionBuilder()->add("user_table.username IN (?)", [$usernames]);
 			$userList->readObjects();
-			
+
 			foreach ($userList as $user) {
 				$users[mb_strtolower($user->username)] = $user;
 				self::$userProfiles[$user->userID] = $user;
 			}
-			
+
 			foreach ($usernames as $username) {
 				if (!isset($users[$username])) {
 					$users[$username] = null;
 				}
 			}
 		}
-		
+
 		// revert usernames to original case
 		foreach ($users as $username => $user) {
 			unset($users[$username]);
@@ -426,49 +427,56 @@ class UserProfile extends DatabaseObjectDecorator implements ITitledLinkObject {
 				$users[$caseSensitiveUsernames[$username]] = $user;
 			}
 		}
-		
+
 		return $users;
 	}
-	
+
 	/**
 	 * Returns true if current user fulfills the required permissions.
-	 * 
+	 *
 	 * @param	string		$name
 	 * @return	boolean
 	 */
 	public function isAccessible($name) {
 		/** @noinspection PhpVariableVariableInspection */
+		$data = ['result' => true, 'args' => [$name]];
+
 		switch ($this->$name) {
 			case self::ACCESS_EVERYONE:
-				return true;
+				$data['result'] = true;
 			break;
-			
+
 			case self::ACCESS_REGISTERED:
-				return (WCF::getUser()->userID ? true : false);
+				$data['result'] = (WCF::getUser()->userID ? true : false);
 			break;
-			
+
 			case self::ACCESS_FOLLOWING:
-				return ($this->isFollowing(WCF::getUser()->userID) ? true : false);
+				$data['result'] = ($this->isFollowing(WCF::getUser()->userID) ? true : false);
 			break;
-			
+
 			case self::ACCESS_NOBODY:
-				return false;
+				$data['result'] = false;
 			break;
 		}
+
+		EventHandler::getInstance()->fireAction($this, 'isAccessible', $data);
+		return $data['result'];
 	}
-	
+
 	/**
 	 * Returns true if current user profile is protected.
-	 * 
+	 *
 	 * @return	boolean
 	 */
 	public function isProtected() {
-		return (!WCF::getSession()->getPermission('admin.general.canViewPrivateUserOptions') && !$this->isAccessible('canViewProfile') && $this->userID != WCF::getUser()->userID);
+		$data = ['result' => (!WCF::getSession()->getPermission('admin.general.canViewPrivateUserOptions') && !$this->isAccessible('canViewProfile') && $this->userID != WCF::getUser()->userID)];
+		EventHandler::getInstance()->fireAction($this, 'isProtected', $data);
+		return $data['result'];
 	}
-	
+
 	/**
 	 * Returns the age of this user.
-	 * 
+	 *
 	 * @param	integer		$year
 	 * @return	integer
 	 */
@@ -482,7 +490,7 @@ class UserProfile extends DatabaseObjectDecorator implements ITitledLinkObject {
 					return $year - $birthdayYear;
 				}
 			}
-			
+
 			return 0;
 		}
 		else {
@@ -494,14 +502,14 @@ class UserProfile extends DatabaseObjectDecorator implements ITitledLinkObject {
 					$this->__age = 0;
 				}
 			}
-			
+
 			return $this->__age;
 		}
 	}
-	
+
 	/**
 	 * Returns the formatted birthday of this user.
-	 * 
+	 *
 	 * @param	integer		$year
 	 * @return	string
 	 */
@@ -512,62 +520,62 @@ class UserProfile extends DatabaseObjectDecorator implements ITitledLinkObject {
 		if (isset($value[0])) $birthdayYear = intval($value[0]);
 		if (isset($value[1])) $month = intval($value[1]);
 		if (isset($value[2])) $day = intval($value[2]);
-		
+
 		if (!$month || !$day) return '';
-		
+
 		$d = new \DateTime();
 		$d->setTimezone(WCF::getUser()->getTimeZone());
 		$d->setDate($birthdayYear, $month, $day);
 		$dateFormat = (($this->birthdayShowYear && $birthdayYear) ? WCF::getLanguage()->get(DateUtil::DATE_FORMAT) : str_replace('Y', '', WCF::getLanguage()->get(DateUtil::DATE_FORMAT)));
 		$birthday = DateUtil::localizeDate($d->format($dateFormat), $dateFormat, WCF::getLanguage());
-		
+
 		if ($this->birthdayShowYear) {
 			$age = $this->getAge($year);
 			if ($age > 0) {
 				$birthday .= ' ('.$age.')';
 			}
 		}
-		
+
 		return $birthday;
 	}
-	
+
 	/**
 	 * Returns the age of user account in days.
-	 * 
+	 *
 	 * @return	integer
 	 */
 	public function getProfileAge() {
 		return (TIME_NOW - $this->registrationDate) / 86400;
 	}
-	
+
 	/**
 	 * Returns the value of the permission with the given name.
-	 * 
+	 *
 	 * @param	string		$permission
 	 * @return	mixed		permission value
 	 */
 	public function getPermission($permission) {
 		if ($this->groupData === null) $this->loadGroupData();
-		
+
 		if (!isset($this->groupData[$permission])) return false;
 		return $this->groupData[$permission];
 	}
-	
+
 	/**
 	 * Returns the user title of this user.
-	 * 
+	 *
 	 * @return	string
 	 */
 	public function getUserTitle() {
 		if ($this->userTitle) return $this->userTitle;
 		if ($this->getRank()) return WCF::getLanguage()->get($this->getRank()->rankTitle);
-		
+
 		return '';
 	}
-	
+
 	/**
 	 * Returns the user rank.
-	 * 
+	 *
 	 * @return	UserRank
 	 */
 	public function getRank() {
@@ -588,7 +596,7 @@ class UserProfile extends DatabaseObjectDecorator implements ITitledLinkObject {
 				else {
 					// load storage data
 					$data = UserStorageHandler::getInstance()->getField('userRank', $this->userID);
-					
+
 					if ($data === null) {
 						$this->rank = new UserRank($this->rankID);
 						UserStorageHandler::getInstance()->update($this->userID, 'userRank', serialize($this->rank));
@@ -599,10 +607,10 @@ class UserProfile extends DatabaseObjectDecorator implements ITitledLinkObject {
 				}
 			}
 		}
-		
+
 		return $this->rank;
 	}
-	
+
 	/**
 	 * Loads group data from cache.
 	 */
@@ -613,10 +621,10 @@ class UserProfile extends DatabaseObjectDecorator implements ITitledLinkObject {
 			$this->groupData = [];
 		}
 	}
-	
+
 	/**
 	 * Returns the old username of this user.
-	 * 
+	 *
 	 * @return	string
 	 */
 	public function getOldUsername() {
@@ -625,102 +633,102 @@ class UserProfile extends DatabaseObjectDecorator implements ITitledLinkObject {
 				return $this->oldUsername;
 			}
 		}
-		
+
 		return '';
 	}
-	
+
 	/**
 	 * Returns true if this user can edit his profile.
-	 * 
+	 *
 	 * @return	boolean
 	 */
 	public function canEditOwnProfile() {
 		return ($this->activationCode ? false : true);
 	}
-	
+
 	/**
 	 * Returns the encoded email address.
-	 * 
+	 *
 	 * @return	string
 	 */
 	public function getEncodedEmail() {
 		return StringUtil::encodeAllChars($this->email);
 	}
-	
+
 	/**
 	 * Returns true if the current user is connected with Facebook.
-	 * 
+	 *
 	 * @return	boolean
 	 */
 	public function isConnectedWithFacebook() {
 		return StringUtil::startsWith($this->authData, 'facebook:');
 	}
-	
+
 	/**
 	 * Returns true if the current user is connected with GitHub.
-	 * 
+	 *
 	 * @return	boolean
 	 */
 	public function isConnectedWithGithub() {
 		return StringUtil::startsWith($this->authData, 'github:');
 	}
-	
+
 	/**
 	 * Returns true if the current user is connected with Google Plus.
-	 * 
+	 *
 	 * @return	boolean
 	 */
 	public function isConnectedWithGoogle() {
 		return StringUtil::startsWith($this->authData, 'google:');
 	}
-	
+
 	/**
 	 * Returns true if the current user is connected with Twitter.
-	 * 
+	 *
 	 * @return	boolean
 	 */
 	public function isConnectedWithTwitter() {
 		return StringUtil::startsWith($this->authData, 'twitter:');
 	}
-	
+
 	/**
 	 * Returns 3rd party auth provider name.
-	 * 
+	 *
 	 * @return	string
 	 */
 	public function getAuthProvider() {
 		if (!$this->authData) {
 			return '';
 		}
-		
+
 		return mb_substr($this->authData, 0, mb_strpos($this->authData, ':'));
 	}
-	
+
 	/**
 	 * Return true if the user's signature is visible.
-	 * 
+	 *
 	 * @return	boolean
 	 */
 	public function showSignature() {
 		if (!$this->signature) return false;
 		if ($this->disableSignature) return false;
 		if (WCF::getUser()->userID && !WCF::getUser()->showSignature) return false;
-		
+
 		return true;
 	}
-	
+
 	/**
 	 * Returns the parsed signature.
-	 * 
+	 *
 	 * @return	string
 	 */
 	public function getSignature() {
 		return SignatureCache::getInstance()->getSignature($this->getDecoratedObject());
 	}
-	
+
 	/**
 	 * Returns the formatted value of the user option with the given name.
-	 * 
+	 *
 	 * @param	string		$name
 	 * @return	mixed
 	 */
@@ -728,16 +736,16 @@ class UserProfile extends DatabaseObjectDecorator implements ITitledLinkObject {
 		// get value
 		$value = $this->getUserOption($name);
 		if (!$value) return '';
-		
+
 		$option = ViewableUserOption::getUserOption($name);
 		if (!$option->isVisible()) return '';
 		$option->setOptionValue($this->getDecoratedObject());
 		return $option->optionValue;
 	}
-	
+
 	/**
 	 * Returns true, if the active user has access to the user option with the given name.
-	 * 
+	 *
 	 * @param	string		$name
 	 * @return	boolean
 	 */
@@ -745,63 +753,63 @@ class UserProfile extends DatabaseObjectDecorator implements ITitledLinkObject {
 		$option = ViewableUserOption::getUserOption($name);
 		return $option->isVisible();
 	}
-	
+
 	/**
 	 * Returns the formatted username.
-	 * 
+	 *
 	 * @return	string
 	 */
 	public function getFormattedUsername() {
 		$username = StringUtil::encodeHTML($this->username);
-		
+
 		if ($this->userOnlineGroupID) {
 			$group = UserGroup::getGroupByID($this->userOnlineGroupID);
 			if ($group !== null && $group->userOnlineMarking && $group->userOnlineMarking != '%s') {
 				return str_replace('%s', $username, $group->userOnlineMarking);
 			}
 		}
-		
+
 		return $username;
 	}
-	
+
 	/**
 	 * Returns a HTML anchor link pointing to the decorated user.
-	 * 
+	 *
 	 * @return	string
 	 */
 	public function getAnchorTag() {
 		return '<a href="'.$this->getLink().'" class="userLink" data-user-id="'.$this->userID.'">'.StringUtil::encodeHTML($this->username).'</a>';
 	}
-	
+
 	/**
 	 * @inheritDoc
 	 */
 	public function getLink() {
 		return $this->getDecoratedObject()->getLink();
 	}
-	
+
 	/**
 	 * @inheritDoc
 	 */
 	public function getTitle() {
 		return $this->getDecoratedObject()->getTitle();
 	}
-	
+
 	/**
 	 * Sets the session-based last activity time.
-	 * 
+	 *
 	 * @param       integer         $timestamp
 	 */
 	public function setSessionLastActivityTime($timestamp) {
 		$this->object->data['sessionLastActivityTime'] = $timestamp;
 	}
-	
+
 	/**
 	 * Returns an "empty" user profile object for a guest with the given username.
-	 * 
+	 *
 	 * Such objects can also be used in situations where the relevant user has been deleted
 	 * but their original username is still known.
-	 * 
+	 *
 	 * @param	string		$username
 	 * @return	UserProfile
 	 * @since	3.0
@@ -810,3 +818,4 @@ class UserProfile extends DatabaseObjectDecorator implements ITitledLinkObject {
 		return new UserProfile(new User(null, ['username' => $username]));
 	}
 }
+

--- a/wcfsetup/install/files/lib/data/user/UserProfile.class.php
+++ b/wcfsetup/install/files/lib/data/user/UserProfile.class.php
@@ -21,12 +21,12 @@ use wcf\util\StringUtil;
 
 /**
  * Decorates the user object and provides functions to retrieve data for user profiles.
- *
+ * 
  * @author	Marcel Werk
  * @copyright	2001-2016 WoltLab GmbH
  * @license	GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
  * @package	WoltLabSuite\Core\Data\User
- *
+ * 
  * @method	User	getDecoratedObject()
  * @mixin	User
  */
@@ -35,89 +35,89 @@ class UserProfile extends DatabaseObjectDecorator implements ITitledLinkObject {
 	 * @inheritDoc
 	 */
 	protected static $baseClass = User::class;
-
+	
 	/**
 	 * cached list of user profiles
 	 * @var	UserProfile[]
 	 */
 	protected static $userProfiles = [];
-
+	
 	/**
 	 * list of ignored user ids
 	 * @var	integer[]
 	 */
 	protected $ignoredUserIDs = null;
-
+	
 	/**
 	 * list of follower user ids
 	 * @var	integer[]
 	 */
 	protected $followerUserIDs = null;
-
+	
 	/**
 	 * list of following user ids
 	 * @var	integer[]
 	 */
 	protected $followingUserIDs = null;
-
+	
 	/**
 	 * user avatar
 	 * @var	IUserAvatar
 	 */
 	protected $avatar = null;
-
+	
 	/**
 	 * user rank object
 	 * @var	UserRank
 	 */
 	protected $rank = null;
-
+	
 	/**
 	 * age of this user
 	 * @var	integer
 	 */
 	protected $__age = null;
-
+	
 	/**
 	 * group data and permissions
 	 * @var	mixed[][]
 	 */
 	protected $groupData = null;
-
+	
 	/**
 	 * current location of this user.
 	 * @var	string
 	 */
 	protected $currentLocation = null;
-
+	
 	const GENDER_MALE = 1;
 	const GENDER_FEMALE = 2;
-
+	
 	const ACCESS_EVERYONE = 0;
 	const ACCESS_REGISTERED = 1;
 	const ACCESS_FOLLOWING = 2;
 	const ACCESS_NOBODY = 3;
-
+	
 	/**
 	 * @inheritDoc
 	 */
 	public function __toString() {
 		return $this->getDecoratedObject()->__toString();
 	}
-
+	
 	/**
 	 * Returns a list of all user ids being followed by current user.
-	 *
+	 * 
 	 * @return	integer[]
 	 */
 	public function getFollowingUsers() {
 		if ($this->followingUserIDs === null) {
 			$this->followingUserIDs = [];
-
+			
 			if ($this->userID) {
 				// get ids
 				$data = UserStorageHandler::getInstance()->getField('followingUserIDs', $this->userID);
-
+				
 				// cache does not exist or is outdated
 				if ($data === null) {
 					$sql = "SELECT	followUserID
@@ -126,7 +126,7 @@ class UserProfile extends DatabaseObjectDecorator implements ITitledLinkObject {
 					$statement = WCF::getDB()->prepareStatement($sql);
 					$statement->execute([$this->userID]);
 					$this->followingUserIDs = $statement->fetchAll(\PDO::FETCH_COLUMN);
-
+					
 					// update storage data
 					UserStorageHandler::getInstance()->update($this->userID, 'followingUserIDs', serialize($this->followingUserIDs));
 				}
@@ -135,23 +135,23 @@ class UserProfile extends DatabaseObjectDecorator implements ITitledLinkObject {
 				}
 			}
 		}
-
+		
 		return $this->followingUserIDs;
 	}
-
+	
 	/**
 	 * Returns a list of user ids following current user.
-	 *
+	 * 
 	 * @return	integer[]
 	 */
 	public function getFollowers() {
 		if ($this->followerUserIDs === null) {
 			$this->followerUserIDs = [];
-
+			
 			if ($this->userID) {
 				// get ids
 				$data = UserStorageHandler::getInstance()->getField('followerUserIDs', $this->userID);
-
+				
 				// cache does not exist or is outdated
 				if ($data === null) {
 					$sql = "SELECT	userID
@@ -160,7 +160,7 @@ class UserProfile extends DatabaseObjectDecorator implements ITitledLinkObject {
 					$statement = WCF::getDB()->prepareStatement($sql);
 					$statement->execute([$this->userID]);
 					$this->followerUserIDs = $statement->fetchAll(\PDO::FETCH_COLUMN);
-
+					
 					// update storage data
 					UserStorageHandler::getInstance()->update($this->userID, 'followerUserIDs', serialize($this->followerUserIDs));
 				}
@@ -169,23 +169,23 @@ class UserProfile extends DatabaseObjectDecorator implements ITitledLinkObject {
 				}
 			}
 		}
-
+		
 		return $this->followerUserIDs;
 	}
-
+	
 	/**
 	 * Returns a list of ignored user ids.
-	 *
+	 * 
 	 * @return	integer[]
 	 */
 	public function getIgnoredUsers() {
 		if ($this->ignoredUserIDs === null) {
 			$this->ignoredUserIDs = [];
-
+			
 			if ($this->userID) {
 				// get ids
 				$data = UserStorageHandler::getInstance()->getField('ignoredUserIDs', $this->userID);
-
+				
 				// cache does not exist or is outdated
 				if ($data === null) {
 					$sql = "SELECT	ignoreUserID
@@ -194,7 +194,7 @@ class UserProfile extends DatabaseObjectDecorator implements ITitledLinkObject {
 					$statement = WCF::getDB()->prepareStatement($sql);
 					$statement->execute([$this->userID]);
 					$this->ignoredUserIDs = $statement->fetchAll(\PDO::FETCH_COLUMN);
-
+					
 					// update storage data
 					UserStorageHandler::getInstance()->update($this->userID, 'ignoredUserIDs', serialize($this->ignoredUserIDs));
 				}
@@ -203,43 +203,43 @@ class UserProfile extends DatabaseObjectDecorator implements ITitledLinkObject {
 				}
 			}
 		}
-
+		
 		return $this->ignoredUserIDs;
 	}
-
+	
 	/**
 	 * Returns true if current user is following given user id.
-	 *
+	 * 
 	 * @param	integer		$userID
 	 * @return	boolean
 	 */
 	public function isFollowing($userID) {
 		return in_array($userID, $this->getFollowingUsers());
 	}
-
+	
 	/**
 	 * Returns true if given user ids follows current user.
-	 *
+	 * 
 	 * @param	integer		$userID
 	 * @return	boolean
 	 */
 	public function isFollower($userID) {
 		return in_array($userID, $this->getFollowers());
 	}
-
+	
 	/**
 	 * Returns true if given user is ignored.
-	 *
+	 * 
 	 * @param	integer		$userID
 	 * @return	boolean
 	 */
 	public function isIgnoredUser($userID) {
 		return in_array($userID, $this->getIgnoredUsers());
 	}
-
+	
 	/**
 	 * Returns the user's avatar.
-	 *
+	 * 
 	 * @return	IUserAvatar
 	 */
 	public function getAvatar() {
@@ -266,28 +266,28 @@ class UserProfile extends DatabaseObjectDecorator implements ITitledLinkObject {
 					}
 				}
 			}
-
+			
 			// use default avatar
 			if ($this->avatar === null) {
 				$this->avatar = new DefaultAvatar();
 			}
 		}
-
+		
 		return $this->avatar;
 	}
-
+	
 	/**
 	 * Returns true if the active user can view the avatar of this user.
-	 *
+	 * 
 	 * @return	boolean
 	 */
 	public function canSeeAvatar() {
 		return (WCF::getUser()->userID == $this->userID || WCF::getSession()->getPermission('user.profile.avatar.canSeeAvatars'));
 	}
-
+	
 	/**
 	 * Returns true if this user is currently online.
-	 *
+	 * 
 	 * @return	boolean
 	 */
 	public function isOnline() {
@@ -296,44 +296,44 @@ class UserProfile extends DatabaseObjectDecorator implements ITitledLinkObject {
 		}
 		return false;
 	}
-
+	
 	/**
 	 * Returns true if the active user can view the online status of this user.
-	 *
+	 * 
 	 * @return	boolean
 	 */
 	public function canViewOnlineStatus() {
 		return (WCF::getUser()->userID == $this->userID || WCF::getSession()->getPermission('admin.user.canViewInvisible') || $this->isAccessible('canViewOnlineStatus'));
 	}
-
+	
 	/**
 	 * Returns the current location of this user.
-	 *
+	 * 
 	 * @return	string
 	 */
 	public function getCurrentLocation() {
 		if ($this->currentLocation === null) {
 			$userOnline = new UserOnline($this->getDecoratedObject());
 			$userOnline->setLocation();
-
+			
 			$this->currentLocation = $userOnline->getLocation();
 		}
-
+		
 		return $this->currentLocation;
 	}
-
+	
 	/**
 	 * Returns the last activity time.
-	 *
+	 * 
 	 * @return	integer
 	 */
 	public function getLastActivityTime() {
 		return max($this->lastActivityTime, $this->sessionLastActivityTime);
 	}
-
+	
 	/**
 	 * Returns a new user profile object.
-	 *
+	 * 
 	 * @param	integer				$userID
 	 * @return	UserProfile
 	 * @deprecated	3.0, use UserProfileRuntimeCache::getObject()
@@ -341,48 +341,48 @@ class UserProfile extends DatabaseObjectDecorator implements ITitledLinkObject {
 	public static function getUserProfile($userID) {
 		return UserProfileRuntimeCache::getInstance()->getObject($userID);
 	}
-
+	
 	/**
 	 * Returns a list of user profiles.
-	 *
+	 * 
 	 * @param	integer[]		$userIDs
 	 * @return	UserProfile[]
 	 * @deprecated	3.0, use UserProfileRuntimeCache::getObjects()
 	 */
 	public static function getUserProfiles(array $userIDs) {
 		$users = UserProfileRuntimeCache::getInstance()->getObjects($userIDs);
-
+		
 		// this method does not return null for non-existing user profiles
 		foreach ($users as $userID => $user) {
 			if ($user === null) {
 				unset($users[$userID]);
 			}
 		}
-
+		
 		return $users;
 	}
-
+	
 	/**
 	 * Returns the user profile of the user with the given name.
-	 *
+	 * 
 	 * @param	string		$username
 	 * @return	UserProfile
 	 */
 	public static function getUserProfileByUsername($username) {
 		$users = self::getUserProfilesByUsername([$username]);
-
+		
 		return $users[$username];
 	}
-
+	
 	/**
 	 * Returns the user profiles of the users with the given names.
-	 *
+	 * 
 	 * @param	string[]	$usernames
 	 * @return	UserProfile[]
 	 */
 	public static function getUserProfilesByUsername(array $usernames) {
 		$users = [];
-
+		
 		// save case sensitive usernames
 		$caseSensitiveUsernames = [];
 		foreach ($usernames as &$username) {
@@ -391,7 +391,7 @@ class UserProfile extends DatabaseObjectDecorator implements ITitledLinkObject {
 			$username = $tmp;
 		}
 		unset($username);
-
+		
 		// check cache
 		$userProfiles = UserProfileRuntimeCache::getInstance()->getCachedObjects();
 		foreach ($usernames as $index => $username) {
@@ -402,24 +402,24 @@ class UserProfile extends DatabaseObjectDecorator implements ITitledLinkObject {
 				}
 			}
 		}
-
+		
 		if (!empty($usernames)) {
 			$userList = new UserProfileList();
 			$userList->getConditionBuilder()->add("user_table.username IN (?)", [$usernames]);
 			$userList->readObjects();
-
+			
 			foreach ($userList as $user) {
 				$users[mb_strtolower($user->username)] = $user;
 				self::$userProfiles[$user->userID] = $user;
 			}
-
+			
 			foreach ($usernames as $username) {
 				if (!isset($users[$username])) {
 					$users[$username] = null;
 				}
 			}
 		}
-
+		
 		// revert usernames to original case
 		foreach ($users as $username => $user) {
 			unset($users[$username]);
@@ -427,45 +427,45 @@ class UserProfile extends DatabaseObjectDecorator implements ITitledLinkObject {
 				$users[$caseSensitiveUsernames[$username]] = $user;
 			}
 		}
-
+		
 		return $users;
 	}
-
+	
 	/**
 	 * Returns true if current user fulfills the required permissions.
-	 *
+	 * 
 	 * @param	string		$name
 	 * @return	boolean
 	 */
 	public function isAccessible($name) {
 		/** @noinspection PhpVariableVariableInspection */
 		$data = ['result' => true, 'args' => [$name]];
-
+		
 		switch ($this->$name) {
 			case self::ACCESS_EVERYONE:
 				$data['result'] = true;
 			break;
-
+			
 			case self::ACCESS_REGISTERED:
 				$data['result'] = (WCF::getUser()->userID ? true : false);
 			break;
-
+			
 			case self::ACCESS_FOLLOWING:
 				$data['result'] = ($this->isFollowing(WCF::getUser()->userID) ? true : false);
 			break;
-
+			
 			case self::ACCESS_NOBODY:
 				$data['result'] = false;
 			break;
 		}
-
+		
 		EventHandler::getInstance()->fireAction($this, 'isAccessible', $data);
 		return $data['result'];
 	}
-
+	
 	/**
 	 * Returns true if current user profile is protected.
-	 *
+	 * 
 	 * @return	boolean
 	 */
 	public function isProtected() {
@@ -473,10 +473,10 @@ class UserProfile extends DatabaseObjectDecorator implements ITitledLinkObject {
 		EventHandler::getInstance()->fireAction($this, 'isProtected', $data);
 		return $data['result'];
 	}
-
+	
 	/**
 	 * Returns the age of this user.
-	 *
+	 * 
 	 * @param	integer		$year
 	 * @return	integer
 	 */
@@ -490,7 +490,7 @@ class UserProfile extends DatabaseObjectDecorator implements ITitledLinkObject {
 					return $year - $birthdayYear;
 				}
 			}
-
+			
 			return 0;
 		}
 		else {
@@ -502,14 +502,14 @@ class UserProfile extends DatabaseObjectDecorator implements ITitledLinkObject {
 					$this->__age = 0;
 				}
 			}
-
+			
 			return $this->__age;
 		}
 	}
-
+	
 	/**
 	 * Returns the formatted birthday of this user.
-	 *
+	 * 
 	 * @param	integer		$year
 	 * @return	string
 	 */
@@ -520,62 +520,62 @@ class UserProfile extends DatabaseObjectDecorator implements ITitledLinkObject {
 		if (isset($value[0])) $birthdayYear = intval($value[0]);
 		if (isset($value[1])) $month = intval($value[1]);
 		if (isset($value[2])) $day = intval($value[2]);
-
+		
 		if (!$month || !$day) return '';
-
+		
 		$d = new \DateTime();
 		$d->setTimezone(WCF::getUser()->getTimeZone());
 		$d->setDate($birthdayYear, $month, $day);
 		$dateFormat = (($this->birthdayShowYear && $birthdayYear) ? WCF::getLanguage()->get(DateUtil::DATE_FORMAT) : str_replace('Y', '', WCF::getLanguage()->get(DateUtil::DATE_FORMAT)));
 		$birthday = DateUtil::localizeDate($d->format($dateFormat), $dateFormat, WCF::getLanguage());
-
+		
 		if ($this->birthdayShowYear) {
 			$age = $this->getAge($year);
 			if ($age > 0) {
 				$birthday .= ' ('.$age.')';
 			}
 		}
-
+		
 		return $birthday;
 	}
-
+	
 	/**
 	 * Returns the age of user account in days.
-	 *
+	 * 
 	 * @return	integer
 	 */
 	public function getProfileAge() {
 		return (TIME_NOW - $this->registrationDate) / 86400;
 	}
-
+	
 	/**
 	 * Returns the value of the permission with the given name.
-	 *
+	 * 
 	 * @param	string		$permission
 	 * @return	mixed		permission value
 	 */
 	public function getPermission($permission) {
 		if ($this->groupData === null) $this->loadGroupData();
-
+		
 		if (!isset($this->groupData[$permission])) return false;
 		return $this->groupData[$permission];
 	}
-
+	
 	/**
 	 * Returns the user title of this user.
-	 *
+	 * 
 	 * @return	string
 	 */
 	public function getUserTitle() {
 		if ($this->userTitle) return $this->userTitle;
 		if ($this->getRank()) return WCF::getLanguage()->get($this->getRank()->rankTitle);
-
+		
 		return '';
 	}
-
+	
 	/**
 	 * Returns the user rank.
-	 *
+	 * 
 	 * @return	UserRank
 	 */
 	public function getRank() {
@@ -596,7 +596,7 @@ class UserProfile extends DatabaseObjectDecorator implements ITitledLinkObject {
 				else {
 					// load storage data
 					$data = UserStorageHandler::getInstance()->getField('userRank', $this->userID);
-
+					
 					if ($data === null) {
 						$this->rank = new UserRank($this->rankID);
 						UserStorageHandler::getInstance()->update($this->userID, 'userRank', serialize($this->rank));
@@ -607,10 +607,10 @@ class UserProfile extends DatabaseObjectDecorator implements ITitledLinkObject {
 				}
 			}
 		}
-
+		
 		return $this->rank;
 	}
-
+	
 	/**
 	 * Loads group data from cache.
 	 */
@@ -621,10 +621,10 @@ class UserProfile extends DatabaseObjectDecorator implements ITitledLinkObject {
 			$this->groupData = [];
 		}
 	}
-
+	
 	/**
 	 * Returns the old username of this user.
-	 *
+	 * 
 	 * @return	string
 	 */
 	public function getOldUsername() {
@@ -633,102 +633,102 @@ class UserProfile extends DatabaseObjectDecorator implements ITitledLinkObject {
 				return $this->oldUsername;
 			}
 		}
-
+		
 		return '';
 	}
-
+	
 	/**
 	 * Returns true if this user can edit his profile.
-	 *
+	 * 
 	 * @return	boolean
 	 */
 	public function canEditOwnProfile() {
 		return ($this->activationCode ? false : true);
 	}
-
+	
 	/**
 	 * Returns the encoded email address.
-	 *
+	 * 
 	 * @return	string
 	 */
 	public function getEncodedEmail() {
 		return StringUtil::encodeAllChars($this->email);
 	}
-
+	
 	/**
 	 * Returns true if the current user is connected with Facebook.
-	 *
+	 * 
 	 * @return	boolean
 	 */
 	public function isConnectedWithFacebook() {
 		return StringUtil::startsWith($this->authData, 'facebook:');
 	}
-
+	
 	/**
 	 * Returns true if the current user is connected with GitHub.
-	 *
+	 * 
 	 * @return	boolean
 	 */
 	public function isConnectedWithGithub() {
 		return StringUtil::startsWith($this->authData, 'github:');
 	}
-
+	
 	/**
 	 * Returns true if the current user is connected with Google Plus.
-	 *
+	 * 
 	 * @return	boolean
 	 */
 	public function isConnectedWithGoogle() {
 		return StringUtil::startsWith($this->authData, 'google:');
 	}
-
+	
 	/**
 	 * Returns true if the current user is connected with Twitter.
-	 *
+	 * 
 	 * @return	boolean
 	 */
 	public function isConnectedWithTwitter() {
 		return StringUtil::startsWith($this->authData, 'twitter:');
 	}
-
+	
 	/**
 	 * Returns 3rd party auth provider name.
-	 *
+	 * 
 	 * @return	string
 	 */
 	public function getAuthProvider() {
 		if (!$this->authData) {
 			return '';
 		}
-
+		
 		return mb_substr($this->authData, 0, mb_strpos($this->authData, ':'));
 	}
-
+	
 	/**
 	 * Return true if the user's signature is visible.
-	 *
+	 * 
 	 * @return	boolean
 	 */
 	public function showSignature() {
 		if (!$this->signature) return false;
 		if ($this->disableSignature) return false;
 		if (WCF::getUser()->userID && !WCF::getUser()->showSignature) return false;
-
+		
 		return true;
 	}
-
+	
 	/**
 	 * Returns the parsed signature.
-	 *
+	 * 
 	 * @return	string
 	 */
 	public function getSignature() {
 		return SignatureCache::getInstance()->getSignature($this->getDecoratedObject());
 	}
-
+	
 	/**
 	 * Returns the formatted value of the user option with the given name.
-	 *
+	 * 
 	 * @param	string		$name
 	 * @return	mixed
 	 */
@@ -736,16 +736,16 @@ class UserProfile extends DatabaseObjectDecorator implements ITitledLinkObject {
 		// get value
 		$value = $this->getUserOption($name);
 		if (!$value) return '';
-
+		
 		$option = ViewableUserOption::getUserOption($name);
 		if (!$option->isVisible()) return '';
 		$option->setOptionValue($this->getDecoratedObject());
 		return $option->optionValue;
 	}
-
+	
 	/**
 	 * Returns true, if the active user has access to the user option with the given name.
-	 *
+	 * 
 	 * @param	string		$name
 	 * @return	boolean
 	 */
@@ -753,63 +753,63 @@ class UserProfile extends DatabaseObjectDecorator implements ITitledLinkObject {
 		$option = ViewableUserOption::getUserOption($name);
 		return $option->isVisible();
 	}
-
+	
 	/**
 	 * Returns the formatted username.
-	 *
+	 * 
 	 * @return	string
 	 */
 	public function getFormattedUsername() {
 		$username = StringUtil::encodeHTML($this->username);
-
+		
 		if ($this->userOnlineGroupID) {
 			$group = UserGroup::getGroupByID($this->userOnlineGroupID);
 			if ($group !== null && $group->userOnlineMarking && $group->userOnlineMarking != '%s') {
 				return str_replace('%s', $username, $group->userOnlineMarking);
 			}
 		}
-
+		
 		return $username;
 	}
-
+	
 	/**
 	 * Returns a HTML anchor link pointing to the decorated user.
-	 *
+	 * 
 	 * @return	string
 	 */
 	public function getAnchorTag() {
 		return '<a href="'.$this->getLink().'" class="userLink" data-user-id="'.$this->userID.'">'.StringUtil::encodeHTML($this->username).'</a>';
 	}
-
+	
 	/**
 	 * @inheritDoc
 	 */
 	public function getLink() {
 		return $this->getDecoratedObject()->getLink();
 	}
-
+	
 	/**
 	 * @inheritDoc
 	 */
 	public function getTitle() {
 		return $this->getDecoratedObject()->getTitle();
 	}
-
+	
 	/**
 	 * Sets the session-based last activity time.
-	 *
+	 * 
 	 * @param       integer         $timestamp
 	 */
 	public function setSessionLastActivityTime($timestamp) {
 		$this->object->data['sessionLastActivityTime'] = $timestamp;
 	}
-
+	
 	/**
 	 * Returns an "empty" user profile object for a guest with the given username.
-	 *
+	 * 
 	 * Such objects can also be used in situations where the relevant user has been deleted
 	 * but their original username is still known.
-	 *
+	 * 
 	 * @param	string		$username
 	 * @return	UserProfile
 	 * @since	3.0

--- a/wcfsetup/install/files/lib/data/user/UserProfile.class.php
+++ b/wcfsetup/install/files/lib/data/user/UserProfile.class.php
@@ -460,6 +460,7 @@ class UserProfile extends DatabaseObjectDecorator implements ITitledLinkObject {
 		}
 		
 		EventHandler::getInstance()->fireAction($this, 'isAccessible', $data);
+		
 		return $data['result'];
 	}
 	
@@ -469,11 +470,7 @@ class UserProfile extends DatabaseObjectDecorator implements ITitledLinkObject {
 	 * @return	boolean
 	 */
 	public function isProtected() {
-		$data = [
-			'result' => (!WCF::getSession()->getPermission('admin.general.canViewPrivateUserOptions') && !$this->isAccessible('canViewProfile') && $this->userID != WCF::getUser()->userID)
-		];
-		EventHandler::getInstance()->fireAction($this, 'isProtected', $data);
-		return $data['result'];
+		return (!WCF::getSession()->getPermission('admin.general.canViewPrivateUserOptions') && !$this->isAccessible('canViewProfile') && $this->userID != WCF::getUser()->userID);
 	}
 	
 	/**

--- a/wcfsetup/install/files/lib/data/user/UserProfile.class.php
+++ b/wcfsetup/install/files/lib/data/user/UserProfile.class.php
@@ -439,7 +439,7 @@ class UserProfile extends DatabaseObjectDecorator implements ITitledLinkObject {
 	 */
 	public function isAccessible($name) {
 		/** @noinspection PhpVariableVariableInspection */
-		$data = ['result' => true, 'args' => [$name]];
+		$data = ['result' => true, 'name' => $name];
 		
 		switch ($this->$name) {
 			case self::ACCESS_EVERYONE:
@@ -469,7 +469,9 @@ class UserProfile extends DatabaseObjectDecorator implements ITitledLinkObject {
 	 * @return	boolean
 	 */
 	public function isProtected() {
-		$data = ['result' => (!WCF::getSession()->getPermission('admin.general.canViewPrivateUserOptions') && !$this->isAccessible('canViewProfile') && $this->userID != WCF::getUser()->userID)];
+		$data = [
+            'result' => (!WCF::getSession()->getPermission('admin.general.canViewPrivateUserOptions') && !$this->isAccessible('canViewProfile') && $this->userID != WCF::getUser()->userID)
+        ];
 		EventHandler::getInstance()->fireAction($this, 'isProtected', $data);
 		return $data['result'];
 	}
@@ -818,4 +820,3 @@ class UserProfile extends DatabaseObjectDecorator implements ITitledLinkObject {
 		return new UserProfile(new User(null, ['username' => $username]));
 	}
 }
-

--- a/wcfsetup/install/files/lib/data/user/UserProfile.class.php
+++ b/wcfsetup/install/files/lib/data/user/UserProfile.class.php
@@ -470,8 +470,8 @@ class UserProfile extends DatabaseObjectDecorator implements ITitledLinkObject {
 	 */
 	public function isProtected() {
 		$data = [
-            'result' => (!WCF::getSession()->getPermission('admin.general.canViewPrivateUserOptions') && !$this->isAccessible('canViewProfile') && $this->userID != WCF::getUser()->userID)
-        ];
+			'result' => (!WCF::getSession()->getPermission('admin.general.canViewPrivateUserOptions') && !$this->isAccessible('canViewProfile') && $this->userID != WCF::getUser()->userID)
+		];
 		EventHandler::getInstance()->fireAction($this, 'isProtected', $data);
 		return $data['result'];
 	}

--- a/wcfsetup/install/files/lib/data/user/online/UsersOnlineList.class.php
+++ b/wcfsetup/install/files/lib/data/user/online/UsersOnlineList.class.php
@@ -164,6 +164,7 @@ class UsersOnlineList extends SessionList {
 		switch ($canViewOnlineStatus) {
 			case 0: // everyone
 				$data['result'] = true;
+				break;
 			case 1: // registered
 				if (WCF::getUser()->userID) $data['result'] = true;
 				break;

--- a/wcfsetup/install/files/lib/data/user/online/UsersOnlineList.class.php
+++ b/wcfsetup/install/files/lib/data/user/online/UsersOnlineList.class.php
@@ -4,12 +4,13 @@ use wcf\data\option\OptionAction;
 use wcf\data\session\SessionList;
 use wcf\data\user\group\UserGroup;
 use wcf\data\user\User;
+use wcf\system\event\EventHandler;
 use wcf\system\WCF;
 use wcf\util\StringUtil;
 
 /**
  * Represents a list of currently online users.
- * 
+ *
  * @author	Marcel Werk
  * @copyright	2001-2016 WoltLab GmbH
  * @license	GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
@@ -25,7 +26,7 @@ class UsersOnlineList extends SessionList {
 	 * @inheritDoc
 	 */
 	public $sqlOrderBy = 'user_table.username';
-	
+
 	/**
 	 * users online stats
 	 * @var	array
@@ -36,39 +37,39 @@ class UsersOnlineList extends SessionList {
 		'members' => 0,
 		'guests' => 0
 	];
-	
+
 	/**
 	 * users online markings
 	 * @var	array
 	 */
 	public $usersOnlineMarkings = null;
-	
+
 	/**
 	 * @inheritDoc
 	 */
 	public function __construct() {
 		parent::__construct();
-		
+
 		$this->sqlSelects .= "user_avatar.*, user_option_value.*, user_group.userOnlineMarking, user_table.*";
-		
+
 		$this->sqlConditionJoins .= " LEFT JOIN wcf".WCF_N."_user user_table ON (user_table.userID = session.userID)";
 		$this->sqlJoins .= " LEFT JOIN wcf".WCF_N."_user user_table ON (user_table.userID = session.userID)";
 		$this->sqlJoins .= " LEFT JOIN wcf".WCF_N."_user_option_value user_option_value ON (user_option_value.userID = user_table.userID)";
 		$this->sqlJoins .= " LEFT JOIN wcf".WCF_N."_user_avatar user_avatar ON (user_avatar.avatarID = user_table.avatarID)";
 		$this->sqlJoins .= " LEFT JOIN wcf".WCF_N."_user_group user_group ON (user_group.groupID = user_table.userOnlineGroupID)";
-		
+
 		$this->getConditionBuilder()->add('session.lastActivityTime > ?', [TIME_NOW - USER_ONLINE_TIMEOUT]);
 	}
-	
+
 	/**
 	 * @inheritDoc
 	 */
 	public function readObjects() {
 		parent::readObjects();
-		
+
 		$objects = $this->objects;
 		$this->indexToObject = $this->objects = [];
-		
+
 		foreach ($objects as $object) {
 			$object = new UserOnline(new User(null, null, $object));
 			if (!$object->userID || self::isVisible($object->userID, $object->canViewOnlineStatus)) {
@@ -79,14 +80,14 @@ class UsersOnlineList extends SessionList {
 		$this->objectIDs = $this->indexToObject;
 		$this->rewind();
 	}
-	
+
 	/**
 	 * Fetches users online stats.
 	 */
 	public function readStats() {
 		$conditionBuilder = clone $this->getConditionBuilder();
 		$conditionBuilder->add('session.spiderID IS NULL');
-		
+
 		$sql = "SELECT		user_option_value.userOption".User::getUserOptionID('canViewOnlineStatus')." AS canViewOnlineStatus, session.userID
 			FROM		wcf".WCF_N."_session session
 			LEFT JOIN	wcf".WCF_N."_user_option_value user_option_value
@@ -98,7 +99,7 @@ class UsersOnlineList extends SessionList {
 			$this->stats['total']++;
 			if ($row['userID']) {
 				$this->stats['members']++;
-				
+
 				if ($row['canViewOnlineStatus'] && !self::isVisible($row['userID'], $row['canViewOnlineStatus'])) {
 					$this->stats['invisible']++;
 				}
@@ -108,16 +109,16 @@ class UsersOnlineList extends SessionList {
 			}
 		}
 	}
-	
+
 	/**
 	 * Returns a list of the users online markings.
-	 * 
+	 *
 	 * @return	array
 	 */
 	public function getUsersOnlineMarkings() {
 		if ($this->usersOnlineMarkings === null) {
 			$this->usersOnlineMarkings = $priorities = [];
-			
+
 			// get groups
 			foreach (UserGroup::getGroupsByType() as $group) {
 				if ($group->userOnlineMarking != '%s') {
@@ -125,14 +126,14 @@ class UsersOnlineList extends SessionList {
 					$this->usersOnlineMarkings[] = str_replace('%s', StringUtil::encodeHTML(WCF::getLanguage()->get($group->groupName)), $group->userOnlineMarking);
 				}
 			}
-			
+
 			// sort list
 			array_multisort($priorities, SORT_DESC, $this->usersOnlineMarkings);
 		}
-		
+
 		return $this->usersOnlineMarkings;
 	}
-	
+
 	/**
 	 * Checks the users online record.
 	 */
@@ -147,29 +148,33 @@ class UsersOnlineList extends SessionList {
 			$optionAction->executeAction();
 		}
 	}
-	
+
 	/**
 	 * Checks the 'canViewOnlineStatus' setting.
-	 * 
+	 *
 	 * @param	integer		$userID
 	 * @param	integer		$canViewOnlineStatus
 	 * @return	boolean
 	 */
 	public static function isVisible($userID, $canViewOnlineStatus) {
-		if (WCF::getSession()->getPermission('admin.user.canViewInvisible') || $userID == WCF::getUser()->userID) return true;
-		
+		$data = ['result' => false, 'args' => [$userID, $canViewOnlineStatus]];
+
+		if (WCF::getSession()->getPermission('admin.user.canViewInvisible') || $userID == WCF::getUser()->userID) $data['result'] = true;
+
 		switch ($canViewOnlineStatus) {
 			case 0: // everyone
-				return true;
+				$data['result'] = true;
 			case 1: // registered
-				if (WCF::getUser()->userID) return true;
+				if (WCF::getUser()->userID) $data['result'] = true;
 				break;
 			case 2: // following
 				/** @noinspection PhpUndefinedMethodInspection */
-				if (WCF::getUserProfileHandler()->isFollower($userID)) return true;
+				if (WCF::getUserProfileHandler()->isFollower($userID)) $data['result'] = true;
 				break;
 		}
-		
-		return false;
+
+		EventHandler::getInstance()->fireAction(get_called_class(), 'isVisible', $data);
+		return $data['result'];
 	}
 }
+

--- a/wcfsetup/install/files/lib/data/user/online/UsersOnlineList.class.php
+++ b/wcfsetup/install/files/lib/data/user/online/UsersOnlineList.class.php
@@ -157,9 +157,9 @@ class UsersOnlineList extends SessionList {
 	 * @return	boolean
 	 */
 	public static function isVisible($userID, $canViewOnlineStatus) {
+		if (WCF::getSession()->getPermission('admin.user.canViewInvisible') || $userID == WCF::getUser()->userID) return true;
+
 		$data = ['result' => false, 'userID' => $userID, 'canViewOnlineStatus' => $canViewOnlineStatus];
-		
-		if (WCF::getSession()->getPermission('admin.user.canViewInvisible') || $userID == WCF::getUser()->userID) $data['result'] = true;
 		
 		switch ($canViewOnlineStatus) {
 			case 0: // everyone
@@ -174,6 +174,7 @@ class UsersOnlineList extends SessionList {
 		}
 		
 		EventHandler::getInstance()->fireAction(get_called_class(), 'isVisible', $data);
+		
 		return $data['result'];
 	}
 }

--- a/wcfsetup/install/files/lib/data/user/online/UsersOnlineList.class.php
+++ b/wcfsetup/install/files/lib/data/user/online/UsersOnlineList.class.php
@@ -10,7 +10,7 @@ use wcf\util\StringUtil;
 
 /**
  * Represents a list of currently online users.
- *
+ * 
  * @author	Marcel Werk
  * @copyright	2001-2016 WoltLab GmbH
  * @license	GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
@@ -26,7 +26,7 @@ class UsersOnlineList extends SessionList {
 	 * @inheritDoc
 	 */
 	public $sqlOrderBy = 'user_table.username';
-
+	
 	/**
 	 * users online stats
 	 * @var	array
@@ -37,39 +37,39 @@ class UsersOnlineList extends SessionList {
 		'members' => 0,
 		'guests' => 0
 	];
-
+	
 	/**
 	 * users online markings
 	 * @var	array
 	 */
 	public $usersOnlineMarkings = null;
-
+	
 	/**
 	 * @inheritDoc
 	 */
 	public function __construct() {
 		parent::__construct();
-
+		
 		$this->sqlSelects .= "user_avatar.*, user_option_value.*, user_group.userOnlineMarking, user_table.*";
-
+		
 		$this->sqlConditionJoins .= " LEFT JOIN wcf".WCF_N."_user user_table ON (user_table.userID = session.userID)";
 		$this->sqlJoins .= " LEFT JOIN wcf".WCF_N."_user user_table ON (user_table.userID = session.userID)";
 		$this->sqlJoins .= " LEFT JOIN wcf".WCF_N."_user_option_value user_option_value ON (user_option_value.userID = user_table.userID)";
 		$this->sqlJoins .= " LEFT JOIN wcf".WCF_N."_user_avatar user_avatar ON (user_avatar.avatarID = user_table.avatarID)";
 		$this->sqlJoins .= " LEFT JOIN wcf".WCF_N."_user_group user_group ON (user_group.groupID = user_table.userOnlineGroupID)";
-
+		
 		$this->getConditionBuilder()->add('session.lastActivityTime > ?', [TIME_NOW - USER_ONLINE_TIMEOUT]);
 	}
-
+	
 	/**
 	 * @inheritDoc
 	 */
 	public function readObjects() {
 		parent::readObjects();
-
+		
 		$objects = $this->objects;
 		$this->indexToObject = $this->objects = [];
-
+		
 		foreach ($objects as $object) {
 			$object = new UserOnline(new User(null, null, $object));
 			if (!$object->userID || self::isVisible($object->userID, $object->canViewOnlineStatus)) {
@@ -80,14 +80,14 @@ class UsersOnlineList extends SessionList {
 		$this->objectIDs = $this->indexToObject;
 		$this->rewind();
 	}
-
+	
 	/**
 	 * Fetches users online stats.
 	 */
 	public function readStats() {
 		$conditionBuilder = clone $this->getConditionBuilder();
 		$conditionBuilder->add('session.spiderID IS NULL');
-
+		
 		$sql = "SELECT		user_option_value.userOption".User::getUserOptionID('canViewOnlineStatus')." AS canViewOnlineStatus, session.userID
 			FROM		wcf".WCF_N."_session session
 			LEFT JOIN	wcf".WCF_N."_user_option_value user_option_value
@@ -99,7 +99,7 @@ class UsersOnlineList extends SessionList {
 			$this->stats['total']++;
 			if ($row['userID']) {
 				$this->stats['members']++;
-
+				
 				if ($row['canViewOnlineStatus'] && !self::isVisible($row['userID'], $row['canViewOnlineStatus'])) {
 					$this->stats['invisible']++;
 				}
@@ -109,16 +109,16 @@ class UsersOnlineList extends SessionList {
 			}
 		}
 	}
-
+	
 	/**
 	 * Returns a list of the users online markings.
-	 *
+	 * 
 	 * @return	array
 	 */
 	public function getUsersOnlineMarkings() {
 		if ($this->usersOnlineMarkings === null) {
 			$this->usersOnlineMarkings = $priorities = [];
-
+			
 			// get groups
 			foreach (UserGroup::getGroupsByType() as $group) {
 				if ($group->userOnlineMarking != '%s') {
@@ -126,14 +126,14 @@ class UsersOnlineList extends SessionList {
 					$this->usersOnlineMarkings[] = str_replace('%s', StringUtil::encodeHTML(WCF::getLanguage()->get($group->groupName)), $group->userOnlineMarking);
 				}
 			}
-
+			
 			// sort list
 			array_multisort($priorities, SORT_DESC, $this->usersOnlineMarkings);
 		}
-
+		
 		return $this->usersOnlineMarkings;
 	}
-
+	
 	/**
 	 * Checks the users online record.
 	 */
@@ -148,19 +148,19 @@ class UsersOnlineList extends SessionList {
 			$optionAction->executeAction();
 		}
 	}
-
+	
 	/**
 	 * Checks the 'canViewOnlineStatus' setting.
-	 *
+	 * 
 	 * @param	integer		$userID
 	 * @param	integer		$canViewOnlineStatus
 	 * @return	boolean
 	 */
 	public static function isVisible($userID, $canViewOnlineStatus) {
 		$data = ['result' => false, 'args' => [$userID, $canViewOnlineStatus]];
-
+		
 		if (WCF::getSession()->getPermission('admin.user.canViewInvisible') || $userID == WCF::getUser()->userID) $data['result'] = true;
-
+		
 		switch ($canViewOnlineStatus) {
 			case 0: // everyone
 				$data['result'] = true;
@@ -172,7 +172,7 @@ class UsersOnlineList extends SessionList {
 				if (WCF::getUserProfileHandler()->isFollower($userID)) $data['result'] = true;
 				break;
 		}
-
+		
 		EventHandler::getInstance()->fireAction(get_called_class(), 'isVisible', $data);
 		return $data['result'];
 	}

--- a/wcfsetup/install/files/lib/data/user/online/UsersOnlineList.class.php
+++ b/wcfsetup/install/files/lib/data/user/online/UsersOnlineList.class.php
@@ -157,7 +157,7 @@ class UsersOnlineList extends SessionList {
 	 * @return	boolean
 	 */
 	public static function isVisible($userID, $canViewOnlineStatus) {
-		$data = ['result' => false, 'args' => [$userID, $canViewOnlineStatus]];
+		$data = ['result' => false, 'userID' => $userID, 'canViewOnlineStatus' => $canViewOnlineStatus];
 		
 		if (WCF::getSession()->getPermission('admin.user.canViewInvisible') || $userID == WCF::getUser()->userID) $data['result'] = true;
 		
@@ -177,4 +177,3 @@ class UsersOnlineList extends SessionList {
 		return $data['result'];
 	}
 }
-


### PR DESCRIPTION
Use case for me is a friend system plugin that, among other features, allows users to make their profile or status only visible to friends. To implement this, I need to be able to change the return value of the three methods listed in the title.
I had actually found a "workaround" by replacing the decorator class of the UserProfileList with a subclass of UserProfile that introduced such events, but it was a pretty ugly hack and didn't work everywhere. That's why I was advised by a staff member to create this patch.