### PR TITLE
BoxPackageInstallationPlugin::$boxes should be BoxEditor always instead of Box|BoxEditor

### DIFF
--- a/wcfsetup/install/files/lib/system/package/plugin/BoxPackageInstallationPlugin.class.php
+++ b/wcfsetup/install/files/lib/system/package/plugin/BoxPackageInstallationPlugin.class.php
@@ -24,7 +24,7 @@ class BoxPackageInstallationPlugin extends AbstractXMLPackageInstallationPlugin 
 	
 	/**
 	 * list of created or updated boxes by id
-	 * @var Box[]
+	 * @var BoxEditor[]
 	 */
 	protected $boxes = [];
 	
@@ -283,7 +283,7 @@ class BoxPackageInstallationPlugin extends AbstractXMLPackageInstallationPlugin 
 		// updating boxes is only supported for 'system' type boxes, all other
 		// types would potentially overwrite changes made by the user if updated
 		if (!empty($row) && $row['boxType'] !== 'system') {
-			$box = new Box(null, $row);
+			$box = new BoxEditor(new Box(null, $row));
 		}
 		else {
 			$box = parent::import($row, $data);
@@ -314,7 +314,7 @@ class BoxPackageInstallationPlugin extends AbstractXMLPackageInstallationPlugin 
 			
 			WCF::getDB()->beginTransaction();
 			foreach ($this->content as $boxID => $contentData) {
-				$boxEditor = new BoxEditor($this->boxes[$boxID]);
+				$boxEditor = $this->boxes[$boxID];
 				
 				foreach ($contentData as $languageCode => $content) {
 					$languageID = null;


### PR DESCRIPTION
`$box = parent::import($row, $data);` returns an instance of `BoxEditor` as specified in `AbstractXMLPackageInstallationPlugin.class.php::import()`
`$box = new Box(null, $row);` provides a DatabaseObject-Class
`$boxEditor = new BoxEditor($this->boxes[$boxID]);` in line 317 expected an object of class `Box` in all cases, which causes an exception if a `BoxEditor` is given (by inheritance)

```
Message: Object does not match 'wcf\data\box\Box' (given object is of class 'wcf\data\box\BoxEditor')
WoltLab Suite version: 3.1.0 Alpha 1
======
Error Class: wcf\system\exception\SystemException
Error Message: Object does not match 'wcf\data\box\Box' (given object is of class 'wcf\data\box\BoxEditor')
Error Code: 0
File: /core/lib/data/DatabaseObjectDecorator.class.php (39)
Extra Information: -
Stack Trace: [{"file":"\/core\/lib\/system\/package\/plugin\/BoxPackageInstallationPlugin.class.php","line":317,"function":"__construct","class":"wcf\\data\\DatabaseObjectDecorator","type":"->","args":["wcf\\data\\box\\BoxEditor"]},{"file":"\/core\/lib\/system\/package\/plugin\/AbstractXMLPackageInstallationPlugin.class.php","line":174,"function":"postImport","class":"wcf\\system\\package\\plugin\\BoxPackageInstallationPlugin","type":"->","args":[]},{"file":"\/core\/lib\/system\/package\/plugin\/AbstractXMLPackageInstallationPlugin.class.php","line":66,"function":"importItems","class":"wcf\\system\\package\\plugin\\AbstractXMLPackageInstallationPlugin","type":"->","args":["DOMXPath"]},{"file":"\/UpdateClasses.php","line":650,"function":"install","class":"wcf\\system\\package\\plugin\\AbstractXMLPackageInstallationPlugin","type":"->","args":[]},{"file":"UpdateClasses.php","line":531,"function":"updateXML","class":"wcf\\system\\package\\Updater","type":"->","args":[]},{"file":"\/update.php","line":11,"function":"run","class":"wcf\\system\\package\\Updater","type":"->","args":[]}]
<<<<
```