### PR TITLE
fix SendMailUserBulkProcessing

### DIFF
--- a/wcfsetup/install/files/lib/system/bulk/processing/user/SendMailUserBulkProcessingAction.class.php
+++ b/wcfsetup/install/files/lib/system/bulk/processing/user/SendMailUserBulkProcessingAction.class.php
@@ -58,7 +58,7 @@ class SendMailUserBulkProcessingAction extends AbstractUserBulkProcessingAction 
 			// save config in session
 			$userMailData = WCF::getSession()->getVar('userMailData');
 			if ($userMailData === null) $userMailData = [];
-			$this->mailID = count($userMailData);
+			$this->mailID = count($userMailData) + 1;
 			$userMailData[$this->mailID] = [
 				'action' => '',
 				'enableHTML' => $this->enableHTML,


### PR DESCRIPTION
The first try to send an email will fail, because `mailID` is `0` (and as consequence empty for PHP), so the worker is not triggered by the template (https://github.com/WoltLab/WCF/blob/master/wcfsetup/install/files/acp/templates/sendMailUserBulkProcessing.tpl#L45).