### PR TITLE
fix error messages if account is already liked with 3rdparty

### DIFF
--- a/wcfsetup/install/files/lib/action/FacebookAuthAction.class.php
+++ b/wcfsetup/install/files/lib/action/FacebookAuthAction.class.php
@@ -90,7 +90,7 @@ class FacebookAuthAction extends AbstractAction {
 			if ($user->userID) {
 				// a user is already connected, but we are logged in, break
 				if (WCF::getUser()->userID) {
-					throw new NamedUserException(WCF::getLanguage()->get('wcf.user.3rdparty.facebook.connect.error.inuse'));
+					throw new NamedUserException(WCF::getLanguage()->getDynamicVariable('wcf.user.3rdparty.facebook.connect.error.inuse'));
 				}
 				// perform login
 				else {

--- a/wcfsetup/install/files/lib/action/GithubAuthAction.class.php
+++ b/wcfsetup/install/files/lib/action/GithubAuthAction.class.php
@@ -84,7 +84,7 @@ class GithubAuthAction extends AbstractAction {
 			if ($user->userID) {
 				// a user is already connected, but we are logged in, break
 				if (WCF::getUser()->userID) {
-					throw new NamedUserException(WCF::getLanguage()->get('wcf.user.3rdparty.github.connect.error.inuse'));
+					throw new NamedUserException(WCF::getLanguage()->getDynamicVariable('wcf.user.3rdparty.github.connect.error.inuse'));
 				}
 				// perform login
 				else {

--- a/wcfsetup/install/files/lib/action/GoogleAuthAction.class.php
+++ b/wcfsetup/install/files/lib/action/GoogleAuthAction.class.php
@@ -83,7 +83,7 @@ class GoogleAuthAction extends AbstractAction {
 			if ($user->userID) {
 				// a user is already connected, but we are logged in, break
 				if (WCF::getUser()->userID) {
-					throw new NamedUserException(WCF::getLanguage()->get('wcf.user.3rdparty.google.connect.error.inuse'));
+					throw new NamedUserException(WCF::getLanguage()->getDynamicVariable('wcf.user.3rdparty.google.connect.error.inuse'));
 				}
 				// perform login
 				else {

--- a/wcfsetup/install/files/lib/action/TwitterAuthAction.class.php
+++ b/wcfsetup/install/files/lib/action/TwitterAuthAction.class.php
@@ -78,7 +78,7 @@ class TwitterAuthAction extends AbstractAction {
 			if ($user->userID) {
 				// a user is already connected, but we are logged in, break
 				if (WCF::getUser()->userID) {
-					throw new NamedUserException(WCF::getLanguage()->get('wcf.user.3rdparty.twitter.connect.error.inuse'));
+					throw new NamedUserException(WCF::getLanguage()->getDynamicVariable('wcf.user.3rdparty.twitter.connect.error.inuse'));
 				}
 				// perform login
 				else {


### PR DESCRIPTION
the language items for those error-messages use template-scripting (`{if LANGUAGE_USE_INFORMAL_VARIANT}deinem{else}Ihrem{/if}`) which is not supported by `Language::get()`, but `Language::getDynamicVariable()`