### PR TITLE
Added beforeProcess event to HtmlOutputNodeProcessor

### DIFF
--- a/wcfsetup/install/files/lib/system/html/output/node/HtmlOutputNodeProcessor.class.php
+++ b/wcfsetup/install/files/lib/system/html/output/node/HtmlOutputNodeProcessor.class.php
@@ -61,7 +61,7 @@ class HtmlOutputNodeProcessor extends AbstractHtmlNodeProcessor {
 	 */
 	public function process() {
 		// fire event action
-		EventHandler::getInstance()->fireAction($this, 'preProcess');
+		EventHandler::getInstance()->fireAction($this, 'beforeProcess');
 		
 		// highlight keywords
 		$this->highlightKeywords();

--- a/wcfsetup/install/files/lib/system/html/output/node/HtmlOutputNodeProcessor.class.php
+++ b/wcfsetup/install/files/lib/system/html/output/node/HtmlOutputNodeProcessor.class.php
@@ -2,6 +2,7 @@
 namespace wcf\system\html\output\node;
 use wcf\system\bbcode\HtmlBBCodeParser;
 use wcf\system\bbcode\KeywordHighlighter;
+use wcf\system\event\EventHandler;
 use wcf\system\html\node\AbstractHtmlNodeProcessor;
 use wcf\system\html\node\IHtmlNode;
 use wcf\util\DOMUtil;
@@ -59,6 +60,9 @@ class HtmlOutputNodeProcessor extends AbstractHtmlNodeProcessor {
 	 * @inheritDoc
 	 */
 	public function process() {
+		// fire event action
+		EventHandler::getInstance()->fireAction($this, 'preProcess');
+		
 		// highlight keywords
 		$this->highlightKeywords();
 		


### PR DESCRIPTION
Added possibility for plugins to change html output on every request (like it is done with keywords highlighting)

This event is needed for the lexicon plugin to support dynamic detection of lexicon entries. This event is a replacement the old wcf\system\bbcode\MessageParser :: beforeParsing event in WCF 2.1.