### PR TITLE
Added getter to HtmlOutputNodeProcessor to expose output type

### DIFF
--- a/wcfsetup/install/files/lib/system/html/output/node/HtmlOutputNodeProcessor.class.php
+++ b/wcfsetup/install/files/lib/system/html/output/node/HtmlOutputNodeProcessor.class.php
@@ -57,6 +57,15 @@ class HtmlOutputNodeProcessor extends AbstractHtmlNodeProcessor {
 	}
 	
 	/**
+	 * Returns the current output type.
+	 * 
+	 * @return 	string
+	 */
+	public function getOutputType() {
+		return $this->outputType;
+	}
+	
+	/**
 	 * @inheritDoc
 	 */
 	public function process() {


### PR DESCRIPTION
Added getter to expose output type to event listener, otherwise it is not possible to handle the output manipulated by an EventListener correctly. 