### PR TITLE
Consistently use 'IObjectCondition' instead of 'IUserCondition'

### DIFF
--- a/wcfsetup/install/files/lib/system/condition/UserAvatarCondition.class.php
+++ b/wcfsetup/install/files/lib/system/condition/UserAvatarCondition.class.php
@@ -3,6 +3,8 @@ namespace wcf\system\condition;
 use wcf\data\condition\Condition;
 use wcf\data\user\User;
 use wcf\data\user\UserList;
+use wcf\data\DatabaseObject;
+use wcf\data\DatabaseObjectDecorator;
 use wcf\data\DatabaseObjectList;
 use wcf\system\WCF;
 
@@ -14,8 +16,9 @@ use wcf\system\WCF;
  * @license	GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
  * @package	WoltLabSuite\Core\System\Condition
  */
-class UserAvatarCondition extends AbstractSelectCondition implements IContentCondition, IObjectListCondition, IUserCondition {
+class UserAvatarCondition extends AbstractSelectCondition implements IContentCondition, IObjectCondition, IObjectListCondition {
 	use TObjectListUserCondition;
+	use TObjectUserCondition;
 	
 	/**
 	 * @inheritDoc
@@ -72,18 +75,22 @@ class UserAvatarCondition extends AbstractSelectCondition implements IContentCon
 	/**
 	 * @inheritDoc
 	 */
-	public function checkUser(Condition $condition, User $user) {
-		switch ($condition->userAvatar) {
+	public function checkObject(DatabaseObject $object, array $conditionData) {
+		if (!($object instanceof User) || ($object instanceof DatabaseObjectDecorator && !($object->getDecoratedObject() instanceof User))) {
+			throw new \InvalidArgumentException("Object is no (decorated) instance of '".User::class."', instance of '".get_class($object)."' given.");
+		}
+		
+		switch ($conditionData['userAvatar']) {
 			case self::NO_AVATAR:
-				return !$user->avatarID && !$user->enableGravatar;
+				return !$object->avatarID && !$object->enableGravatar;
 			break;
 			
 			case self::AVATAR:
-				return $user->avatarID != 0;
+				return $object->avatarID != 0;
 			break;
 			
 			case self::GRAVATAR:
-				return $user->enableGravatar;
+				return $object->enableGravatar;
 			break;
 		}
 	}
@@ -110,6 +117,6 @@ class UserAvatarCondition extends AbstractSelectCondition implements IContentCon
 	public function showContent(Condition $condition) {
 		if (!WCF::getUser()->userID) return false;
 		
-		return $this->checkUser($condition, WCF::getUser());
+		return $this->checkObject(WCF::getUser(), $condition->conditionData);
 	}
 }

--- a/wcfsetup/install/files/lib/system/condition/UserEmailCondition.class.php
+++ b/wcfsetup/install/files/lib/system/condition/UserEmailCondition.class.php
@@ -3,6 +3,8 @@ namespace wcf\system\condition;
 use wcf\data\condition\Condition;
 use wcf\data\user\User;
 use wcf\data\user\UserList;
+use wcf\data\DatabaseObject;
+use wcf\data\DatabaseObjectDecorator;
 use wcf\data\DatabaseObjectList;
 use wcf\system\WCF;
 
@@ -14,8 +16,9 @@ use wcf\system\WCF;
  * @license	GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
  * @package	WoltLabSuite\Core\System\Condition
  */
-class UserEmailCondition extends AbstractTextCondition implements IContentCondition, IObjectListCondition, IUserCondition {
+class UserEmailCondition extends AbstractTextCondition implements IContentCondition, IObjectCondition, IObjectListCondition {
 	use TObjectListUserCondition;
+	use TObjectUserCondition;
 	
 	/**
 	 * @inheritDoc
@@ -41,8 +44,12 @@ class UserEmailCondition extends AbstractTextCondition implements IContentCondit
 	/**
 	 * @inheritDoc
 	 */
-	public function checkUser(Condition $condition, User $user) {
-		return mb_strpos($user->email, $condition->email) !== false;
+	public function checkObject(DatabaseObject $object, array $conditionData) {
+		if (!($object instanceof User) || ($object instanceof DatabaseObjectDecorator && !($object->getDecoratedObject() instanceof User))) {
+			throw new \InvalidArgumentException("Object is no (decorated) instance of '".User::class."', instance of '".get_class($object)."' given.");
+		}
+		
+		return mb_strpos($object->email, $conditionData['email']) !== false;
 	}
 	
 	/**
@@ -51,6 +58,6 @@ class UserEmailCondition extends AbstractTextCondition implements IContentCondit
 	public function showContent(Condition $condition) {
 		if (!WCF::getUser()->userID) return false;
 		
-		return $this->checkUser($condition, WCF::getUser());
+		return $this->checkObject(WCF::getUser(), $condition->conditionData);
 	}
 }

--- a/wcfsetup/install/files/lib/system/condition/UserTimestampPropertyCondition.class.php
+++ b/wcfsetup/install/files/lib/system/condition/UserTimestampPropertyCondition.class.php
@@ -14,7 +14,7 @@ use wcf\system\WCF;
  * @package	WoltLabSuite\Core\System\Condition
  * @since	3.0
  */
-class UserTimestampPropertyCondition extends AbstractTimestampCondition implements IContentCondition, IUserCondition {
+class UserTimestampPropertyCondition extends AbstractTimestampCondition implements IContentCondition, IObjectCondition {
 	use TObjectListUserCondition;
 	use TObjectUserCondition;
 	
@@ -43,6 +43,6 @@ class UserTimestampPropertyCondition extends AbstractTimestampCondition implemen
 	public function showContent(Condition $condition) {
 		if (!WCF::getUser()->userID) return false;
 		
-		return $this->checkUser($condition, WCF::getUser());
+		return $this->checkObject(WCF::getUser(), $condition->conditionData);
 	}
 }

--- a/wcfsetup/install/files/lib/system/condition/UserUsernameCondition.class.php
+++ b/wcfsetup/install/files/lib/system/condition/UserUsernameCondition.class.php
@@ -3,6 +3,8 @@ namespace wcf\system\condition;
 use wcf\data\condition\Condition;
 use wcf\data\user\User;
 use wcf\data\user\UserList;
+use wcf\data\DatabaseObject;
+use wcf\data\DatabaseObjectDecorator;
 use wcf\data\DatabaseObjectList;
 use wcf\system\WCF;
 
@@ -14,8 +16,9 @@ use wcf\system\WCF;
  * @license	GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
  * @package	WoltLabSuite\Core\System\Condition
  */
-class UserUsernameCondition extends AbstractTextCondition implements IContentCondition, IObjectListCondition, IUserCondition {
+class UserUsernameCondition extends AbstractTextCondition implements IContentCondition, IObjectCondition, IObjectListCondition {
 	use TObjectListUserCondition;
+	use TObjectUserCondition;
 	
 	/**
 	 * @inheritDoc
@@ -41,8 +44,12 @@ class UserUsernameCondition extends AbstractTextCondition implements IContentCon
 	/**
 	 * @inheritDoc
 	 */
-	public function checkUser(Condition $condition, User $user) {
-		return mb_strpos($user->username, $condition->username) !== false;
+	public function checkObject(DatabaseObject $object, array $conditionData) {
+		if (!($object instanceof User) || ($object instanceof DatabaseObjectDecorator && !($object->getDecoratedObject() instanceof User))) {
+			throw new \InvalidArgumentException("Object is no (decorated) instance of '".User::class."', instance of '".get_class($object)."' given.");
+		}
+		
+		return mb_strpos($object->username, $conditionData['username']) !== false;
 	}
 	
 	/**
@@ -51,6 +58,6 @@ class UserUsernameCondition extends AbstractTextCondition implements IContentCon
 	public function showContent(Condition $condition) {
 		if (!WCF::getUser()->userID) return false;
 		
-		return $this->checkUser($condition, WCF::getUser());
+		return $this->checkObject(WCF::getUser(), $condition->conditionData);
 	}
 }


### PR DESCRIPTION
New conditions  implement `IObjectCondition` instead of `IUserCondition` which provides a more generalized `checkObject()` method. Old ones still stick with `IUserCondition` but implement at the same time `IObjectListCondition` which leads to a mixture of `*User` and `*Object` methods.

For consistency "old" conditions should also implement `IObjectCondition` instead of `IUserCondition`. This can be achieved by using the (already existing!) `TObjectUserCondition` trait which redirects `checkUser()` calls to `checkObject()` if necessary.