### PR TITLE
js templateplugin: don't load minified JS within ACP

### DIFF
--- a/wcfsetup/install/files/lib/system/template/plugin/JsFunctionTemplatePlugin.class.php
+++ b/wcfsetup/install/files/lib/system/template/plugin/JsFunctionTemplatePlugin.class.php
@@ -77,7 +77,7 @@ class JsFunctionTemplatePlugin implements IFunctionTemplatePlugin {
 		}
 		
 		$this->includedFiles[$src] = true;
-		$src .= (!ENABLE_DEBUG_MODE ? '.min' : '') . '.js?v=' . LAST_UPDATE_TIME;
+		$src .= (!ENABLE_DEBUG_MODE && !(isset($tagArgs['acp']) && $tagArgs['acp'] === 'true') ? '.min' : '') . '.js?v=' . LAST_UPDATE_TIME;
 		
 		$relocate = !RequestHandler::getInstance()->isACPRequest() && (!isset($tagArgs['core']) || $tagArgs['core'] !== 'true');
 		$html = '<script' . ($relocate ? ' data-relocate="true"' : '') . ' src="' . $src . '"></script>'."\n";


### PR DESCRIPTION
After this commit `{js acp='true' file='WCF.ACP'}` to `wcf/acp/js/WCF.ACP.js?v=...` instead of `wcf/acp/js/WCF.ACP.min.js?v=...`
even if `ENABLE_DEBUG_MODE=0` since it's not recommended to load minified JS within acp-templates at all.