### PR TITLE
Added missing comma in de.xml

### DIFF
--- a/wcfsetup/install/lang/de.xml
+++ b/wcfsetup/install/lang/de.xml
@@ -889,7 +889,7 @@
 		<item name="wcf.acp.option.category.security.censorship"><![CDATA[Zensur]]></item>
 		<item name="wcf.acp.option.category.general.system.jquery"><![CDATA[jQuery]]></item>
 		<item name="wcf.acp.option.exception_privacy"><![CDATA[Privatsphäre]]></item>
-		<item name="wcf.acp.option.exception_privacy.description"><![CDATA[Gibt an, wie detailliert die Fehlermeldungen sind. „Privat“ versteckt Fehler vollständig, „Gekürzt“ versucht private Informationen zu verstecken und „Öffentlich“ (nur bei aktivem Debug-Modus) zeigt alle Informationen an.]]></item>
+		<item name="wcf.acp.option.exception_privacy.description"><![CDATA[Gibt an, wie detailliert die Fehlermeldungen sind. „Privat“ versteckt Fehler vollständig, „Gekürzt“ versucht, private Informationen zu verstecken und „Öffentlich“ (nur bei aktivem Debug-Modus) zeigt alle Informationen an.]]></item>
 		<item name="wcf.acp.option.exception_privacy.public"><![CDATA[Öffentlich]]></item>
 		<item name="wcf.acp.option.exception_privacy.reduced"><![CDATA[Gekürzt]]></item>
 		<item name="wcf.acp.option.exception_privacy.private"><![CDATA[Privat]]></item>


### PR DESCRIPTION
Behind the word `versucht` in the language variable `wcf.acp.option.exception_privacy.description` a comma was missing.