### PR TITLE
Improve error message for missing instruction file

### DIFF
--- a/wcfsetup/install/files/lib/system/package/validation/PackageValidationArchive.class.php
+++ b/wcfsetup/install/files/lib/system/package/validation/PackageValidationArchive.class.php
@@ -247,10 +247,12 @@ class PackageValidationArchive implements \RecursiveIterator {
 		for ($i = 0, $length = count($instructions); $i < $length; $i++) {
 			$instruction = $instructions[$i];
 			if (!PackageValidationManager::getInstance()->validatePackageInstallationPluginInstruction($this->archive, $instruction['pip'], $instruction['value'])) {
+				$defaultFilename = PackageValidationManager::getInstance()->getDefaultFilenameForPackageInstallationPlugin($instruction['pip']);
+				
 				throw new PackageValidationException(PackageValidationException::MISSING_INSTRUCTION_FILE, [
 					'pip' => $instruction['pip'],
 					'type' => $type,
-					'value' => $instruction['value']
+					'value' => $instruction['value'] ?: $defaultFilename
 				]);
 			}
 		}

--- a/wcfsetup/install/files/lib/system/package/validation/PackageValidationManager.class.php
+++ b/wcfsetup/install/files/lib/system/package/validation/PackageValidationManager.class.php
@@ -188,4 +188,20 @@ class PackageValidationManager extends SingletonFactory {
 		
 		return true;
 	}
+	
+	/**
+	 * Returns the default filename for the given pip name. If no default filename
+	 * exists `null` is returned.
+	 * 
+	 * @param	string			$pip
+	 * @return	string|null
+	 * @since	3.1
+	 */
+	public function getDefaultFilenameForPackageInstallationPlugin($pip) {
+		if (isset($this->packageInstallationPlugins[$pip])) {
+			return call_user_func([$this->packageInstallationPlugins[$pip], 'getDefaultFilename']);
+		}
+		
+		return null;
+	}
 }


### PR DESCRIPTION
At the moment if you use the short instruction syntax (`<instruction type="file" />`) you get the following not helpful error message if the file cannot be found. 

"The install-instructions specify the file “” for the Package Installation Plugin “file”, but it cannot be found in the specified location."

This PR solves this by using the default filename for the error message if the instruction looks like `<instruction type="file" />`.