### PR TITLE
Fix empty lines in CodeMetacodeConverter

### DIFF
--- a/wcfsetup/install/files/lib/system/html/metacode/converter/CodeMetacodeConverter.class.php
+++ b/wcfsetup/install/files/lib/system/html/metacode/converter/CodeMetacodeConverter.class.php
@@ -72,7 +72,7 @@ class CodeMetacodeConverter extends AbstractMetacodeConverter {
 		/** @var \DOMElement $node */
 		foreach ($childNodes as $node) {
 			if ($node->nodeType === XML_ELEMENT_NODE && $node->nodeName === 'p') {
-				DOMUtil::insertAfter($node->ownerDocument->createTextNode("\n\n"), $node);
+				DOMUtil::insertAfter($node->ownerDocument->createTextNode("\n"), $node);
 				
 				$brs = $node->getElementsByTagName('br');
 				while ($brs->length) {


### PR DESCRIPTION
This seams to be an relict from the alpha stage where paragraphes have been handled as two new lines.
Now its a bit missleading as it looks in the editor fine and gets messed up after sending.