### PR TITLE
use meta data before searching page by controller

### DIFF
--- a/wcfsetup/install/files/lib/system/WCF.class.php
+++ b/wcfsetup/install/files/lib/system/WCF.class.php
@@ -7,7 +7,6 @@ use wcf\data\package\PackageCache;
 use wcf\data\package\PackageEditor;
 use wcf\data\page\Page;
 use wcf\data\page\PageCache;
-use wcf\page\CmsPage;
 use wcf\system\application\ApplicationHandler;
 use wcf\system\application\IApplication;
 use wcf\system\box\BoxHandler;
@@ -826,12 +825,8 @@ class WCF {
 			return null;
 		}
 		
-		if (self::getActiveRequest()->getClassName() === CmsPage::class) {
-			$metaData = self::getActiveRequest()->getMetaData();
-			return PageCache::getInstance()->getPage($metaData['cms']['pageID']);
-		}
-		
-		return PageCache::getInstance()->getPageByController(self::getActiveRequest()->getClassName());
+		$pageID = self::getActiveRequest()->getPageID();
+		return $pageID ? PageCache::getInstance()->getPage($pageID) : null;
 	}
 	
 	/**


### PR DESCRIPTION
`self::getActiveRequest()->getPageID()` will check the meta data for a page id before it searches the first match of the controller's classname.
This is also used by the BoxHandler, so it seems to be inconsistent in it's handling. In some special cases (in my case it's a Fireball-Page) the BoyHandler will return a valid page id and assigns the boxes correctly while this method returns null or the first match which is wrong in the most cases.
This change would improve the page-mapping and should not have any unwanted side-effects.

In a nutshell: You can shorten the whole method to
```php
if (self::getActiveRequest() === null) {
	return null;
}

$pageID = self::getActiveRequest()->getPageID();
return $pageID ? PageCache::getInstance()->getPage($pageID) : null;
```
because it covers both look-ups the method contains (before this commit).