### PR TITLE
inherited language system

### DIFF
--- a/wcfsetup/install/files/acp/templates/languageAdd.tpl
+++ b/wcfsetup/install/files/acp/templates/languageAdd.tpl
@@ -78,7 +78,7 @@
 			<dd>
 				<select id="parentID" name="parentID">
 					{foreach from=$languages item=language}
-						{if $action == 'edit' && $language->languageID != $languageID}<option value="{@$language->languageID}"{if $language->languageID == $parentID} selected{/if}>{$language->languageName} ({$language->languageCode})</option>{/if}
+						{if $action != 'edit' || ($action == 'edit' && $language->languageID != $languageID)}<option value="{@$language->languageID}"{if $language->languageID == $parentID} selected{/if}>{$language->languageName} ({$language->languageCode})</option>{/if}
 					{/foreach}
 				</select>
 				{if $errorField == 'parentID'}

--- a/wcfsetup/install/files/acp/templates/languageAdd.tpl
+++ b/wcfsetup/install/files/acp/templates/languageAdd.tpl
@@ -72,6 +72,27 @@
 				<small>{lang}wcf.acp.language.countryCode.description{/lang}</small>
 			</dd>
 		</dl>
+
+		<dl{if $errorField == 'parentID'} class="formError"{/if}>
+			<dt><label for="parentID">{lang}wcf.acp.language.parent{/lang}</label></dt>
+			<dd>
+				<select id="parentID" name="parentID">
+					{foreach from=$languages item=language}
+						{if $action == 'edit' && $language->languageID != $languageID}<option value="{@$language->languageID}"{if $language->languageID == $parentID} selected{/if}>{$language->languageName} ({$language->languageCode})</option>{/if}
+					{/foreach}
+				</select>
+				{if $errorField == 'parentID'}
+					<small class="innerError">
+						{if $errorType == 'empty'}
+							{lang}wcf.global.form.error.empty{/lang}
+						{else}
+							{lang}wcf.acp.language.parent.error.{@$errorType}{/lang}
+						{/if}
+					</small>
+				{/if}
+				<small>{lang}wcf.acp.language.parent.description{/lang}</small>
+			</dd>
+		</dl>
 		
 		{if $action == 'add'}
 			<dl{if $errorField == 'sourceLanguageID'} class="formError"{/if}>

--- a/wcfsetup/install/files/lib/acp/form/LanguageAddForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/LanguageAddForm.class.php
@@ -58,6 +58,18 @@ class LanguageAddForm extends AbstractForm {
 	public $languages = [];
 	
 	/**
+	 * parent language id
+	 * @var	integer
+	 */
+	public $parentID = 0;
+	
+	/**
+	 * parent language object
+	 * @var	Language
+	 */
+	public $parentLanguage = null;
+	
+	/**
 	 * source language object
 	 * @var	Language
 	 */
@@ -79,6 +91,7 @@ class LanguageAddForm extends AbstractForm {
 		if (isset($_POST['languageName'])) $this->languageName = StringUtil::trim($_POST['languageName']);
 		if (isset($_POST['languageCode'])) $this->languageCode = StringUtil::trim($_POST['languageCode']);
 		if (isset($_POST['sourceLanguageID'])) $this->sourceLanguageID = intval($_POST['sourceLanguageID']);
+		if (isset($_POST['parentID'])) $this->parentID = intval($_POST['parentID']);
 	}
 	
 	/**
@@ -102,6 +115,9 @@ class LanguageAddForm extends AbstractForm {
 		
 		// source language id
 		$this->validateSource();
+		
+		// parent language id
+		$this->validateParent();
 	}
 	
 	/**
@@ -132,6 +148,19 @@ class LanguageAddForm extends AbstractForm {
 	}
 	
 	/**
+	 * Validates given parent language.
+	 */
+	protected function validateParent() {
+		if (empty($this->parentID)) return;
+		
+		// get language
+		$this->parentLanguage = LanguageFactory::getInstance()->getLanguage($this->parentID);
+		if (!$this->parentLanguage->languageID) {
+			throw new UserInputException('parentID');
+		}
+	}
+	
+	/**
 	 * @inheritDoc
 	 */
 	public function save() {
@@ -140,7 +169,8 @@ class LanguageAddForm extends AbstractForm {
 		$this->language = LanguageEditor::create([
 			'countryCode' => mb_strtolower($this->countryCode),
 			'languageName' => $this->languageName,
-			'languageCode' => mb_strtolower($this->languageCode)
+			'languageCode' => mb_strtolower($this->languageCode),
+			'parentID' => $this->parentID ?: null
 		]);
 		$languageEditor = new LanguageEditor($this->sourceLanguage);
 		$languageEditor->copy($this->language);
@@ -159,7 +189,7 @@ class LanguageAddForm extends AbstractForm {
 		
 		// reset values
 		$this->countryCode = $this->languageCode = $this->languageName = '';
-		$this->sourceLanguageID = 0;
+		$this->sourceLanguageID = $this->parentID = 0;
 	}
 	
 	/**
@@ -183,6 +213,8 @@ class LanguageAddForm extends AbstractForm {
 			'languageCode' => $this->languageCode,
 			'sourceLanguageID' => $this->sourceLanguageID,
 			'languages' => $this->languages,
+			'parentID' => $this->parentID,
+			'parentLanguage' => $this->parentLanguage,
 			'action' => 'add'
 		]);
 	}

--- a/wcfsetup/install/files/lib/acp/form/LanguageEditForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/LanguageEditForm.class.php
@@ -4,6 +4,7 @@ use wcf\data\language\Language;
 use wcf\data\language\LanguageEditor;
 use wcf\form\AbstractForm;
 use wcf\system\exception\IllegalLinkException;
+use wcf\system\exception\UserInputException;
 use wcf\system\language\LanguageFactory;
 use wcf\system\WCF;
 
@@ -52,6 +53,24 @@ class LanguageEditForm extends LanguageAddForm {
 	/**
 	 * @inheritDoc
 	 */
+	protected function validateParent() {
+		parent::validateParent();
+		
+		if ($this->languageID == $this->parentID) {
+			throw new UserInputException('parentID', 'parentsItself');
+		}
+		
+		$language = $this->language;
+		while ($language = LanguageFactory::getInstance()->getLanguage($language->languageID)) {
+			if ($language->languageID == $this->parentID) {
+				throw new UserInputException('parentID', 'parentsItself');
+			}
+		}
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
 	public function save() {
 		AbstractForm::save();
 		
@@ -59,7 +78,8 @@ class LanguageEditForm extends LanguageAddForm {
 		$editor->update([
 			'countryCode' => mb_strtolower($this->countryCode),
 			'languageName' => $this->languageName,
-			'languageCode' => mb_strtolower($this->languageCode)
+			'languageCode' => mb_strtolower($this->languageCode),
+			'parentID' => $this->parentID
 		]);
 		LanguageFactory::getInstance()->clearCache();
 		$this->saved();
@@ -78,6 +98,9 @@ class LanguageEditForm extends LanguageAddForm {
 			$this->countryCode = $this->language->countryCode;
 			$this->languageName = $this->language->languageName;
 			$this->languageCode = $this->language->languageCode;
+			$this->parentID = $this->language->parentID;
+			
+			if ($this->parentID) $this->parentLanguage = LanguageFactory::getInstance()->getLanguage($this->parentID);
 		}
 	}
 	

--- a/wcfsetup/install/files/lib/data/article/Article.class.php
+++ b/wcfsetup/install/files/lib/data/article/Article.class.php
@@ -175,6 +175,9 @@ class Article extends DatabaseObject implements ILinkableObject {
 			if (isset($this->articleContents[WCF::getLanguage()->languageID])) {
 				return $this->articleContents[WCF::getLanguage()->languageID];
 			}
+			if (WCF::getLanguage()->parentID && isset($this->articleContents[WCF::getLanguage()->parentID])) {
+				return $this->articleContents[WCF::getLanguage()->parentID];
+			}
 		}
 		else {
 			if (!empty($this->articleContents[0])) {

--- a/wcfsetup/install/files/lib/data/language/Language.class.php
+++ b/wcfsetup/install/files/lib/data/language/Language.class.php
@@ -19,6 +19,7 @@ use wcf\system\WCF;
  * @property-read	integer		$isDefault		is `1` if the language is the default language, otherwise `0`
  * @property-read	integer		$hasContent		is `1` if the language can be selected when creating language-specific content, otherwise `0`
  * @property-read	integer		$isDisabled		is `1` if the language is disabled and thus not selectable, otherwise `0`
+ * @property-read	integer		$parentID		unique id of the parent-language
  */
 class Language extends DatabaseObject {
 	/**
@@ -44,6 +45,12 @@ class Language extends DatabaseObject {
 	 * @var	integer
 	 */
 	public $packageID = PACKAGE_ID;
+	
+	/**
+	 * the language's parent language
+	 * @var Language||null
+	 */
+	protected $parentLanguage = null;
 	
 	/**
 	 * Returns the name of this language.
@@ -104,6 +111,12 @@ class Language extends DatabaseObject {
 			return '';
 		}
 		
+		// check if the language item exists within the parental language
+		if ($this->parentID) {
+			$parentValue = LanguageFactory::getInstance()->getLanguage($this->parentID)->get($item);
+			return $parentValue;
+		}
+		
 		// return plain input
 		return $item;
 	}
@@ -125,6 +138,12 @@ class Language extends DatabaseObject {
 			$variables['__language'] = $this;
 			
 			return WCF::getTPL()->fetchString($this->dynamicItems[$item], $variables);
+		}
+		
+		// check if the dynamic language item exists within the parental language
+		if ($this->parentID) {
+			$parentValue = LanguageFactory::getInstance()->getLanguage($this->parentID)->getDynamicVariable($item, $variables, $optional);
+			if ($parentValue !== $staticItem) return $parentValue;
 		}
 		
 		return $staticItem;

--- a/wcfsetup/install/files/lib/data/page/Page.class.php
+++ b/wcfsetup/install/files/lib/data/page/Page.class.php
@@ -12,6 +12,7 @@ use wcf\system\cache\builder\ApplicationCacheBuilder;
 use wcf\system\cache\builder\RoutingCacheBuilder;
 use wcf\system\database\util\PreparedStatementConditionBuilder;
 use wcf\system\exception\SystemException;
+use wcf\system\language\LanguageFactory;
 use wcf\system\request\LinkHandler;
 use wcf\system\WCF;
 
@@ -142,6 +143,11 @@ class Page extends DatabaseObject implements ILinkableObject, ITitledObject {
 		$statement->execute($conditions->getParameters());
 		$row = $statement->fetchSingleRow();
 		if ($row !== false) return new PageContent(null, $row);
+		
+		$language = LanguageFactory::getInstance()->getLanguage($languageID);
+		if ($language->parentID) {
+			return $this->getPageContentByLanguage($language->parentID);
+		}
 		
 		return null;
 	}

--- a/wcfsetup/install/lang/de-informal.xml
+++ b/wcfsetup/install/lang/de-informal.xml
@@ -1,0 +1,3927 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<language xmlns="http://www.woltlab.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.woltlab.com http://www.woltlab.com/XSD/vortex/language.xsd" languagecode="de-informal" languagename="Deutsch informell" countrycode="de">
+	<category name="wcf.acl">
+		<item name="wcf.acl.access"><![CDATA[Zugangsbeschränkung]]></item>
+		<item name="wcf.acl.access.grant"><![CDATA[Zugang gewähren]]></item>
+		<item name="wcf.acl.access.granted"><![CDATA[Erlaubte Benutzer und Benutzergruppen]]></item>
+		<item name="wcf.acl.allowAll"><![CDATA[Inhalt ist für alle Benutzer sichtbar]]></item>
+		
+		<item name="wcf.acl.option.deny"><![CDATA[Verweigern]]></item>
+		<item name="wcf.acl.option.fullAccess"><![CDATA[Vollzugriff]]></item>
+		<item name="wcf.acl.option.grant"><![CDATA[Erlauben]]></item>
+		<item name="wcf.acl.permissions"><![CDATA[Benutzer- und Benutzergruppenrechte]]></item>
+		<item name="wcf.acl.user.permissions"><![CDATA[Benutzerrechte]]></item>
+		<item name="wcf.acl.search.description"><![CDATA[Benutzer- oder Benutzergruppenname eingeben …]]></item>
+		<item name="wcf.acl.search.user.description"><![CDATA[Benutzername eingeben …]]></item>
+	</category>
+	
+	<category name="wcf.acl.option">
+		<item name="wcf.acl.option.com.woltlab.wcf.label.canViewLabel"><![CDATA[Kann Labels sehen]]></item>
+		<item name="wcf.acl.option.com.woltlab.wcf.label.canSetLabel"><![CDATA[Kann Labels setzen]]></item>
+		<item name="wcf.acl.option.com.woltlab.wcf.article.category.canReadArticle"><![CDATA[Kann Artikel lesen]]></item>
+	</category>
+	
+	<category name="wcf.acp.ad">
+		<item name="wcf.acp.ad.ad"><![CDATA[Werbung]]></item>
+		<item name="wcf.acp.ad.ad.description"><![CDATA[HTML-Code der Werbung]]></item>
+		<item name="wcf.acp.ad.add"><![CDATA[Werbung hinzufügen]]></item>
+		<item name="wcf.acp.ad.conditions"><![CDATA[Bedingungen]]></item>
+		<item name="wcf.acp.ad.conditions.description"><![CDATA[Werden keine Bedingungen ausgewählt, wird die Werbung für jeden Benutzer angezeigt.]]></item>
+		<item name="wcf.acp.ad.conditions.page"><![CDATA[Seite]]></item>
+		<item name="wcf.acp.ad.conditions.page.description"><![CDATA[Die vom Benutzer aufgerufene Seite muss folgende Bedingungen erfüllen, damit die Werbung angezeigt wird.]]></item>
+		<item name="wcf.acp.ad.conditions.pointInTime"><![CDATA[Zeitpunkt]]></item>
+		<item name="wcf.acp.ad.conditions.pointInTime.description"><![CDATA[Leg den Zeitpunkt fest, zu dem die Werbung angezeigt werden soll.]]></item>
+		<item name="wcf.acp.ad.conditions.user"><![CDATA[Aktiver Benutzer]]></item>
+		<item name="wcf.acp.ad.conditions.user.description"><![CDATA[Der aktive Benutzer muss die folgenden Bedingungen erfüllen, damit die Werbung angezeigt wird.]]></item>
+		<item name="wcf.acp.ad.delete.confirmMessage"><![CDATA[Willst du die Werbung <span class="confirmationObject">{$ad->adName}</span> wirklich löschen?]]></item>
+		<item name="wcf.acp.ad.edit"><![CDATA[Werbung bearbeiten]]></item>
+		<item name="wcf.acp.ad.isDisabled"><![CDATA[Werbung deaktivieren]]></item>
+		<item name="wcf.acp.ad.list"><![CDATA[Werbung]]></item>
+		<item name="wcf.acp.ad.location"><![CDATA[Position]]></item>
+		<item name="wcf.acp.ad.location.category.com.woltlab.wcf.global"><![CDATA[global]]></item>
+		<item name="wcf.acp.ad.location.com.woltlab.wcf.logo"><![CDATA[Logo]]></item>
+		<item name="wcf.acp.ad.location.com.woltlab.wcf.header.content"><![CDATA[Inhaltsbereich (oben)]]></item>
+		<item name="wcf.acp.ad.location.com.woltlab.wcf.footer.content"><![CDATA[Inhaltsbereich (unten)]]></item>
+		<item name="wcf.acp.ad.location.com.woltlab.wcf.sidebar.top"><![CDATA[Sidebar (oben)]]></item>
+		<item name="wcf.acp.ad.location.com.woltlab.wcf.sidebar.bottom"><![CDATA[Sidebar (unten)]]></item>
+		<item name="wcf.acp.ad.location.com.woltlab.wcf.footer.bottom"><![CDATA[Seitenende]]></item>
+		<item name="wcf.acp.ad.showOrder.description"><![CDATA[Legt die Reihenfolge fest, in der die Werbung angezeigt werden.]]></item>
+	</category>
+	
+	<category name="wcf.acp.application">
+		<item name="wcf.acp.application.cookie"><![CDATA[Cookie-Einstellungen]]></item>
+		<item name="wcf.acp.application.cookie.warning"><![CDATA[Die folgenden Einstellungen stellen sicher, dass der Login gespeichert wird und ein automatischer Login möglich ist. Du musst diese Einstellungen anpassen, sollte sich die Domain geändert haben. Solltest du dir bei dem korrekten Wert nicht sicher sein, übernimm bitte die exakte Angabe im Feld „Domain“.]]></item>
+		<item name="wcf.acp.application.cookieDomain"><![CDATA[Cookie-Domain]]></item>
+		<item name="wcf.acp.application.cookieDomain.error.containsPath"><![CDATA[Die Cookie-Domain darf keine Pfadangaben enthalten]]></item>
+		<item name="wcf.acp.application.cookieDomain.error.invalid"><![CDATA[Die Cookie-Domain stimmt nicht mit der oben angegebenen Domain überein (Subdomains wie zum Beispiel „www“ dürfen weggelassen werden).]]></item>
+		<item name="wcf.acp.application.domain"><![CDATA[Domain-Einstellungen]]></item>
+		<item name="wcf.acp.application.domainName"><![CDATA[Domain]]></item>
+		<item name="wcf.acp.application.domainName.description"><![CDATA[Gib die Domain an, über die diese App erreichbar ist. Wenn die App zum Beispiel unter „http://www.example.com/community/forum/“ erreichbar ist, müsste hier die korrekte Angabe „www.example.com“ lauten.]]></item>
+		<item name="wcf.acp.application.domainName.error.containsPath"><![CDATA[Die Domain darf keine Pfadangaben enthalten]]></item>
+		<item name="wcf.acp.application.domainPath"><![CDATA[Pfad]]></item>
+		<item name="wcf.acp.application.domainPath.error.conflict"><![CDATA[Dieser Pfad ist bereits durch die App „{$conflictApplication->getName()}“ belegt]]></item>
+		<item name="wcf.acp.application.domainPath.description"><![CDATA[Gib den Pfad an, über den diese App erreichbar ist. Wenn die App zum Beispiel unter „http://www.example.com/community/forum/“ erreichbar ist, müsste hier die korrekte Angabe „/community/forum/“ lauten.]]></item>
+		<item name="wcf.acp.application.edit"><![CDATA[App bearbeiten]]></item>
+		<item name="wcf.acp.application.edit.title"><![CDATA[App bearbeiten: „<a href="{link controller='Package' id=$application->packageID}{/link}">{$application->getPackage()->getName()}</a>“]]></item>
+		<item name="wcf.acp.application.landingPage"><![CDATA[Einstiegsseite]]></item>
+		<item name="wcf.acp.application.landingPage.description"><![CDATA[Optional: Gib die Seite an, die angezeigt wird, wenn diese App direkt aufgerufen wird.]]></item>
+		<item name="wcf.acp.application.list"><![CDATA[Installierte Apps]]></item>
+	</category>
+	
+	<category name="wcf.acp.article">
+		<item name="wcf.acp.article.add"><![CDATA[Artikel hinzufügen]]></item>
+		<item name="wcf.acp.article.edit"><![CDATA[Artikel bearbeiten]]></item>
+		<item name="wcf.acp.article.list"><![CDATA[Artikel]]></item>
+		<item name="wcf.acp.article.author"><![CDATA[Autor]]></item>
+		<item name="wcf.acp.article.button.toggleI18n"><![CDATA[Mehrsprachigkeit]]></item>
+		<item name="wcf.acp.article.button.viewArticle"><![CDATA[Vorschau anzeigen]]></item>
+		<item name="wcf.acp.article.category"><![CDATA[Kategorie]]></item>
+		<item name="wcf.acp.article.content"><![CDATA[Inhalt]]></item>
+		<item name="wcf.acp.article.delete.confirmMessage"><![CDATA[Willst du {if $isArticleEdit|empty}den Artikel <span class="confirmationObject">{$article->getTitle()}</span>{else}diesen Artikel{/if} wirklich löschen?]]></item>
+		<item name="wcf.acp.article.enableComments"><![CDATA[Kommentare aktivieren]]></item>
+		<item name="wcf.acp.article.i18n"><![CDATA[Mehrsprachigkeit]]></item>
+		<item name="wcf.acp.article.i18n.none"><![CDATA[Einsprachiger Artikel]]></item>
+		<item name="wcf.acp.article.i18n.none.description"><![CDATA[Der Inhalt der Seite ist sprachneutral oder soll nur in einer Sprache verfasst werden.]]></item>
+		<item name="wcf.acp.article.i18n.i18n"><![CDATA[Mehrsprachiger Artikel]]></item>
+		<item name="wcf.acp.article.i18n.i18n.description"><![CDATA[Inhalt wird individuell pro Sprache festgelegt.]]></item>
+		<item name="wcf.acp.article.i18n.source"><![CDATA[Inhalt übernehmen]]></item>
+		<item name="wcf.acp.article.i18n.toI18n.confirmMessage"><![CDATA[Willst du diesen Artikel wirklich in einen mehrsprachigen Artikel umwandeln? Der aktuelle Inhalt wird für alle Sprachen übernommen, und die Bearbeitungshistorie für diesen Artikel wird gelöscht.<br><br>Bitte speichere alle Änderungen, bevor Sie fortfahren.]]></item>
+		<item name="wcf.acp.article.i18n.fromI18n.confirmMessage"><![CDATA[Willst du diesen Artikel wirklich in einen einsprachigen Artikel umwandeln? Die ausgewählte Sprache wird dabei als zukünftigen Inhalt übernommen. Die Angaben in anderen Sprachen, sowie die Bearbeitungshistorie dieses Artikels, werden bei diesem Vorgang verworfen.<br><br>Bitte speichere alle Änderungen, bevor Sie fortfahren.]]></item>
+		<item name="wcf.acp.article.image"><![CDATA[Artikel-Bild]]></item>
+		<item name="wcf.acp.article.teaserImage"><![CDATA[Teaser-Bild]]></item>
+		<item name="wcf.acp.article.publicationDate"><![CDATA[Veröffentlichungsdatum]]></item>
+		<item name="wcf.acp.article.publicationDate.error.invalid"><![CDATA[Du hast ein ungültiges Veröffentlichungsdatum angegeben.]]></item>
+		<item name="wcf.acp.article.publicationStatus"><![CDATA[Status]]></item>
+		<item name="wcf.acp.article.publicationStatus.unpublished"><![CDATA[Unveröffentlicht]]></item>
+		<item name="wcf.acp.article.publicationStatus.published"><![CDATA[Veröffentlicht]]></item>
+		<item name="wcf.acp.article.publicationStatus.delayed"><![CDATA[Zeitgesteuerte Veröffentlichung]]></item>
+		<item name="wcf.acp.article.restore.confirmMessage"><![CDATA[Willst du {if $isArticleEdit|empty}den Artikel <span class="confirmationObject">{$article->getTitle()}</span>{else}diesen Artikel{/if} wirklich wiederherstellen?]]></item>
+		<item name="wcf.acp.article.setCategory"><![CDATA[Kategorie ändern]]></item>
+		<item name="wcf.acp.article.teaser"><![CDATA[Einleitungstext]]></item>
+		<item name="wcf.acp.article.trash.confirmMessage"><![CDATA[Willst du {if $isArticleEdit|empty}den Artikel <span class="confirmationObject">{$article->getTitle()}</span>{else}diesen Artikel{/if} wirklich in den Papierkorb verschieben?]]></item>
+		<item name="wcf.acp.article.trash.notice"><![CDATA[Dieser Artikel befindet sich im Papierkorb und wird gegenwärtig nicht angezeigt.]]></item>
+		<item name="wcf.acp.article.views"><![CDATA[Zugriffe]]></item>
+		<item name="wcf.acp.article.lastVersion"><![CDATA[Es gibt <a href="{link controller='VersionTrackerList' objectType='com.woltlab.wcf.article' objectID=$article->articleID}{/link}">vorherige Versionen</a> dieses Artikels, die letzte Änderung erfolgte durch <a href="{link controller='UserEdit' id=$lastVersion->userID}{/link}">{$lastVersion->username}</a> ({@$lastVersion->time|time}).]]></item>
+	</category>
+	
+	<category name="wcf.acp.attachment">
+		<item name="wcf.acp.attachment.list"><![CDATA[Dateianhänge]]></item>
+		<item name="wcf.acp.attachment.stats"><![CDATA[<ul class="inlineList dotSeparated"><li>{#$stats.count} {if $stats.count == 1}Dateianhang{else}Dateianhänge{/if}</li><li>{@$stats.size|filesize}</li><li>{#$stats.downloads} Download{if $stats.downloads != 1}s{/if}</li></ul>]]></item>
+	</category>
+	
+	<category name="wcf.acp.bbcode">
+		<item name="wcf.acp.bbcode.add"><![CDATA[BBCode hinzufügen]]></item>
+		<item name="wcf.acp.bbcode.add.userGroupOptionInfo"><![CDATA[Beachte, dass der neu erstellte BBCode standardmäßig überall verwendet werden kann. Soll das nicht der Fall sein, bearbeite nach der Erstellung des BBCodes die entsprechenden Benutzergruppenrechte.]]></item>
+		<item name="wcf.acp.bbcode.attribute"><![CDATA[Attribut]]></item>
+		<item name="wcf.acp.bbcode.attribute.attributeHtml"><![CDATA[HTML-Code des Attributs]]></item>
+		<item name="wcf.acp.bbcode.attribute.validationPattern"><![CDATA[Regulärer Ausdruck zur Validierung]]></item>
+		<item name="wcf.acp.bbcode.attribute.validationPattern.error.invalid"><![CDATA[Dies ist kein gültiger regulärer Ausdruck.]]></item>
+		<item name="wcf.acp.bbcode.attribute.required"><![CDATA[Attribut muss ausgefüllt sein]]></item>
+		<item name="wcf.acp.bbcode.attribute.useText"><![CDATA[Inhalt übernehmen]]></item>
+		<item name="wcf.acp.bbcode.attribute.useText.description"><![CDATA[Soll der Inhalt des BBCodes als Wert für dieses Attribut übernommen werden, wenn es nicht gesetzt ist?]]></item>
+		<item name="wcf.acp.bbcode.attributes"><![CDATA[Attribute]]></item>
+		<item name="wcf.acp.bbcode.bbcodeTag"><![CDATA[BBCode]]></item>
+		<item name="wcf.acp.bbcode.bbcodeTag.error.inUse"><![CDATA[Dieser BBCode ist bereits vorhanden.]]></item>
+		<item name="wcf.acp.bbcode.bbcodeTag.error.invalid"><![CDATA[Dieser BBCode ist ungültig.]]></item>
+		<item name="wcf.acp.bbcode.buttonLabel"><![CDATA[Button-Beschriftung]]></item>
+		<item name="wcf.acp.bbcode.className"><![CDATA[Klassen-Name]]></item>
+		<item name="wcf.acp.bbcode.className.error.notFound"><![CDATA[Diese Klasse wurde nicht gefunden.]]></item>
+		<item name="wcf.acp.bbcode.delete.sure"><![CDATA[Willst du den BBCode <span class="confirmationObject">[{$bbcode->bbcodeTag}]</span> wirklich löschen?]]></item>
+		<item name="wcf.acp.bbcode.edit"><![CDATA[BBCode bearbeiten]]></item>
+		<item name="wcf.acp.bbcode.htmlClose"><![CDATA[Schließendes HTML-Tag]]></item>
+		<item name="wcf.acp.bbcode.htmlOpen"><![CDATA[Öffnendes HTML-Tag]]></item>
+		<item name="wcf.acp.bbcode.isBlockElement"><![CDATA[BBCode als Block-Element behandeln]]></item>
+		<item name="wcf.acp.bbcode.isBlockElement.description"><![CDATA[Bei der Verarbeitung von BBCodes gelten abweichende Regeln für die Behandlung von Block-Elementen. Diese können Zeilenumbrüche und Absätze enthalten und beanspruchen immer die volle Breite; Typische Beispiele sind Zitate oder Listen.<br>Hinweis: Diese Option darf nicht für Inline-Elemente (z.B. Fettdruck oder Links) gesetzt werden.]]></item>
+		<item name="wcf.acp.bbcode.isSourceCode"><![CDATA[Inhalt als Quelltext behandeln]]></item>
+		<item name="wcf.acp.bbcode.isSourceCode.description"><![CDATA[Der Inhalt dieses BBCodes wird als Quelltext interpretiert, BBCodes und Smileys werden nicht umgewandelt.]]></item>
+		<item name="wcf.acp.bbcode.list"><![CDATA[BBCodes]]></item>
+		
+		<item name="wcf.acp.bbcode.mediaProvider.add"><![CDATA[Medienanbieter hinzufügen]]></item>
+		<item name="wcf.acp.bbcode.mediaProvider.className"><![CDATA[Klassen-Name]]></item>
+		<item name="wcf.acp.bbcode.mediaProvider.className.error.notFound"><![CDATA[Diese Klasse wurde nicht gefunden.]]></item>
+		<item name="wcf.acp.bbcode.mediaProvider.delete.sure"><![CDATA[Willst du den Medienanbieter <span class="confirmationObject">{$mediaProvider->title}</span> wirklich löschen?]]></item>
+		<item name="wcf.acp.bbcode.mediaProvider.edit"><![CDATA[Medienanbieter bearbeiten]]></item>
+		<item name="wcf.acp.bbcode.mediaProvider.html"><![CDATA[HTML-Code]]></item>
+		<item name="wcf.acp.bbcode.mediaProvider.html.description"><![CDATA[Gib{literal} hier den HTML-Code für das Medium an. Variablen im Format <code>{$variable}</code> werden durch die entsprechend benannte Untergruppe des regulären Ausdrucks ersetzt.<br>
+		Beispiel:<br>
+		<code>{$ID}</code> wird durch die beispielhaften Medium-IDs der Erklärung oberhalb ersetzt.{/literal}]]></item>
+		<item name="wcf.acp.bbcode.mediaProvider.list"><![CDATA[Medienanbieter]]></item>
+		<item name="wcf.acp.bbcode.mediaProvider.regex"><![CDATA[Regulärer Ausdruck]]></item>
+		<item name="wcf.acp.bbcode.mediaProvider.regex.description"><![CDATA[Gib hier das Linkformat als <a href="{@$__wcf->getPath('wcf')}acp/dereferrer.php?url=http%3A%2F%2Fde.wikipedia.org%2Fwiki%2FRegul%25C3%25A4rer_Ausdruck">regulären Ausdruck</a> an.<br>
+		Mehrere Ausdrücke können zeilenweise angegeben werden.<br>
+		Beispiele für die Medium-ID Erkennungen:
+		<ul>
+			<li><code>(?&lt;ID&gt;[0-9]+)</code> erkennt eine Medium-ID aus Zahlen.</li>
+			<li><code>(?&lt;ID&gt;[0-9a-zA-Z]+)</code> erkennt eine alphanumerische Medium-ID.</li>
+		</ul>]]></item>
+		<item name="wcf.acp.bbcode.mediaProvider.regex.error.invalid"><![CDATA[Dies ist kein gültiger regulärer Ausdruck.]]></item>
+		<item name="wcf.acp.bbcode.mediaProvider.title"><![CDATA[Medienanbieter]]></item>
+		<item name="wcf.acp.bbcode.showButton"><![CDATA[Button im WYSIWYG-Editor anzeigen]]></item>
+		<item name="wcf.acp.bbcode.wysiwygIcon"><![CDATA[Button-Grafik]]></item>
+		<item name="wcf.acp.bbcode.wysiwygIcon.description"><![CDATA[Die Grafik muss sich im Verzeichnis wcf/icon/ befinden, alternativ kann ein <a href="{@$__wcf->getPath('wcf')}acp/dereferrer.php?url=http%3A%2F%2Ffontawesome.io%2Ficons%2F">FontAwesome</a>-Icon genutzt werden, z.B. „fa-caret-square-o-up“.]]></item>
+	</category>
+	
+	<category name="wcf.acp.box">
+		<item name="wcf.acp.box.add"><![CDATA[Box hinzufügen]]></item>
+		<item name="wcf.acp.box.boxController"><![CDATA[Controller]]></item>
+		<item name="wcf.acp.box.content"><![CDATA[Inhalt]]></item>
+		<item name="wcf.acp.box.contents"><![CDATA[Inhalte]]></item>
+		<item name="wcf.acp.box.cssClassName"><![CDATA[CSS-Klassen]]></item>
+		<item name="wcf.acp.box.delete.confirmMessage"><![CDATA[Willst du die Box <span class="confirmationObject">{$box->name}</span> wirklich löschen?]]></item>
+		<item name="wcf.acp.box.edit"><![CDATA[Box bearbeiten]]></item>
+		<item name="wcf.acp.box.image"><![CDATA[Box-Bild]]></item>
+		<item name="wcf.acp.box.i18n"><![CDATA[Mehrsprachigkeit]]></item>
+		<item name="wcf.acp.box.i18n.i18n"><![CDATA[Mehrsprachige Box]]></item>
+		<item name="wcf.acp.box.i18n.i18n.description"><![CDATA[Inhalt wird individuell pro Sprache festgelegt.]]></item>
+		<item name="wcf.acp.box.i18n.none"><![CDATA[Einsprachige Box]]></item>
+		<item name="wcf.acp.box.i18n.none.description"><![CDATA[Der Inhalt der Seite ist sprachneutral oder soll nur in einer Sprache verfasst werden.]]></item>
+		<item name="wcf.acp.box.link"><![CDATA[Verlinkung]]></item>
+		<item name="wcf.acp.box.linkType.none"><![CDATA[Keine]]></item>
+		<item name="wcf.acp.box.linkType.internal"><![CDATA[Interner Link]]></item>
+		<item name="wcf.acp.box.linkType.external"><![CDATA[Externer Link]]></item>
+		<item name="wcf.acp.box.link.externalURL"><![CDATA[Externe URL]]></item>
+		<item name="wcf.acp.box.list"><![CDATA[Boxen]]></item>
+		<item name="wcf.acp.box.name.error.notUnique"><![CDATA[Dieser Name wird bereits von einer anderen Box verwendet.]]></item>
+		<item name="wcf.acp.box.position"><![CDATA[Position]]></item>
+		<item name="wcf.acp.box.position.error.invalid"><![CDATA[Die ausgewählte Position ist ungültig.]]></item>
+		<item name="wcf.acp.box.position.hero"><![CDATA[Hero]]></item>
+		<item name="wcf.acp.box.position.headerBoxes"><![CDATA[Kopfzeile]]></item>
+		<item name="wcf.acp.box.position.top"><![CDATA[Über Inhaltsbereich]]></item>
+		<item name="wcf.acp.box.position.sidebarLeft"><![CDATA[Linke Seitenleiste]]></item>
+		<item name="wcf.acp.box.position.contentTop"><![CDATA[Im Inhaltsbereich oben]]></item>
+		<item name="wcf.acp.box.position.sidebarRight"><![CDATA[Rechte Seitenleiste]]></item>
+		<item name="wcf.acp.box.position.contentBottom"><![CDATA[Im Inhaltsbereich unten]]></item>
+		<item name="wcf.acp.box.position.bottom"><![CDATA[Unter Inhaltsbereich]]></item>
+		<item name="wcf.acp.box.position.footerBoxes"><![CDATA[Fußzeile]]></item>
+		<item name="wcf.acp.box.position.footer"><![CDATA[Seitenende]]></item>
+		<item name="wcf.acp.box.position.mainMenu"><![CDATA[Hauptmenü]]></item>
+		<item name="wcf.acp.box.settings"><![CDATA[Einstellungen]]></item>
+		<item name="wcf.acp.box.settings.limit"><![CDATA[Maximale Anzahl]]></item>
+		<item name="wcf.acp.box.showHeader"><![CDATA[Box-Titel anzeigen]]></item>
+		<item name="wcf.acp.box.type"><![CDATA[Box-Typ]]></item>
+		<item name="wcf.acp.box.type.html"><![CDATA[HTML]]></item>
+		<item name="wcf.acp.box.type.html.description"><![CDATA[Direkte Eingabe des gesamten HTML für den Inhaltsbereich mit maximaler Flexibilität.]]></item>
+		<item name="wcf.acp.box.type.system"><![CDATA[System]]></item>
+		<item name="wcf.acp.box.type.system.description"><![CDATA[Dynamische Box mit individueller Konfiguration.]]></item>
+		<item name="wcf.acp.box.type.text"><![CDATA[Text]]></item>
+		<item name="wcf.acp.box.type.text.description"><![CDATA[Erstellung des Inhaltes mit Hilfe des WYSIWYG-Editors (empfohlen).]]></item>
+		<item name="wcf.acp.box.type.tpl"><![CDATA[Template]]></item>
+		<item name="wcf.acp.box.type.tpl.description"><![CDATA[Eingabemöglichkeit entspricht dem Typ „HTML“, zusätzlich wird Template-Scripting unterstützt.]]></item>
+		<item name="wcf.acp.box.visibleEverywhere"><![CDATA[Box überall sichtbar]]></item>
+		<item name="wcf.acp.box.visibilityException.visible"><![CDATA[Box auf ausgewählten Seiten <strong>explizit anzeigen</strong>]]></item>
+		<item name="wcf.acp.box.visibilityException.hidden"><![CDATA[Box auf ausgewählten Seiten <strong>nicht anzeigen</strong>]]></item>
+		<item name="wcf.acp.box.boxController.com.woltlab.wcf.articleCategories"><![CDATA[Artikel-Kategorien]]></item>
+		<item name="wcf.acp.box.boxController.com.woltlab.wcf.articleCommentList"><![CDATA[Artikel-Kommentare]]></item>
+		<item name="wcf.acp.box.boxController.com.woltlab.wcf.articleList"><![CDATA[Artikel]]></item>
+		<item name="wcf.acp.box.boxController.com.woltlab.wcf.articleTagCloud"><![CDATA[Artikel-Tags]]></item>
+		<item name="wcf.acp.box.boxController.com.woltlab.wcf.followingsOnline"><![CDATA[Benutzer online, denen der aktive Nutzer folgt]]></item>
+		<item name="wcf.acp.box.boxController.com.woltlab.wcf.pageCommentList"><![CDATA[Seiten-Kommentare]]></item>
+		<item name="wcf.acp.box.boxController.com.woltlab.wcf.paidSubscriptions"><![CDATA[Bezahlte Mitgliedschaften]]></item>
+		<item name="wcf.acp.box.boxController.com.woltlab.wcf.recentActivityList"><![CDATA[Letzte Aktivitäten]]></item>
+		<item name="wcf.acp.box.boxController.com.woltlab.wcf.registerButton"><![CDATA[Registrierungs-Button]]></item>
+		<item name="wcf.acp.box.boxController.com.woltlab.wcf.signedInAs"><![CDATA[Angemeldet als]]></item>
+		<item name="wcf.acp.box.boxController.com.woltlab.wcf.staffOnlineList"><![CDATA[Team-Mitglieder online]]></item>
+		<item name="wcf.acp.box.boxController.com.woltlab.wcf.statistics"><![CDATA[Statistiken]]></item>
+		<item name="wcf.acp.box.boxController.com.woltlab.wcf.todaysBirthdays"><![CDATA[Heutige Geburtstage]]></item>
+		<item name="wcf.acp.box.boxController.com.woltlab.wcf.todaysFollowingBirthdays"><![CDATA[Heutige Geburtstage von Benutzern, denen der aktive Nutzer folgt]]></item>
+		<item name="wcf.acp.box.boxController.com.woltlab.wcf.userList"><![CDATA[Mitglieder]]></item>
+		<item name="wcf.acp.box.boxController.com.woltlab.wcf.userOnlineList"><![CDATA[Benutzer online]]></item>
+		<item name="wcf.acp.box.boxController.com.woltlab.wcf.whoWasOnline"><![CDATA[Wer war online]]></item>
+		<item name="wcf.acp.box.linkPageObjectID.error.invalid"><![CDATA[Die eingetragene ID ist ungültig.]]></item>
+		<item name="wcf.acp.box.lastVersion"><![CDATA[Es gibt <a href="{link controller='VersionTrackerList' objectType='com.woltlab.wcf.box' objectID=$box->boxID}{/link}">vorherige Versionen</a> dieser Box, die letzte Änderung erfolgte durch <a href="{link controller='UserEdit' id=$lastVersion->userID}{/link}">{$lastVersion->username}</a> ({@$lastVersion->time|time}).]]></item>
+		<item name="wcf.acp.box.originIsNotSystem"><![CDATA[Eigene Boxen]]></item>
+	</category>
+	
+	<category name="wcf.acp.cache">
+		<item name="wcf.acp.cache.button.clear"><![CDATA[Cache leeren]]></item>
+		<item name="wcf.acp.cache.clear.sure"><![CDATA[Willst du den Cache wirklich komplett leeren?]]></item>
+		<item name="wcf.acp.cache.data"><![CDATA[Eigenschaften]]></item>
+		<item name="wcf.acp.cache.data.files"><![CDATA[Dateien]]></item>
+		<item name="wcf.acp.cache.data.size"><![CDATA[Größe]]></item>
+		<item name="wcf.acp.cache.data.source"><![CDATA[Quelle]]></item>
+		<item name="wcf.acp.cache.data.version"><![CDATA[Version]]></item>
+		<item name="wcf.acp.cache.list"><![CDATA[Cache]]></item>
+		<item name="wcf.acp.cache.list.mtime"><![CDATA[Letzte Aktualisierung]]></item>
+		<item name="wcf.acp.cache.list.name"><![CDATA[Name]]></item>
+		<item name="wcf.acp.cache.list.perm"><![CDATA[Zugriffsrechte]]></item>
+		<item name="wcf.acp.cache.list.size"><![CDATA[Größe]]></item>
+		<item name="wcf.acp.cache.source.type.DiskCacheSource"><![CDATA[Dateisystem]]></item>
+		<item name="wcf.acp.cache.source.type.MemcachedCacheSource"><![CDATA[Memcached]]></item>
+		<item name="wcf.acp.cache.source.type.RedisCacheSource"><![CDATA[Redis]]></item>
+		<item name="wcf.acp.cache.type.data"><![CDATA[Daten]]></item>
+		<item name="wcf.acp.cache.type.language"><![CDATA[Sprachen]]></item>
+		<item name="wcf.acp.cache.type.style"><![CDATA[Stile]]></item>
+		<item name="wcf.acp.cache.type.template"><![CDATA[Templates]]></item>
+	</category>
+	
+	<category name="wcf.acp.captcha">
+		<item name="wcf.acp.captcha.question.add"><![CDATA[Captcha-Frage hinzufügen]]></item>
+		<item name="wcf.acp.captcha.question.answers"><![CDATA[Antworten]]></item>
+		<item name="wcf.acp.captcha.question.answers.description"><![CDATA[Gib pro Zeile eine mögliche Antwort ein. Antworten, die mit „~“ beginnen und enden, werden als reguläre Ausdrücke interpretiert.]]></item>
+		<item name="wcf.acp.captcha.question.answers.error.invalidRegex"><![CDATA[Der reguläre Ausdruck „{$invalidRegex}“ ist ungültig.]]></item>
+		<item name="wcf.acp.captcha.question.delete.confirmMessage"><![CDATA[Willst du die Frage <span class="confirmationObject">{$question->question|language}</span> wirklich löschen?]]></item>
+		<item name="wcf.acp.captcha.question.edit"><![CDATA[Captcha-Frage bearbeiten]]></item>
+		<item name="wcf.acp.captcha.question.isDisabled"><![CDATA[Frage deaktivieren]]></item>
+		<item name="wcf.acp.captcha.question.list"><![CDATA[Captcha-Fragen]]></item>
+		<item name="wcf.acp.captcha.question.question"><![CDATA[Frage]]></item>
+	</category>
+	
+	<category name="wcf.acp.contact">
+		<item name="wcf.acp.contact.options"><![CDATA[Eingabefelder]]></item>
+		<item name="wcf.acp.contact.option.add"><![CDATA[Eingabefeld hinzufügen]]></item>
+		<item name="wcf.acp.contact.option.edit"><![CDATA[Eingabefeld bearbeiten]]></item>
+		<item name="wcf.acp.contact.recipients"><![CDATA[Empfänger]]></item>
+		<item name="wcf.acp.contact.recipient.add"><![CDATA[Empfänger hinzufügen]]></item>
+		<item name="wcf.acp.contact.recipient.edit"><![CDATA[Empfänger bearbeiten]]></item>
+		<item name="wcf.acp.contact.recipient.isDisabled"><![CDATA[Empfänger deaktivieren]]></item>
+		<item name="wcf.acp.contact.recipient.name"><![CDATA[Angezeigter Name]]></item>
+		<item name="wcf.acp.contact.settings"><![CDATA[Kontakt-Formular bearbeiten]]></item>
+	</category>
+	
+	<category name="wcf.acp.cronjob">
+		<item name="wcf.acp.cronjob.list"><![CDATA[Cronjobs]]></item>
+		<item name="wcf.acp.cronjob.add"><![CDATA[Cronjob hinzufügen]]></item>
+		<item name="wcf.acp.cronjob.subtitle"><![CDATA[„Zeitgesteuerte Aufgaben“]]></item>
+		<item name="wcf.acp.cronjob.startDom"><![CDATA[Tag des Monats]]></item>
+		<item name="wcf.acp.cronjob.startDom.description"><![CDATA[Tage des Monats (1 - 31), an denen der Cronjob ausgeführt werden soll.]]></item>
+		<item name="wcf.acp.cronjob.startDomShort"><![CDATA[D]]></item>
+		<item name="wcf.acp.cronjob.startDow"><![CDATA[Tag der Woche]]></item>
+		<item name="wcf.acp.cronjob.startDow.description"><![CDATA[Tage der Woche (0 - 6 mit Sonntag = 0, oder mon - sun), an denen der Cronjob ausgeführt werden soll.]]></item>
+		<item name="wcf.acp.cronjob.startDowShort"><![CDATA[DoW]]></item>
+		<item name="wcf.acp.cronjob.startHour"><![CDATA[Stunde]]></item>
+		<item name="wcf.acp.cronjob.startHour.description"><![CDATA[Stunden (0 - 23), in denen der Cronjob ausgeführt werden soll.]]></item>
+		<item name="wcf.acp.cronjob.startHourShort"><![CDATA[h]]></item>
+		<item name="wcf.acp.cronjob.startMinute"><![CDATA[Minute]]></item>
+		<item name="wcf.acp.cronjob.startMinute.description"><![CDATA[Minuten (0 - 59), in denen der Cronjob ausgeführt werden soll.]]></item>
+		<item name="wcf.acp.cronjob.startMinuteShort"><![CDATA[m]]></item>
+		<item name="wcf.acp.cronjob.startMonth"><![CDATA[Monat]]></item>
+		<item name="wcf.acp.cronjob.startMonth.description"><![CDATA[Monate (1 - 12, oder jan - dec), an denen der Cronjob ausgeführt werden soll.]]></item>
+		<item name="wcf.acp.cronjob.startMonthShort"><![CDATA[M]]></item>
+		<item name="wcf.acp.cronjob.description"><![CDATA[Beschreibung]]></item>
+		<item name="wcf.acp.cronjob.nextExec"><![CDATA[Nächste Ausführung]]></item>
+		<item name="wcf.acp.cronjob.edit"><![CDATA[Cronjob bearbeiten]]></item>
+		<item name="wcf.acp.cronjob.className"><![CDATA[PHP-Klassenname]]></item>
+		<item name="wcf.acp.cronjob.timing"><![CDATA[Zeitsteuerung]]></item>
+		<item name="wcf.acp.cronjob.intro"><![CDATA[Das Anlegen von Cronjobs (zeitgesteuerten Aufgaben) erfordert eine genaue Kenntnis der Crontab-Syntax auf Unix-ähnlichen Systemen. Weiterführende Informationen dazu erhälst du auf dieser Website: <a href="{@$__wcf->getPath('wcf')}acp/dereferrer.php?url={"http://www.unixgeeks.org/security/newbie/unix/cron-1.html"|rawurlencode}" class="externalURL">Newbie: Intro to cron</a>]]></item>
+		<item name="wcf.acp.cronjob.execute"><![CDATA[Cronjob jetzt ausführen]]></item>
+		<item name="wcf.acp.cronjob.className.error.doesNotExist"><![CDATA[Eine Klasse mit dem angegebenen Namen existiert nicht.]]></item>
+		<item name="wcf.acp.cronjob.timing.error.invalid"><![CDATA[Das Zeitformat ist ungültig.]]></item>
+		<item name="wcf.acp.cronjob.delete.sure"><![CDATA[Willst du den Cronjob <span class="confirmationObject">{$cronjob->description|language}</span> wirklich löschen?]]></item>
+		<item name="wcf.acp.cronjob.log"><![CDATA[Protokoll der ausgeführten Cronjobs]]></item>
+		<item name="wcf.acp.cronjob.log.clear"><![CDATA[Protokoll leeren]]></item>
+		<item name="wcf.acp.cronjob.log.clear.confirm"><![CDATA[Willst du alle Protokoll-Einträge wirklich löschen?]]></item>
+		<item name="wcf.acp.cronjob.log.execTime"><![CDATA[Ausgeführt]]></item>
+		<item name="wcf.acp.cronjob.log.status"><![CDATA[Status]]></item>
+		<item name="wcf.acp.cronjob.log.success"><![CDATA[Erfolgreich]]></item>
+		<item name="wcf.acp.cronjob.log.error"><![CDATA[Fehler]]></item>
+		<item name="wcf.acp.cronjob.log.error.showDetails"><![CDATA[Details anzeigen]]></item>
+		<item name="wcf.acp.cronjob.log.error.details"><![CDATA[Fehlermeldung]]></item>
+		<item name="wcf.acp.cronjob.log.noEntries"><![CDATA[Derzeit sind keine Einträge vorhanden.]]></item>
+	</category>
+		
+	<category name="wcf.acp.dataImport">
+		<item name="wcf.acp.dataImport"><![CDATA[Datenimport]]></item>
+		<item name="wcf.acp.dataImport.cli.configure.data.alreadySelected"><![CDATA[Diese Daten werden bereits importiert.]]></item>
+		<item name="wcf.acp.dataImport.cli.configure.data.error.noSelection"><![CDATA[Du hast keine Daten zum Import ausgewählt. Der Import wird beendet.]]></item>
+		<item name="wcf.acp.dataImport.cli.configure.data.error.invalid"><![CDATA[Der ausgewählte Datentyp ist ungültig.]]></item>
+		<item name="wcf.acp.dataImport.cli.configure.data.selectAll"><![CDATA[Alle Daten]]></item>
+		<item name="wcf.acp.dataImport.cli.info.wcf"><![CDATA[Du hast keine App beim Skript-Aufruf mittels --packageID={PACKAGE_ID} geladen. Wenn du Daten für eine App importieren möchtest, musst du das Skript mit der ID des entsprechenden Pakets starten. Möchtest du mit dem Import fortfahren? [YN]]]></item>
+		<item name="wcf.acp.dataImport.cli.selection"><![CDATA[Auswahl? [{if $minSelection == $maxSelection}{$minSelection}{else}{$minSelection}-{$maxSelection}{/if}]]]></item>
+		<item name="wcf.acp.dataImport.completed"><![CDATA[Import abgeschlossen.]]></item>
+		<item name="wcf.acp.dataImport.configure.data"><![CDATA[Daten]]></item>
+		<item name="wcf.acp.dataImport.configure.data.description"><![CDATA[Folgende Daten importieren:]]></item>
+		<item name="wcf.acp.dataImport.configure.database"><![CDATA[Datenbank-Zugang]]></item>
+		<item name="wcf.acp.dataImport.configure.database.host"><![CDATA[Hostname]]></item>
+		<item name="wcf.acp.dataImport.configure.database.user"><![CDATA[Benutzername]]></item>
+		<item name="wcf.acp.dataImport.configure.database.password"><![CDATA[Passwort]]></item>
+		<item name="wcf.acp.dataImport.configure.database.name"><![CDATA[Datenbankname]]></item>
+		<item name="wcf.acp.dataImport.configure.database.prefix"><![CDATA[Tabellen-Präfix]]></item>
+		<item name="wcf.acp.dataImport.configure.fileSystem"><![CDATA[Datei-System-Zugang]]></item>
+		<item name="wcf.acp.dataImport.configure.fileSystem.path"><![CDATA[Pfad zur Installation]]></item>
+		<item name="wcf.acp.dataImport.configure.fileSystem.path.description"><![CDATA[Wird für den Import von Datei-basierten Inhalten (wie z.B. Avatare) benötigt.]]></item>
+		<item name="wcf.acp.dataImport.configure.database.error"><![CDATA[Beim Verbindungsversuch mit der Datenbank ist folgender Fehler aufgetreten:
+		<br><strong>{$exception->getMessage()}<br>{$exception->getErrorDesc()}</strong>]]></item>
+		<item name="wcf.acp.dataImport.configure.fileSystem.path.error"><![CDATA[Es wurde keine Installation unter dem angegeben Pfad gefunden.]]></item>
+		<item name="wcf.acp.dataImport.configure.settings"><![CDATA[Einstellungen]]></item>
+		<item name="wcf.acp.dataImport.configure.settings.userMergeMode"><![CDATA[Verhalten bei sich überschneidenden Benutzeraccounts]]></item>
+		<item name="wcf.acp.dataImport.configure.settings.userMergeMode.4"><![CDATA[Benutzeraccounts mit identischer E-Mail-Adresse zusammenlegen]]></item>
+		<item name="wcf.acp.dataImport.configure.settings.userMergeMode.5"><![CDATA[Benutzeraccounts mit identischem Namen oder identischer E-Mail-Adresse zusammenlegen]]></item>
+		<item name="wcf.acp.dataImport.data.com.woltlab.wcf.user"><![CDATA[Benutzer]]></item>
+		<item name="wcf.acp.dataImport.data.com.woltlab.wcf.user.group"><![CDATA[Benutzergruppen]]></item>
+		<item name="wcf.acp.dataImport.data.com.woltlab.wcf.user.option"><![CDATA[Benutzerprofilfelder]]></item>
+		<item name="wcf.acp.dataImport.data.com.woltlab.wcf.user.follower"><![CDATA[Follower]]></item>
+		<item name="wcf.acp.dataImport.data.com.woltlab.wcf.user.rank"><![CDATA[Benutzerränge]]></item>
+		<item name="wcf.acp.dataImport.data.com.woltlab.wcf.user.avatar"><![CDATA[Avatare]]></item>
+		<item name="wcf.acp.dataImport.data.com.woltlab.wcf.user.comment"><![CDATA[Pinnwand-Kommentare]]></item>
+		<item name="wcf.acp.dataImport.data.com.woltlab.wcf.user.comment.response"><![CDATA[Pinnwand-Kommentar-Antworten]]></item>
+		<item name="wcf.acp.dataImport.data.com.woltlab.wcf.label"><![CDATA[Labels]]></item>
+		<item name="wcf.acp.dataImport.data.com.woltlab.wcf.smiley"><![CDATA[Smileys]]></item>
+		<item name="wcf.acp.dataImport.data.com.woltlab.wcf.smiley.category"><![CDATA[Smiley-Kategorien]]></item>
+		<item name="wcf.acp.dataImport.data.com.woltlab.wcf.article"><![CDATA[Artikel]]></item>
+		<item name="wcf.acp.dataImport.data.com.woltlab.wcf.article.category"><![CDATA[Artikel-Kategorien]]></item>
+		<item name="wcf.acp.dataImport.data.com.woltlab.wcf.article.comment"><![CDATA[Artikel-Kommentare]]></item>
+		<item name="wcf.acp.dataImport.data.com.woltlab.wcf.media"><![CDATA[Medien]]></item>
+		<item name="wcf.acp.dataImport.existingMapping.confirmMessage"><![CDATA[Willst du die bestehenden Zuordnungen wirklich löschen?]]></item>
+		<item name="wcf.acp.dataImport.existingMapping.notice"><![CDATA[Es existieren Zuordnungen eines früheren Import-Vorganges, diese werden verwendet, um Inhalte aus dem importierten Forum einwandfrei zuzuordnen. Wenn du den Import-Vorgang vollständig abgeschlossen hast, kannst du diese Zuordnungen <a id="deleteMapping">löschen</a>. Du solltest die Zuordnungen nicht löschen, wenn du jetzt oder zukünftig noch weitere Inhalte aus dem selben Forum übernehmen willst.]]></item>
+		<item name="wcf.acp.dataImport.exporter"><![CDATA[Datenquelle]]></item>
+		<item name="wcf.acp.dataImport.selectExporter"><![CDATA[Datenquelle wählen]]></item>
+		<item name="wcf.acp.dataImport.selectExporter.error.invalid"><![CDATA[Die ausgewählte Datenquelle ist ungültig.]]></item>
+		<item name="wcf.acp.dataImport.selectExporter.noExporters"><![CDATA[Es wurde keine Datenquelle für einen Datenimport gefunden.]]></item>
+		<item name="wcf.acp.dataImport.started"><![CDATA[Import begonnen.]]></item>
+	</category>
+	
+	<category name="wcf.acp.exceptionLog">
+		<item name="wcf.acp.exceptionLog"><![CDATA[Protokollierte Fehler]]></item>
+		<item name="wcf.acp.exceptionLog.exception.message"><![CDATA[Fehlermeldung]]></item>
+		<item name="wcf.acp.exceptionLog.exception.class"><![CDATA[Art]]></item>
+		<item name="wcf.acp.exceptionLog.exception.file"><![CDATA[Datei (Zeile)]]></item>
+		<item name="wcf.acp.exceptionLog.exception.requestURI"><![CDATA[Aufgerufene URL]]></item>
+		<item name="wcf.acp.exceptionLog.exception.referrer"><![CDATA[Referrer]]></item>
+		<item name="wcf.acp.exceptionLog.exception.stacktrace"><![CDATA[Stacktrace]]></item>
+		<item name="wcf.acp.exceptionLog.exception.copy"><![CDATA[Fehlermeldung kopieren]]></item>
+		<item name="wcf.acp.exceptionLog.exceptionNotFound"><![CDATA[Es wurde kein Fehler mit der ID „{$exceptionID}“ gefunden.]]></item>
+		<item name="wcf.acp.exceptionLog.search"><![CDATA[Suche]]></item>
+		<item name="wcf.acp.exceptionLog.search.exceptionID"><![CDATA[Fehler-ID]]></item>
+		<item name="wcf.acp.exceptionLog.search.logFile"><![CDATA[Datei]]></item>
+		<item name="wcf.acp.exceptionLog.exception.date"><![CDATA[Datum]]></item>
+		<item name="wcf.acp.exceptionLog.exception.userAgent"><![CDATA[Browser]]></item>
+		<item name="wcf.acp.exceptionLog.exception.memory"><![CDATA[Arbeitsspeicher]]></item>
+	</category>
+	
+	<category name="wcf.acp.group">
+		<item name="wcf.acp.group.add"><![CDATA[Benutzergruppe hinzufügen]]></item>
+		<item name="wcf.acp.group.delete.sure"><![CDATA[Willst du die Benutzergruppe <span class="confirmationObject">{$group->groupName|language}</span> wirklich löschen?]]></item>
+		<item name="wcf.acp.group.edit"><![CDATA[Benutzergruppe bearbeiten]]></item>
+		<item name="wcf.acp.group.option.editingOption"><![CDATA[Benutzergruppeneinstellung bearbeiten]]></item>
+		<item name="wcf.acp.group.edit.warning.selfIsMember"><![CDATA[Du bist Mitglied dieser Benutzergruppe! Änderungen an den Zugriffsrechten dieser Benutzergruppe können dazu führen, dass du aus der Administrationsoberfläche ausgeschlossen wirst. Bitte sei entsprechend vorsichtig!]]></item>
+		<item name="wcf.acp.group.group1"><![CDATA[Jeder]]></item>
+		<item name="wcf.acp.group.group2"><![CDATA[Gäste]]></item>
+		<item name="wcf.acp.group.group3"><![CDATA[Registrierte Benutzer]]></item>
+		<item name="wcf.acp.group.group4"><![CDATA[Administratoren]]></item>
+		<item name="wcf.acp.group.group5"><![CDATA[Moderatoren]]></item>
+		<item name="wcf.acp.group.list"><![CDATA[Benutzergruppen]]></item>
+		<item name="wcf.acp.group.members"><![CDATA[Mitglieder]]></item>
+		<item name="wcf.acp.group.option.admin.content.cms.canManageMenu"><![CDATA[Kann Seitenmenü verwalten]]></item>
+		<item name="wcf.acp.group.option.admin.general.canUseAcp"><![CDATA[Kann Administrationsoberfläche betreten]]></item>
+		<item name="wcf.acp.group.option.admin.general.canUseAcp.description"><![CDATA[Mitglieder dieser Benutzergruppe können die Administrationsoberfläche betreten und dort abhängig von den weiteren Zugriffsrechten verschiedene Aktionen durchführen. Diese Option muss aktiviert sein, wenn diesen Benutzern andere administrative Funktionen erlaubt werden sollen.]]></item>
+		<item name="wcf.acp.group.option.admin.general.canViewPrivateUserOptions"><![CDATA[Kann versteckte Profilinformationen sehen]]></item>
+		<item name="wcf.acp.group.option.admin.language.canManageLanguage"><![CDATA[Kann Sprachen verwalten]]></item>
+		<item name="wcf.acp.group.option.admin.configuration.canEditOption"><![CDATA[Kann allgemeine Einstellungen vornehmen]]></item>
+		<item name="wcf.acp.group.option.admin.style.canUseDisabledStyle"><![CDATA[Kann deaktivierte Stile benutzen]]></item>
+		<item name="wcf.acp.group.option.admin.management.canViewLog"><![CDATA[Kann Protokolle abrufen]]></item>
+		<item name="wcf.acp.group.option.admin.configuration.canManageApplication"><![CDATA[Kann Apps verwalten]]></item>
+		<item name="wcf.acp.group.option.admin.management.canManageCronjob"><![CDATA[Kann zeitgesteuerte Aufgaben verwalten]]></item>
+		<item name="wcf.acp.group.option.admin.configuration.package.canEditServer"><![CDATA[Kann Update-Server bearbeiten]]></item>
+		<item name="wcf.acp.group.option.admin.configuration.package.canInstallPackage"><![CDATA[Kann Pakete installieren]]></item>
+		<item name="wcf.acp.group.option.admin.configuration.package.canUninstallPackage"><![CDATA[Kann Pakete deinstallieren]]></item>
+		<item name="wcf.acp.group.option.admin.configuration.package.canUpdatePackage"><![CDATA[Kann Pakete aktualisieren]]></item>
+		<item name="wcf.acp.group.option.admin.user.accessibleGroups"><![CDATA[Zugängliche Benutzergruppen]]></item>
+		<item name="wcf.acp.group.option.admin.user.accessibleGroups.description"><![CDATA[Mitglieder dieser Benutzergruppe haben auf diese Gruppen Zugriff. Zusätzlich muss angegeben werden, ob z.B. die Benutzergruppe bearbeitet werden darf.]]></item>
+		<item name="wcf.acp.group.option.admin.user.canAddGroup"><![CDATA[Kann neue Benutzergruppen erstellen]]></item>
+		<item name="wcf.acp.group.option.admin.user.canAddUser"><![CDATA[Kann neue Benutzer erstellen]]></item>
+		<item name="wcf.acp.group.option.admin.user.canDeleteGroup"><![CDATA[Kann Benutzergruppen löschen]]></item>
+		<item name="wcf.acp.group.option.admin.user.canDeleteUser"><![CDATA[Kann Benutzer löschen]]></item>
+		<item name="wcf.acp.group.option.admin.user.canEditGroup"><![CDATA[Kann Benutzergruppen bearbeiten]]></item>
+		<item name="wcf.acp.group.option.admin.user.canEditMailAddress"><![CDATA[Kann E-Mail-Adressen bearbeiten]]></item>
+		<item name="wcf.acp.group.option.admin.user.canEditPassword"><![CDATA[Kann Kennwörter bearbeiten]]></item>
+		<item name="wcf.acp.group.option.admin.user.canEditUser"><![CDATA[Kann Benutzer bearbeiten]]></item>
+		<item name="wcf.acp.group.option.admin.user.canMailUser"><![CDATA[Kann E-Mails an Benutzer senden]]></item>
+		<item name="wcf.acp.group.option.admin.user.canSearchUser"><![CDATA[Kann Benutzer suchen]]></item>
+		<item name="wcf.acp.group.option.category.admin"><![CDATA[Administrative Rechte]]></item>
+		<item name="wcf.acp.group.option.category.admin.customization"><![CDATA[Anpassung]]></item>
+		<item name="wcf.acp.group.option.category.admin.management"><![CDATA[Verwaltung]]></item>
+		<item name="wcf.acp.group.option.category.admin.general"><![CDATA[Allgemeine Rechte]]></item>
+		<item name="wcf.acp.group.option.category.admin.language"><![CDATA[Sprachen]]></item>
+		<item name="wcf.acp.group.option.category.admin.style"><![CDATA[Stile]]></item>
+		<item name="wcf.acp.group.option.category.admin.configuration"><![CDATA[Konfiguration]]></item>
+		<item name="wcf.acp.group.option.category.admin.configuration.package"><![CDATA[Pakete]]></item>
+		<item name="wcf.acp.group.option.category.admin.user"><![CDATA[Benutzer]]></item>
+		<item name="wcf.acp.group.option.category.admin.user.group"><![CDATA[Benutzergruppen]]></item>
+		<item name="wcf.acp.group.option.category.admin.user.user"><![CDATA[Benutzer]]></item>
+		<item name="wcf.acp.group.option.category.mod"><![CDATA[Moderative Rechte]]></item>
+		<item name="wcf.acp.group.option.category.user"><![CDATA[Allgemeine Rechte]]></item>
+		<item name="wcf.acp.group.option.category.user.message"><![CDATA[Nachrichten]]></item>
+		<item name="wcf.acp.group.option.category.user.message.comment"><![CDATA[Kommentare]]></item>
+		<item name="wcf.acp.group.option.error.cannotDropPrivileges"><![CDATA[Es muss immer mindestens eine Benutzergruppe mit vollen Rechen geben, es ist daher nicht möglich diese Berechtigung einzuschränken.]]></item>
+		<item name="wcf.acp.group.option.error.exceedsOwnPermission"><![CDATA[Du kannst Benutzergruppen keine Berechtigungen gewähren, die deine eigenen Berechtigungen übersteigen.]]></item>
+		<item name="wcf.acp.group.option.error.tooHigh"><![CDATA[Der angegebene Wert ist zu hoch.{if $option->maxvalue !== null} Der maximale Wert ist {#$option->maxvalue}.{/if}]]></item>
+		<item name="wcf.acp.group.option.error.tooLow"><![CDATA[Der angegebene Wert ist zu gering.{if $option->minvalue !== null} Der minimale Wert ist {#$option->minvalue}.{/if}]]></item>
+		<item name="wcf.acp.group.showMembers"><![CDATA[Zeige die Mitglieder dieser Benutzergruppe]]></item>
+		<item name="wcf.acp.group.option.admin.general.canViewPageDuringOfflineMode"><![CDATA[Kann Seite im Wartungsmodus aufrufen]]></item>
+		<item name="wcf.acp.group.option.admin.user.canBanUser"><![CDATA[Kann Benutzer sperren]]></item>
+		<item name="wcf.acp.group.option.category.admin.template"><![CDATA[Templates]]></item>
+		<item name="wcf.acp.group.option.admin.template.canManageTemplate"><![CDATA[Kann Templates verwalten]]></item>
+		<item name="wcf.acp.group.option.admin.style.canManageStyle"><![CDATA[Kann Stile verwalten]]></item>
+		<item name="wcf.acp.group.option.category.admin.content"><![CDATA[Inhalt]]></item>
+		<item name="wcf.acp.group.option.admin.content.canBulkRevertContentChanges"><![CDATA[Kann Änderungen der letzten Tage zurücksetzen]]></item>
+		<item name="wcf.acp.group.option.category.admin.application"><![CDATA[Apps]]></item>
+		<item name="wcf.acp.group.option.category.mod.general"><![CDATA[Allgemeine Rechte]]></item>
+		<item name="wcf.acp.group.option.category.admin.user.option"><![CDATA[Benutzerprofilfelder]]></item>
+		<item name="wcf.acp.group.option.admin.user.canManageUserOption"><![CDATA[Kann Benutzerprofilfelder verwalten]]></item>
+		<item name="wcf.acp.group.option.category.user.message.attachment"><![CDATA[Dateianhänge]]></item>
+		<item name="wcf.acp.group.option.user.attachment.maxSize"><![CDATA[Maximale Dateianhangsgröße]]></item>
+		<item name="wcf.acp.group.option.user.attachment.allowedExtensions"><![CDATA[Erlaubte Dateiendungen]]></item>
+		<item name="wcf.acp.group.option.user.attachment.allowedExtensions.description"><![CDATA[Eine Dateiendung pro Zeile]]></item>
+		<item name="wcf.acp.group.option.user.attachment.maxCount"><![CDATA[Maximale Dateianhänge pro Nachricht]]></item>
+		<item name="wcf.acp.group.option.user.attachment.maxCount.description"><![CDATA[]]></item>
+		<item name="wcf.acp.group.option.category.admin.attachment"><![CDATA[Dateianhänge]]></item>
+		<item name="wcf.acp.group.option.admin.attachment.canManageAttachment"><![CDATA[Kann Dateianhänge verwalten]]></item>
+		<item name="wcf.acp.group.option.category.admin.content.bbcode"><![CDATA[BBCodes]]></item>
+		<item name="wcf.acp.group.option.admin.content.bbcode.canManageBBCode"><![CDATA[Kann BBCodes verwalten]]></item>
+		<item name="wcf.acp.group.option.category.admin.content.smiley"><![CDATA[Smileys]]></item>
+		<item name="wcf.acp.group.option.admin.content.smiley.canManageSmiley"><![CDATA[Kann Smileys verwalten]]></item>
+		<item name="wcf.acp.group.option.user.comment.floodControlTime"><![CDATA[Mindestzeit zwischen zwei Kommentaren]]></item>
+		<item name="wcf.acp.group.option.user.comment.floodControlTime.description"><![CDATA[Mindestzeit, die zwischen zwei hintereinander folgenden Kommentaren oder Antworten vergehen muss. [Zeit in Sekunden, 0 für unbeschränkt]]]></item>
+		<item name="wcf.acp.group.option.user.message.disallowedBBCodes"><![CDATA[Nicht erlaubte BBCodes]]></item>
+		<item name="wcf.acp.group.option.user.message.disallowedBBCodes.description"><![CDATA[Die hier ausgewählten BBCodes dürfen von Mitgliedern dieser Benutzergruppe <em>nicht</em> verwendet werden.]]></item>
+		<item name="wcf.acp.group.option.admin.user.rank.canManageRank"><![CDATA[Kann Benutzerränge verwalten]]></item>
+		<item name="wcf.acp.group.option.admin.user.canEditActivityPoints"><![CDATA[Kann Aktivitätspunkte bearbeiten]]></item>
+		<item name="wcf.acp.group.option.admin.user.canViewInvisible"><![CDATA[Kann unsichtbare Benutzer sehen]]></item>
+		<item name="wcf.acp.group.option.admin.user.canViewIpAddress"><![CDATA[Kann die IP-Adressen der Benutzer sehen]]></item>
+		<item name="wcf.acp.group.option.category.user.profile"><![CDATA[Benutzerprofile]]></item>
+		<item name="wcf.acp.group.option.category.user.profile.avatar"><![CDATA[Avatare]]></item>
+		<item name="wcf.acp.group.option.category.admin.user.rank"><![CDATA[Benutzerränge]]></item>
+		<item name="wcf.acp.group.option.category.user.signature"><![CDATA[Signaturen]]></item>
+		<item name="wcf.acp.group.option.user.profile.avatar.allowedFileExtensions"><![CDATA[Erlaubte Dateiendungen]]></item>
+		<item name="wcf.acp.group.option.user.profile.avatar.canSeeAvatars"><![CDATA[Kann Avatare anderer Benutzer sehen]]></item>
+		<item name="wcf.acp.group.option.user.profile.avatar.canUploadAvatar"><![CDATA[Kann eigenen Avatar hochladen]]></item>
+		<item name="wcf.acp.group.option.user.profile.avatar.maxSize"><![CDATA[Maximale Dateigröße]]></item>
+		<item name="wcf.acp.group.option.user.profile.canChangeEmail"><![CDATA[Kann E-Mail-Adresse ändern]]></item>
+		<item name="wcf.acp.group.option.user.profile.canEditUserTitle"><![CDATA[Kann eigenen Benutzertitel bearbeiten]]></item>
+		<item name="wcf.acp.group.option.user.profile.canMail"><![CDATA[Kann E-Mails an andere Benutzer senden]]></item>
+		<item name="wcf.acp.group.option.user.profile.canQuit"><![CDATA[Kann Benutzerkonto löschen]]></item>
+		<item name="wcf.acp.group.option.user.profile.canRename"><![CDATA[Kann Benutzernamen ändern]]></item>
+		<item name="wcf.acp.group.option.user.profile.canViewMembersList"><![CDATA[Kann Mitglieder-Liste sehen]]></item>
+		<item name="wcf.acp.group.option.user.profile.canViewUserProfile"><![CDATA[Kann Benutzerprofile sehen]]></item>
+		<item name="wcf.acp.group.option.user.profile.canViewUsersOnlineList"><![CDATA[Kann Benutzer-Online-Listen sehen]]></item>
+		<item name="wcf.acp.group.option.user.profile.canViewStatistics"><![CDATA[Kann Statistiken sehen]]></item>
+		<item name="wcf.acp.group.option.user.signature.disallowedBBCodes"><![CDATA[Nicht erlaubte BBCodes]]></item>
+		<item name="wcf.acp.group.option.user.signature.disallowedBBCodes.description"><![CDATA[Die hier ausgewählten BBCodes dürfen von Mitgliedern dieser Benutzergruppe in ihrer Signatur <em>nicht</em> verwendet werden.]]></item>
+		<item name="wcf.acp.group.priority"><![CDATA[Priorisierung]]></item>
+		<item name="wcf.acp.group.priority.description"><![CDATA[Bestimmt u.a. die Reihenfolge auf der Team-Seite sowie die Auswahl von Benutzerrängen und „Wer ist online“-Darstellungen auf Basis der höchsten Priorität.]]></item>
+		<item name="wcf.acp.group.userOnlineMarking"><![CDATA[„Benutzer online“-Darstellung]]></item>
+		<item name="wcf.acp.group.userOnlineMarking.description"><![CDATA[Du kannst die HTML-Formatierung für Mitglieder dieser Benutzergruppe in der „Wer ist online“-Anzeige anpassen. <em>&lt;strong&gt;%s&lt;/strong&gt;</em> stellt Mitglieder dieser Gruppe beispielsweise in Fettdruck dar.]]></item>
+		<item name="wcf.acp.group.userOnlineMarking.error.invalid"><![CDATA[Die Darstellung muss „%s“ enthalten]]></item>
+		<item name="wcf.acp.group.showOnTeamPage"><![CDATA[Mitglieder dieser Benutzergruppe auf der Team-Seite anzeigen]]></item>
+		<item name="wcf.acp.group.option.admin.user.canEnableUser"><![CDATA[Kann Benutzer aktivieren]]></item>
+		<item name="wcf.acp.group.option.user.profile.renamePeriod"><![CDATA[Umbenennung]]></item>
+		<item name="wcf.acp.group.option.user.profile.renamePeriod.description"><![CDATA[Zeitraum nach dem Mitglieder dieser Benutzergruppe ihren Benutzernamen ändern können. [Zeit in Tagen]]]></item>
+		<item name="wcf.acp.group.option.user.profile.cannotBeIgnored"><![CDATA[Kann nicht blockiert werden]]></item>
+		<item name="wcf.acp.group.option.mod.general.canUseModeration"><![CDATA[Kann Moderation benutzen]]></item>
+		<item name="wcf.acp.group.option.category.user.like"><![CDATA[Like-System]]></item>
+		<item name="wcf.acp.group.option.user.like.canViewLike"><![CDATA[Kann vergebene Likes sehen]]></item>
+		<item name="wcf.acp.group.option.user.like.canLike"><![CDATA[Kann Inhalte liken]]></item>
+		<item name="wcf.acp.group.option.category.user.profileComment"><![CDATA[Benutzerprofil-Pinnwand]]></item>
+		<item name="wcf.acp.group.option.user.profileComment.canAddComment"><![CDATA[Kann Kommentare erstellen]]></item>
+		<item name="wcf.acp.group.option.user.profileComment.canAddCommentWithoutModeration"><![CDATA[Kann Kommentare ohne Moderation erstellen]]></item>
+		<item name="wcf.acp.group.option.user.profileComment.canEditComment"><![CDATA[Kann eigene Kommentare bearbeiten]]></item>
+		<item name="wcf.acp.group.option.user.profileComment.canDeleteComment"><![CDATA[Kann eigene Kommentare löschen]]></item>
+		<item name="wcf.acp.group.option.user.profileComment.canDeleteCommentInOwnProfile"><![CDATA[Kann Kommentare an der eigenen Pinnwand löschen]]></item>
+		<item name="wcf.acp.group.option.mod.profileComment.canEditComment"><![CDATA[Kann Kommentare bearbeiten]]></item>
+		<item name="wcf.acp.group.option.mod.profileComment.canDeleteComment"><![CDATA[Kann Kommentare löschen]]></item>
+		<item name="wcf.acp.group.option.mod.profileComment.canModerateComment"><![CDATA[Kann Kommentare moderieren]]></item>
+		<item name="wcf.acp.group.option.category.mod.profileComment"><![CDATA[Benutzerprofil-Pinnwand]]></item>
+		<item name="wcf.acp.group.option.admin.content.label.canManageLabel"><![CDATA[Kann Labels verwalten]]></item>
+		<item name="wcf.acp.group.option.category.admin.content.label"><![CDATA[Labels]]></item>
+		<item name="wcf.acp.group.option.category.admin.content.tag"><![CDATA[Tags]]></item>
+		<item name="wcf.acp.group.option.admin.content.tag.canManageTag"><![CDATA[Kann Tags verwalten]]></item>
+		<item name="wcf.acp.group.option.user.signature.maxLength"><![CDATA[Maximale Signaturlänge]]></item>
+		<item name="wcf.acp.group.option.admin.management.canImportData"><![CDATA[Kann Daten importieren]]></item>
+		<item name="wcf.acp.group.option.admin.management.canRebuildData"><![CDATA[Kann Anzeigen aktualisieren]]></item>
+		<item name="wcf.acp.group.description"><![CDATA[Beschreibung der Benutzergruppe]]></item>
+		<item name="wcf.acp.group.button.choose"><![CDATA[Benutzergruppe wählen]]></item>
+		<item name="wcf.acp.group.option.error.validationFailed"><![CDATA[Du hast einen ungültigen Inhalt eingegeben.]]></item>
+		<item name="wcf.acp.group.option.admin.user.canDisableAvatar"><![CDATA[Kann Avatar sperren]]></item>
+		<item name="wcf.acp.group.option.admin.user.canDisableSignature"><![CDATA[Kann Signatur sperren]]></item>
+		<item name="wcf.acp.group.option.admin.user.canManageGroupAssignment"><![CDATA[Kann automatische Gruppenzuordnungen verwalten]]></item>
+		<item name="wcf.acp.group.assignment.add"><![CDATA[Automatische Benutzergruppen-Zuordnung hinzufügen]]></item>
+		<item name="wcf.acp.group.assignment.button.add"><![CDATA[Automatische Zuordnung hinzufügen]]></item>
+		<item name="wcf.acp.group.assignment.button.list"><![CDATA[Automatische Zuordnungen auflisten]]></item>
+		<item name="wcf.acp.group.assignment.conditions"><![CDATA[Bedingungen]]></item>
+		<item name="wcf.acp.group.assignment.conditions.description"><![CDATA[Benutzer müssen die folgenden Bedingungen erfüllen, um automatisch der Benutzergruppe hinzugefügt zu werden]]></item>
+		<item name="wcf.acp.group.assignment.delete.confirmMessage"><![CDATA[Willst du die automatische Benutzergruppen-Zuordnung <span class="confirmationObject">{$assignment->title}</span> wirklich löschen?]]></item>
+		<item name="wcf.acp.group.assignment.edit"><![CDATA[Automatische Benutzergruppen-Zuordnung bearbeiten]]></item>
+		<item name="wcf.acp.group.assignment.error.noConditions"><![CDATA[Du hast keine Bedingungen ausgewählt.]]></item>
+		<item name="wcf.acp.group.assignment.list"><![CDATA[Automatische Benutzergruppen-Zuordnungen]]></item>
+		<item name="wcf.acp.group.assignment.userGroup"><![CDATA[Benutzergruppe]]></item>
+		<item name="wcf.acp.group.assignment.isDisabled"><![CDATA[Automatische Zuordnung deaktivieren]]></item>
+		<item name="wcf.acp.group.assignment.title.error.tooLong"><![CDATA[Der eingegebene Titel ist zu lang. Die maximale Länge beträgt 255 Zeichen.]]></item>
+		<item name="wcf.acp.group.option.admin.notice.canManageNotice"><![CDATA[Kann Hinweise verwalten]]></item>
+		<item name="wcf.acp.group.option.admin.ad.canManageAd"><![CDATA[Kann Werbung verwalten]]></item>
+		<item name="wcf.acp.group.option.user.profile.aboutMeMaxLength"><![CDATA[Maximallänge „Über mich“]]></item>
+		<item name="wcf.acp.group.option.user.profile.canReportContent"><![CDATA[Kann Inhalte melden]]></item>
+		<item name="wcf.acp.group.option.admin.captcha.canManageCaptchaQuestion"><![CDATA[Kann Captcha-Fragen verwalten]]></item>
+		<item name="wcf.acp.group.button.copy"><![CDATA[Benutzergruppe kopieren]]></item>
+		<item name="wcf.acp.group.copy.confirmMessage"><![CDATA[Willst du die Benutzergruppe <span class="confirmationObject">{$group->groupName|language|encodeJS}</span> wirklich kopieren?]]></item>
+		<item name="wcf.acp.group.copy.copyACLOptions"><![CDATA[Objekt-Berechtigungen kopieren]]></item>
+		<item name="wcf.acp.group.copy.copyACLOptions.description"><![CDATA[Berechtigungen, die für bestimmte Objekte wie Labelgruppen gesetzt wurden, werden auch für die neue Benutzergruppe übernommen.]]></item>
+		<item name="wcf.acp.group.copy.copyMembers"><![CDATA[Mitglieder kopieren]]></item>
+		<item name="wcf.acp.group.copy.copyMembers.description"><![CDATA[Mitglieder der kopierten Benutzergruppe werden automatisch auch Mitglied der neuen Benutzergruppe sein.]]></item>
+		<item name="wcf.acp.group.copy.copyUserGroupOptions"><![CDATA[Berechtigungen kopieren]]></item>
+		<item name="wcf.acp.group.copy.copyUserGroupOptions.description"><![CDATA[Die neue Benutzergruppe wird die gleichen Berechtigungen besitzen wie die kopierte Benutzergruppe.]]></item>
+		<item name="wcf.acp.group.option.admin.paidSubscription.canManageSubscription"><![CDATA[Kann bezahlte Mitgliedschaften verwalten]]></item>
+		<item name="wcf.acp.group.option.user.tag.canViewTag"><![CDATA[Kann Tag sehen]]></item>
+		<item name="wcf.acp.group.option.category.user.cms"><![CDATA[CMS]]></item>
+		<item name="wcf.acp.group.option.admin.content.article.canManageArticle"><![CDATA[Kann Artikel verwalten]]></item>
+		<item name="wcf.acp.group.option.admin.content.article.canContributeArticle"><![CDATA[Kann Artikel einreichen]]></item>
+		<item name="wcf.acp.group.option.admin.content.article.canManageCategory"><![CDATA[Kann Artikel-Kategorien verwalten]]></item>
+		<item name="wcf.acp.group.option.admin.content.cms.canManageBox"><![CDATA[Kann Boxen verwalten]]></item>
+		<item name="wcf.acp.group.option.admin.content.cms.canManageMedia"><![CDATA[Kann Medien verwalten]]></item>
+		<item name="wcf.acp.group.option.admin.content.cms.canManagePage"><![CDATA[Kann Seiten verwalten]]></item>
+		<item name="wcf.acp.group.option.admin.content.cms.canUseMedia"><![CDATA[Kann Medien einbinden]]></item>
+		<item name="wcf.acp.group.option.category.mod.cms"><![CDATA[CMS]]></item>
+		<item name="wcf.acp.group.option.category.mod.article"><![CDATA[Artikel]]></item>
+		<item name="wcf.acp.group.option.category.mod.page"><![CDATA[Seiten]]></item>
+		<item name="wcf.acp.group.option.category.user.article"><![CDATA[Artikel]]></item>
+		<item name="wcf.acp.group.option.category.user.page"><![CDATA[Seiten]]></item>
+		<item name="wcf.acp.group.option.mod.article.canDeleteComment"><![CDATA[Kann Kommentare löschen]]></item>
+		<item name="wcf.acp.group.option.mod.article.canEditComment"><![CDATA[Kann Kommentare bearbeiten]]></item>
+		<item name="wcf.acp.group.option.mod.article.canModerateComment"><![CDATA[Kann Kommentare moderieren]]></item>
+		<item name="wcf.acp.group.option.mod.page.canDeleteComment"><![CDATA[Kann Kommentare löschen]]></item>
+		<item name="wcf.acp.group.option.mod.page.canEditComment"><![CDATA[Kann Kommentare bearbeiten]]></item>
+		<item name="wcf.acp.group.option.mod.page.canModerateComment"><![CDATA[Kann Kommentare moderieren]]></item>
+		<item name="wcf.acp.group.option.user.article.canAddComment"><![CDATA[Kann Kommentare erstellen]]></item>
+		<item name="wcf.acp.group.option.user.article.canAddCommentWithoutModeration"><![CDATA[Kann Kommentare ohne Moderation erstellen]]></item>
+		<item name="wcf.acp.group.option.user.article.canDeleteComment"><![CDATA[Kann eigene Kommentare löschen]]></item>
+		<item name="wcf.acp.group.option.user.article.canEditComment"><![CDATA[Kann eigene Kommentare bearbeiten]]></item>
+		<item name="wcf.acp.group.option.user.article.canReadArticle"><![CDATA[Kann Artikel lesen]]></item>
+		<item name="wcf.acp.group.option.user.page.canAddComment"><![CDATA[Kann Kommentare erstellen]]></item>
+		<item name="wcf.acp.group.option.user.page.canAddCommentWithoutModeration"><![CDATA[Kann Kommentare ohne Moderation erstellen]]></item>
+		<item name="wcf.acp.group.option.user.page.canDeleteComment"><![CDATA[Kann eigene Kommentare löschen]]></item>
+		<item name="wcf.acp.group.option.user.page.canEditComment"><![CDATA[Kann eigene Kommentare bearbeiten]]></item>
+		<item name="wcf.acp.group.excludedInTinyBuild"><![CDATA[Seitenbeschleunigung für Gäste ist aktiv]]></item>
+		<item name="wcf.acp.group.excludedInTinyBuild.notice"><![CDATA[Die Seitenbeschleunigung für Gäste ist aktiv, einige Berechtigungen werden daher unabhängig von den hier eingestellten Werten verweigert. Betroffene Einstellungen werden mit dem Blitz-Symbol (<span class="icon icon16 fa-bolt red"></span>) markiert.]]></item>
+		<item name="wcf.acp.group.option.admin.contact.canManageContactForm"><![CDATA[Kann Kontakt-Formular verwalten]]></item>
+		<item name="wcf.acp.group.option.category.admin.user.trophy"><![CDATA[Trophäen]]></item>
+		<item name="wcf.acp.group.option.admin.trophy.canManageTrophy"><![CDATA[Kann Trophäen verwalten]]></item>
+		<item name="wcf.acp.group.option.admin.trophy.canAwardTrophy"><![CDATA[Kann Trophäen verleihen]]></item>
+	</category>
+	
+	<category name="wcf.acp.index">
+		<item name="wcf.acp.index.credits"><![CDATA[Über WoltLab Suite&trade;]]></item>
+		<item name="wcf.acp.index.credits.contributor"><![CDATA[Mitwirkende]]></item>
+		<item name="wcf.acp.index.credits.designer"><![CDATA[Design]]></item>
+		<item name="wcf.acp.index.credits.developedBy"><![CDATA[Software entwickelt von]]></item>
+		<item name="wcf.acp.index.credits.developer"><![CDATA[Programmierung]]></item>
+		<item name="wcf.acp.index.credits.productManager"><![CDATA[Projektleitung]]></item>
+		<item name="wcf.acp.index.credits.trademarks"><![CDATA[„WoltLab&reg;“ und „Burning Board&reg;“ sind eingetragene Gemeinschaftsmarken beim europäischen Harmonisierungsamt für den Binnenmarkt (OHIM) in Alicante, Spanien.]]></item>
+		<item name="wcf.acp.index.credits.contributor.more"><![CDATA[Weitere]]></item>
+		<item name="wcf.acp.index.innoDBWarning"><![CDATA[Die MySQL-Einstellung „innodb_flush_log_at_trx_commit“ steht auf dem Wert „1“ und verursacht dadurch eine starke Verlangsamung bestimmter Datenbankabfragen. Es wird empfohlen diesen Wert auf „2“ zu setzen.]]></item>
+		<item name="wcf.acp.index.inRescueMode"><![CDATA[Du rufst diese Installation über eine abweichende Domain auf, etwa auf Grund eines Umzuges. Bitte korrigiere die Einstellungen unter <a href="{link controller='ApplicationManagement'}{/link}">Apps verwalten</a>.]]></item>
+		<item name="wcf.acp.index.tmpBroken"><![CDATA[Für den ordnungsgemäßen Betrieb muss das Verzeichnis „{WCF_DIR|concat:'tmp/'}“ existieren und beschreibbar sein. Bitte überprüfe auch die Zugriffsrechte auf den Ordner „{'WCF_DIR'|constant}“.]]></item>
+		<item name="wcf.acp.index.news"><![CDATA[Nachrichten]]></item>
+		<item name="wcf.acp.index.setup.notice"><![CDATA[Die Installation wird in wenigen Augenblicken automatisch gestartet, bitte lade diese Seite nicht neu.]]></item>
+		<item name="wcf.acp.index.setup.title"><![CDATA[Bitte warten]]></item>
+		<item name="wcf.acp.index.system"><![CDATA[System]]></item>
+		<item name="wcf.acp.index.system.software"><![CDATA[Software]]></item>
+		<item name="wcf.acp.index.system.software.wcfVersion"><![CDATA[WoltLab Suite&trade;-Version]]></item>
+		<item name="wcf.acp.index.system.server"><![CDATA[Server]]></item>
+		<item name="wcf.acp.index.system.os"><![CDATA[Betriebssystem]]></item>
+		<item name="wcf.acp.index.system.webserver"><![CDATA[Webserver]]></item>
+		<item name="wcf.acp.index.system.php"><![CDATA[PHP-Version]]></item>
+		<item name="wcf.acp.index.system.mySQLVersion"><![CDATA[MySQL-Version]]></item>
+		<item name="wcf.acp.index.system.load"><![CDATA[Aktueller UNIX Load]]></item>
+		<item name="wcf.acp.index.woltlab.website"><![CDATA[Website]]></item>
+		<item name="wcf.acp.index.woltlab.forums"><![CDATA[Supportforum]]></item>
+		<item name="wcf.acp.index.woltlab.tickets"><![CDATA[Ticket-Support]]></item>
+		<item name="wcf.acp.index.woltlab.pluginStore"><![CDATA[Plugin-Store]]></item>
+		<item name="wcf.acp.index.tinyBuild"><![CDATA[Die Seitenbeschleunigung für Gäste verbessert die Ladezeiten für Besucher und Suchmaschinen, es wird empfohlen diese <a href="{link controller='Option' id=1 optionName="visitor_use_tiny_build"}#category_module.system{/link}">zu aktivieren</a>.]]></item>
+	</category>
+	
+	<category name="wcf.acp.label">
+		<item name="wcf.acp.label.add"><![CDATA[Label hinzufügen]]></item>
+		<item name="wcf.acp.label.cssClassName"><![CDATA[CSS-Klassen]]></item>
+		<item name="wcf.acp.label.cssClassName.error.invalid"><![CDATA[Die gewählte CSS-Klasse ist ungültig.]]></item>
+		<item name="wcf.acp.label.defaultValue"><![CDATA[Label]]></item>
+		<item name="wcf.acp.label.delete.sure"><![CDATA[Willst du das Label <span class="confirmationObject">{$label}</span> wirklich löschen?]]></item>
+		<item name="wcf.acp.label.edit"><![CDATA[Label bearbeiten]]></item>
+		<item name="wcf.acp.label.error.noGroups"><![CDATA[Bevor du ein Label hinzufügen kannst, musst du eine <a href="{link controller='LabelGroupAdd'}{/link}">Labelgruppe hinzufügen</a>.]]></item>
+		<item name="wcf.acp.label.group"><![CDATA[Labelgruppe]]></item>
+		<item name="wcf.acp.label.group.add"><![CDATA[Labelgruppe hinzufügen]]></item>
+		<item name="wcf.acp.label.group.category.connect"><![CDATA[Verfügbarkeit]]></item>
+		<item name="wcf.acp.label.group.delete.sure"><![CDATA[Willst du die Labelgruppe <span class="confirmationObject">{$group->groupName|language}</span> wirklich löschen?]]></item>
+		<item name="wcf.acp.label.group.edit"><![CDATA[Labelgruppe bearbeiten]]></item>
+		<item name="wcf.acp.label.group.error.invalid"><![CDATA[Die gewählte Labelgruppe ist ungültig.]]></item>
+		<item name="wcf.acp.label.group.forceSelection"><![CDATA[Label aus dieser Gruppe muss zwingend ausgewählt werden]]></item>
+		<item name="wcf.acp.label.group.list"><![CDATA[Labelgruppen]]></item>
+		<item name="wcf.acp.label.group.permanentSelection"><![CDATA[Die ausgewählte Labelgruppe kann nachträglich nicht mehr verändert werden.]]></item>
+		<item name="wcf.acp.label.label"><![CDATA[Label]]></item>
+		<item name="wcf.acp.label.list"><![CDATA[Labels]]></item>
+		<item name="wcf.acp.label.group.groupName.description"><![CDATA[Der Titel ist für alle Benutzer sichtbar, die Zugriff auf diese Labelgruppe haben.]]></item>
+		<item name="wcf.acp.label.group.groupDescription.description"><![CDATA[Die optionale Beschreibung wird nur in der Administrationsoberfläche angezeigt.]]></item>
+		<item name="wcf.acp.label.showOrder.description"><![CDATA[Reihenfolge des Labels innerhalb seiner Labelgruppe. Wenn du das Feld leer lässt, wird das Label an letzter Position einsortiert.]]></item>
+		<item name="wcf.acp.label.sortAfterGroupFiltering"><![CDATA[Wenn du die Label-Liste nur nach einer bestimmten Labelgruppe filterst, kannst du die Labels innerhalb dieser Gruppe durch Ziehen und Loslassen sortieren.]]></item>
+		<item name="wcf.acp.label.filter"><![CDATA[Filter]]></item>
+		<item name="wcf.acp.label.container.com.woltlab.wcf.article.category"><![CDATA[Artikel]]></item>
+	</category>
+	
+	<category name="wcf.acp.language">
+		<item name="wcf.acp.language.add"><![CDATA[Sprache hinzufügen]]></item>
+		<item name="wcf.acp.language.add.languageCode.error.notUnique"><![CDATA[Dieser Sprachcode wird bereits von einer anderen im System installierten Sprache verwendet.]]></item>
+		<item name="wcf.acp.language.add.source"><![CDATA[Vorlage]]></item>
+		<item name="wcf.acp.language.code"><![CDATA[Sprachcode]]></item>
+		<item name="wcf.acp.language.code.description"><![CDATA[Gib hier den passenden Sprachcode nach <strong>ISO 639-1</strong> an. Weitere Informationen zu Sprachcodes findest du unter <a href="http://de.wikipedia.org/wiki/ISO_639-1" class="externalURL">http://de.wikipedia.org/wiki/ISO_639-1</a>.]]></item>
+		<item name="wcf.acp.language.countryCode"><![CDATA[Ländercode]]></item>
+		<item name="wcf.acp.language.countryCode.description"><![CDATA[Gib hier den passenden Ländercode nach <strong>ISO 3166-1</strong> an. Weitere Informationen zu Ländercodes findest du unter <a href="http://de.wikipedia.org/wiki/ISO-3166-1-Kodierliste" class="externalURL">http://de.wikipedia.org/wiki/ISO-3166-1-Kodierliste</a>.]]></item>
+		<item name="wcf.acp.language.customVariables"><![CDATA[Veränderte Variablen]]></item>
+		<item name="wcf.acp.language.delete.sure"><![CDATA[Willst du die Sprache <span class="confirmationObject">{$language->languageName}</span> wirklich löschen?]]></item>
+		<item name="wcf.acp.language.edit"><![CDATA[Sprache bearbeiten]]></item>
+		<item name="wcf.acp.language.export"><![CDATA[Sprache exportieren]]></item>
+		<item name="wcf.acp.language.export.allPackages"><![CDATA[Alle Pakete]]></item>
+		<item name="wcf.acp.language.export.customValues"><![CDATA[Veränderte Variablen exportieren]]></item>
+		<item name="wcf.acp.language.export.selectPackages"><![CDATA[Pakete auswählen]]></item>
+		<item name="wcf.acp.language.import.error"><![CDATA[Beim Importieren der Sprachdatei ist folgender Fehler aufgetreten:]]></item>
+		<item name="wcf.acp.language.import.source.file"><![CDATA[Pfad zur Sprachdatei]]></item>
+		<item name="wcf.acp.language.import.source.file.description"><![CDATA[Gib hier den relativen Pfad zu einer gültigen XML-Sprachdatei an.]]></item>
+		<item name="wcf.acp.language.import.source.upload"><![CDATA[Sprachdatei vom lokalen Computer hochladen]]></item>
+		<item name="wcf.acp.language.list"><![CDATA[Sprachen]]></item>
+		<item name="wcf.acp.language.multilingualism"><![CDATA[Mehrsprachigkeit verwalten]]></item>
+		<item name="wcf.acp.language.multilingualism.enable"><![CDATA[Mehrsprachige Inhalte aktivieren]]></item>
+		<item name="wcf.acp.language.multilingualism.enable.description"><![CDATA[Hast du mehrere Sprachen installiert, können sich deine Mitglieder die Programmoberfläche in diesen Sprachen anzeigen lassen. Erstellte Inhalte werden durch die aktivierte Mehrsprachigkeit außerdem einer Sprache zugeordnet. Die Benutzer können in ihrem Profil auswählen, ob ausschließlich Inhalte bestimmter Sprachen angezeigt werden. Bei der Erstellung von Inhalten ist standardmäßig die aktive Oberflächensprache voreingestellt.]]></item>
+		<item name="wcf.acp.language.multilingualism.languages"><![CDATA[Inhalte in folgenden Sprachen zulassen]]></item>
+		<item name="wcf.acp.language.multilingualism.languages.error.empty"><![CDATA[Um die Mehrsprachigkeit zu nutzen, musst du mindestens zwei Sprachen auswählen.]]></item>
+		<item name="wcf.acp.language.parent"><![CDATA[Übergeordnete Sprache]]></item>
+		<item name="wcf.acp.language.parent.description"><![CDATA[Die hier angegebene Sprache wird als Fallback verwendet, falls in der eigentlichen Sprache eine Sprachvariable nicht vorhanden ist.]]></item>
+		<item name="wcf.acp.language.parent.error.parentsItself"><![CDATA[Eine Sprache kann nicht ihre eigene übergeordnete Sprache sein.]]></item>
+		<item name="wcf.acp.language.setAsDefault"><![CDATA[Zur Standardsprache machen]]></item>
+		<item name="wcf.acp.language.variables"><![CDATA[Variablen]]></item>
+		<item name="wcf.acp.language.users"><![CDATA[Verwendet von]]></item>
+		<item name="wcf.acp.language.import"><![CDATA[Sprache importieren]]></item>
+		<item name="wcf.acp.language.item.list"><![CDATA[Texte verwalten]]></item>
+		<item name="wcf.acp.language.category"><![CDATA[Kategorie]]></item>
+		<item name="wcf.acp.language.item.value"><![CDATA[Inhalt]]></item>
+		<item name="wcf.acp.language.item.customValue"><![CDATA[Eigener Inhalt]]></item>
+		<item name="wcf.acp.language.item.useCustomValue"><![CDATA[Eigene Version verwenden]]></item>
+		<item name="wcf.acp.language.item.customValues"><![CDATA[Veränderte Inhalte finden]]></item>
+		<item name="wcf.acp.language.item.disabledCustomValues"><![CDATA[Deaktivierte veränderte Inhalte finden]]></item>
+		<item name="wcf.acp.language.name.description"><![CDATA[Name der Sprache]]></item>
+		<item name="wcf.acp.language.add.source.description"><![CDATA[Die ausgewählte Sprache wird als Vorlage benutzt. Alle Sprachvariablen werden in die neue Sprache kopiert.]]></item>
+		<item name="wcf.acp.language.item.oldValue"><![CDATA[Ursprünglicher Inhalt]]></item>
+		<item name="wcf.acp.language.item.oldValue.description"><![CDATA[Deine veränderte Fassung basierte auf dem unten stehenden Stand vom {$item->languageCustomItemDisableTime|date}.]]></item>
+		<item name="wcf.acp.language.item.recentlyDisabledCustomValues"><![CDATA[Kürzlich deaktivierte Inhalte finden (Letzten 7 Tagen)]]></item>
+		<item name="wcf.acp.language.item.hasRecentlyDisabledCustomValues"><![CDATA[{if $recentlyDisabledCustomValues == 1}Eine{else}{#$recentlyDisabledCustomValues}{/if} individuell angepasste {if $recentlyDisabledCustomValues == 1}Sprachvariable wurde{else}Sprachvariablen wurden{/if} vor Kurzem <a href="{link controller='LanguageItemList' hasRecentlyDisabledCustomValue=1}{/link}">automatisch deaktiviert</a>.]]></item>
+	</category>
+	
+	<category name="wcf.acp.masterPassword">
+		<item name="wcf.acp.masterPassword"><![CDATA[Hauptkennwort]]></item>
+		<item name="wcf.acp.masterPassword.confirm"><![CDATA[Hauptkennwort wiederholen]]></item>
+		<item name="wcf.acp.masterPassword.enter"><![CDATA[Hauptkennwort erforderlich]]></item>
+		<item name="wcf.acp.masterPassword.enter.description"><![CDATA[Die aufgerufene Seite oder Aktion erfordert aus Sicherheitsgründen die Eingabe des Hauptkennwortes. Pro Sitzung ist die Eingabe des Hauptkennwortes nur einmal erforderlich. Falls du das Hauptkennwort vergessen haben solltest, kannst du es zurücksetzen, indem du die Datei <em>{@$relativeWcfDir}acp/masterPassword.inc.php</em> löschst.]]></item>
+		<item name="wcf.acp.masterPassword.error.notEqual"><![CDATA[Die eingegebenen Kennwörter sind nicht identisch.]]></item>
+		<item name="wcf.acp.masterPassword.error.notSecure"><![CDATA[Das Kennwort wurde als unsicher eingestuft. Das Kennwort sollte mindestens acht Zeichen lang sein, große und kleine lateinische Buchstaben, Zahlen und Sonderzeichen enthalten. Es darf nicht mit den Kennwörtern von anderen Administratoren übereinstimmen.]]></item>
+		<item name="wcf.acp.masterPassword.error.invalid"><![CDATA[Das Hauptkennwort ist nicht korrekt. Falls du das Hauptkennwort vergessen haben solltest, kannst du es zurücksetzen, indem du die Datei <em>{@$relativeWcfDir}acp/masterPassword.inc.php</em> löschst.]]></item>
+		<item name="wcf.acp.masterPassword.example"><![CDATA[Vorschlag]]></item>
+		<item name="wcf.acp.masterPassword.example.set"><![CDATA[Vorschlag übernehmen]]></item>
+		<item name="wcf.acp.masterPassword.init"><![CDATA[Hauptkennwort festlegen]]></item>
+		<item name="wcf.acp.masterPassword.init.description"><![CDATA[Das Hauptkennwort ist ein zusätzlicher Schutz für sicherheitskritische Funktionen. Du solltest ein möglichst sicheres Kennwort verwenden, dass sich von deinem regulären Administrator-Kennwort unterscheidet, Dritten nicht bekannt ist und auch nicht auf anderen Internetseiten verwendet wird.]]></item>
+	</category>
+		
+	<category name="wcf.acp.menu">
+		<item name="wcf.acp.menu.link.management"><![CDATA[Verwaltung]]></item>
+		<item name="wcf.acp.menu.link.maintenance"><![CDATA[Wartung]]></item>
+		<item name="wcf.acp.menu.link.maintenance.cache"><![CDATA[Cache]]></item>
+		<item name="wcf.acp.menu.link.application.management"><![CDATA[Apps verwalten]]></item>
+		<item name="wcf.acp.menu.link.application"><![CDATA[Apps]]></item>
+		<item name="wcf.acp.menu.link.content"><![CDATA[Inhalt]]></item>
+		<item name="wcf.acp.menu.link.cronjob"><![CDATA[Cronjobs]]></item>
+		<item name="wcf.acp.menu.link.cronjob.add"><![CDATA[Cronjob hinzufügen]]></item>
+		<item name="wcf.acp.menu.link.cronjob.list"><![CDATA[Cronjobs]]></item>
+		<item name="wcf.acp.menu.link.language"><![CDATA[Sprachen]]></item>
+		<item name="wcf.acp.menu.link.language.import"><![CDATA[Sprache importieren]]></item>
+		<item name="wcf.acp.menu.link.language.item.list"><![CDATA[Texte verwalten]]></item>
+		<item name="wcf.acp.menu.link.language.list"><![CDATA[Sprachen]]></item>
+		<item name="wcf.acp.menu.link.language.multilingualism"><![CDATA[Mehrsprachigkeit verwalten]]></item>
+		<item name="wcf.acp.menu.link.log"><![CDATA[Protokoll]]></item>
+		<item name="wcf.acp.menu.link.log.session"><![CDATA[Sitzungen]]></item>
+		<item name="wcf.acp.menu.link.log.cronjob"><![CDATA[Cronjobs]]></item>
+		<item name="wcf.acp.menu.link.log.exception"><![CDATA[Fehler]]></item>
+		<item name="wcf.acp.menu.link.group"><![CDATA[Benutzergruppen]]></item>
+		<item name="wcf.acp.menu.link.group.add"><![CDATA[Benutzergruppe hinzufügen]]></item>
+		<item name="wcf.acp.menu.link.group.mail"><![CDATA[E-Mail an Gruppenmitglieder]]></item>
+		<item name="wcf.acp.menu.link.group.list"><![CDATA[Benutzergruppen]]></item>
+		<item name="wcf.acp.menu.link.customization"><![CDATA[Anpassung]]></item>
+		<item name="wcf.acp.menu.link.option"><![CDATA[Optionen]]></item>
+		<item name="wcf.acp.menu.link.package"><![CDATA[Pakete]]></item>
+		<item name="wcf.acp.menu.link.package.install"><![CDATA[Paket installieren]]></item>
+		<item name="wcf.acp.menu.link.package.server.list"><![CDATA[Paket-Server]]></item>
+		<item name="wcf.acp.menu.link.package.server.add"><![CDATA[Server hinzufügen]]></item>
+		<item name="wcf.acp.menu.link.package.list"><![CDATA[Pakete]]></item>
+		<item name="wcf.acp.menu.link.style"><![CDATA[Stile]]></item>
+		<item name="wcf.acp.menu.link.style.add"><![CDATA[Stil hinzufügen]]></item>
+		<item name="wcf.acp.menu.link.style.import"><![CDATA[Stil importieren]]></item>
+		<item name="wcf.acp.menu.link.style.list"><![CDATA[Stile]]></item>
+		<item name="wcf.acp.menu.link.configuration"><![CDATA[Konfiguration]]></item>
+		<item name="wcf.acp.menu.link.user"><![CDATA[Benutzer]]></item>
+		<item name="wcf.acp.menu.link.user.add"><![CDATA[Benutzer hinzufügen]]></item>
+		<item name="wcf.acp.menu.link.user.list"><![CDATA[Benutzer]]></item>
+		<item name="wcf.acp.menu.link.user.mail"><![CDATA[E-Mail an alle Benutzer]]></item>
+		<item name="wcf.acp.menu.link.user.management"><![CDATA[Benutzer]]></item>
+		<item name="wcf.acp.menu.link.user.bulkProcessing"><![CDATA[Benutzer-Massenbearbeitung]]></item>
+		<item name="wcf.acp.menu.link.user.search"><![CDATA[Benutzer suchen]]></item>
+		<item name="wcf.acp.menu.link.user.option"><![CDATA[Profilfelder]]></item>
+		<item name="wcf.acp.menu.link.user.option.list"><![CDATA[Profilfelder]]></item>
+		<item name="wcf.acp.menu.link.user.option.add"><![CDATA[Profilfeld hinzufügen]]></item>
+		<item name="wcf.acp.menu.link.user.option.category.list"><![CDATA[Profilfeld-Kategorien]]></item>
+		<item name="wcf.acp.menu.link.user.option.category.add"><![CDATA[Profilfeld-Kategorie hinzufügen]]></item>
+		<item name="wcf.acp.menu.link.userOptionDefaults"><![CDATA[Benutzerprofil-Einstellungen]]></item>
+		<item name="wcf.acp.menu.link.user.profileMenu"><![CDATA[Benutzerprofil-Menü]]></item>
+		<item name="wcf.acp.menu.link.template"><![CDATA[Templates]]></item>
+		<item name="wcf.acp.menu.link.template.list"><![CDATA[Templates]]></item>
+		<item name="wcf.acp.menu.link.template.add"><![CDATA[Template hinzufügen]]></item>
+		<item name="wcf.acp.menu.link.template.group.list"><![CDATA[Templategruppen]]></item>
+		<item name="wcf.acp.menu.link.template.group.add"><![CDATA[Templategruppe hinzufügen]]></item>
+		<item name="wcf.acp.menu.link.attachment"><![CDATA[Dateianhänge]]></item>
+		<item name="wcf.acp.menu.link.attachment.list"><![CDATA[Dateianhänge]]></item>
+		<item name="wcf.acp.menu.link.bbcode"><![CDATA[BBCodes]]></item>
+		<item name="wcf.acp.menu.link.bbcode.add"><![CDATA[BBCode hinzufügen]]></item>
+		<item name="wcf.acp.menu.link.bbcode.list"><![CDATA[BBCodes]]></item>
+		<item name="wcf.acp.menu.link.bbcode.mediaProvider.add"><![CDATA[Medienanbieter hinzufügen]]></item>
+		<item name="wcf.acp.menu.link.bbcode.mediaProvider.list"><![CDATA[Medienanbieter]]></item>
+		<item name="wcf.acp.menu.link.smiley"><![CDATA[Smileys]]></item>
+		<item name="wcf.acp.menu.link.smiley.add"><![CDATA[Smiley hinzufügen]]></item>
+		<item name="wcf.acp.menu.link.smiley.list"><![CDATA[Smileys]]></item>
+		<item name="wcf.acp.menu.link.smiley.category.add"><![CDATA[Smiley-Kategorie hinzufügen]]></item>
+		<item name="wcf.acp.menu.link.smiley.category.list"><![CDATA[Smiley-Kategorien]]></item>
+		<item name="wcf.acp.menu.link.activityPoint"><![CDATA[Aktivitätspunkte]]></item>
+		<item name="wcf.acp.menu.link.user.rank"><![CDATA[Benutzerränge]]></item>
+		<item name="wcf.acp.menu.link.user.rank.list"><![CDATA[Benutzerränge]]></item>
+		<item name="wcf.acp.menu.link.user.rank.add"><![CDATA[Benutzerrang hinzufügen]]></item>
+		<item name="wcf.acp.menu.link.label"><![CDATA[Labels]]></item>
+		<item name="wcf.acp.menu.link.label.add"><![CDATA[Label hinzufügen]]></item>
+		<item name="wcf.acp.menu.link.label.list"><![CDATA[Labels]]></item>
+		<item name="wcf.acp.menu.link.label.group.add"><![CDATA[Labelgruppe hinzufügen]]></item>
+		<item name="wcf.acp.menu.link.label.group.list"><![CDATA[Labelgruppen]]></item>
+		<item name="wcf.acp.menu.link.tag"><![CDATA[Tags]]></item>
+		<item name="wcf.acp.menu.link.tag.add"><![CDATA[Tag hinzufügen]]></item>
+		<item name="wcf.acp.menu.link.tag.list"><![CDATA[Tags]]></item>
+		<item name="wcf.acp.menu.link.maintenance.import"><![CDATA[Datenimport]]></item>
+		<item name="wcf.acp.menu.link.maintenance.rebuildData"><![CDATA[Anzeigen aktualisieren]]></item>
+		<item name="wcf.acp.menu.link.stat"><![CDATA[Statistiken]]></item>
+		<item name="wcf.acp.menu.link.stat.list"><![CDATA[Statistiken]]></item>
+		<item name="wcf.acp.menu.link.group.assignment"><![CDATA[Automatische Zuordnungen]]></item>
+		<item name="wcf.acp.menu.link.group.assignment.add"><![CDATA[Automatische Zuordnung hinzufügen]]></item>
+		<item name="wcf.acp.menu.link.notice"><![CDATA[Hinweise]]></item>
+		<item name="wcf.acp.menu.link.notice.add"><![CDATA[Hinweis hinzufügen]]></item>
+		<item name="wcf.acp.menu.link.notice.list"><![CDATA[Hinweise]]></item>
+		<item name="wcf.acp.menu.link.ad"><![CDATA[Werbung]]></item>
+		<item name="wcf.acp.menu.link.ad.add"><![CDATA[Werbung hinzufügen]]></item>
+		<item name="wcf.acp.menu.link.ad.list"><![CDATA[Werbung]]></item>
+		<item name="wcf.acp.menu.link.captcha"><![CDATA[Captchas]]></item>
+		<item name="wcf.acp.menu.link.captcha.question.add"><![CDATA[Frage hinzufügen]]></item>
+		<item name="wcf.acp.menu.link.captcha.question.list"><![CDATA[Captcha-Fragen]]></item>
+		<item name="wcf.acp.menu.link.log.authentication.failure"><![CDATA[Fehlgeschlagene Anmeldungen]]></item>
+		<item name="wcf.acp.menu.link.paidSubscription"><![CDATA[Bezahlte Mitgliedschaften]]></item>
+		<item name="wcf.acp.menu.link.paidSubscription.add"><![CDATA[Mitgliedschaft hinzufügen]]></item>
+		<item name="wcf.acp.menu.link.paidSubscription.list"><![CDATA[Mitgliedschaften]]></item>
+		<item name="wcf.acp.menu.link.paidSubscription.user.list"><![CDATA[Aktive Mitgliedschaften]]></item>
+		<item name="wcf.acp.menu.link.paidSubscription.transactionLog.list"><![CDATA[Transaktionen]]></item>
+		<item name="wcf.acp.menu.link.notificationPresetSettings"><![CDATA[Benachrichtigungen]]></item>
+		<item name="wcf.acp.menu.link.cms"><![CDATA[CMS]]></item>
+		<item name="wcf.acp.menu.link.cms.page.list"><![CDATA[Seiten]]></item>
+		<item name="wcf.acp.menu.link.cms.page.add"><![CDATA[Seite hinzufügen]]></item>
+		<item name="wcf.acp.menu.link.cms.menu.list"><![CDATA[Menüs]]></item>
+		<item name="wcf.acp.menu.link.cms.menu.add"><![CDATA[Menü hinzufügen]]></item>
+		<item name="wcf.acp.menu.link.cms.box.list"><![CDATA[Boxen]]></item>
+		<item name="wcf.acp.menu.link.cms.box.add"><![CDATA[Box hinzufügen]]></item>
+		<item name="wcf.acp.menu.link.media"><![CDATA[Medien]]></item>
+		<item name="wcf.acp.menu.link.media.list"><![CDATA[Medien]]></item>
+		<item name="wcf.acp.menu.link.media.category.list"><![CDATA[Kategorien]]></item>
+		<item name="wcf.acp.menu.link.media.category.add"><![CDATA[Kategorie hinzufügen]]></item>
+		<item name="wcf.acp.menu.link.article"><![CDATA[Artikel]]></item>
+		<item name="wcf.acp.menu.link.article.list"><![CDATA[Artikel]]></item>
+		<item name="wcf.acp.menu.link.article.add"><![CDATA[Artikel hinzufügen]]></item>
+		<item name="wcf.acp.menu.link.article.category.list"><![CDATA[Kategorien]]></item>
+		<item name="wcf.acp.menu.link.article.category.add"><![CDATA[Kategorie hinzufügen]]></item>
+		<item name="wcf.acp.menu.link.maintenance.sitemap"><![CDATA[Sitemaps]]></item>
+		<item name="wcf.acp.menu.add"><![CDATA[Menü hinzufügen]]></item>
+		<item name="wcf.acp.menu.delete.confirmMessage"><![CDATA[Willst du das Menü <span class="confirmationObject">{lang}{$menu->title}{/lang}</span> wirklich löschen?]]></item>
+		<item name="wcf.acp.menu.edit"><![CDATA[Menü bearbeiten]]></item>
+		<item name="wcf.acp.menu.list"><![CDATA[Menüs]]></item>
+		<item name="wcf.acp.menu.item.add"><![CDATA[Menüpunkt hinzufügen]]></item>
+		<item name="wcf.acp.menu.item.delete.confirmMessage"><![CDATA[Willst du den Menüpunkt <span class="confirmationObject">{lang}{$menuItemNode->title}{/lang}</span> wirklich löschen?]]></item>
+		<item name="wcf.acp.menu.item.edit"><![CDATA[Menüpunkt bearbeiten]]></item>
+		<item name="wcf.acp.menu.item.externalURL"><![CDATA[Externe URL]]></item>
+		<item name="wcf.acp.menu.item.isDisabled"><![CDATA[Menüpunkt deaktivieren]]></item>
+		<item name="wcf.acp.menu.item.link"><![CDATA[Verlinkung]]></item>
+		<item name="wcf.acp.menu.item.link.external"><![CDATA[Externer Link]]></item>
+		<item name="wcf.acp.menu.item.link.internal"><![CDATA[Interner Link]]></item>
+		<item name="wcf.acp.menu.item.list"><![CDATA[Menüpunkte]]></item>
+		<item name="wcf.acp.menu.item.parentItem"><![CDATA[Übergeordneter Menüpunkt]]></item>
+		<item name="wcf.acp.menu.link.other"><![CDATA[Sonstiges]]></item>
+		<item name="wcf.acp.menu.item.pageObjectID.error.invalid"><![CDATA[Die eingetragene ID ist ungültig.]]></item>
+		<item name="wcf.acp.menu.link.contact.settings"><![CDATA[Kontakt-Formular]]></item>
+		<item name="wcf.acp.menu.link.trophy"><![CDATA[Trophäen]]></item>
+		<item name="wcf.acp.menu.link.trophy.category.list"><![CDATA[Kategorien]]></item>
+		<item name="wcf.acp.menu.link.trophy.category.add"><![CDATA[Kategorie hinzufügen]]></item>
+	</category>
+	
+	<category name="wcf.acp.notice">
+		<item name="wcf.acp.notice.add"><![CDATA[Hinweis hinzufügen]]></item>
+		<item name="wcf.acp.notice.cssClassName"><![CDATA[Darstellung]]></item>
+		<item name="wcf.acp.notice.cssClassName.description"><![CDATA[Du kannst aus den vorgegebenen Darstellungen wählen oder eine eigene Darstellung durch Angabe einer <abbr title="Cascading Style Sheets">CSS</abbr>-Klasse nutzen.]]></item>
+		<item name="wcf.acp.notice.cssClassName.error"><![CDATA[Fehlermeldung]]></item>
+		<item name="wcf.acp.notice.cssClassName.error.invalid"><![CDATA[Die gewählte CSS-Klasse ist ungültig.]]></item>
+		<item name="wcf.acp.notice.cssClassName.info"><![CDATA[Information]]></item>
+		<item name="wcf.acp.notice.cssClassName.success"><![CDATA[Erfolgsmeldung]]></item>
+		<item name="wcf.acp.notice.cssClassName.warning"><![CDATA[Warnung]]></item>
+		<item name="wcf.acp.notice.conditions"><![CDATA[Bedingungen]]></item>
+		<item name="wcf.acp.notice.conditions.description"><![CDATA[Werden keine Bedingungen ausgewählt, wird der Hinweis für jeden Benutzer auf allen Seiten angezeigt.]]></item>
+		<item name="wcf.acp.notice.conditions.page"><![CDATA[Seite]]></item>
+		<item name="wcf.acp.notice.conditions.page.description"><![CDATA[Die vom Benutzer aufgerufene Seite muss folgende Bedingungen erfüllen, damit der Hinweis angezeigt wird.]]></item>
+		<item name="wcf.acp.notice.conditions.pointInTime"><![CDATA[Zeitpunkt]]></item>
+		<item name="wcf.acp.notice.conditions.pointInTime.description"><![CDATA[Leg den Zeitpunkt fest, zu dem der Hinweis angezeigt werden soll.]]></item>
+		<item name="wcf.acp.notice.conditions.user"><![CDATA[Aktiver Benutzer]]></item>
+		<item name="wcf.acp.notice.conditions.user.description"><![CDATA[Der aktive Benutzer muss die folgenden Bedingungen erfüllen, damit der Hinweis angezeigt wird.]]></item>
+		<item name="wcf.acp.notice.delete.confirmMessage"><![CDATA[Willst du den Hinweis <span class="confirmationObject">{$notice->noticeName}</span> wirklich löschen?]]></item>
+		<item name="wcf.acp.notice.edit"><![CDATA[Hinweis bearbeiten]]></item>
+		<item name="wcf.acp.notice.example"><![CDATA[Beispieltext für einen Hinweis]]></item>
+		<item name="wcf.acp.notice.isDisabled"><![CDATA[Hinweis deaktivieren]]></item>
+		<item name="wcf.acp.notice.isDismissible"><![CDATA[Benutzer kann Hinweis ausblenden]]></item>
+		<item name="wcf.acp.notice.isDismissible.description"><![CDATA[Ein einmal von einem Benutzer ausgeblendeter Hinweis wird bei erneutem Seitenaufruf nicht mehr angezeigt.]]></item>
+		<item name="wcf.acp.notice.list"><![CDATA[Hinweise]]></item>
+		<item name="wcf.acp.notice.notice"><![CDATA[Hinweis]]></item>
+		<item name="wcf.acp.notice.notice.description"><![CDATA[<code>{literal}{$username}{/literal}</code> wird durch den Namen und <code>{literal}{$email}{/literal}</code> durch die Email-Adresse des aktuellen Benutzers ersetzt.]]></item>
+		<item name="wcf.acp.notice.noticeUseHtml"><![CDATA[HTML im Hinweis verwenden]]></item>
+		<item name="wcf.acp.notice.resetIsDismissed"><![CDATA[Ausgeblendete Hinweise erneut anzeigen]]></item>
+		<item name="wcf.acp.notice.resetIsDismissed.description"><![CDATA[Der Hinweis wird jenen Benutzern wieder angezeigt, die die ursprüngliche Version bereits ausgeblendet haben. Gästen, die den Hinweis bereits ausgeblendet haben, wird dieser nur in einer neuen Session erneut angezeigt.]]></item>
+		<item name="wcf.acp.notice.showOrder.description"><![CDATA[Legt die Reihenfolge fest, in der die Hinweise angezeigt werden.]]></item>
+	</category>
+	
+	<category name="wcf.acp.option">
+		<item name="wcf.acp.option.blacklist_hostnames"><![CDATA[Hostname ausschließen]]></item>
+		<item name="wcf.acp.option.blacklist_hostnames.description"><![CDATA[Ein Hostname pro Zeile]]></item>
+		<item name="wcf.acp.option.blacklist_ip_addresses"><![CDATA[IP-Adresse ausschließen]]></item>
+		<item name="wcf.acp.option.blacklist_ip_addresses.description"><![CDATA[Eine Adresse pro Zeile]]></item>
+		<item name="wcf.acp.option.blacklist_user_agents"><![CDATA[Browser-Kennung ausschließen]]></item>
+		<item name="wcf.acp.option.blacklist_user_agents.description"><![CDATA[Eine Browser-Kennung (User-Agent) pro Zeile]]></item>
+		<item name="wcf.acp.option.cache_source_memcached_host"><![CDATA[Memcached-Server]]></item>
+		<item name="wcf.acp.option.cache_source_memcached_host.description"><![CDATA[Mehrere Server können zeilenweise angegeben und die Gewichtung als dritter Parameter angegeben werden, zum Beispiel „localhost:11211:67“ oder „10.0.13.37:31337:33“.]]></item>
+		<item name="wcf.acp.option.cache_source_redis_host"><![CDATA[Redis-Server]]></item>
+		<item name="wcf.acp.option.cache_source_redis_host.description"><![CDATA[Die Adresse des Servers, zum Beispiel „localhost“ oder „10.0.13.37:1337“.]]></item>
+		<item name="wcf.acp.option.cache_source_type"><![CDATA[Cache-Methode]]></item>
+		<item name="wcf.acp.option.cache_source_type.description"><![CDATA[Beachte, dass einige Methoden spezielle Anforderungen an das Server-System stellen und nicht auf jedem Server zur Verfügung stehen.]]></item>
+		<item name="wcf.acp.option.cache_source_type.disk"><![CDATA[Dateisystem (Standard)]]></item>
+		<item name="wcf.acp.option.cache_source_type.memcached"><![CDATA[Memcached]]></item>
+		<item name="wcf.acp.option.cache_source_type.redis"><![CDATA[Redis]]></item>
+		<item name="wcf.acp.option.category.general"><![CDATA[Allgemein]]></item>
+		<item name="wcf.acp.option.category.general.cache"><![CDATA[Cache]]></item>
+		<item name="wcf.acp.option.category.general.cache.general"><![CDATA[Allgemein]]></item>
+		<item name="wcf.acp.option.category.general.cache.memcached"><![CDATA[Memcached]]></item>
+		<item name="wcf.acp.option.category.general.cache.memcached.description"><![CDATA[Memcached speichert häufig benötigte Daten im Arbeitsspeicher zwischen. Dies kann die Last auf die Datenbank und das Dateisystem drastisch reduzieren. Lies mehr über dieses Thema auf der folgenden Seite: <a href="http://memcached.org/" class="externalURL">memcached.org</a>.]]></item>
+		<item name="wcf.acp.option.category.general.cache.redis"><![CDATA[Redis]]></item>
+		<item name="wcf.acp.option.category.general.cache.redis.description"><![CDATA[Redis speichert häufig benötigte Daten im Arbeitsspeicher zwischen. Dies kann die Last auf die Datenbank und das Dateisystem drastisch reduzieren. Lies mehr über dieses Thema auf der folgenden Seite: <a href="http://redis.io/" class="externalURL">redis.io</a>.]]></item>
+		<item name="wcf.acp.option.category.general.system.date"><![CDATA[Datum &amp; Zeit]]></item>
+		<item name="wcf.acp.option.category.general.system.image"><![CDATA[Grafik]]></item>
+		<item name="wcf.acp.option.category.general.system"><![CDATA[System]]></item>
+		<item name="wcf.acp.option.category.general.system.error"><![CDATA[Fehlermeldungen]]></item>
+		<item name="wcf.acp.option.category.general.system.cookie"><![CDATA[Cookies]]></item>
+		<item name="wcf.acp.option.category.general.system.http"><![CDATA[HTTP]]></item>
+		<item name="wcf.acp.option.category.general.system.proxy"><![CDATA[Proxy-Server]]></item>
+		<item name="wcf.acp.option.category.general.system.proxy.description"><![CDATA[Hier kannst du optional Proxy-Server für Verbindungen zu externen Servern konfigurieren.]]></item>
+		<item name="wcf.acp.option.category.general.system.search"><![CDATA[Suche]]></item>
+		<item name="wcf.acp.option.category.general.system.search.description"><![CDATA[Die Änderung des Backends erfordert die Aktualisierung des Such-Index über die Seite „Anzeigen aktualisieren“.]]></item>
+		<item name="wcf.acp.option.category.general.mail"><![CDATA[E-Mails]]></item>
+		<item name="wcf.acp.option.category.general.mail.general"><![CDATA[Allgemein]]></item>
+		<item name="wcf.acp.option.category.general.mail.send"><![CDATA[Versand]]></item>
+		<item name="wcf.acp.option.category.general.page"><![CDATA[Seite]]></item>
+		<item name="wcf.acp.option.category.general.page.seo"><![CDATA[Suchmaschinenoptimierung (SEO)]]></item>
+		<item name="wcf.acp.option.category.general.page.sitemap"><![CDATA[Sitemap]]></item>
+		<item name="wcf.acp.option.category.message"><![CDATA[Nachrichten]]></item>
+		<item name="wcf.acp.option.category.message.general"><![CDATA[Allgemein]]></item>
+		<item name="wcf.acp.option.category.module"><![CDATA[Module]]></item>
+		<item name="wcf.acp.option.category.module.content"><![CDATA[Inhalte]]></item>
+		<item name="wcf.acp.option.category.module.user"><![CDATA[Benutzer]]></item>
+		<item name="wcf.acp.option.category.module.system"><![CDATA[System]]></item>
+		<item name="wcf.acp.option.category.module.community"><![CDATA[Community]]></item>
+		<item name="wcf.acp.option.category.module.customization"><![CDATA[Anpassung]]></item>
+		<item name="wcf.acp.option.category.security"><![CDATA[Sicherheit]]></item>
+		<item name="wcf.acp.option.category.security.blacklist"><![CDATA[Blacklist]]></item>
+		<item name="wcf.acp.option.category.security.general"><![CDATA[Allgemein]]></item>
+		<item name="wcf.acp.option.category.security.general.session"><![CDATA[Sitzungen]]></item>
+		<item name="wcf.acp.option.category.security.general.secrets"><![CDATA[Geheimschlüssel]]></item>
+		<item name="wcf.acp.option.category.general.offline"><![CDATA[Wartungsmodus]]></item>
+		<item name="wcf.acp.option.category.user"><![CDATA[Benutzer]]></item>
+		<item name="wcf.acp.option.category.user.general"><![CDATA[Allgemein]]></item>
+		<item name="wcf.acp.option.category.security.antispam"><![CDATA[Anti-Spam]]></item>
+		<item name="wcf.acp.option.category.security.censorship"><![CDATA[Zensur]]></item>
+		<item name="wcf.acp.option.exception_privacy"><![CDATA[Privatsphäre]]></item>
+		<item name="wcf.acp.option.exception_privacy.description"><![CDATA[Gibt an, wie detailliert die Fehlermeldungen sind. „Privat“ versteckt Fehler vollständig, „Gekürzt“ versucht private Informationen zu verstecken und „Öffentlich“ (nur bei aktivem Debug-Modus) zeigt alle Informationen an.]]></item>
+		<item name="wcf.acp.option.exception_privacy.public"><![CDATA[Öffentlich]]></item>
+		<item name="wcf.acp.option.exception_privacy.reduced"><![CDATA[Gekürzt]]></item>
+		<item name="wcf.acp.option.exception_privacy.private"><![CDATA[Privat]]></item>
+		<item name="wcf.acp.option.cookie_domain"><![CDATA[Cookiedomain]]></item>
+		<item name="wcf.acp.option.cookie_domain.description"><![CDATA[Standardmäßig solltest du dieses Feld frei lassen, da ein Ausfüllen nur in wenigen Fällen notwendig ist.]]></item>
+		<item name="wcf.acp.option.cookie_path"><![CDATA[Cookiepfad]]></item>
+		<item name="wcf.acp.option.cookie_path.description"><![CDATA[Der Cookiepfad wird absolut zum Document Root angegeben - also z.B. "/forum" für http://www.woltlab.de/forum.]]></item>
+		<item name="wcf.acp.option.cookie_prefix"><![CDATA[Präfix für Cookienamen]]></item>
+		<item name="wcf.acp.option.error.controllerReplacementCollision"><![CDATA[Das Alias „{$urlControllerReplacementError}“ kollidiert mit einem real existierenden Controller und ist daher unzulässig.]]></item>
+		<item name="wcf.acp.option.error.controllerReplacementDuplicateAlias"><![CDATA[Das Alias „{$urlControllerReplacementError}“ wird bereits verwendet.]]></item>
+		<item name="wcf.acp.option.error.controllerReplacementDuplicateController"><![CDATA[Dem Controller „{$urlControllerReplacementError}“ wurde bereits ein Alias zugewiesen.]]></item>
+		<item name="wcf.acp.option.error.controllerReplacementInvalidFormat"><![CDATA[Die Angabe muss im Format „realer-name=neuer-name“ erfolgen, die Zeile „{$urlControllerReplacementError}“ is ungültig.]]></item>
+		<item name="wcf.acp.option.error.controllerReplacementUnknown"><![CDATA[Der Controller „{$urlControllerReplacementError}“ ist unbekannt.]]></item>
+		<item name="wcf.acp.option.error.tooHigh"><![CDATA[Der angegebene Wert ist zu hoch.{if $option->maxvalue !== null} Der maximale Wert ist {#$option->maxvalue}.{/if}]]></item>
+		<item name="wcf.acp.option.error.tooLow"><![CDATA[Der angegebene Wert ist zu gering.{if $option->minvalue !== null} Der minimale Wert ist {#$option->minvalue}.{/if}]]></item>
+		<item name="wcf.acp.option.http_enable_gzip"><![CDATA[Gzip-Komprimierung aktivieren]]></item>
+		<item name="wcf.acp.option.http_enable_gzip.description"><![CDATA[Aktiviert die Komprimierung der Inhalte bei der Übertragung vom Server an den Client. Dies reduziert den Traffic und kann den Ladevorgang erheblich beschleunigen.]]></item>
+		<item name="wcf.acp.option.http_send_x_frame_options"><![CDATA[Einbindung in einem Frame verhindern]]></item>
+		<item name="wcf.acp.option.http_send_x_frame_options.description"><![CDATA[Sendet den <a href="{@$__wcf->getPath()}acp/dereferrer.php?url={'http://de.wikipedia.org/wiki/Clickjacking'|rawurlencode}" class="externalURL">„X-Frame-Options“</a> Header, um die Einbettung dieser Seite in einem Frame zu verhindern (sendet „SAMEORIGIN“).]]></item>
+		<item name="wcf.acp.option.image_adapter_type"><![CDATA[Grafik-Bibliothek]]></item>
+		<item name="wcf.acp.option.image_adapter_type.gd"><![CDATA[GD Graphics Library (Standard)]]></item>
+		<item name="wcf.acp.option.image_adapter_type.imagick"><![CDATA[ImageMagick]]></item>
+		<item name="wcf.acp.option.image_adapter_type.description"><![CDATA[Bibliothek für die Generierung von Grafiken, wird z.B. für die Skalierung von hochgeladenen Bildern verwendet. „ImageMagick“ ist in der Regel deutlich schneller, steht aber nicht auf jedem Server zur Verfügung.]]></item>
+		<item name="wcf.acp.option.log_ip_address"><![CDATA[Speicherung von IP-Adressen]]></item>
+		<item name="wcf.acp.option.log_ip_address.description"><![CDATA[Aktiviert die Speicherung von IP-Adressen der Benutzer in z.B. Sitzungen, Benutzerprofilen, Forenbeiträgen.]]></item>
+		<item name="wcf.acp.option.mail_admin_address"><![CDATA[Administrator-Adresse]]></item>
+		<item name="wcf.acp.option.mail_admin_address.description"><![CDATA[E-Mail-Adresse des Administrators]]></item>
+		<item name="wcf.acp.option.mail_from_address"><![CDATA[Absender-Adresse]]></item>
+		<item name="wcf.acp.option.mail_from_address.description"><![CDATA[Absender-Adresse für automatisch generierte E-Mails]]></item>
+		<item name="wcf.acp.option.mail_from_name"><![CDATA[Absender-Name]]></item>
+		<item name="wcf.acp.option.mail_from_name.description"><![CDATA[Absender-Name für automatisch generierte E-Mails]]></item>
+		<item name="wcf.acp.option.mail_send_method"><![CDATA[Versandmethode]]></item>
+		<item name="wcf.acp.option.mail_send_method.debug"><![CDATA[Debug]]></item>
+		<item name="wcf.acp.option.mail_send_method.php"><![CDATA[PHP]]></item>
+		<item name="wcf.acp.option.mail_send_method.smtp"><![CDATA[SMTP]]></item>
+		<item name="wcf.acp.option.mail_signature"><![CDATA[Signatur]]></item>
+		<item name="wcf.acp.option.mail_signature.description"><![CDATA[Die Signatur wird an jede automatisch generierte E-Mail angehängt.]]></item>
+		<item name="wcf.acp.option.mail_smtp_host"><![CDATA[SMTP-Server]]></item>
+		<item name="wcf.acp.option.mail_smtp_port"><![CDATA[SMTP-Port]]></item>
+		<item name="wcf.acp.option.mail_smtp_starttls"><![CDATA[SMTP-Verschlüsselung]]></item>
+		<item name="wcf.acp.option.mail_smtp_starttls.none"><![CDATA[Deaktivieren]]></item>
+		<item name="wcf.acp.option.mail_smtp_starttls.may"><![CDATA[Wenn unterstützt]]></item>
+		<item name="wcf.acp.option.mail_smtp_starttls.encrypt"><![CDATA[Erzwingen]]></item>
+		<item name="wcf.acp.option.mail_smtp_starttls.description"><![CDATA[Diese Einstellung steuert die Verwendung von „STARTTLS“. Deaktiviere diese Option, wenn du E-Mails über SSL (Port 465) versendest!]]></item>
+		<item name="wcf.acp.option.mail_smtp_user"><![CDATA[SMTP-Benutzer]]></item>
+		<item name="wcf.acp.option.mail_smtp_password"><![CDATA[SMTP-Kennwort]]></item>
+		<item name="wcf.acp.option.mail_use_f_param"><![CDATA[„-f“ Parameter verwenden]]></item>
+		<item name="wcf.acp.option.mail_use_f_param.description"><![CDATA[Der „-f“-Parameter sorgt bei der PHP-Versandmethode dafür, dass der korrekte Absender gesetzt wird. Diese Einstellung wird möglicherweise nicht von jedem Server unterstützt. Versuche in diesem Falle die Option zu deaktivieren.]]></item>
+		<item name="wcf.acp.option.meta_description"><![CDATA[Meta Description]]></item>
+		<item name="wcf.acp.option.meta_keywords"><![CDATA[Meta Keywords]]></item>
+		<item name="wcf.acp.option.og_image"><![CDATA[Standardwert „Open Graph“-Bild]]></item>
+		<item name="wcf.acp.option.og_image.description"><![CDATA[Pfad zur Bilddatei, die beim Verlinken von Inhalten auf Facebook, Twitter und anderen „Social Media“-Seiten standardmäßig eingebunden wird.]]></item>
+		<item name="wcf.acp.option.module_master_password"><![CDATA[Hauptkennwort aktivieren]]></item>
+		<item name="wcf.acp.option.module_master_password.description"><![CDATA[Aktiviert die zusätzliche Eingabe eines Kennworts beim Aufruf von sicherheitskritischen Bereichen.]]></item>
+		<item name="wcf.acp.option.page_description"><![CDATA[Seitenbeschreibung]]></item>
+		<item name="wcf.acp.option.page_title"><![CDATA[Titel der Seite]]></item>
+		<item name="wcf.acp.option.proxy_server_http"><![CDATA[Proxy-Server (HTTP)]]></item>
+		<item name="wcf.acp.option.session_timeout"><![CDATA[Gültigkeitslänge einer Sitzung]]></item>
+		<item name="wcf.acp.option.session_timeout.description"><![CDATA[]]></item>
+		<item name="wcf.acp.option.session_validate_ip_address"><![CDATA[IP-Adresse der Sitzung überprüfen]]></item>
+		<item name="wcf.acp.option.session_validate_ip_address.description"><![CDATA[Eine Aktivierung dieser Einstellung kann Benutzer ausschließen, die mit wechselnden IP-Adressen im Internet unterwegs sind.]]></item>
+		<item name="wcf.acp.option.session_validate_user_agent"><![CDATA[Browser-Kennung der Sitzung überprüfen]]></item>
+		<item name="wcf.acp.option.session_enable_virtualization"><![CDATA[Virtuelle Sessions erlauben]]></item>
+		<item name="wcf.acp.option.session_enable_virtualization.description"><![CDATA[Benutzer können sich mit mehreren Endgeräten (PC, Tablet, Smartphone, etc.) gleichzeitig anmelden, alle Geräte nutzen dann die selbe Sitzung. Die Abschaltung dieser Option hat zur Folge, dass ein Benutzer nur von einem einzigen Gerät gleichzeitig angemeldet sein darf und sich unter Umständen die Geräte auf diese Weise gegenseitig abmelden. Die Deaktivierung dieser Option wird nicht empfohlen und sollte nur vorgenommen werden, wenn du dir der Konsequenzen bewusst sind.]]></item>
+		<item name="wcf.acp.option.timezone"><![CDATA[Zeitzone]]></item>
+		<item name="wcf.acp.option.timezone.description"><![CDATA[Standard-Zeitzone deiner Seite]]></item>
+		<item name="wcf.acp.option.user_online_timeout"><![CDATA[Timeout für Benutzer-Online]]></item>
+		<item name="wcf.acp.option.user_online_timeout.description"><![CDATA[Zeit in Sekunden, in der der Benutzer trotz Inaktivität als online markiert werden soll.]]></item>
+		<item name="wcf.acp.option.offline"><![CDATA[Wartungsmodus aktivieren]]></item>
+		<item name="wcf.acp.option.offline.description"><![CDATA[Deaktiviert alle installierten Apps (z.B. für Wartungsarbeiten).]]></item>
+		<item name="wcf.acp.option.offline_message"><![CDATA[Wartungshinweis]]></item>
+		<item name="wcf.acp.option.offline_message.description"><![CDATA[Gib hier eine Meldung ein, die angezeigt wird, solange sich die Seite im Wartungsmodus befindet.]]></item>
+		<item name="wcf.acp.option.offline_message_allow_html"><![CDATA[HTML-Code im Hinweistext verwenden]]></item>
+		<item name="wcf.acp.option.offline_message_allow_html.description"><![CDATA[Aktiviere diese Option, wenn du HTML-Code im Hinweistext verwenden möchtest.]]></item>
+		<item name="wcf.acp.option.show_version_number"><![CDATA[Versionsnummer der Software im Copyright-Hinweis anzeigen]]></item>
+		<item name="wcf.acp.option.enable_debug_mode"><![CDATA[Debug-Modus aktivieren]]></item>
+		<item name="wcf.acp.option.enable_debug_mode.description"><![CDATA[Aktiviert ausführliche Fehlerberichte. Diese Option sollte im Live-Betrieb abgeschaltet werden.]]></item>
+		<item name="wcf.acp.option.external_link_rel_nofollow"><![CDATA[Externe Links mit dem Attribut „rel="nofollow"“ versehen]]></item>
+		<item name="wcf.acp.option.external_link_rel_nofollow.description"><![CDATA[Das Attribut „rel="nofollow"“ weist Suchmaschinen an, einen bestimmten Link auf einer Seite zu ignorieren.]]></item>
+		<item name="wcf.acp.option.external_link_target_blank"><![CDATA[Externe Links in neuem Fenster öffnen]]></item>
+		<item name="wcf.acp.option.external_link_target_blank.description"><![CDATA[Setzt das Attribut „target="_blank"“ auf externe Links und weist den Browser dadurch an, einen aufgerufenen Link in einem neuen Browser-Fenster zu öffnen.]]></item>
+		<item name="wcf.acp.option.enable_benchmark"><![CDATA[Benchmark aktivieren]]></item>
+		<item name="wcf.acp.option.enable_benchmark.description"><![CDATA[Diese Option sollte im Live-Betrieb abgeschaltet werden.]]></item>
+		<item name="wcf.acp.option.category.general.system.packageServer"><![CDATA[Update-Server]]></item>
+		<item name="wcf.acp.option.package_server_auth_code"><![CDATA[Authentifizierung-Code]]></item>
+		<item name="wcf.acp.option.package_server_auth_code.description"><![CDATA[Deinen Authentifizierung-Code findest du in deinem Kundenkonto auf woltlab.com.]]></item>
+		<item name="wcf.acp.option.enable_woltlab_news"><![CDATA[WoltLab-Nachrichten anzeigen]]></item>
+		<item name="wcf.acp.option.enable_woltlab_news.description"><![CDATA[Aktiviert die Anzeige aktueller WoltLab-Nachrichten auf der Startseite der Administrationsoberfläche.]]></item>
+		<item name="wcf.acp.option.category.security.antispam.recaptcha"><![CDATA[reCAPTCHA]]></item>
+		<item name="wcf.acp.option.recaptcha_publickey"><![CDATA[Websiteschlüssel]]></item>
+		<item name="wcf.acp.option.recaptcha_publickey.description"><![CDATA[Einen eigenen Websiteschlüssel für die Nutzung der reCAPTCHA-Funktion kannst du auf der Website von <a href="https://www.google.com/recaptcha/admin" class="externalURL">reCAPTCHA</a> beantragen.]]></item>
+		<item name="wcf.acp.option.recaptcha_privatekey"><![CDATA[Geheimer Schlüssel]]></item>
+		<item name="wcf.acp.option.category.message.attachment"><![CDATA[Dateianhänge]]></item>
+		<item name="wcf.acp.option.attachment_enable_thumbnails"><![CDATA[Vorschaugrafiken von hochgeladenen Bilder erzeugen]]></item>
+		<item name="wcf.acp.option.attachment_retain_dimensions"><![CDATA[Bildformat beim Erzeugen von Vorschaugrafiken beibehalten]]></item>
+		<item name="wcf.acp.option.attachment_thumbnail_height"><![CDATA[Höhe der Vorschaugrafiken]]></item>
+		<item name="wcf.acp.option.attachment_thumbnail_width"><![CDATA[Breite der Vorschaugrafiken]]></item>
+		<item name="wcf.acp.option.attachment_storage"><![CDATA[Speicherort der Dateianhänge]]></item>
+		<item name="wcf.acp.option.attachment_storage.description"><![CDATA[Du kannst optional einen vom Standard abweichenden Speicherort für die Dateianhänge definieren. Bereits existierende Dateianhänge müssen bei einer Änderung des Speicherortes manuell in den neuen Ort übertragen werden.]]></item>
+		<item name="wcf.acp.option.module_attachment"><![CDATA[Dateianhänge]]></item>
+		<item name="wcf.acp.option.module_smiley"><![CDATA[Smileys]]></item>
+		<item name="wcf.acp.option.category.message.censorship"><![CDATA[Zensur-Funktion]]></item>
+		<item name="wcf.acp.option.censored_words"><![CDATA[Zu zensierende Wörter]]></item>
+		<item name="wcf.acp.option.censored_words.description"><![CDATA[Ein Wort pro Zeile. Sollte bei der Erstellung einer Nachricht eines dieser Wörter verwendet werden, so wird die Erstellung verweigert.<br>
+<em>Verwende „*“, um Wortteile zu finden: „wolt*“ findet auch „woltlab“</em><br>
+<em>Verwende „~“, um Worttrennungen zu finden: „wolt~“ findet auch „wolt-lab“</em>]]></item>
+		<item name="wcf.acp.option.enable_censorship"><![CDATA[Zensur aktivieren]]></item>
+		<item name="wcf.acp.option.enable_censorship.description"><![CDATA[Aktiviert die Zensur der unten angegebenen Wörter in allen von Benutzern geschriebenen Texten.]]></item>
+		<item name="wcf.acp.option.category.message.general.share"><![CDATA[Teilen]]></item>
+		<item name="wcf.acp.option.enable_share_buttons"><![CDATA[Buttons zum Teilen von Inhalten anzeigen]]></item>
+		<item name="wcf.acp.option.category.message.general.edit"><![CDATA[Bearbeitungen]]></item>
+		<item name="wcf.acp.option.module_edit_history"><![CDATA[Bearbeitungsverlauf aktivieren]]></item>
+		<item name="wcf.acp.option.module_edit_history.description"><![CDATA[Speichert die alten Versionen von Benutzerinhalten.]]></item>
+		<item name="wcf.acp.option.edit_history_expiration"><![CDATA[Speicherzeit]]></item>
+		<item name="wcf.acp.option.edit_history_expiration.description"><![CDATA[Zeitraum, nachdem alte Einträge aus dem Bearbeitungsverlauf entfernt werden [0, um die Entfernung gänzlich zu deaktivieren]]]></item>
+		<item name="wcf.acp.option.github_public_key"><![CDATA[GitHub Client ID]]></item>
+		<item name="wcf.acp.option.github_public_key.description"><![CDATA[Du kannst deine Client ID und dein Client Secret bei <a href="{@$__wcf->getPath()}acp/dereferrer.php?url={'https://github.com/settings/developers'|rawurlencode}" class="externalURL">GitHub</a> anfordern. Die Callback URL ist: {link controller="GithubAuth" forceFrontend=true}{/link}]]></item>
+		<item name="wcf.acp.option.github_private_key"><![CDATA[GitHub Client Secret]]></item>
+		<item name="wcf.acp.option.twitter_public_key"><![CDATA[Twitter API key]]></item>
+		<item name="wcf.acp.option.twitter_public_key.description"><![CDATA[Du kannst deinen API key und dein API secret bei <a href="{@$__wcf->getPath()}acp/dereferrer.php?url={'https://dev.twitter.com/apps'|rawurlencode}" class="externalURL">Twitter</a> anfordern. Die Callback URL ist: {link controller="TwitterAuth" forceFrontend=true}{/link}]]></item>
+		<item name="wcf.acp.option.twitter_private_key"><![CDATA[Twitter API secret]]></item>
+		<item name="wcf.acp.option.facebook_public_key"><![CDATA[Facebook APP-ID]]></item>
+		<item name="wcf.acp.option.facebook_public_key.description"><![CDATA[Du kannst deine APP-ID und deinen Anwendungs-Geheimcode bei <a href="{@$__wcf->getPath()}acp/dereferrer.php?url={'https://developers.facebook.com/apps'|rawurlencode}" class="externalURL">Facebook</a> anfordern. Die OAuth redirect URI ist: {link controller="FacebookAuth" forceFrontend=true}{/link}]]></item>
+		<item name="wcf.acp.option.facebook_private_key"><![CDATA[Facebook Anwendungs-Geheimcode]]></item>
+		<item name="wcf.acp.option.google_public_key"><![CDATA[Google Client ID]]></item>
+		<item name="wcf.acp.option.google_public_key.description"><![CDATA[Du kannst deine Client ID und dein Client Secret bei <a href="{@$__wcf->getPath()}acp/dereferrer.php?url={'https://code.google.com/apis/console/'|rawurlencode}" class="externalURL">Google</a> anfordern. Die Redirect-URI ist: {link controller="GoogleAuth" forceFrontend=true}{/link}]]></item>
+		<item name="wcf.acp.option.google_private_key"><![CDATA[Google Client Secret]]></item>
+		<item name="wcf.acp.option.category.dashboard"><![CDATA[Dashboard]]></item>
+		<item name="wcf.acp.option.category.dashboard.content"><![CDATA[Inhaltsbereich]]></item>
+		<item name="wcf.acp.option.category.dashboard.sidebar"><![CDATA[Seitenleiste]]></item>
+		<item name="wcf.acp.option.category.user.profile"><![CDATA[Profil]]></item>
+		<item name="wcf.acp.option.category.user.avatar"><![CDATA[Avatar]]></item>
+		<item name="wcf.acp.option.category.user.signature"><![CDATA[Signatur]]></item>
+		<item name="wcf.acp.option.category.user.title"><![CDATA[Benutzertitel]]></item>
+		<item name="wcf.acp.option.category.user.cleanup"><![CDATA[Aufräumaktionen]]></item>
+		<item name="wcf.acp.option.category.user.list"><![CDATA[Mitgliederlisten]]></item>
+		<item name="wcf.acp.option.category.user.list.members"><![CDATA[Mitgliederliste]]></item>
+		<item name="wcf.acp.option.category.user.list.online"><![CDATA[„Benutzer online“-Liste]]></item>
+		<item name="wcf.acp.option.category.user.register"><![CDATA[Registrierung]]></item>
+		<item name="wcf.acp.option.category.user.password"><![CDATA[Kennwort]]></item>
+		<item name="wcf.acp.option.category.user.ban"><![CDATA[Filter]]></item>
+		<item name="wcf.acp.option.category.user.3rdPartyAuth"><![CDATA[Authentifizierung über Drittanbieter]]></item>
+		<item name="wcf.acp.option.module_gravatar"><![CDATA[Gravatare]]></item>
+		<item name="wcf.acp.option.module_gravatar.description"><![CDATA[Aktiviert die Unterstützung für Gravatare („Global Recognized Avatar“).]]></item>
+		<item name="wcf.acp.option.module_users_online"><![CDATA[„Benutzer online“-Anzeige]]></item>
+		<item name="wcf.acp.option.module_user_rank"><![CDATA[Benutzerränge]]></item>
+		<item name="wcf.acp.option.module_user_signature"><![CDATA[Signaturen]]></item>
+		<item name="wcf.acp.option.module_team_page"><![CDATA[Team-Seite]]></item>
+		<item name="wcf.acp.option.register_enable_password_security_check"><![CDATA[Sicherheitsüberprüfung aktivieren]]></item>
+		<item name="wcf.acp.option.register_enable_password_security_check.description"><![CDATA[Kennwörter werden auf ihre Sicherheit geprüft. Unsichere Kennwörter werden abgelehnt.]]></item>
+		<item name="wcf.acp.option.register_password_min_length"><![CDATA[Minimale Kennwortlänge]]></item>
+		<item name="wcf.acp.option.register_password_must_contain_digit"><![CDATA[Kennwort muss Zahlen enthalten]]></item>
+		<item name="wcf.acp.option.register_password_must_contain_lower_case"><![CDATA[Kennwort muss Kleinbuchstaben enthalten]]></item>
+		<item name="wcf.acp.option.register_password_must_contain_special_char"><![CDATA[Kennwort muss Sonderzeichen enthalten]]></item>
+		<item name="wcf.acp.option.register_password_must_contain_upper_case"><![CDATA[Kennwort muss Großbuchstaben enthalten]]></item>
+		<item name="wcf.acp.option.register_forbidden_usernames"><![CDATA[Reservierte Namen]]></item>
+		<item name="wcf.acp.option.register_forbidden_usernames.description"><![CDATA[Namen, die nicht als Benutzername verwendet werden dürfen. Ein Name pro Zeile]]></item>
+		<item name="wcf.acp.option.register_forbidden_emails"><![CDATA[Reservierte E-Mail-Adressen]]></item>
+		<item name="wcf.acp.option.register_forbidden_emails.description"><![CDATA[E-Mail-Adressen, die nicht bei der Registrierung verwendet werden dürfen. Eine Adresse pro Zeile]]></item>
+		<item name="wcf.acp.option.register_allowed_emails"><![CDATA[Erlaubte E-Mail-Adressen]]></item>
+		<item name="wcf.acp.option.register_allowed_emails.description"><![CDATA[E-Mail-Adressen, die ausschließlich bei der Registrierung verwendet werden dürfen. Eine Adresse pro Zeile]]></item>
+		<item name="wcf.acp.option.register_username_min_length"><![CDATA[Minimale Benutzernamenlänge]]></item>
+		<item name="wcf.acp.option.register_username_max_length"><![CDATA[Maximale Benutzernamenlänge]]></item>
+		<item name="wcf.acp.option.register_username_force_ascii"><![CDATA[Benutzernamen auf ASCII-Zeichen beschränken]]></item>
+		<item name="wcf.acp.option.register_min_user_age"><![CDATA[Mindestalter]]></item>
+		<item name="wcf.acp.option.register_min_user_age.description"><![CDATA[Eine Angabe hier führt dazu, dass das Geburtsdatum während der Registrierung abgefragt und zum Pflichtfeld wird.]]></item>
+		<item name="wcf.acp.option.register_disabled"><![CDATA[Registrierung deaktivieren]]></item>
+		<item name="wcf.acp.option.register_disabled.description"><![CDATA[Schaltet die Registrierung für neue Benutzer gänzlich ab. Neue Benutzer können nur noch manuell durch den Administrator angelegt werden.]]></item>
+		<item name="wcf.acp.option.register_enable_disclaimer"><![CDATA[Nutzungsbedingungen aktivieren]]></item>
+		<item name="wcf.acp.option.register_enable_disclaimer.description"><![CDATA[Die Nutzungsbedingungen müssen durch den Benutzer vor der Registrierung akzeptiert werden.]]></item>
+		<item name="wcf.acp.option.register_admin_notification"><![CDATA[Administrator über neue Registrierungen per E-Mail benachrichtigen]]></item>
+		<item name="wcf.acp.option.register_activation_method"><![CDATA[Aktivierungsmethode]]></item>
+		<item name="wcf.acp.option.register_activation_method.byAdmin"><![CDATA[Aktivierung erfolgt durch Administrator]]></item>
+		<item name="wcf.acp.option.register_activation_method.byUser"><![CDATA[Benutzer aktiviert sich durch E-Mail-Bestätigung]]></item>
+		<item name="wcf.acp.option.register_activation_method.disabled"><![CDATA[Keine Aktivierung notwendig]]></item>
+		<item name="wcf.acp.option.signature_max_image_height"><![CDATA[Maximale Höhe von Signatur-Bildern]]></item>
+		<item name="wcf.acp.option.sitemap_index_time_frame"><![CDATA[Zeitfenster der Indexierung]]></item>
+		<item name="wcf.acp.option.sitemap_index_time_frame.description"><![CDATA[Maximales Alter der Objekte um in die Sitemap aufgenommen zu werden [0 um das Zeitfenster zu deaktivieren].]]></item>
+		<item name="wcf.acp.option.user_title_max_length"><![CDATA[Maximale Länge des Benutzertitels]]></item>
+		<item name="wcf.acp.option.user_forbidden_titles"><![CDATA[Reservierte Benutzertitel]]></item>
+		<item name="wcf.acp.option.user_forbidden_titles.description"><![CDATA[Benutzertitel, die nicht verwendet werden dürfen. Ein Titel pro Zeile]]></item>
+		<item name="wcf.acp.option.profile_show_old_username"><![CDATA[Alten Namen anzeigen]]></item>
+		<item name="wcf.acp.option.profile_show_old_username.description"><![CDATA[Zeitraum in dem bei Änderungen des Benutzernamens zusätzlich der alte Benutzername im Profil angezeigt wird.]]></item>
+		<item name="wcf.acp.option.members_list_users_per_page"><![CDATA[Mitglieder pro Seite]]></item>
+		<item name="wcf.acp.option.members_list_default_sort_field"><![CDATA[Standard-Sortierung]]></item>
+		<item name="wcf.acp.option.members_list_default_sort_field.description"><![CDATA[]]></item>
+		<item name="wcf.acp.option.members_list_default_sort_order"><![CDATA[Standard-Reihenfolge]]></item>
+		<item name="wcf.acp.option.members_list_default_sort_order.description"><![CDATA[]]></item>
+		<item name="wcf.acp.option.users_online_show_guests"><![CDATA[Unregistrierte Benutzer auflisten]]></item>
+		<item name="wcf.acp.option.users_online_show_robots"><![CDATA[Suchmaschinen-Roboter auflisten]]></item>
+		<item name="wcf.acp.option.users_online_default_sort_field"><![CDATA[Standard-Sortierung]]></item>
+		<item name="wcf.acp.option.users_online_default_sort_field.description"><![CDATA[]]></item>
+		<item name="wcf.acp.option.users_online_default_sort_order"><![CDATA[Standard-Reihenfolge]]></item>
+		<item name="wcf.acp.option.users_online_default_sort_order.description"><![CDATA[]]></item>
+		<item name="wcf.acp.option.users_online_page_refresh"><![CDATA[Seite automatisch neu laden]]></item>
+		<item name="wcf.acp.option.users_online_page_refresh.description"><![CDATA[Zeitraum nachdem die Seite automatisch neu geladen wird. [0, um Neuladen abzuschalten]]]></item>
+		<item name="wcf.acp.option.user_cleanup_notification_lifetime"><![CDATA[Benachrichtigungen]]></item>
+		<item name="wcf.acp.option.user_cleanup_notification_lifetime.description"><![CDATA[Zeitraum nach dem Benachrichtigungen automatisch verworfen werden.]]></item>
+		<item name="wcf.acp.option.user_cleanup_activity_event_lifetime"><![CDATA[Letzte Aktivitäten]]></item>
+		<item name="wcf.acp.option.user_cleanup_activity_event_lifetime.description"><![CDATA[Zeitraum nach dem letzte Aktivitäten automatisch verworfen werden.]]></item>
+		<item name="wcf.acp.option.user_cleanup_profile_visitor_lifetime"><![CDATA[Profil-Besucher]]></item>
+		<item name="wcf.acp.option.user_cleanup_profile_visitor_lifetime.description"><![CDATA[Zeitraum nach dem Profil-Besucher automatisch verworfen werden.]]></item>
+		<item name="wcf.acp.option.category.message.general.likes"><![CDATA[Like-System]]></item>
+		<item name="wcf.acp.option.module_like"><![CDATA[Like-System]]></item>
+		<item name="wcf.acp.option.like_allow_for_own_content"><![CDATA[Benutzer können eigene Inhalte liken]]></item>
+		<item name="wcf.acp.option.like_enable_dislike"><![CDATA[Benutzer können Inhalte disliken]]></item>
+		<item name="wcf.acp.option.like_show_summary"><![CDATA[Zusammenfassung anzeigen]]></item>
+		<item name="wcf.acp.option.module_user_profile_wall"><![CDATA[Benutzerprofil-Pinnwand]]></item>
+		<item name="wcf.acp.option.category.message.sidebar"><![CDATA[Seitenleiste]]></item>
+		<item name="wcf.acp.option.message_sidebar_enable_online_status"><![CDATA[Online-Status der Autoren anzeigen]]></item>
+		<item name="wcf.acp.option.message_sidebar_enable_likes_received"><![CDATA[Anzahl der erhaltenen Likes der Autoren anzeigen]]></item>
+		<item name="wcf.acp.option.message_sidebar_enable_activity_points"><![CDATA[Aktivitätspunkte der Autoren anzeigen]]></item>
+		<item name="wcf.acp.option.message_sidebar_user_options"><![CDATA[Ausgewählte Profilfelder der Autoren anzeigen]]></item>
+		<item name="wcf.acp.option.module_tagging"><![CDATA[Tagging]]></item>
+		<item name="wcf.acp.option.module_tagging.description"><![CDATA[Aktiviert die Funktion für das Taggen von Inhalten.]]></item>
+		<item name="wcf.acp.option.tagging_max_tag_length"><![CDATA[Maximale Tag-Länge]]></item>
+		<item name="wcf.acp.option.message_max_quote_depth"><![CDATA[Maximale Zitat-Tiefe]]></item>
+		<item name="wcf.acp.option.message_max_quote_depth.description"><![CDATA[Der Wert „1“ erlaubt nur direkte Zitate, aber keine Zitate in Zitaten. Bei „2“ oder mehr dürfen Zitate selbst Zitate enthalten bis zur angegebenen Tiefe. Mit dem Wert „0“ wird diese Funktion deaktiviert und es können beliebig oft Zitate ineinander verschachtelt werden.]]></item>
+		<item name="wcf.acp.option.category.message.search"><![CDATA[Suchfunktion]]></item>
+		<item name="wcf.acp.option.search_results_per_page"><![CDATA[Ergebnisse pro Seite]]></item>
+		<item name="wcf.acp.option.search_default_sort_field"><![CDATA[Standardsortierung]]></item>
+		<item name="wcf.acp.option.search_default_sort_field.description"><![CDATA[]]></item>
+		<item name="wcf.acp.option.search_default_sort_order"><![CDATA[Standardreihenfolge]]></item>
+		<item name="wcf.acp.option.search_default_sort_order.description"><![CDATA[]]></item>
+		<item name="wcf.acp.option.category.message.general.poll"><![CDATA[Umfragen]]></item>
+		<item name="wcf.acp.option.module_poll"><![CDATA[Umfragen]]></item>
+		<item name="wcf.acp.option.poll_max_options"><![CDATA[Maximale Anzahl an Antworten]]></item>
+		<item name="wcf.acp.option.error.validationFailed"><![CDATA[Du hast einen ungültigen Inhalt eingegeben.]]></item>
+		<item name="wcf.acp.option.module_members_list"><![CDATA[Mitgliederliste]]></item>
+		<item name="wcf.acp.option.footer_code"><![CDATA[Footer-Code]]></item>
+		<item name="wcf.acp.option.footer_code.description"><![CDATA[Der hier angegebene Code wird im Fußbereich jeder Seite ausgegeben. Der Footer-Code eignet sich z.B. sehr gut für die Einbindung von Diensten wie „Google Analytics“ oder „Piwik“.]]></item>
+		<item name="wcf.acp.option.profile_enable_visitors"><![CDATA[Profil-Besucher anzeigen]]></item>
+		<item name="wcf.acp.option.url_title_component_replacement"><![CDATA[URL-Ersetzungen]]></item>
+		<item name="wcf.acp.option.url_title_component_replacement.description"><![CDATA[Du kannst den in URLs enthaltenen Titel durch eigene Ersetzungen verändern. Dies kann z.B. zum Ersetzen von Umlauten oder zum Expandieren von Abkürzungen genutzt werden. (Eine Ersetzung pro Zeile)<br>
+Beispiele:<br>
+WBB=WoltLab Burning Board<br>
+GmbH=Gesellschaft mit beschränkter Haftung]]></item>
+		<item name="wcf.acp.option.users_online_record_no_guests"><![CDATA[Nur registrierte Benutzer im Benutzer-Online-Rekord zählen]]></item>
+		<item name="wcf.acp.option.users_online_enable_legend"><![CDATA[Legende der Benutzergruppen anzeigen]]></item>
+		<item name="wcf.acp.option.category.general.system.googleMaps"><![CDATA[Google Maps]]></item>
+		<item name="wcf.acp.option.google_maps_zoom"><![CDATA[Karten-Zoom]]></item>
+		<item name="wcf.acp.option.google_maps_zoom.description"><![CDATA[Standard-Einstellung des Karten-Zooms]]></item>
+		<item name="wcf.acp.option.google_maps_type"><![CDATA[Karten-Typ]]></item>
+		<item name="wcf.acp.option.google_maps_type.description"><![CDATA[Standard-Einstellung des Karten-Typs]]></item>
+		<item name="wcf.acp.option.google_maps_type.hybrid"><![CDATA[Hybrid]]></item>
+		<item name="wcf.acp.option.google_maps_type.map"><![CDATA[Karte]]></item>
+		<item name="wcf.acp.option.google_maps_type.satellite"><![CDATA[Satellit]]></item>
+		<item name="wcf.acp.option.google_maps_type.physical"><![CDATA[Gelände]]></item>
+		<item name="wcf.acp.option.google_maps_enable_scale_control"><![CDATA[Karten-Maßstab anzeigen]]></item>
+		<item name="wcf.acp.option.google_maps_enable_dragging"><![CDATA[Ziehen der Karte zulassen]]></item>
+		<item name="wcf.acp.option.google_maps_enable_dragging.description"><![CDATA[Du kannst die Karte durch das Gedrückthalten der linken Maustaste verschieben.]]></item>
+		<item name="wcf.acp.option.google_maps_enable_scroll_wheel_zoom"><![CDATA[Zoom durch Mausrad zulassen]]></item>
+		<item name="wcf.acp.option.google_maps_enable_double_click_zoom"><![CDATA[Zoom durch Doppelklick zulassen]]></item>
+		<item name="wcf.acp.option.google_maps_default_latitude"><![CDATA[Standard-Kartenposition (Breitengrad)]]></item>
+		<item name="wcf.acp.option.google_maps_default_longitude"><![CDATA[Standard-Kartenposition (Längengrad)]]></item>
+		<item name="wcf.acp.option.google_maps_access_user_location"><![CDATA[Aktuelle Benutzerposition verwenden]]></item>
+		<item name="wcf.acp.option.google_maps_access_user_location.description"><![CDATA[Bei der Angabe von Positionen wird die aktuelle Position des Benutzers als Ausgangspunkt auf der Karte verwendet.]]></item>
+		<item name="wcf.acp.option.message_sidebar_enable_user_online_marking"><![CDATA[„Benutzer online“-Darstellung für Benutzernamen verwenden]]></item>
+		<item name="wcf.acp.option.module_cookie_policy_page"><![CDATA[Erklärung zum „Einsatz von Cookies“ aktivieren]]></item>
+		<item name="wcf.acp.option.module_cookie_policy_page.description"><![CDATA[Weist Besucher beim ersten Aufruf der Seite gemäß EU-Richtlinie 2009/136/EG auf den Einsatz von Cookies hin.]]></item>
+		<item name="wcf.acp.option.show_update_notice_frontend"><![CDATA[Hinweis bei neuen Updates für Pakete im Frontend anzeigen]]></item>
+		<item name="wcf.acp.option.url_omit_index_php"><![CDATA[Link-Umschreibungen aktivieren]]></item>
+		<item name="wcf.acp.option.url_omit_index_php.description"><![CDATA[Wandelt Links in eine vereinfachte Form um, aus „http://example.com/index.php?thread/1-dies-ist-ein-test/“ wird „http://example.com/thread/1-dies-ist-ein-test/“ und vergleichbar. Achtung: Die Aktivierung der Link-Umschreibungen erfordert Rewrite-Unterstützung in deinem Webserver sowie eine entsprechende Konfiguration. Fehlerhafte Einstellungen können hier dazu führen, dass Links nicht mehr aufrufbar sind.<br>Eine Anleitung zur Einrichtung deines Webservers findest du in diesem Artikel: <a href="{@$__wcf->getPath()}acp/dereferrer.php?url=https%3A%2F%2Fwww.woltlab.com%2Farticle%2F24-konfiguration-von-benutzerfreundlichen-urls-seo-urls%2F" class="externalURL">Konfiguration von benutzerfreundlichen URLs (SEO-URLs)</a>]]></item>
+		<item name="wcf.acp.option.module_wcf_ad"><![CDATA[Werbung]]></item>
+		<item name="wcf.acp.option.module_wcf_ad.description"><![CDATA[Aktiviert die <a href="{link controller='AdList'}{/link}">Verwaltung von Werbe-Anzeigen</a>.]]></item>
+		<item name="wcf.acp.option.captcha_type"><![CDATA[Captcha-Art]]></item>
+		<item name="wcf.acp.option.register_use_captcha"><![CDATA[Captcha in Registrierung aktivieren]]></item>
+		<item name="wcf.acp.option.lost_password_use_captcha"><![CDATA[Captcha in „Kennwort vergessen“ aktivieren]]></item>
+		<item name="wcf.acp.option.profile_mail_use_captcha"><![CDATA[Captcha in „E-Mail an Benutzer schicken“ aktivieren]]></item>
+		<item name="wcf.acp.option.search_use_captcha"><![CDATA[Captcha in Suchfunktion aktivieren]]></item>
+		<item name="wcf.acp.option.category.security.antispam.captcha"><![CDATA[Captchas]]></item>
+		<item name="wcf.acp.option.category.security.general.authentication"><![CDATA[Benutzer-Authentifikation]]></item>
+		<item name="wcf.acp.option.enable_user_authentication_failure"><![CDATA[Fehlgeschlagene Anmeldeversuche protokollieren]]></item>
+		<item name="wcf.acp.option.user_authentication_failure_timeout"><![CDATA[Zeitraum der Überwachung]]></item>
+		<item name="wcf.acp.option.user_authentication_failure_timeout.description"><![CDATA[Zeitraum aus dem fehlgeschlagene Anmeldeversuche für unten genannte Maßnahmen berücksichtigt werden.]]></item>
+		<item name="wcf.acp.option.user_authentication_failure_ip_captcha"><![CDATA[Captcha bei Anmeldung (IP)]]></item>
+		<item name="wcf.acp.option.user_authentication_failure_ip_captcha.description"><![CDATA[Wird die angegebene Anzahl von fehlgeschlagenen Anmeldeversuchen von einer IP-Adresse überschritten, muss der Benutzer ein Captcha ausfüllen.]]></item>
+		<item name="wcf.acp.option.user_authentication_failure_ip_block"><![CDATA[Blockierung der Anmeldung]]></item>
+		<item name="wcf.acp.option.user_authentication_failure_ip_block.description"><![CDATA[Wird die angegebene Anzahl von fehlgeschlagenen Anmeldeversuchen von einer IP-Adresse überschritten, wird die Anmeldung für diesen Benutzer vorübergehend vollständig blockiert.]]></item>
+		<item name="wcf.acp.option.user_authentication_failure_user_captcha"><![CDATA[Captcha bei Anmeldung (Benutzer)]]></item>
+		<item name="wcf.acp.option.user_authentication_failure_user_captcha.description"><![CDATA[Wird die angegebene Anzahl von fehlgeschlagenen Anmeldeversuchen auf einen Benutzer-Account überschritten, muss der Benutzer ein Captcha ausfüllen.]]></item>
+		<item name="wcf.acp.option.user_authentication_failure_expiration"><![CDATA[Löschung von alten Protokolleinträgen]]></item>
+		<item name="wcf.acp.option.user_authentication_failure_expiration.description"><![CDATA[Legt fest nach welchem Zeitraum protokollierte Anmeldeversuche gelöscht werden.]]></item>
+		<item name="wcf.acp.option.signature_secret"><![CDATA[Geheimer Schlüssel]]></item>
+		<item name="wcf.acp.option.signature_secret.description"><![CDATA[Ein geheimer Schlüssel, welcher zur Überprüfung von übertragenen Daten bestimmter Funktionen dient. Dieser Schlüssel ist vertraulich zu behandeln! Der Schlüssel wurde bei der Installation zufällig generiert und sollte nur in Ausnahmefällen geändert werden. Achtung: Dieser Schlüssel muss mindestens 15 Zeichen lang sein.]]></item>
+		<item name="wcf.acp.option.gravatar_default_type"><![CDATA[Standard Gravatar-Typ]]></item>
+		<item name="wcf.acp.option.gravatar_default_type.description"><![CDATA[Der <a class="externalURL" href="{@$__wcf->getPath()}acp/dereferrer.php?url=https://de.gravatar.com/site/implement/images/#default-image">Standard-Gravatar-Typ</a>, wenn einer E-Mail kein Gravatar zugeordnet werden kann.]]></item>
+		<item name="wcf.acp.option.gravatar_default_type.404"><![CDATA[Kein Standard-Gravatar]]></item>
+		<item name="wcf.acp.option.gravatar_default_type.identicon"><![CDATA[Identicon]]></item>
+		<item name="wcf.acp.option.gravatar_default_type.wavatar"><![CDATA[Wavatar]]></item>
+		<item name="wcf.acp.option.gravatar_default_type.monsterid"><![CDATA[Monster-ID]]></item>
+		<item name="wcf.acp.option.gravatar_default_type.retro"><![CDATA[Retro]]></item>
+		<item name="wcf.acp.option.search_engine"><![CDATA[Suche]]></item>
+		<item name="wcf.acp.option.search_engine.mysql"><![CDATA[MySQL FULLTEXT (Standard)]]></item>
+		<item name="wcf.acp.option.enable_pluginstore_widget"><![CDATA[Empfohlene Plugins anzeigen]]></item>
+		<item name="wcf.acp.option.enable_pluginstore_widget.description"><![CDATA[Aktiviert die Anzeige empfohlener Produkte aus dem WoltLab® Plugin-Store auf der Startseite der Administrationsoberfläche.]]></item>
+		<item name="wcf.acp.option.category.general.payment"><![CDATA[Zahlungsoptionen]]></item>
+		<item name="wcf.acp.option.available_payment_methods"><![CDATA[Unterstützte Zahlungsanbieter]]></item>
+		<item name="wcf.acp.option.paypal_email_address"><![CDATA[PayPal-E-Mail-Adresse]]></item>
+		<item name="wcf.acp.option.paypal_email_address.description"><![CDATA[Für die Abwicklung von PayPal-Zahlungen wird ein PayPal-Business-Konto mit aktivierter sofortiger Zahlungsbestätigung (IPN) benötigt.]]></item>
+		<item name="wcf.acp.option.module_paid_subscription"><![CDATA[Bezahlte Mitgliedschaften aktivieren]]></item>
+		<item name="wcf.acp.option.module_paid_subscription.description"><![CDATA[Aktiviert die <a href="{link controller='PaidSubscriptionList'}{/link}">Verwaltung der bezahlten Mitgliedschaften</a>.]]></item>
+		<item name="wcf.acp.option.paid_subscription_enable_tos_confirmation"><![CDATA[Benutzer müssen vor dem Kauf Nutzungsbedingungen akzeptieren]]></item>
+		<item name="wcf.acp.option.paid_subscription_tos_url"><![CDATA[URL zu Nutzungsbedingungen]]></item>
+		<item name="wcf.acp.option.category.general.payment.paidSubscription"><![CDATA[Bezahlte Mitgliedschaften]]></item>
+		<item name="wcf.acp.option.google_maps_api_key"><![CDATA[Browser-API-Schlüssel]]></item>
+		<item name="wcf.acp.option.google_maps_api_key.description"><![CDATA[Google stellt <a href="{@$__wcf->getPath()}acp/dereferrer.php?url={'https://developers.google.com/maps/documentation/javascript/get-api-key'|rawurlencode}" class="externalURL">hier</a> eine ausführliche Anleitung bereit, wie du einen API-Schlüssel erstellen kannst.]]></item>
+		<item name="wcf.acp.option.suffix.days"><![CDATA[Tage]]></item>
+		<item name="wcf.acp.option.suffix.minutes"><![CDATA[Minuten]]></item>
+		<item name="wcf.acp.option.suffix.percent"><![CDATA[%]]></item>
+		<item name="wcf.acp.option.suffix.pixel"><![CDATA[Pixel]]></item>
+		<item name="wcf.acp.option.suffix.seconds"><![CDATA[Sekunden]]></item>
+		<item name="wcf.acp.option.suffix.years"><![CDATA[Jahre]]></item>
+		<item name="wcf.acp.option.type.boolean.never"><![CDATA[Nie]]></item>
+		<item name="wcf.acp.option.type.boolean.no"><![CDATA[Nein]]></item>
+		<item name="wcf.acp.option.type.boolean.yes"><![CDATA[Ja]]></item>
+		<item name="wcf.acp.option.category.cms"><![CDATA[CMS]]></item>
+		<item name="wcf.acp.option.category.cms.article"><![CDATA[Artikel]]></item>
+		<item name="wcf.acp.option.category.cms.media"><![CDATA[Medien]]></item>
+		<item name="wcf.acp.option.articles_per_page"><![CDATA[Artikel pro Seite]]></item>
+		<item name="wcf.acp.option.article_enable_comments_default_value"><![CDATA[Kommentare aktivieren [Vorgabewert]]]></item>
+		<item name="wcf.acp.option.article_enable_like"><![CDATA[Likes aktivieren]]></item>
+		<item name="wcf.acp.option.article_related_articles"><![CDATA[Anzahl verwandter Artikel]]></item>
+		<item name="wcf.acp.option.article_related_articles_match_threshold"><![CDATA[Übereinstimmung von verwandten Artikeln]]></item>
+		<item name="wcf.acp.option.article_related_articles_match_threshold.description"><![CDATA[Menge an Tags, die für eine Erkennung als verwandter Artikel übereinstimmen müssen.]]></item>
+		<item name="wcf.acp.option.article_show_about_author"><![CDATA[„Über den Autor“ anzeigen]]></item>
+		<item name="wcf.acp.option.category.message.general.image"><![CDATA[Bilder]]></item>
+		<item name="wcf.acp.option.module_article"><![CDATA[Artikel]]></item>
+		<item name="wcf.acp.option.module_image_proxy"><![CDATA[Zwischenspeicherung von externen Bilder aktivieren]]></item>
+		<item name="wcf.acp.option.image_proxy_expiration"><![CDATA[Speicherzeit]]></item>
+		<item name="wcf.acp.option.share_buttons_providers"><![CDATA[Anbieter zum Teilen von Inhalten]]></item>
+		<item name="wcf.acp.option.show_style_changer"><![CDATA[Stil-Auswahl anzeigen]]></item>
+		<item name="wcf.acp.option.language_use_informal_variant"><![CDATA[Informelle Anrede verwenden]]></item>
+		<item name="wcf.acp.option.category.cms.media.thumbnail"><![CDATA[Vorschaugrafiken]]></item>
+		<item name="wcf.acp.option.media_large_thumbnail_height"><![CDATA[Höhe der großen Vorschaugrafiken]]></item>
+		<item name="wcf.acp.option.media_large_thumbnail_retain_dimensions"><![CDATA[Bildformat beim Erzeugen von großen Vorschaugrafiken beibehalten]]></item>
+		<item name="wcf.acp.option.media_large_thumbnail_width"><![CDATA[Breite der großen Vorschaugrafiken]]></item>
+		<item name="wcf.acp.option.media_medium_thumbnail_height"><![CDATA[Höhe der mittleren Vorschaugrafiken]]></item>
+		<item name="wcf.acp.option.media_medium_thumbnail_retain_dimensions"><![CDATA[Bildformat beim Erzeugen von mittleren Vorschaugrafiken beibehalten]]></item>
+		<item name="wcf.acp.option.media_medium_thumbnail_width"><![CDATA[Breite der mittleren Vorschaugrafiken]]></item>
+		<item name="wcf.acp.option.media_small_thumbnail_height"><![CDATA[Höhe der kleinen Vorschaugrafiken]]></item>
+		<item name="wcf.acp.option.media_small_thumbnail_retain_dimensions"><![CDATA[Bildformat beim Erzeugen von kleinen Vorschaugrafiken beibehalten]]></item>
+		<item name="wcf.acp.option.media_small_thumbnail_width"><![CDATA[Breite der kleinen Vorschaugrafiken]]></item>
+		<item name="wcf.acp.option.article_sort_order"><![CDATA[Sortierungsreihenfolge]]></item>
+		<item name="wcf.acp.option.article_sort_order.description"><![CDATA[Standard-Reihenfolge für die Liste der Artikel.]]></item>
+		<item name="wcf.acp.option.use_page_title_on_landing_page"><![CDATA[Titel der Seite als Überschrift auf Startseite anzeigen]]></item>
+		<item name="wcf.acp.option.head_code"><![CDATA[Head-Code]]></item>
+		<item name="wcf.acp.option.head_code.description"><![CDATA[Der hier angegebene Code wird im Head-Tag jeder Seite ausgegeben. Der Head-Code eignet sich z.B. sehr gut für die Einbindung von zusätzlichen Meta-Tags.]]></item>
+		<item name="wcf.acp.option.avatar_default_type"><![CDATA[Standard Avatar-Typ]]></item>
+		<item name="wcf.acp.option.avatar_default_type.initials"><![CDATA[Initialen]]></item>
+		<item name="wcf.acp.option.avatar_default_type.silhouette"><![CDATA[Silhouette]]></item>
+		<item name="wcf.acp.option.article_enable_visit_tracking"><![CDATA[Gelesen-Markierung für Artikel aktivieren]]></item>
+		<item name="wcf.acp.option.enable_ad_rotation"><![CDATA[Werbung abwechselnd anzeigen]]></item>
+		<item name="wcf.acp.option.enable_ad_rotation.description"><![CDATA[Sollte einer Position mehr als eine Werbung zugewiesen sein, so wird bei jedem Aufruf eine zufällige Werbung angezeigt. Bei Deaktivierung dieser Option werden alle Werbungen parallel angezeigt.]]></item>
+		<item name="wcf.acp.option.visitor_use_tiny_build"><![CDATA[Seitenbeschleunigung für Gäste aktivieren (Experimentell)]]></item>
+		<item name="wcf.acp.option.visitor_use_tiny_build.description"><![CDATA[Aktiviert einen besonderen Modus in dem Gästen und Suchmaschinen stark reduzierte JavaScript-Dateien ausgeliefert werden, um das Laden als auch den Seitenaufbau zu beschleunigen.<br><strong>Warnung:</strong> Dieser Modus arbeitet sehr restriktiv und untersagt unter anderem jeglichen Schreibzugriff, bitte überprüfen Sie, ob alle installierten Plugins mit diesem Modus kompatibel sind.]]></item>
+		<item name="wcf.acp.option.fb_share_app_id"><![CDATA[Facebook App ID]]></item>
+		<item name="wcf.acp.option.fb_share_app_id.description"><![CDATA[Die App ID kann direkt über das <a href="{@$__wcf->getPath('wcf')}acp/dereferrer.php?url=https%3A%2F%2Fdevelopers.facebook.com%2Fdocs%2Fapps%2Fregister%3Flocale%3Dde_DE">App-Dashboard angefordert werden</a>, und wird für die Open Graph-Tags zum Teilen verwendet.]]></item>
+		<item name="wcf.acp.option.enable_polling"><![CDATA[Hintergrund-Aktualisierung von Benachrichtigungen aktivieren]]></item>
+		<item name="wcf.acp.option.enable_polling.description"><![CDATA[Neue Benachrichtigungen werden in periodischen Abständen automatisch abgerufen. Der Aktualisierungs-Intervall beträgt 5 Minuten und wird bei Inaktivität schrittweise auf 15 Minuten reduziert.]]></item>
+		<item name="wcf.acp.option.enable_desktop_notifications"><![CDATA[Desktop-Benachrichtigungen verwenden]]></item>
+		<item name="wcf.acp.option.enable_desktop_notifications.description"><![CDATA[Neue Benachrichtigungen, die im Hintergrund aberufen wurden, werden als kleines Benachrichtigungsfenster unmittelbar angezeigt. Einige wenige Browser, z. B. Internet Explorer, unterstützen diese Funktion nicht.]]></item>
+		<item name="wcf.acp.option.module_contact_form"><![CDATA[Kontakt-Formular aktivieren]]></item>
+		<item name="wcf.acp.option.module_contact_form.description"><![CDATA[Aktiviert das Kontakt-Formular, nach Aktivierung können Sie die <a href="{link controller='ContactSettings'}{/link}">Eingabefelder und Empfänger</a> individuell konfigurieren.]]></item>
+		<item name="wcf.acp.option.module_trophy"><![CDATA[Trophäen]]></item>
+	</category>
+	
+	<category name="wcf.acp.customOption">
+		<item name="wcf.acp.customOption.list"><![CDATA[Eingabefelder]]></item>
+		<item name="wcf.acp.customOption.optionType"><![CDATA[Feldtyp]]></item>
+		<item name="wcf.acp.customOption.optionType.boolean"><![CDATA[Ja/Nein]]></item>
+		<item name="wcf.acp.customOption.optionType.boolean.yes"><![CDATA[Ja]]></item>
+		<item name="wcf.acp.customOption.optionType.boolean.no"><![CDATA[Nein]]></item>
+		<item name="wcf.acp.customOption.optionType.checkboxes"><![CDATA[Checkboxen]]></item>
+		<item name="wcf.acp.customOption.optionType.date"><![CDATA[Datum]]></item>
+		<item name="wcf.acp.customOption.optionType.integer"><![CDATA[Ganze Zahl]]></item>
+		<item name="wcf.acp.customOption.optionType.float"><![CDATA[Dezimalzahl]]></item>
+		<item name="wcf.acp.customOption.optionType.multiSelect"><![CDATA[Multi-Select]]></item>
+		<item name="wcf.acp.customOption.optionType.radioButton"><![CDATA[Radio-Buttons]]></item>
+		<item name="wcf.acp.customOption.optionType.select"><![CDATA[Select]]></item>
+		<item name="wcf.acp.customOption.optionType.text"><![CDATA[Einzeiliger Text]]></item>
+		<item name="wcf.acp.customOption.optionType.textarea"><![CDATA[Mehrzeiliger Text]]></item>
+		<item name="wcf.acp.customOption.optionType.message"><![CDATA[Mehrzeiliger Text (BBCode-Unterstützung)]]></item>
+		<item name="wcf.acp.customOption.optionType.URL"><![CDATA[Link]]></item>
+		<item name="wcf.acp.customOption.add"><![CDATA[Eingabefeld hinzufügen]]></item>
+		<item name="wcf.acp.customOption.edit"><![CDATA[Eingabefeld bearbeiten]]></item>
+		<item name="wcf.acp.customOption.showOrder"><![CDATA[Reihenfolge]]></item>
+		<item name="wcf.acp.customOption.delete.confirmMessage"><![CDATA[Willst du das Eingabefeld <span class="confirmationObject">{$option->optionTitle|language}</span> wirklich löschen?]]></item>
+		<item name="wcf.acp.customOption.defaultValue"><![CDATA[Standardwert]]></item>
+		<item name="wcf.acp.customOption.defaultValue.description"><![CDATA[Wert, der beim erstmaligen Ausfüllen als Standard vorgegeben ist.]]></item>
+		<item name="wcf.acp.customOption.typeData"><![CDATA[Eigenschaften]]></item>
+		<item name="wcf.acp.customOption.selectOptions"><![CDATA[Auswahloptionen]]></item>
+		<item name="wcf.acp.customOption.selectOptions.description"><![CDATA[Hier kannst du pro Zeile Auswahloptionen eintragen, beispielsweise bei einer Select-Box. Beachte, dass bei der Verwendung des Doppelpunktes der linke Teil der Zeile als interner Bezeichner verwendet wird. Dieser erlaubt es den Text zu ändern, ohne, dass die Auswahl von Benutzern verloren geht.]]></item>
+		<item name="wcf.acp.customOption.validationPattern"><![CDATA[Regulärer Ausdruck zur Validierung]]></item>
+		<item name="wcf.acp.customOption.validationPattern.description"><![CDATA[Trage hier den regulären Ausdruck ein, um die Eingabe der Benutzer zu validieren.]]></item>
+		<item name="wcf.acp.customOption.required"><![CDATA[Das Feld muss zwingend ausgefüllt werden.]]></item>
+	</category>
+	
+	<category name="wcf.acp.package">
+		<item name="wcf.acp.package.application.installed"><![CDATA[Installierte Apps]]></item>
+		<item name="wcf.acp.package.application.title"><![CDATA[Apps]]></item>
+		<item name="wcf.acp.package.author"><![CDATA[Entwickler]]></item>
+		<item name="wcf.acp.package.availableVersions"><![CDATA[Verfügbare Versionen]]></item>
+		<item name="wcf.acp.package.button.info"><![CDATA[Informationen]]></item>
+		<item name="wcf.acp.package.button.installPackage"><![CDATA[Paket installieren]]></item>
+		<item name="wcf.acp.package.button.uninstall"><![CDATA[Deinstallieren]]></item>
+		<item name="wcf.acp.package.button.update"><![CDATA[Aktualisieren]]></item>
+		<item name="wcf.acp.package.dependencies.dependent"><![CDATA[Abhängige Pakete]]></item>
+		<item name="wcf.acp.package.dependencies.dependent.description"><![CDATA[Pakete, die dieses Paket zwingend für den Betrieb benötigen]]></item>
+		<item name="wcf.acp.package.dependencies.required"><![CDATA[Benötigte Pakete]]></item>
+		<item name="wcf.acp.package.dependencies.required.description"><![CDATA[Pakete, die zwingend für den Betrieb dieses Paketes benötigt werden]]></item>
+		<item name="wcf.acp.package.dependencies.title"><![CDATA[Abhängigkeiten]]></item>
+		<item name="wcf.acp.package.description"><![CDATA[Beschreibung]]></item>
+		<item name="wcf.acp.package.error.cli.installIsApplication"><![CDATA[Apps können per CLI nicht installiert werden.]]></item>
+		<item name="wcf.acp.package.error.noUniqueAbbrevation"><![CDATA[Es ist bereits eine App installiert, die die gleiche Abkürzung besitzt.]]></item>
+		<item name="wcf.acp.package.error.noValidPackage"><![CDATA[Das angegebene Archiv ist kein gültiges Paket.]]></item>
+		<item name="wcf.acp.package.error.sql.createTable"><![CDATA[Existierende Tabellen überschreiben]]></item>
+		<item name="wcf.acp.package.error.sql.createTable.description"><![CDATA[Die oben genannten Tabellen existieren bereits und werden beim Fortfahren der Installation überschrieben. Alle Daten dieser Tabellen gehen unwiderruflich verloren.]]></item>
+		<item name="wcf.acp.package.error.sql.dropTable"><![CDATA[Existierende Tabellen löschen]]></item>
+		<item name="wcf.acp.package.error.sql.dropTable.description"><![CDATA[Die oben genannten Tabellen existieren bereits und werden beim Fortfahren der Installation entfernt. Alle Daten dieser Tabellen gehen unwiderruflich verloren.]]></item>
+		<item name="wcf.acp.package.error.uniqueAlreadyInstalled"><![CDATA[Dieses Paket ist bereits installiert und kann nicht mehrfach installiert werden.]]></item>
+		<item name="wcf.acp.package.error.noValidInstall"><![CDATA[Das angegebene Paket lässt keine Neuinstallation zu.]]></item>
+		<item name="wcf.acp.package.error.noValidUpdate"><![CDATA[Paket „{$package->packageName|language}“ kann mit dem angegebenen Archiv nicht aktualisiert werden.]]></item>
+		<item name="wcf.acp.package.identifier"><![CDATA[Bezeichner]]></item>
+		<item name="wcf.acp.package.information.properties"><![CDATA[Eigenschaften]]></item>
+		<item name="wcf.acp.package.information.title"><![CDATA[Informationen]]></item>
+		<item name="wcf.acp.package.installDate"><![CDATA[Installationsdatum]]></item>
+		<item name="wcf.acp.package.installation.packageStatus"><![CDATA[Status]]></item>
+		<item name="wcf.acp.package.installation.packageStatus.delivered"><![CDATA[vom Paket bereitgestellt]]></item>
+		<item name="wcf.acp.package.installation.packageStatus.installed"><![CDATA[bereits installiert]]></item>
+		<item name="wcf.acp.package.installation.packageStatus.invalidDeliveredPackage"><![CDATA[falsches Paket bereitgestellt ({$package.deliveredPackage})]]></item>
+		<item name="wcf.acp.package.installation.packageStatus.missing"><![CDATA[fehlt]]></item>
+		<item name="wcf.acp.package.installation.packageStatus.missingVersion"><![CDATA[fehlende Paket-Version ({if $package.existingVersion|isset}installierte Version: {$package.existingVersion}{else}bereitgestellte Version: {$package.deliveredVersion}{/if})]]></item>
+		<item name="wcf.acp.package.installation.rollback"><![CDATA[Installation rückgängig machen]]></item>
+		<item name="wcf.acp.package.installation.step.install"><![CDATA[„{$packageName}“ wird installiert …]]></item>
+		<item name="wcf.acp.package.installation.step.install.success"><![CDATA[Installation abgeschlossen]]></item>
+		<item name="wcf.acp.package.installation.step.update"><![CDATA[„{$packageName}“ wird aktualisiert …]]></item>
+		<item name="wcf.acp.package.installation.step.update.success"><![CDATA[Aktualisierung abgeschlossen]]></item>
+		<item name="wcf.acp.package.installedVersion"><![CDATA[Installierte Version]]></item>
+		<item name="wcf.acp.package.install.confirmMessage"><![CDATA[Willst du das Paket <span class="confirmationObject">{@$package->getName()}</span> wirklich installieren?]]></item>
+		<item name="wcf.acp.package.install.error.excludedPackages"><![CDATA[Dieses Paket kann aufgrund der folgenden bereits installierten Pakete nicht installiert werden:]]></item>
+		<item name="wcf.acp.package.install.error.excludedPackages.excludedPackage"><![CDATA[„{$excludedPackage}“ ({$excludedPackage->package}){if $excludedPackage->excludedPackageVersion} (ausgeschlossene Version: {$excludedPackage->excludedPackageVersion}, installierte Version: {$excludedPackage->packageVersion}){/if}]]></item>
+		<item name="wcf.acp.package.install.error.excludingPackages"><![CDATA[Die folgenden bereits installierten Pakete schließen eine Installation dieses Pakets aus:]]></item>
+		<item name="wcf.acp.package.install.error.excludingPackages.excludingPackage"><![CDATA[„{$excludingPackage}“ ({$excludingPackage->package}){if $excludingPackage->excludedPackageVersion} (ausgeschlossene Version: {$excludingPackage->excludedPackageVersion}){/if}]]></item>
+		<item name="wcf.acp.package.install.error.missingRequirements"><![CDATA[Die Abhängigkeiten dieses Paketes konnten nicht aufgelöst werden.]]></item>
+		<item name="wcf.acp.package.install.installingImportedStyle"><![CDATA[Bei der hochgeladenen Datei handelt es sich um ein Paket, welches einen Stil enthält.]]></item>
+		<item name="wcf.acp.package.install.optionalPackage.missingRequirements"><![CDATA[Installation nicht möglich, nicht alle benötigten Pakete sind installiert.]]></item>
+		<item name="wcf.acp.package.install.step.prepare"><![CDATA[Installation wird vorbereitet …]]></item>
+		<item name="wcf.acp.package.install.title"><![CDATA[Paket-Installation]]></item>
+		<item name="wcf.acp.package.installation.requiredVersion"><![CDATA[Benötigte Version]]></item>
+		<item name="wcf.acp.package.license"><![CDATA[Lizenz]]></item>
+		<item name="wcf.acp.package.list"><![CDATA[Paketliste]]></item>
+		<item name="wcf.acp.package.name"><![CDATA[Paket]]></item>
+		<item name="wcf.acp.package.packageDate"><![CDATA[Erstellungsdatum]]></item>
+		<item name="wcf.acp.package.packageDir.notAvailable"><![CDATA[Das angegebene Verzeichnis enthält bereits eine App.]]></item>
+		<item name="wcf.acp.package.plugin.installed"><![CDATA[Installierte Pakete]]></item>
+		<item name="wcf.acp.package.plugin.title"><![CDATA[Erweiterungen]]></item>
+		<item name="wcf.acp.package.search"><![CDATA[Paket suchen]]></item>
+		<item name="wcf.acp.package.search.package"><![CDATA[Paketbezeichner]]></item>
+		<item name="wcf.acp.package.search.package.description"><![CDATA[Suche nach einem bestimmten Paketbezeichner, z.B. „com.woltlab.wcf“]]></item>
+		<item name="wcf.acp.package.search.packageDescription"><![CDATA[Paketbeschreibung]]></item>
+		<item name="wcf.acp.package.search.packageName"><![CDATA[Paketname]]></item>
+		<item name="wcf.acp.package.search.resultList"><![CDATA[Suchergebnisse]]></item>
+		<item name="wcf.acp.package.searchForUpdates"><![CDATA[Updates suchen]]></item>
+		<item name="wcf.acp.package.searchForUpdates.noResults"><![CDATA[Dein System ist auf dem aktuellen Stand, es wurden keine ausstehenden Updates gefunden.]]></item>
+		<item name="wcf.acp.package.source.upload"><![CDATA[Paket hochladen]]></item>
+		<item name="wcf.acp.package.source.upload.description"><![CDATA[Gib eine Paketdatei von deinem lokalen Rechner an.]]></item>
+		<item name="wcf.acp.package.startInstall"><![CDATA[Paket installieren]]></item>
+		<item name="wcf.acp.package.startUpdate"><![CDATA[Paket „{@$package->getName()}“ aktualisieren]]></item>
+		<item name="wcf.acp.package.type.application"><![CDATA[App]]></item>
+		<item name="wcf.acp.package.type.plugin"><![CDATA[Erweiterung]]></item>
+		<item name="wcf.acp.package.uninstallation.confirm"><![CDATA[Willst du das Paket <span class="confirmationObject">{@$package->getName()}</span> wirklich deinstallieren?]]></item>
+		<item name="wcf.acp.package.uninstallation.step.success"><![CDATA[Deinstallation abgeschlossen]]></item>
+		<item name="wcf.acp.package.uninstallation.step.uninstall"><![CDATA[Paket „{$queue->packageName}“ wird deinstalliert …]]></item>
+		<item name="wcf.acp.package.uninstallation.title"><![CDATA[Deinstallation]]></item>
+		<item name="wcf.acp.package.uninstall.step.prepare"><![CDATA[Deinstallation wird vorbereitet …]]></item>
+		<item name="wcf.acp.package.updateDate"><![CDATA[Aktualisierungsdatum]]></item>
+		<item name="wcf.acp.package.update.credentials"><![CDATA[Zugangsdaten]]></item>
+		<item name="wcf.acp.package.update.error.listNotFound"><![CDATA[Die Paketliste konnte nicht abgerufen werden]]></item>
+		<item name="wcf.acp.package.update.errorCode.401"><![CDATA[Deine Angaben sind ungültig, bitte überprüfe {if $updateServer->requiresLicense()}Lizenz- und Seriennummer{else}Benutzername und Passwort{/if}.]]></item>
+		<item name="wcf.acp.package.update.errorCode.402"><![CDATA[{if $updateServer->requiresLicense()}Lizenz- und Seriennummer{else}Benutzername und Passwort{/if} wurden vom Server akzeptiert, es handelt sich aber um einer kommerzielles Produkt auf das diese Zugangsdaten keinen Zugriff haben.]]></item>
+		<item name="wcf.acp.package.update.errorCode.403"><![CDATA[Du bist nicht berechtigt auf dieses Paket zuzugreifen.]]></item>
+		<item name="wcf.acp.package.update.authInsufficient"><![CDATA[Die eingegebenen Zugangsdaten sind korrekt, aber berechtigen nicht zum Download dieses Pakets.]]></item>
+		<item name="wcf.acp.package.update.licenseNo"><![CDATA[Lizenznummer]]></item>
+		<item name="wcf.acp.package.update.password"><![CDATA[Passwort]]></item>
+		<item name="wcf.acp.package.update.saveCredentials"><![CDATA[Zugangsdaten speichern]]></item>
+		<item name="wcf.acp.package.update.serialNo"><![CDATA[Seriennummer]]></item>
+		<item name="wcf.acp.package.update.server"><![CDATA[Paket-Server]]></item>
+		<item name="wcf.acp.package.update.server.message"><![CDATA[Servermeldung]]></item>
+		<item name="wcf.acp.package.update.server.url"><![CDATA[URL]]></item>
+		<item name="wcf.acp.package.update.title"><![CDATA[Paket-Aktualisierung]]></item>
+		<item name="wcf.acp.package.update.unauthorized"><![CDATA[Authentifizierung erforderlich]]></item>
+		<item name="wcf.acp.package.update.username"><![CDATA[Benutzername]]></item>
+		<item name="wcf.acp.package.update.step.prepare"><![CDATA[Aktualisierung wird vorbereitet …]]></item>
+		<item name="wcf.acp.package.update.excludedPackages"><![CDATA[Konflikt]]></item>
+		<item name="wcf.acp.package.update.excludedPackages.excluded"><![CDATA[Installierte Pakete]]></item>
+		<item name="wcf.acp.package.update.excludedPackages.excluded.description"><![CDATA[Die folgenden installierten Pakete sind mit den zu installierenden Versionen nicht kompatibel]]></item>
+		<item name="wcf.acp.package.update.excludedPackages.excluded.package"><![CDATA[„{$excludedPackage[existingPackageName]}“ in Version „{$excludedPackage[existingPackageVersion]}“ verhindert eine {if $excludedPackage[action] == 'update'}Aktualisierung{else}Installation{/if} von „{$excludedPackage[packageName]}“ {if $excludedPackage[action] == 'update'}auf{else}in{/if} Version „{$excludedPackage[packageVersion]}“]]></item>
+		<item name="wcf.acp.package.update.excludedPackages.excluding"><![CDATA[Zu installierende Pakete]]></item>
+		<item name="wcf.acp.package.update.excludedPackages.excluding.description"><![CDATA[Die folgenden zu installierenden Pakete sind mit installierten Paketen nicht kompatibel]]></item>
+		<item name="wcf.acp.package.update.excludedPackages.excluding.package"><![CDATA[„{$excludedPackage[packageName]}“ in Version „{$excludedPackage[packageVersion]}“ ist mit dem bereits installieren Paket „{$excludedPackage[existingPackageName]}“ nicht kompatibel]]></item>
+		<item name="wcf.acp.package.version"><![CDATA[Version]]></item>
+		<item name="wcf.acp.package.packageDir.input"><![CDATA[Installationsverzeichnis]]></item>
+		<item name="wcf.acp.package.upload"><![CDATA[Paket hochladen]]></item>
+		<item name="wcf.acp.package.optionalPackages"><![CDATA[Optionale Pakete]]></item>
+		<item name="wcf.acp.package.optionalPackages.description"><![CDATA[Es stehen folgende optionale Pakete zur Auswahl:]]></item>
+		<item name="wcf.acp.package.search.error.noMatches"><![CDATA[Es wurden keine Pakete gefunden.]]></item>
+		<item name="wcf.acp.package.url"><![CDATA[Website]]></item>
+		<item name="wcf.acp.package.error.uploadFailed"><![CDATA[Das Hochladen der ausgewählten Datei ist fehlgeschlagen.]]></item>
+		<item name="wcf.acp.package.updates"><![CDATA[Aktualisierungen]]></item>
+		<item name="wcf.acp.package.error.downloadFailed"><![CDATA[Das Herunterladen des Paketes{if $__downloadPackage|isset} „{$__downloadPackage}“{/if} ist fehlgeschlagen.]]></item>
+		<item name="wcf.acp.package.newVersion"><![CDATA[Neue Version]]></item>
+		<item name="wcf.acp.package.validation"><![CDATA[Prüfungsergebnis]]></item>
+		<item name="wcf.acp.package.validation.errorCode.1"><![CDATA[Die Datei „{$archive}“{if !$targetArchive|empty} im Archiv „{$targetArchive}“{/if} konnte nicht gefunden werden.]]></item>
+		<item name="wcf.acp.package.validation.errorCode.2"><![CDATA[Das Paket „{$archive}“ enthält die notwendige „package.xml“ nicht.]]></item>
+		<item name="wcf.acp.package.validation.errorCode.3"><![CDATA[Der Paketbezeichner „{$packageName}“ entspricht nicht den Vorgaben und ist ungültig.]]></item>
+		<item name="wcf.acp.package.validation.errorCode.4"><![CDATA[Die Paketversion „{$packageVersion}“ entspricht nicht den Vorgaben und ist ungültig.]]></item>
+		<item name="wcf.acp.package.validation.errorCode.5"><![CDATA[Das Paket „{lang}{$packageName}{/lang}“ enthält keine gültigen Installations-Anweisungen.]]></item>
+		<item name="wcf.acp.package.validation.errorCode.6"><![CDATA[Das Paket „{lang}{$packageName}{/lang}“ (installierte Version: „{$packageVersion}“) soll auf Version „{$deliveredPackageVersion}“ aktualisiert werden, ein Update wird jedoch nicht unterstützt.]]></item>
+		<item name="wcf.acp.package.validation.errorCode.7"><![CDATA[Die folgenden installierten Paketen schließen die Installation auf Grund von Inkompatibilitäten aus: <ul class="nativeList">{foreach from=$packages item=package}<li>„{$package}“ ({$package->package})</li>{/foreach}</ul>]]></item>
+		<item name="wcf.acp.package.validation.errorCode.8"><![CDATA[Dieses Paket ist inkompatibel mit den folgenden, installierten Paketen: <ul class="nativeList">{foreach from=$packages item=package}<li>„{$package}“ ({$package->package})</li>{/foreach}</ul>]]></item>
+		<item name="wcf.acp.package.validation.errorCode.9"><![CDATA[Die Installation erfordert das Paket „{$packageName}“ in Version „{$packageVersion}“ oder höher, das mitgelieferte Paket trägt aber die Versionsnummer „{$deliveredPackageVersion}“.]]></item>
+		<item name="wcf.acp.package.validation.errorCode.10"><![CDATA[Benötigt das Paket {if $package === null}„{$packageName}“{else}„{$package}“{/if} in Version „{$packageVersion}“ oder höher, {if $package === null}dies ist aber weder installiert noch wird es mitgeliefert.{else}es ist aber nur Version „{$package->packageVersion}“ installiert.{/if}]]></item>
+		<item name="wcf.acp.package.validation.errorCode.11"><![CDATA[Die {if $type == 'install'}Installations{else}Update{/if}-Anweisungen geben für das Package Installation Plugin „{$pip}“ die Datei „{$value}“ an, diese ist jedoch nicht im Archiv enthalten. Mögliche Ursachen:<ul class="nativeList"><li>Die Datei wurde dem Archiv nicht hinzugefügt</li><li>Die Datei existiert, jedoch sind der Dateiname und die Angabe in den Anweisungen abweichend (Tippfehler)</li></ul>]]></item>
+		<item name="wcf.acp.package.validation.errorCode.12"><![CDATA[Das Paket „{lang}{$packageName}{/lang}“ ist bereits in Version „{$packageVersion}“ installiert.]]></item>
+		<item name="wcf.acp.package.validation.failed"><![CDATA[Das hochgeladene Paket kann nicht installiert werden, bitte beachte das unten stehende Prüfungsergebnis.]]></item>
+	</category>
+	
+	<category name="wcf.acp.page">
+		<item name="wcf.acp.page.add"><![CDATA[Seite hinzufügen]]></item>
+		<item name="wcf.acp.page.application"><![CDATA[App]]></item>
+		<item name="wcf.acp.page.boxes"><![CDATA[Ausgewählte Boxen auf dieser Seite anzeigen]]></item>
+		<item name="wcf.acp.page.boxOrder"><![CDATA[Boxen sortieren]]></item>
+		<item name="wcf.acp.page.boxOrder.discard"><![CDATA[Sortierung verwerfen]]></item>
+		<item name="wcf.acp.page.boxOrder.discard.confirmMessage"><![CDATA[Willst du die individuelle Sortierung der Boxen für diese Seite wirklich löschen?]]></item>
+		<item name="wcf.acp.page.boxOrder.pageAdd"><![CDATA[Du kannst die individuelle Sortierung der Boxen für diese Seite nach dem Speichern festlegen.]]></item>
+		<item name="wcf.acp.page.boxOrder.pageEdit"><![CDATA[Du kannst die Sortierung der angezeigten Boxen <a href="{link controller='PageBoxOrder' id=$page->pageID}{/link}">individuell festlegen</a>, bitte speichere zuvor deine Änderungen.]]></item>
+		<item name="wcf.acp.page.boxOrder.position.content"><![CDATA[(Inhalt)]]></item>
+		<item name="wcf.acp.page.button.boxOrder"><![CDATA[Boxen sortieren]]></item>
+		<item name="wcf.acp.page.button.viewPage"><![CDATA[Vorschau anzeigen]]></item>
+		<item name="wcf.acp.page.content"><![CDATA[Inhalt]]></item>
+		<item name="wcf.acp.page.contents"><![CDATA[Inhalte]]></item>
+		<item name="wcf.acp.page.customURL"><![CDATA[Individuelle URL]]></item>
+		<item name="wcf.acp.page.customURL.error.invalid"><![CDATA[Du hast eine ungültige URL eingegeben. Erlaubte Zeichen sind Buchstaben, Nummern, Bindestrich, Unterstrich und Schrägstrich.]]></item>
+		<item name="wcf.acp.page.customURL.error.notUnique"><![CDATA[Diese URL wird bereits von einer anderen Seite verwendet.]]></item>
+		<item name="wcf.acp.page.delete.confirmMessage"><![CDATA[Willst du die Seite <span class="confirmationObject">{$page->name}</span> wirklich löschen?]]></item>
+		<item name="wcf.acp.page.edit"><![CDATA[Seite bearbeiten]]></item>
+		<item name="wcf.acp.page.i18n"><![CDATA[Mehrsprachigkeit]]></item>
+		<item name="wcf.acp.page.i18n.i18n"><![CDATA[Mehrsprachige Seite]]></item>
+		<item name="wcf.acp.page.i18n.i18n.description"><![CDATA[Inhalt, URL und Meta-Daten werden individuell pro Sprache festgelegt.]]></item>
+		<item name="wcf.acp.page.i18n.none"><![CDATA[Einsprachige Seite]]></item>
+		<item name="wcf.acp.page.i18n.none.description"><![CDATA[Der Inhalt der Seite ist sprachneutral oder soll nur in einer Sprache verfasst werden.]]></item>
+		<item name="wcf.acp.page.isLandingPage"><![CDATA[Seite ist Startseite]]></item>
+		<item name="wcf.acp.page.isDisabled"><![CDATA[Seite deaktivieren]]></item>
+		<item name="wcf.acp.page.lastUpdateTime"><![CDATA[Letzte Aktualisierung]]></item>
+		<item name="wcf.acp.page.list"><![CDATA[Seiten]]></item>
+		<item name="wcf.acp.page.metaDescription"><![CDATA[Meta Description]]></item>
+		<item name="wcf.acp.page.metaKeywords"><![CDATA[Meta Keywords]]></item>
+		<item name="wcf.acp.page.name.error.notUnique"><![CDATA[Dieser Name wird bereits von einer anderen Seite verwendet.]]></item>
+		<item name="wcf.acp.page.page"><![CDATA[Seite]]></item>
+		<item name="wcf.acp.page.parentPage"><![CDATA[Übergeordnete Seite]]></item>
+		<item name="wcf.acp.page.parentPage.none"><![CDATA[Keine]]></item>
+		<item name="wcf.acp.page.type"><![CDATA[Seiten-Typ]]></item>
+		<item name="wcf.acp.page.type.html"><![CDATA[HTML]]></item>
+		<item name="wcf.acp.page.type.html.description"><![CDATA[Direkte Eingabe des gesamten HTML für den Inhaltsbereich mit maximaler Flexibilität.]]></item>
+		<item name="wcf.acp.page.type.system"><![CDATA[System]]></item>
+		<item name="wcf.acp.page.type.text"><![CDATA[Text]]></item>
+		<item name="wcf.acp.page.type.text.description"><![CDATA[Erstellung des Inhaltes mit Hilfe des WYSIWYG-Editors (empfohlen).]]></item>
+		<item name="wcf.acp.page.type.tpl"><![CDATA[Template]]></item>
+		<item name="wcf.acp.page.type.tpl.description"><![CDATA[Eingabemöglichkeit entspricht dem Typ „HTML“, zusätzlich wird Template-Scripting unterstützt.]]></item>
+		<item name="wcf.acp.page.url"><![CDATA[URL]]></item>
+		<item name="wcf.acp.page.cssClassName"><![CDATA[CSS-Klassen]]></item>
+		<item name="wcf.acp.page.availableDuringOfflineMode"><![CDATA[Seite ist im Wartungsmodus aufrufbar]]></item>
+		<item name="wcf.acp.page.allowSpidersToIndex"><![CDATA[Seite darf von Suchmaschinen-Robotern indiziert werden]]></item>
+		<item name="wcf.acp.page.addPageToMainMenu"><![CDATA[Seite automatisch in das Hauptmenü aufnehmen]]></item>
+		<item name="wcf.acp.page.lastVersion"><![CDATA[Es gibt <a href="{link controller='VersionTrackerList' objectType='com.woltlab.wcf.page' objectID=$page->pageID}{/link}">vorherige Versionen</a> dieser Seite, die letzte Änderung erfolgte durch <a href="{link controller='UserEdit' id=$lastVersion->userID}{/link}">{$lastVersion->username}</a> ({@$lastVersion->time|time}).]]></item>
+		<item name="wcf.acp.page.originIsNotSystem"><![CDATA[Eigene Seiten]]></item>
+	</category>
+	
+	<category name="wcf.acp.paidSubscription">
+		<item name="wcf.acp.paidSubscription.list"><![CDATA[Bezahlte Mitgliedschaften]]></item>
+		<item name="wcf.acp.paidSubscription.add"><![CDATA[Mitgliedschaft hinzufügen]]></item>
+		<item name="wcf.acp.paidSubscription.edit"><![CDATA[Mitgliedschaft bearbeiten]]></item>
+		<item name="wcf.acp.paidSubscription.userGroups"><![CDATA[Benutzergruppen]]></item>
+		<item name="wcf.acp.paidSubscription.userGroups.description"><![CDATA[Käufer dieser Mitgliedschaft werden automatisch den ausgewählten Benutzergruppen hinzugefügt.]]></item>
+		<item name="wcf.acp.paidSubscription.cost"><![CDATA[Kosten]]></item>
+		<item name="wcf.acp.paidSubscription.subscriptionLength.permanent"><![CDATA[Unbegrenzte Laufzeit]]></item>
+		<item name="wcf.acp.paidSubscription.subscriptionLength"><![CDATA[Laufzeit]]></item>
+		<item name="wcf.acp.paidSubscription.subscriptionLengthUnit.D"><![CDATA[Tag(e)]]></item>
+		<item name="wcf.acp.paidSubscription.subscriptionLengthUnit.M"><![CDATA[Monat(e)]]></item>
+		<item name="wcf.acp.paidSubscription.subscriptionLengthUnit.Y"><![CDATA[Jahr(e)]]></item>
+		<item name="wcf.acp.paidSubscription.subscriptionLength.error.invalid"><![CDATA[Du hast eine ungültige Laufzeit eingegeben. Für die Auswahl „Tage“ liegt der zulässige Maximalwert bei 90, für „Monate“ bei 24 und für „Jahre“ bei fünf.]]></item>
+		<item name="wcf.acp.paidSubscription.showOrder.description"><![CDATA[Legt die Reihenfolge fest, in der die bezahlten Mitgliedschaften angezeigt werden.]]></item>
+		<item name="wcf.acp.paidSubscription.isDisabled"><![CDATA[Mitgliedschaft deaktivieren]]></item>
+		<item name="wcf.acp.paidSubscription.isDisabled.description"><![CDATA[Entfernt diese bezahlte Mitgliedschaft aus dem Angebot.]]></item>
+		<item name="wcf.acp.paidSubscription.isRecurring"><![CDATA[Regelmäßige Abbuchung]]></item>
+		<item name="wcf.acp.paidSubscription.isRecurring.description"><![CDATA[Aktiviert die automatische Abbuchung der Kosten vom Konto des Käufers, um die Mitgliedschaft automatisch zu verlängern.]]></item>
+		<item name="wcf.acp.paidSubscription.paymentOptions"><![CDATA[Zahlungsoptionen]]></item>
+		<item name="wcf.acp.paidSubscription.user.list"><![CDATA[Aktive Mitgliedschaften]]></item>
+		<item name="wcf.acp.paidSubscription.user.endDate"><![CDATA[Ablaufdatum]]></item>
+		<item name="wcf.acp.paidSubscription.subscription"><![CDATA[Mitgliedschaft]]></item>
+		<item name="wcf.acp.paidSubscription.transactionLog.list"><![CDATA[Transaktionen]]></item>
+		<item name="wcf.acp.paidSubscription.transactionLog.paymentMethod"><![CDATA[Zahlungsmethode]]></item>
+		<item name="wcf.acp.paidSubscription.transactionLog.transactionID"><![CDATA[Transaktions-ID]]></item>
+		<item name="wcf.acp.paidSubscription.transactionLog.logTime"><![CDATA[Datum]]></item>
+		<item name="wcf.acp.paidSubscription.transactionLog.logMessage"><![CDATA[Aktion]]></item>
+		<item name="wcf.acp.paidSubscription.transactionLog"><![CDATA[Transaktion]]></item>
+		<item name="wcf.acp.paidSubscription.transactionLog.transactionDetails"><![CDATA[Details]]></item>
+		<item name="wcf.acp.paidSubscription.excludedSubscriptions"><![CDATA[Andere Mitgliedschaften ausschließen]]></item>
+		<item name="wcf.acp.paidSubscription.excludedSubscriptions.description"><![CDATA[Du kannst den Erwerb anderer bezahlter Mitgliedschaften für Käufer dieser Mitgliedschaft ausschließen.]]></item>
+		<item name="wcf.acp.paidSubscription.user.delete.confirmMessage"><![CDATA[Willst du die Mitgliedschaft <span class="confirmationObject">{$subscriptionUser->title|language}</span> für den Benutzer <span class="confirmationObject">{$subscriptionUser->username}</span> wirklich entfernen?]]></item>
+		<item name="wcf.acp.paidSubscription.user.add"><![CDATA[Mitgliedschaft manuell zuweisen]]></item>
+		<item name="wcf.acp.paidSubscription.user.edit"><![CDATA[Aktive Mitgliedschaft bearbeiten]]></item>
+		<item name="wcf.acp.paidSubscription.error.noPaymentMethods"><![CDATA[Es muss mindestens ein Zahlungsanbieter in den Optionen unter „Zahlungsoptionen“ ausgewählt sein, um bezahlte Mitgliedschaften erstellen zu können.]]></item>
+		<item name="wcf.acp.paidSubscription.delete.confirmMessage"><![CDATA[Willst du die bezahlte Mitgliedschaft <span class="confirmationObject">{$subscription->title|language}</span> wirklich löschen?]]></item>
+	</category>
+	
+	<category name="wcf.acp.pluginStore">
+		<item name="wcf.acp.pluginStore.api.error"><![CDATA[Fehler {@$status}: Der Server konnte die Anfrage nicht erfolgreich bearbeiten.]]></item>
+		<item name="wcf.acp.pluginStore.api.noSSL"><![CDATA[Die Abfrage der erworbenen Produkte aus dem Plugin-Store kann nur über eine sichere Verbindung erfolgen.<br><br>Deine PHP-Version wurde ohne Unterstützung für OpenSSL kompiliert und kann daher keine sicheren Verbindungen aufbauen, bitte wende dich an deinen Anbieter oder System-Administrator, um diesen Umstand zu korrigieren.]]></item>
+		<item name="wcf.acp.pluginStore.authorization"><![CDATA[Autorisierung erforderlich]]></item>
+		<item name="wcf.acp.pluginStore.authorization.credentials"><![CDATA[Zugangsdaten]]></item>
+		<item name="wcf.acp.pluginStore.authorization.credentials.description"><![CDATA[Bitte gib Benutzername und Passwort für dein WoltLab.com-Benutzerkonto ein.]]></item>
+		<item name="wcf.acp.pluginStore.authorization.credentials.rejected"><![CDATA[Deine Zugangsdaten wurden vom Server abgewiesen, bitte überprüfe Benutzername und Passwort!]]></item>
+		<item name="wcf.acp.pluginStore.authorization.username"><![CDATA[Benutzername]]></item>
+		<item name="wcf.acp.pluginStore.authorization.password"><![CDATA[Passwort]]></item>
+		<item name="wcf.acp.pluginStore.authorization.saveCredentials"><![CDATA[Zugangsdaten für aktuelle Sitzung speichern]]></item>
+		<item name="wcf.acp.pluginStore.purchasedItems.button.search"><![CDATA[Erworbene Produkte (Plugin-Store)]]></item>
+		<item name="wcf.acp.pluginStore.purchasedItems"><![CDATA[Erworbene Produkte (Plugin-Store)]]></item>
+		<item name="wcf.acp.pluginStore.purchasedItems.noResults"><![CDATA[Die Suche ergab keine Treffer, entweder hast du noch keine Produkte erworben oder diese sind nicht kompatibel.]]></item>
+		<item name="wcf.acp.pluginStore.purchasedItems.status.requireUpdate"><![CDATA[Paket-Server muss abgefragt werden]]></item>
+		<item name="wcf.acp.pluginStore.purchasedItems.status.update"><![CDATA[Neuere Version verfügbar]]></item>
+		<item name="wcf.acp.pluginStore.purchasedItems.status.unavailable"><![CDATA[Paket-Server nicht installiert]]></item>
+		<item name="wcf.acp.pluginStore.purchasedItems.status.upToDate"><![CDATA[Aktuellste Version bereits installiert]]></item>
+		<item name="wcf.acp.pluginStore.purchasedItems.status.install.confirmMessage"><![CDATA[Willst du das Produkt <span class="confirmationObject">{$product[packageName]}</span> wirklich installieren?]]></item>
+		<item name="wcf.acp.pluginStore.purchasedItems.updateServer.disabled"><![CDATA[Der Paket-Server für „{$wcfMajorRelease}“ („http://store.woltlab.com/{$wcfMajorRelease}/“) ist deaktiviert und steht weder für Neuinstallation noch Updates zur Verfügung.]]></item>
+		<item name="wcf.acp.pluginStore.purchasedItems.updateServer.missing"><![CDATA[Der Paket-Server für „{$wcfMajorRelease}“ ist bei dir nicht eingetragen. Wenn du die unten stehenden Pakete installieren möchtest, musst du diesen zuvor <a href="{link controller='PackageUpdateServerAdd'}{/link}">hinzufügen</a>.<br>Die Adresse des Servers lautet: „http://store.woltlab.com/{$wcfMajorRelease}/“]]></item>
+		<item name="wcf.acp.pluginStore.purchasedItems.updateServer.requireUpdate"><![CDATA[Der Paket-Server für „{$wcfMajorRelease}“ („http://store.woltlab.com/{$wcfMajorRelease}/“) wurde noch nicht abgefragt, bitte lass zuerst nach Updates suchen, um den Server abzufragen.]]></item>
+	</category>
+	
+	<category name="wcf.acp.rebuildData">
+		<item name="wcf.acp.rebuildData"><![CDATA[Anzeigen aktualisieren]]></item>
+		<item name="wcf.acp.rebuildData.description"><![CDATA[Für eine vollständige Aktualisierung aller Daten (z.B. nach einem Datenimport) führst du die Aktionen bitte in der hier angegebenen Reihenfolge durch.]]></item>
+		<item name="wcf.acp.rebuildData.com.woltlab.wcf.user"><![CDATA[Benutzer aktualisieren]]></item>
+		<item name="wcf.acp.rebuildData.com.woltlab.wcf.user.description"><![CDATA[Aktualisiert Zähler der Benutzer, aktualisiert Benutzerränge]]></item>
+		<item name="wcf.acp.rebuildData.com.woltlab.wcf.like"><![CDATA[Likes aktualisieren]]></item>
+		<item name="wcf.acp.rebuildData.com.woltlab.wcf.like.description"><![CDATA[Berechnet Likes neu]]></item>
+		<item name="wcf.acp.rebuildData.com.woltlab.wcf.like.user"><![CDATA[Like-Benutzer aktualisieren]]></item>
+		<item name="wcf.acp.rebuildData.com.woltlab.wcf.like.user.description"><![CDATA[Aktualisiert die Liste der Like-Benutzer]]></item>
+		<item name="wcf.acp.rebuildData.com.woltlab.wcf.attachment"><![CDATA[Dateianhänge aktualisieren]]></item>
+		<item name="wcf.acp.rebuildData.com.woltlab.wcf.attachment.description"><![CDATA[Erzeugt Vorschaubilder neu]]></item>
+		<item name="wcf.acp.rebuildData.com.woltlab.wcf.media"><![CDATA[Medien aktualisieren]]></item>
+		<item name="wcf.acp.rebuildData.com.woltlab.wcf.media.description"><![CDATA[Erzeugt Vorschaubilder neu]]></item>
+		<item name="wcf.acp.rebuildData.com.woltlab.wcf.statDaily"><![CDATA[Statistiken aktualisieren]]></item>
+		<item name="wcf.acp.rebuildData.com.woltlab.wcf.statDaily.description"><![CDATA[Erzeugt die täglichen Statistiken neu]]></item>
+		<item name="wcf.acp.rebuildData.com.woltlab.wcf.poll"><![CDATA[Umfragen aktualisieren]]></item>
+		<item name="wcf.acp.rebuildData.com.woltlab.wcf.poll.description"><![CDATA[Aktualisiert Zähler der Umfragen]]></item>
+		<item name="wcf.acp.rebuildData.com.woltlab.wcf.article"><![CDATA[Artikel aktualisieren]]></item>
+		<item name="wcf.acp.rebuildData.com.woltlab.wcf.article.description"><![CDATA[Aktualisiert den Suchindex für Artikel]]></item>
+		<item name="wcf.acp.rebuildData.com.woltlab.wcf.databaseConvertEncoding"><![CDATA[Datenbank-Kodierung konvertieren]]></item>
+		<item name="wcf.acp.rebuildData.com.woltlab.wcf.databaseConvertEncoding.description"><![CDATA[Warnung: Die Ausführung dieser Aktion kann bei umfangreichen Datenbanken sehr lange dauern.]]></item>
+		<item name="wcf.acp.rebuildData.com.woltlab.wcf.comment"><![CDATA[Kommentare aktualisieren]]></item>
+		<item name="wcf.acp.rebuildData.com.woltlab.wcf.comment.description"><![CDATA[Aktualisiert die Kommentare]]></item>
+		<item name="wcf.acp.rebuildData.com.woltlab.wcf.page"><![CDATA[Seiten aktualisieren]]></item>
+		<item name="wcf.acp.rebuildData.com.woltlab.wcf.page.description"><![CDATA[Aktualisiert den Suchindex für CMS-Seiten]]></item>
+		<item name="wcf.acp.rebuildData.com.woltlab.wcf.sitemap"><![CDATA[Sitemap aktualisieren]]></item>
+		<item name="wcf.acp.rebuildData.com.woltlab.wcf.sitemap.description"><![CDATA[Erstellt die Sitemap neu.]]></item>
+	</category>
+	
+	<category name="wcf.acp.rescueMode">
+		<item name="wcf.acp.rescueMode"><![CDATA[Systemwiederherstellung]]></item>
+		<item name="wcf.acp.rescueMode.application"><![CDATA[Installierte Apps]]></item>
+		<item name="wcf.acp.rescueMode.application.description"><![CDATA[Bitte passe sowohl die Domain als auch den Pfad jeder aufgeführten App an die geänderten Einstellung an, die Angabe der Domain erfolgt ohne Protokoll („http://“ bzw. „https://“).]]></item>
+		<item name="wcf.acp.rescueMode.credentials"><![CDATA[Zugangsdaten]]></item>
+		<item name="wcf.acp.rescueMode.credentials.description"><![CDATA[Die Änderung der Konfiguration erfordert gültige Zugangsdaten für ein Administrator-Konto mit der Berechtigung die installierten Apps zu verwalten.]]></item>
+		<item name="wcf.acp.rescueMode.description"><![CDATA[Die eingestellte Domains und/oder Pfade stimmen nicht mit der für den Aufruf verwendeten Adresse überein; Dies kann in Folge eines Umzugs auf eine andere Domain oder Veränderung der Verzeichnisstruktur auftreten. Mit Hilfe des unten stehenden Formulars kannst du die Angaben schnell und einfach anpassen.]]></item>
+		<item name="wcf.acp.rescueMode.username.notAuthorized"><![CDATA[Diese Benutzer ist nicht berechtigt die Konfiguration zu verändern.]]></item>
+	</category>
+	
+	<category name="wcf.acp.search">
+		<item name="wcf.acp.search.noResults"><![CDATA[Keine Treffer]]></item>
+		<item name="wcf.acp.search.provider.com.woltlab.wcf.menuItem"><![CDATA[Administrationsmenü]]></item>
+		<item name="wcf.acp.search.provider.com.woltlab.wcf.option"><![CDATA[Optionen]]></item>
+		<item name="wcf.acp.search.provider.com.woltlab.wcf.package"><![CDATA[Pakete]]></item>
+		<item name="wcf.acp.search.provider.com.woltlab.wcf.user"><![CDATA[Benutzer]]></item>
+		<item name="wcf.acp.search.provider.com.woltlab.wcf.userGroupOption"><![CDATA[Berechtigungen]]></item>
+		<item name="wcf.acp.search.provider.com.woltlab.wcf.page"><![CDATA[Seiten]]></item>
+		<item name="wcf.acp.search.provider.com.woltlab.wcf.article"><![CDATA[Artikel]]></item>
+		<item name="wcf.acp.search.provider.com.woltlab.wcf.box"><![CDATA[Boxen]]></item>
+		<item name="wcf.acp.search.result.subtitle"><![CDATA[{implode from=$pieces item=piece glue=' » '}{$piece|language}{/implode}]]></item>
+	</category>
+	
+	<category name="wcf.acp.sitemap">
+		<item name="wcf.acp.sitemap"><![CDATA[Sitemap]]></item>
+		<item name="wcf.acp.sitemap.priority"><![CDATA[Priorität]]></item>
+		<item name="wcf.acp.sitemap.priority.description"><![CDATA[Gebe hier die Priorität der Einträge in dieser Sitemap an. Gültige Werte liegen zwischen 0,0 und 1,0.]]></item>
+		<item name="wcf.acp.sitemap.priority.error.invalid"><![CDATA[Der Wert muss zwischen 0,0 und 1,0 liegen.]]></item>
+		<item name="wcf.acp.sitemap.changeFreq"><![CDATA[Änderungsfrequenz]]></item>
+		<item name="wcf.acp.sitemap.changeFreq.always"><![CDATA[Immer]]></item>
+		<item name="wcf.acp.sitemap.changeFreq.hourly"><![CDATA[Stündlich]]></item>
+		<item name="wcf.acp.sitemap.changeFreq.daily"><![CDATA[Täglich]]></item>
+		<item name="wcf.acp.sitemap.changeFreq.weekly"><![CDATA[Wöchentlich]]></item>
+		<item name="wcf.acp.sitemap.changeFreq.monthly"><![CDATA[Monatlich]]></item>
+		<item name="wcf.acp.sitemap.changeFreq.yearly"><![CDATA[Jährlich]]></item>
+		<item name="wcf.acp.sitemap.changeFreq.never"><![CDATA[Nie]]></item>
+		<item name="wcf.acp.sitemap.rebuildTime"><![CDATA[Erneuerungszeit]]></item>
+		<item name="wcf.acp.sitemap.rebuildTime.description"><![CDATA[Die Zeit nachdem die Sitemap erneuert werden soll.]]></item>
+		<item name="wcf.acp.sitemap.isDisabled"><![CDATA[Sitemap deaktivieren]]></item>
+		<item name="wcf.acp.sitemap.enabled"><![CDATA[Sitemap aktiviert]]></item>
+		<item name="wcf.acp.sitemap.edit"><![CDATA[Sitemap bearbeiten]]></item>
+		<item name="wcf.acp.sitemap.cliInfo"><![CDATA[Die Sitemap kann auch mittels CLI neu generiert werden. Führe dafür <kbd>worker wcf\system\worker\SitemapRebuildWorker</kbd> in einer CLI Session aus.]]></item>
+		<item name="wcf.acp.sitemap.objectType.com.woltlab.wcf.sitemap.object.user"><![CDATA[Benutzer]]></item>
+		<item name="wcf.acp.sitemap.objectType.com.woltlab.wcf.sitemap.object.articleCategory"><![CDATA[Artikel-Kategorien]]></item>
+		<item name="wcf.acp.sitemap.objectType.com.woltlab.wcf.sitemap.object.article"><![CDATA[Artikel]]></item>
+		<item name="wcf.acp.sitemap.objectType.com.woltlab.wcf.sitemap.object.simplePage"><![CDATA[Einfache Seiten]]></item>
+		<item name="wcf.acp.sitemap.objectType.com.woltlab.wcf.sitemap.object.multilingualPage"><![CDATA[Mehrsprachige Seiten]]></item>
+	</category>
+	
+	<category name="wcf.acp.stat">
+		<item name="wcf.acp.stat"><![CDATA[Statistiken]]></item>
+		<item name="wcf.acp.stat.settings"><![CDATA[Einstellungen]]></item>
+		<item name="wcf.acp.stat.period"><![CDATA[Zeitraum]]></item>
+		<item name="wcf.acp.stat.value"><![CDATA[Werte]]></item>
+		<item name="wcf.acp.stat.value.counter"><![CDATA[Veränderung]]></item>
+		<item name="wcf.acp.stat.value.total"><![CDATA[Gesamtanzahl]]></item>
+		<item name="wcf.acp.stat.types"><![CDATA[Daten]]></item>
+		<item name="wcf.acp.stat.timeFormat.daily"><![CDATA[%d.%m.%y]]></item>
+		<item name="wcf.acp.stat.timeFormat.weekly"><![CDATA[%d.%m.%y]]></item>
+		<item name="wcf.acp.stat.timeFormat.monthly"><![CDATA[%b %Y]]></item>
+		<item name="wcf.acp.stat.timeFormat.yearly"><![CDATA[%Y]]></item>
+		<item name="wcf.acp.stat.com.woltlab.wcf.user"><![CDATA[Benutzer]]></item>
+		<item name="wcf.acp.stat.com.woltlab.wcf.attachment"><![CDATA[Dateianhänge]]></item>
+		<item name="wcf.acp.stat.com.woltlab.wcf.attachment.diskUsage"><![CDATA[Dateianhänge-Speicherbedarf (MB)]]></item>
+		<item name="wcf.acp.stat.com.woltlab.wcf.like"><![CDATA[Likes]]></item>
+		<item name="wcf.acp.stat.com.woltlab.wcf.dislike"><![CDATA[Dislikes]]></item>
+		<item name="wcf.acp.stat.com.woltlab.wcf.userProfileComment"><![CDATA[Pinnwand-Kommentare]]></item>
+		<item name="wcf.acp.stat.dateGrouping"><![CDATA[Zeiteinheit]]></item>
+		<item name="wcf.acp.stat.dateGrouping.daily"><![CDATA[Tag]]></item>
+		<item name="wcf.acp.stat.dateGrouping.weekly"><![CDATA[Woche]]></item>
+		<item name="wcf.acp.stat.dateGrouping.monthly"><![CDATA[Monat]]></item>
+		<item name="wcf.acp.stat.dateGrouping.yearly"><![CDATA[Jahr]]></item>
+		<item name="wcf.acp.stat.category.com.woltlab.wcf.general"><![CDATA[Allgemeine Daten]]></item>
+		<item name="wcf.acp.stat.category.com.woltlab.wcf.user"><![CDATA[Benutzer-Daten]]></item>
+		<item name="wcf.acp.stat.noData"><![CDATA[Es liegen keine Daten für den ausgewählten Zeitraum vor.]]></item>
+	</category>
+	
+	<category name="wcf.acp.updateServer">
+		<item name="wcf.acp.updateServer.add"><![CDATA[Server hinzufügen]]></item>
+		<item name="wcf.acp.updateServer.delete.sure"><![CDATA[Willst du den Server <span class="confirmationObject">{$updateServer->serverURL}</span> wirklich löschen?]]></item>
+		<item name="wcf.acp.updateServer.edit"><![CDATA[Server bearbeiten]]></item>
+		<item name="wcf.acp.updateServer.errorMessage"><![CDATA[Fehlermeldungen]]></item>
+		<item name="wcf.acp.updateServer.list"><![CDATA[Update-Server]]></item>
+		<item name="wcf.acp.updateServer.lastErrorMessage"><![CDATA[Beim letzten Verbindungsversuch trat folgender Fehler auf:]]></item>
+		<item name="wcf.acp.updateServer.loginPassword"><![CDATA[Kennwort]]></item>
+		<item name="wcf.acp.updateServer.loginPassword.description"><![CDATA[Kennwort für Authentifizierung (optional)]]></item>
+		<item name="wcf.acp.updateServer.loginUsername"><![CDATA[Benutzername]]></item>
+		<item name="wcf.acp.updateServer.loginUsername.description"><![CDATA[Benutzernamen für Authentifizierung (optional)]]></item>
+		<item name="wcf.acp.updateServer.packages"><![CDATA[Pakete]]></item>
+		<item name="wcf.acp.updateServer.serverURL"><![CDATA[Adresse]]></item>
+		<item name="wcf.acp.updateServer.serverURL.error.invalid"><![CDATA[Die eingetragene Adresse ist ungültig.]]></item>
+		<item name="wcf.acp.updateServer.status"><![CDATA[Status]]></item>
+		<item name="wcf.acp.updateServer.lastUpdateTime"><![CDATA[Letzter Zugriff]]></item>
+	</category>
+	
+	<category name="wcf.acp.sessionLog">
+		<item name="wcf.acp.sessionLog.access.list"><![CDATA[Aktionen der protokollierten Sitzung von „{$sessionLog->username}“]]></item>
+		<item name="wcf.acp.sessionLog.actions"><![CDATA[Aktionen]]></item>
+		<item name="wcf.acp.sessionLog.className"><![CDATA[Klasse]]></item>
+		<item name="wcf.acp.sessionLog.lastActivityTime"><![CDATA[Letzte Aktion]]></item>
+		<item name="wcf.acp.sessionLog.list"><![CDATA[Protokollierte Sitzungen]]></item>
+		<item name="wcf.acp.sessionLog.packageName"><![CDATA[Paket]]></item>
+		<item name="wcf.acp.sessionLog.requestMethod"><![CDATA[Methode]]></item>
+		<item name="wcf.acp.sessionLog.requestURI"><![CDATA[URI]]></item>
+		<item name="wcf.acp.sessionLog.time"><![CDATA[Datum]]></item>
+	</category>
+	
+	<category name="wcf.acp.smiley">
+		<item name="wcf.acp.smiley.list"><![CDATA[Smileys]]></item>
+		<item name="wcf.acp.smiley.delete.sure"><![CDATA[Willst du das Smiley <span class="confirmationObject">{$smiley->smileyTitle|language}</span> wirklich löschen?]]></item>
+		<item name="wcf.acp.smiley.add"><![CDATA[Smiley hinzufügen]]></item>
+		<item name="wcf.acp.smiley.edit"><![CDATA[Smiley bearbeiten]]></item>
+		<item name="wcf.acp.smiley.title"><![CDATA[Titel]]></item>
+		<item name="wcf.acp.smiley.category.add"><![CDATA[Smiley-Kategorie hinzufügen]]></item>
+		<item name="wcf.acp.smiley.category.edit"><![CDATA[Smiley-Kategorie bearbeiten]]></item>
+		<item name="wcf.acp.smiley.category.list"><![CDATA[Smiley-Kategorien]]></item>
+		<item name="wcf.acp.smiley.categoryID"><![CDATA[Kategorie]]></item>
+		<item name="wcf.acp.smiley.categoryID.default"><![CDATA[Standard-Kategorie]]></item>
+		<item name="wcf.acp.smiley.categoryID.error.invalid"><![CDATA[Die gewählte Kategorie ist ungültig.]]></item>
+		<item name="wcf.acp.smiley.smileyCode"><![CDATA[Primärer Smiley-Code]]></item>
+		<item name="wcf.acp.smiley.smileyCode.error.notUnique"><![CDATA[Dieser Smiley-Code wird bereits von einem anderen Smiley verwendet]]></item>
+		<item name="wcf.acp.smiley.aliases"><![CDATA[Alternative Smiley-Codes]]></item>
+		<item name="wcf.acp.smiley.aliases.error.notUnique"><![CDATA[Mindestens ein alternativer Smiley-Code wird bereits von einem anderen Smiley verwendet]]></item>
+		<item name="wcf.acp.smiley.smileyPath"><![CDATA[Smiley-Pfad]]></item>
+		<item name="wcf.acp.smiley.smileyPath.description"><![CDATA[Der Smiley-Pfad wird relativ zu „{$__wcf->getPath()}“ interpretiert.]]></item>
+		<item name="wcf.acp.smiley.smileyPath.error.notFound"><![CDATA[Es wurde keine Datei unter dem angegebenen Pfad gefunden]]></item>
+		<item name="wcf.acp.smiley.smileyFile"><![CDATA[Smiley-Datei]]></item>
+		<item name="wcf.acp.smiley.smileyFile2x"><![CDATA[Smiley-Datei (HD)]]></item>
+		<item name="wcf.acp.smiley.smileyFile2x.description"><![CDATA[Optionale Grafik, die auf hochauflösenden Bildschirmen (z.B. Apple Retina-Display oder 4K/UHD-Monitore) verwendet wird. Diese muss doppelt so groß sein wie die normale Grafik.]]></item>
+		<item name="wcf.acp.smiley.fileUpload"><![CDATA[Smiley hochladen]]></item>
+		<item name="wcf.acp.smiley.fileUpload.description"><![CDATA[Lade hier die Bilddatei des Smileys hoch.]]></item>
+		<item name="wcf.acp.smiley.fileUpload.error.noImage"><![CDATA[Bei der hochgeladenen Datei handelt es sich um keine Bilddatei.]]></item>
+		<item name="wcf.acp.smiley.fileUpload.error.uploadFailed"><![CDATA[Beim Hochladen der Datei ist ein unbekannter Fehler aufgetreten.]]></item>
+	</category>
+	
+	<category name="wcf.acp.style">
+		<item name="wcf.acp.style.add"><![CDATA[Stil hinzufügen]]></item>
+		<item name="wcf.acp.style.advanced"><![CDATA[Erweiterte Einstellungen]]></item>
+		<item name="wcf.acp.style.advanced.custom"><![CDATA[Eigene Deklarationen]]></item>
+		<item name="wcf.acp.style.advanced.individualScss"><![CDATA[Individuelles CSS und SCSS]]></item>
+		<item name="wcf.acp.style.advanced.individualScss.description"><![CDATA[Die Eingabe wird am Ende des Stils eingefügt und kann vollständig aus CSS bestehen. Du hast zusätzlich den Zugriff auf SCSS und alle von WoltLab Suite Core zur Verfügung gestellten Mixins.]]></item>
+		<item name="wcf.acp.style.advanced.original"><![CDATA[Vorgegebene Deklarationen]]></item>
+		<item name="wcf.acp.style.advanced.overrideScss"><![CDATA[Überschreiben von SCSS-Variablen]]></item>
+		<item name="wcf.acp.style.advanced.overrideScss.description"><![CDATA[Du kannst innerhalb dieser Eingabe beliebige SCSS-Variablen überschreiben, die nicht durch den Stil-Editor direkt bearbeitbar sind. Beim Bezug auf andere Variablen muss sichergestellt werden, dass diese in der Reihenfolge vorher definiert wurden. Die Syntax muss wie folgt lauten: „$variableName: variableValue;“]]></item>
+		<item name="wcf.acp.style.advanced.overrideScss.error"><![CDATA[Deine Eingabe war ungültig, bitte überprüfe die folgenden Einträge:]]></item>
+		<item name="wcf.acp.style.advanced.overrideScss.error.invalid"><![CDATA[Eingabe „{$error[text]}“ ungültig]]></item>
+		<item name="wcf.acp.style.advanced.overrideScss.error.predefined"><![CDATA[Variable „{$error[text]}“ wird bereits durch den Stil-Editor gesetzt]]></item>
+		<item name="wcf.acp.style.advanced.overrideScss.error.unknown"><![CDATA[Variable „{$error[text]}“ unbekannt]]></item>
+		<item name="wcf.acp.style.authorName"><![CDATA[Autor]]></item>
+		<item name="wcf.acp.style.authorURL"><![CDATA[Website]]></item>
+		<item name="wcf.acp.style.button.exportStyle"><![CDATA[Export starten]]></item>
+		<item name="wcf.acp.style.button.setAsDefault"><![CDATA[Zum Standard machen]]></item>
+		<item name="wcf.acp.style.colors"><![CDATA[Farbpalette]]></item>
+		<item name="wcf.acp.style.colors.accentBackgroundColor"><![CDATA[Hintergrundfarbe (Akzent)]]></item>
+		<item name="wcf.acp.style.colors.backgroundColor"><![CDATA[Hintergrundfarbe]]></item>
+		<item name="wcf.acp.style.colors.borderColor"><![CDATA[Rahmenfarbe]]></item>
+		<item name="wcf.acp.style.colors.buttons"><![CDATA[Buttons]]></item>
+		<item name="wcf.acp.style.colors.container"><![CDATA[Container]]></item>
+		<item name="wcf.acp.style.colors.content"><![CDATA[Inhaltsbereich]]></item>
+		<item name="wcf.acp.style.colors.color"><![CDATA[Schriftfarbe]]></item>
+		<item name="wcf.acp.style.colors.description"><![CDATA[Wählen Sie eine Kategorie aus, um die Farbpalette zu bearbeiten.]]></item>
+		<item name="wcf.acp.style.colors.dimmedColor"><![CDATA[Schriftfarbe (abgeschwächt)]]></item>
+		<item name="wcf.acp.style.colors.formInput"><![CDATA[Eingabeelemente in Formularen]]></item>
+		<item name="wcf.acp.style.colors.hoverBackgroundColor"><![CDATA[Hintergrundfarbe (Hover)]]></item>
+		<item name="wcf.acp.style.colors.hoverBorderColor"><![CDATA[Rahmenfarbe (Hover)]]></item>
+		<item name="wcf.acp.style.colors.hoverColor"><![CDATA[Schriftfarbe (Hover)]]></item>
+		<item name="wcf.acp.style.colors.linkColor"><![CDATA[Linkfarbe]]></item>
+		<item name="wcf.acp.style.colors.linkHoverColor"><![CDATA[Linkfarbe (Hover)]]></item>
+		<item name="wcf.acp.style.colors.page"><![CDATA[Seite]]></item>
+		<item name="wcf.acp.style.colors.primaryBackgroundColor"><![CDATA[Hintergrundfarbe (primär)]]></item>
+		<item name="wcf.acp.style.colors.primaryBorderColor"><![CDATA[Rahmenfarbe (primär)]]></item>
+		<item name="wcf.acp.style.colors.primaryColor"><![CDATA[Schriftfarbe (primär)]]></item>
+		<item name="wcf.acp.style.colors.selectCategoryByClick"><![CDATA[Kategorie-Direktauswahl]]></item>
+		<item name="wcf.acp.style.colors.tabular"><![CDATA[Tabellarische Auflistungen]]></item>
+		<item name="wcf.acp.style.colors.toggleColorPalette"><![CDATA[Ansicht umschalten]]></item>
+		<item name="wcf.acp.style.colors.userPanel"><![CDATA[Benutzerleiste]]></item>
+		<item name="wcf.acp.style.copyright"><![CDATA[Copyright]]></item>
+		<item name="wcf.acp.style.copyStyle"><![CDATA[Stil kopieren]]></item>
+		<item name="wcf.acp.style.copyStyle.confirmMessage"><![CDATA[Willst du den Stil <span class="confirmationObject">{$style->styleName}</span> wirklich duplizieren?]]></item>
+		<item name="wcf.acp.style.delete.confirmMessage"><![CDATA[Willst du den Stil <span class="confirmationObject">{$style->styleName}</span> wirklich löschen?]]></item>
+		<item name="wcf.acp.style.edit"><![CDATA[Stil bearbeiten]]></item>
+		<item name="wcf.acp.style.exportAsPackage"><![CDATA[Als Paket exportieren]]></item>
+		<item name="wcf.acp.style.exportImages"><![CDATA[Grafiken exportieren ({$style->imagePath})]]></item>
+		<item name="wcf.acp.style.exportTemplates"><![CDATA[Templates exportieren]]></item>
+		<item name="wcf.acp.style.exportStyle"><![CDATA[Stil exportieren]]></item>
+		<item name="wcf.acp.style.exportStyle.asPackage"><![CDATA[Export als Paket]]></item>
+		<item name="wcf.acp.style.exportStyle.asPackage.description"><![CDATA[Wähle hier aus, ob du den Stil „{$style->styleName}“ als Paket exportieren möchtest. Pakete können über die Paketverwaltung installiert oder in den <a href="{@$__wcf->getPath()}acp/dereferrer.php?url=http://www.woltlab.com/de/pluginstore/">WoltLab® Plugin-Store</a> hochgeladen werden.]]></item>
+		<item name="wcf.acp.style.exportStyle.components"><![CDATA[Optionen]]></item>
+		<item name="wcf.acp.style.exportStyle.components.description"><![CDATA[Wähle hier aus, welche Bestandteile des Stils „{$style->styleName}“ mit exportiert werden sollen.]]></item>
+		<item name="wcf.acp.style.general"><![CDATA[Daten]]></item>
+		<item name="wcf.acp.style.general.files"><![CDATA[Dateien]]></item>
+		<item name="wcf.acp.style.globals"><![CDATA[Globale Einstellungen]]></item>
+		<item name="wcf.acp.style.globals.fixedLayoutWidth"><![CDATA[Breite]]></item>
+		<item name="wcf.acp.style.globals.fluidLayoutMinWidth"><![CDATA[Mindestbreite]]></item>
+		<item name="wcf.acp.style.globals.fluidLayoutMaxWidth"><![CDATA[Höchstbreite]]></item>
+		<item name="wcf.acp.style.globals.font"><![CDATA[Schriftbild]]></item>
+		<item name="wcf.acp.style.globals.fontFamily"><![CDATA[Schriftart]]></item>
+		<item name="wcf.acp.style.globals.fontSize"><![CDATA[Schriftgröße]]></item>
+		<item name="wcf.acp.style.globals.layout"><![CDATA[Layout]]></item>
+		<item name="wcf.acp.style.globals.useFluidLayout"><![CDATA[Flexible Breite verwenden]]></item>
+		<item name="wcf.acp.style.image"><![CDATA[Vorschaubild]]></item>
+		<item name="wcf.acp.style.image.description"><![CDATA[Lade hier ein Vorschaubild dieses Stiles hoch, als Bildformate sind JPG und PNG zulässig. Es wird empfohlen Vorschaubilder immer mit der Größe 102px × 64px anzulegen, größere Grafiken werden automatisch skaliert.]]></item>
+		<item name="wcf.acp.style.imagePath"><![CDATA[Bilder-Pfad]]></item>
+		<item name="wcf.acp.style.imagePath.description"><![CDATA[Wenn dein Stil eigene Grafiken benötigt, solltest du diese in einem Unterordner des Ordners „images“ ablegen. Gib hier den Pfad zu diesem Ordner an.]]></item>
+		<item name="wcf.acp.style.importStyle"><![CDATA[Stil importieren]]></item>
+		<item name="wcf.acp.style.import.source"><![CDATA[Datenquelle]]></item>
+		<item name="wcf.acp.style.import.source.upload"><![CDATA[Stil hochladen]]></item>
+		<item name="wcf.acp.style.import.source.upload.description"><![CDATA[Gib eine Stil-Datei von deinem lokalen Rechner an.]]></item>
+		<item name="wcf.acp.style.import.source.error.importFailed"><![CDATA[Der Stil konnte nicht importiert werden. Es handelt sich nicht um eine gültige Stil-Datei.]]></item>
+		<item name="wcf.acp.style.license"><![CDATA[Lizenz]]></item>
+		<item name="wcf.acp.style.list"><![CDATA[Stile]]></item>
+		<item name="wcf.acp.style.packageName"><![CDATA[Paketbezeichner]]></item>
+		<item name="wcf.acp.style.packageName.description"><![CDATA[Gib hier optional den Paketbezeichner in der Form „tld.domain.paketName“ an. Wenn dir beispielsweise die Domain „example.com“ gehört und dein Stil „Blue Sunrise“ heißt, so wäre „com.example.style.blueSunrise“ ein passender und gültiger Paketbezeichner.]]></item>
+		<item name="wcf.acp.style.packageName.error.invalid"><![CDATA[Der eingegebene Paketbezeichner ist ungültig]]></item>
+		<item name="wcf.acp.style.packageName.error.reserved"><![CDATA[Der Paketbezeichner darf nicht mit „com.woltlab.“ beginnen]]></item>
+		<item name="wcf.acp.style.protected"><![CDATA[Dieser Stil ist geschützt und kann nur eingeschränkt verändert werden, du kannst diesen <a class="jsStaticDialog" data-dialog-id="styleDisableProtection">Schutz aufheben</a>.]]></item>
+		<item name="wcf.acp.style.protected.confirm"><![CDATA[Schutz aufheben]]></item>
+		<item name="wcf.acp.style.protected.description"><![CDATA[Importierte bzw. installierte Stile erhalten automatisch einen geschützten Status, dieser unterbindet die Veränderungen der unmittelbar durch den Stil vorgegebenen Deklarationen. Die Aufhebung dieses Schutzes gestattet dir die vollständige Veränderung, verhindert dadurch aber auch eine Aktualisierung mit einer neueren Version des Stils, beispielsweise im Rahmen eines Updates.<br><br>Dieser Schritt wird nicht empfohlen und ist grundsätzlich nicht notwendig, Stile können weiterhin nach belieben angepasst werden, nur die Vorlage selbst kann nicht verändert werden.<br><br>Bitte speicher eventuelle vorgenommene Änderungen bevor du diesen Schritt ausführst.]]></item>
+		<item name="wcf.acp.style.protected.less"><![CDATA[Nur lesend]]></item>
+		<item name="wcf.acp.style.protected.title"><![CDATA[Schutz aufheben]]></item>
+		<item name="wcf.acp.style.styleDate"><![CDATA[Datum]]></item>
+		<item name="wcf.acp.style.styleDescription"><![CDATA[Beschreibung]]></item>
+		<item name="wcf.acp.style.styleName"><![CDATA[Name]]></item>
+		<item name="wcf.acp.style.styleVersion"><![CDATA[Version]]></item>
+		<item name="wcf.acp.style.templateGroupID"><![CDATA[Templategruppe]]></item>
+		<item name="wcf.acp.style.users"><![CDATA[Benutzer]]></item>
+		<item name="wcf.acp.style.image.error.invalidExtension"><![CDATA[Die Datei hat eine ungültige Dateiendung.]]></item>
+		<item name="wcf.acp.style.imagePath.error.invalid"><![CDATA[Du hast einen ungültigen Pfad eingegeben.]]></item>
+		<item name="wcf.acp.style.styleVersion.error.invalid"><![CDATA[Du hast eine ungültige Versionsnummer eingegeben.]]></item>
+		<item name="wcf.acp.style.styleDate.error.invalid"><![CDATA[Du hast ein ungültiges Datum eingegeben.]]></item>
+		<item name="wcf.acp.style.globals.pageLogo"><![CDATA[Seitenlogo]]></item>
+		<item name="wcf.acp.style.globals.pageLogo.description"><![CDATA[Name der Grafik-Datei für das Seitenlogo]]></item>
+		<item name="wcf.acp.style.globals.pageLogo.width"><![CDATA[Breite des Seitenlogos]]></item>
+		<item name="wcf.acp.style.globals.pageLogo.height"><![CDATA[Höhe des Seitenlogos]]></item>
+		<item name="wcf.acp.style.globals.pageLogoMobile"><![CDATA[Seitenlogo (mobile Version)]]></item>
+		<item name="wcf.acp.style.globals.pageLogoMobile.description"><![CDATA[Name der Grafik-Datei für das Seitenlogo (mobile Version)]]></item>
+		<item name="wcf.acp.style.globals.fontSizeDefault"><![CDATA[Schriftgröße (Standard)]]></item>
+		<item name="wcf.acp.style.globals.fontSizeSmall"><![CDATA[Schriftgröße (klein)]]></item>
+		<item name="wcf.acp.style.globals.fontSizeHeadline"><![CDATA[Schriftgröße (Überschrift)]]></item>
+		<item name="wcf.acp.style.globals.fontSizeSection"><![CDATA[Schriftgröße (Sektions-Überschrift)]]></item>
+		<item name="wcf.acp.style.globals.fontSizeTitle"><![CDATA[Schriftgröße (Seiten-Titel)]]></item>
+		<item name="wcf.acp.style.globals.useGoogleFont"><![CDATA[Google-Schriftart aktivieren]]></item>
+		<item name="wcf.acp.style.globals.fontFamilyGoogle"><![CDATA[Schriftart]]></item>
+		<item name="wcf.acp.style.globals.fontFamilyFallback"><![CDATA[Schriftart (Fallback)]]></item>
+		<item name="wcf.acp.style.general.favicon"><![CDATA[Favicon]]></item>
+		<item name="wcf.acp.style.favicon"><![CDATA[Individuelles Favicon]]></item>
+		<item name="wcf.acp.style.favicon.description"><![CDATA[Laden Sie hier ein 256px × 256px großes Bild hoch, als Bildformate sind JPG und PNG zulässig. Das hochgeladene Bild wird für die Erzeugung aller notwendigen Grafiken verwendet.]]></item>
+		<item name="wcf.acp.style.favicon.error.dimensions"><![CDATA[Das Bild muss exakt 256px × 256px groß sein.]]></item>
+		<item name="wcf.acp.style.favicon.error.invalidExtension"><![CDATA[Die Datei hat eine ungültige Dateiendung.]]></item>
+	</category>
+	
+	<category name="wcf.acp.tag">
+		<item name="wcf.acp.tag.add"><![CDATA[Tag hinzufügen]]></item>
+		<item name="wcf.acp.tag.edit"><![CDATA[Tag bearbeiten]]></item>
+		<item name="wcf.acp.tag.delete.sure"><![CDATA[Willst du den Tag <span class="confirmationObject">{$tag}</span> wirklich löschen?]]></item>
+		<item name="wcf.acp.tag.error.languageID.notFound"><![CDATA[Die gewählte Sprache ist ungültig]]></item>
+		<item name="wcf.acp.tag.languageID"><![CDATA[Sprache]]></item>
+		<item name="wcf.acp.tag.list"><![CDATA[Tags]]></item>
+		<item name="wcf.acp.tag.list.search"><![CDATA[Tags suchen]]></item>
+		<item name="wcf.acp.tag.list.search.query"><![CDATA[Suchbegriff]]></item>
+		<item name="wcf.acp.tag.name"><![CDATA[Name]]></item>
+		<item name="wcf.acp.tag.synonyms"><![CDATA[Synonyme]]></item>
+		<item name="wcf.acp.tag.synonymFor"><![CDATA[Synonym für]]></item>
+		<item name="wcf.acp.tag.usageCount"><![CDATA[Verwendungen]]></item>
+		<item name="wcf.acp.tag.error.name.duplicate"><![CDATA[Ein Tag mit diesem Namen existiert bereits.]]></item>
+		<item name="wcf.acp.tag.setAsSynonyms"><![CDATA[Als Synonyme verwenden]]></item>
+		<item name="wcf.acp.tag.setAsSynonyms.description"><![CDATA[Wähle einen Tag aus. Die übrigen Tags werden als Synonyme des ausgewählten Tags verwendet.]]></item>
+	</category>
+	
+	<category name="wcf.acp.template">
+		<item name="wcf.acp.template.list"><![CDATA[Templates]]></item>
+		<item name="wcf.acp.template.group"><![CDATA[Templategruppe]]></item>
+		<item name="wcf.acp.template.group.default"><![CDATA[Standardtemplates]]></item>
+		<item name="wcf.acp.template.group.email"><![CDATA[E-Mail-Templates]]></item>
+		<item name="wcf.acp.template.application"><![CDATA[App]]></item>
+		<item name="wcf.acp.template.add"><![CDATA[Template hinzufügen]]></item>
+		<item name="wcf.acp.template.edit"><![CDATA[Template bearbeiten]]></item>
+		<item name="wcf.acp.template.copy"><![CDATA[Template kopieren]]></item>
+		<item name="wcf.acp.template.diff"><![CDATA[Unterschiede anzeigen]]></item>
+		<item name="wcf.acp.template.diff.compareWith"><![CDATA[Vergleichen mit]]></item>
+		<item name="wcf.acp.template.lastModificationTime"><![CDATA[Letzte Änderung]]></item>
+		<item name="wcf.acp.template.group.list"><![CDATA[Templategruppen]]></item>
+		<item name="wcf.acp.template.group.add"><![CDATA[Templategruppe hinzufügen]]></item>
+		<item name="wcf.acp.template.group.edit"><![CDATA[Templategruppe bearbeiten]]></item>
+		<item name="wcf.acp.template.group.templates"><![CDATA[Templates]]></item>
+		<item name="wcf.acp.template.error.noGroups"><![CDATA[Bevor du ein eigenes Template erstellen kannst, musst du eine <a href="{link controller='TemplateGroupAdd'}{/link}">Templategruppe hinzufügen</a>.]]></item>
+		<item name="wcf.acp.template.group.folderName"><![CDATA[Verzeichnis]]></item>
+		<item name="wcf.acp.template.group.parentTemplateGroup"><![CDATA[Übergeordnete Templategruppe]]></item>
+		<item name="wcf.acp.template.group.name.error.notUnique"><![CDATA[Der eingegebene Name wird bereits von einer anderen Templategruppe verwendet.]]></item>
+		<item name="wcf.acp.template.group.folderName.error.invalid"><![CDATA[Du hast einen ungültigen Verzeichnis-Namen eingegeben.]]></item>
+		<item name="wcf.acp.template.group.folderName.error.notUnique"><![CDATA[Das angegebene Verzeichnis wird bereits von einer anderen Templategruppe verwendet.]]></item>
+		<item name="wcf.acp.template.group.parentTemplateGroupID.error.invalid"><![CDATA[Die ausgewählte übergeordnete Templategruppe ist ungültig.]]></item>
+		<item name="wcf.acp.template.group.delete.sure"><![CDATA[Willst du die Templategruppe <span class="confirmationObject">{$templateGroup->getName()}</span> wirklich löschen?]]></item>
+		<item name="wcf.acp.template.source"><![CDATA[Template-Quelltext]]></item>
+		<item name="wcf.acp.template.name.error.notUnique"><![CDATA[Der eingegebene Name wird bereits von einem anderen Template verwendet.]]></item>
+		<item name="wcf.acp.template.name.error.invalid"><![CDATA[Du hast einen ungültigen Namen eingegeben.]]></item>
+		<item name="wcf.acp.template.delete.sure"><![CDATA[Willst du das Template <span class="confirmationObject">{$template->templateName}</span> wirklich löschen?]]></item>
+	</category>
+	
+	<category name="wcf.acp.user">
+		<item name="wcf.acp.user.add"><![CDATA[Benutzer hinzufügen]]></item>
+		<item name="wcf.acp.user.assignToGroup"><![CDATA[Benutzergruppe zuweisen]]></item>
+		<item name="wcf.acp.user.assignToGroup.markedUsers"><![CDATA[Folgende Benutzer den unten ausgewählten Benutzergruppen zuweisen]]></item>
+		<item name="wcf.acp.user.assignToGroup.success"><![CDATA[{if $users|count > 1}Die{else}Der{/if} Benutzer wurde{if $users|count > 1}n{/if} erfolgreich {if $groupIDs|count > 1}den ausgewählten Benutzergruppen{else}der ausgewählten Benutzergruppe{/if} zugeordnet.]]></item>
+		<item name="wcf.acp.user.banUser"><![CDATA[Benutzer sperren]]></item>
+		<item name="wcf.acp.user.banUser.description"><![CDATA[Der Benutzer wird dauerhaft von der Nutzung aller Funktionen ausgeschlossen und erhält beim Aufruf der Seite eine entsprechende Fehlermeldung.]]></item>
+		<item name="wcf.acp.user.banReason"><![CDATA[Begründung]]></item>
+		<item name="wcf.acp.user.banReason.description"><![CDATA[Die Begründung wird dem gesperrten Benutzer beim Aufruf der Seite angezeigt.]]></item>
+		<item name="wcf.acp.user.ban"><![CDATA[Sperren]]></item>
+		<item name="wcf.acp.user.unban"><![CDATA[Sperrung aufheben]]></item>
+		<item name="wcf.acp.user.ban.expires"><![CDATA[Entsperrung]]></item>
+		<item name="wcf.acp.user.ban.expires.description"><![CDATA[Der Benutzer wird zum festgelegten Zeitpunkt automatisch entsperrt.]]></item>
+		<item name="wcf.acp.user.ban.neverExpires"><![CDATA[Dauerhafte Sperrung]]></item>
+		<item name="wcf.acp.user.ban.sure"><![CDATA[Willst du den/die Benutzer wirklich sperren?]]></item>
+		<item name="wcf.acp.user.delete.sure"><![CDATA[Willst du den Benutzer <span class="confirmationObject">{$user->username}</span> wirklich löschen?]]></item>
+		<item name="wcf.acp.user.edit"><![CDATA[Benutzer bearbeiten]]></item>
+		<item name="wcf.acp.user.edit.warning.selfEdit"><![CDATA[Du bearbeitest dein eigenes Benutzerkonto. Änderungen an den Mitgliedschaften in Benutzergruppen können womöglich dazu führen, dass du aus der Administrationsoberfläche ausgeschlossen wirst. Bitte sei entsprechend vorsichtig!]]></item>
+		<item name="wcf.acp.user.exportEmailAddress"><![CDATA[E-Mail-Adressen exportieren]]></item>
+		<item name="wcf.acp.user.exportEmailAddress.fileType"><![CDATA[Exportformat]]></item>
+		<item name="wcf.acp.user.exportEmailAddress.fileType.csv"><![CDATA[CSV (<em>Character Separated Values</em>)]]></item>
+		<item name="wcf.acp.user.exportEmailAddress.fileType.xml"><![CDATA[XML (<em>Extensible Markup Language</em>)]]></item>
+		<item name="wcf.acp.user.exportEmailAddress.format"><![CDATA[Exporteinstellungen]]></item>
+		<item name="wcf.acp.user.exportEmailAddress.markedUsers"><![CDATA[E-Mail-Adressen von folgenden Benutzern exportieren]]></item>
+		<item name="wcf.acp.user.exportEmailAddress.separator"><![CDATA[Trennzeichen]]></item>
+		<item name="wcf.acp.user.exportEmailAddress.textSeparator"><![CDATA[Texttrenner]]></item>
+		<item name="wcf.acp.user.groups"><![CDATA[Benutzergruppe(n)]]></item>
+		<item name="wcf.acp.user.groups.invertSearch"><![CDATA[Finde Benutzer, die nicht Mitglied der ausgewählten Benutzergruppen sind.]]></item>
+		<item name="wcf.acp.user.list"><![CDATA[Benutzer]]></item>
+		<item name="wcf.acp.user.list.all"><![CDATA[Alle Benutzer]]></item>
+		<item name="wcf.acp.user.list.count"><![CDATA[{#$items} Benutzer]]></item>
+		<item name="wcf.acp.user.merge"><![CDATA[Benutzer zusammenfügen]]></item>
+		<item name="wcf.acp.user.merge.destination"><![CDATA[Ziel]]></item>
+		<item name="wcf.acp.user.merge.destination.description"><![CDATA[Die ausgewählten Benutzer werden in dieses Benutzerkonto zusammengefügt.]]></item>
+		<item name="wcf.acp.user.merge.markedUsers"><![CDATA[Folgende Benutzer zusammenfügen]]></item>
+		<item name="wcf.acp.user.merge.warning"><![CDATA[Das Zusammenfügen von Benutzern aktualisiert aus technischen Gründen nicht alle Verweise, Anzeigen und Zähler. Es ist daher notwendig, dass du nach der Durchführung die entsprechenden Wartungsaufgaben ausführen lässt, um die Anzeigen zu aktualisieren.]]></item>
+		<item name="wcf.acp.user.revertChanges"><![CDATA[Änderungen an Inhalten zurücksetzen]]></item>
+		<item name="wcf.acp.user.revertChanges.timeframe"><![CDATA[Zeitraum]]></item>
+		<item name="wcf.acp.user.revertChanges.timeframe.description"><![CDATA[Zeitraum in dem Änderungen des Benutzers zurückgesetzt werden sollen. Inhalte werden auf die neuste Version, welche entweder älter als der angegebene Zeitraum ist oder welche von einem anderen Nutzer stammt, zurückgesetzt. [Zeitraum in Tagen]]]></item>
+		<item name="wcf.acp.user.revertChanges.markedUsers"><![CDATA[Änderungen folgender Nutzer zurücksetzen]]></item>
+		<item name="wcf.acp.user.search"><![CDATA[Benutzer suchen]]></item>
+		<item name="wcf.acp.user.search.conditions.profile"><![CDATA[Profil]]></item>
+		<item name="wcf.acp.user.search.display"><![CDATA[Darstellung]]></item>
+		<item name="wcf.acp.user.search.display.columns"><![CDATA[Spalten]]></item>
+		<item name="wcf.acp.user.search.display.columns.other"><![CDATA[Sonstiges]]></item>
+		<item name="wcf.acp.user.search.display.columns.profile"><![CDATA[Profil]]></item>
+		<item name="wcf.acp.user.search.display.general"><![CDATA[Allgemein]]></item>
+		<item name="wcf.acp.user.search.display.itemsPerPage"><![CDATA[Benutzer pro Seite]]></item>
+		<item name="wcf.acp.user.search.display.sort"><![CDATA[Sortierung]]></item>
+		<item name="wcf.acp.user.search.error.noMatches"><![CDATA[Zu den angegebenen Kriterien wurde kein Benutzer gefunden.]]></item>
+		<item name="wcf.acp.user.search.matches"><![CDATA[{if $items == 1}Ein Ergebnis{else}{#$items} Ergebnisse{/if}]]></item>
+		<item name="wcf.acp.user.sendMail"><![CDATA[E-Mail an Benutzer senden]]></item>
+		<item name="wcf.acp.user.sendMail.all"><![CDATA[E-Mail an alle Benutzer senden]]></item>
+		<item name="wcf.acp.user.sendMail.enableHTML"><![CDATA[E-Mail als HTML versenden]]></item>
+		<item name="wcf.acp.user.sendMail.from"><![CDATA[Absender]]></item>
+		<item name="wcf.acp.user.sendMail.from.description"><![CDATA[Hier kannst du die E-Mail-Adresse des Absenders definieren.<br>
+Wenn du unter „Konfiguration » Optionen » Allgemein » E-Mails“ alles ausgefüllt hast, wird dieses Feld automatisch ausgefüllt. Solltest du E-Mails per SMTP senden, so achte darauf, dass die E-Mail-Adresse des Absenders auch vom Server akzeptiert werden muss.]]></item>
+		<item name="wcf.acp.user.sendMail.fromName"><![CDATA[Absender-Name]]></item>
+		<item name="wcf.acp.user.sendMail.group"><![CDATA[E-Mail an Gruppenmitglieder senden]]></item>
+		<item name="wcf.acp.user.sendMail.groups"><![CDATA[E-Mail an die Mitglieder folgender Benutzergruppen senden]]></item>
+		<item name="wcf.acp.user.sendMail.mail"><![CDATA[E-Mail]]></item>
+		<item name="wcf.acp.user.sendMail.markedUsers"><![CDATA[E-Mail an folgende Benutzer senden]]></item>
+		<item name="wcf.acp.user.sendMail.subject"><![CDATA[Betreff]]></item>
+		<item name="wcf.acp.user.sendMail.text"><![CDATA[Nachricht]]></item>
+		<item name="wcf.acp.user.quickSearch"><![CDATA[Schnellsuche]]></item>
+		<item name="wcf.acp.user.quickSearch.banned"><![CDATA[Gesperrte Benutzer]]></item>
+		<item name="wcf.acp.user.quickSearch.newest"><![CDATA[Neueste Benutzer]]></item>
+		<item name="wcf.acp.user.option.access"><![CDATA[Zugriff]]></item>
+		<item name="wcf.acp.user.option.add"><![CDATA[Benutzerprofilfeld hinzufügen]]></item>
+		<item name="wcf.acp.user.option.category.add"><![CDATA[Benutzerprofilfeld-Kategorie hinzufügen]]></item>
+		<item name="wcf.acp.user.option.category.delete.sure"><![CDATA[Willst du die Benutzerprofilfeld-Kategorie <span class="confirmationObject">{lang}wcf.user.option.category.{$category->categoryName}{/lang}</span> wirklich löschen?]]></item>
+		<item name="wcf.acp.user.option.category.edit"><![CDATA[Benutzerprofilfeld-Kategorie bearbeiten]]></item>
+		<item name="wcf.acp.user.option.category.options"><![CDATA[Felder]]></item>
+		<item name="wcf.acp.user.option.category.list"><![CDATA[Benutzerprofilfeld-Kategorien]]></item>
+		<item name="wcf.acp.user.option.categoryName"><![CDATA[Kategorie]]></item>
+		<item name="wcf.acp.user.option.defaultValue"><![CDATA[Standardwert]]></item>
+		<item name="wcf.acp.user.option.defaultValue.description"><![CDATA[Wert, der beim erstmaligen Ausfüllen als Standard vorgegeben ist.]]></item>
+		<item name="wcf.acp.user.option.delete.sure"><![CDATA[Willst du das Benutzerprofilfeld <span class="confirmationObject">{lang}wcf.user.option.{$option->optionName}{/lang}</span> wirklich löschen?]]></item>
+		<item name="wcf.acp.user.option.description"><![CDATA[Beschreibung]]></item>
+		<item name="wcf.acp.user.option.edit"><![CDATA[Benutzerprofilfeld bearbeiten]]></item>
+		<item name="wcf.acp.user.option.editable"><![CDATA[Wer darf den Inhalt verändern?]]></item>
+		<item name="wcf.acp.user.option.editable.1"><![CDATA[Eigentümer]]></item>
+		<item name="wcf.acp.user.option.editable.2"><![CDATA[Administrator]]></item>
+		<item name="wcf.acp.user.option.editable.3"><![CDATA[Eigentümer und Administrator]]></item>
+		<item name="wcf.acp.user.option.editable.6"><![CDATA[Eigentümer bei Erstanmeldung und Administrator]]></item>
+		<item name="wcf.acp.user.option.optionType"><![CDATA[Feldtyp]]></item>
+		<item name="wcf.acp.user.option.optionType.description"><![CDATA[Die Namen entsprechen in der Regel den HTML-Elementen, die benötigt werden, um so ein Feld beim Benutzer abzufragen.]]></item>
+		<item name="wcf.acp.user.option.askDuringRegistration"><![CDATA[Das Feld wird im Registrierungs-Formular angezeigt.]]></item>
+		<item name="wcf.acp.user.option.required"><![CDATA[Das Feld muss zwingend durch den Eigentümer ausgefüllt werden.]]></item>
+		<item name="wcf.acp.user.option.searchable"><![CDATA[Das Feld kann über die Mitgliedersuche durchsucht werden.]]></item>
+		<item name="wcf.acp.user.option.selectOptions"><![CDATA[Auswahloptionen]]></item>
+		<item name="wcf.acp.user.option.selectOptions.description"><![CDATA[Hier kannst du pro Zeile Auswahloptionen eintragen, beispielsweise bei einer Select-Box. Beachte, dass bei der Verwendung des Doppelpunktes der linke Teil der Zeile als interner Bezeichner verwendet wird. Dieser erlaubt es den Text zu ändern, ohne, dass die Auswahl von Benutzern verloren geht.]]></item>
+		<item name="wcf.acp.user.option.setDefaults"><![CDATA[Benutzerprofil-Einstellungen verwalten]]></item>
+		<item name="wcf.acp.user.option.setDefaults.applyChangesToExistingUsers"><![CDATA[Änderungen auch auf bestehende Benutzerkonten anwenden]]></item>
+		<item name="wcf.acp.user.option.setDefaults.applyChangesToExistingUsers.description"><![CDATA[Die hier eingestellten Änderungen der Vorgabewerte für Benutzerprofil-Einstellungen werden auch in bestehende Benutzerkonten übernommen. Die entsprechenden Einstellungen der Benutzer werden dabei überschrieben.]]></item>
+		<item name="wcf.acp.user.option.validationPattern"><![CDATA[Regulärer Ausdruck zur Validierung]]></item>
+		<item name="wcf.acp.user.option.validationPattern.description"><![CDATA[Trage hier den regulären Ausdruck ein, um die Eingabe der Benutzer zu validieren.]]></item>
+		<item name="wcf.acp.user.option.list"><![CDATA[Benutzerprofilfelder]]></item>
+		<item name="wcf.acp.user.option.visible"><![CDATA[Wer darf den Inhalt sehen?]]></item>
+		<item name="wcf.acp.user.option.visible.0"><![CDATA[Niemand]]></item>
+		<item name="wcf.acp.user.option.visible.1"><![CDATA[Eigentümer]]></item>
+		<item name="wcf.acp.user.option.visible.2"><![CDATA[Administrator]]></item>
+		<item name="wcf.acp.user.option.visible.3"><![CDATA[Eigentümer und Administrator]]></item>
+		<item name="wcf.acp.user.option.visible.7"><![CDATA[Registrierte Benutzer]]></item>
+		<item name="wcf.acp.user.option.visible.15"><![CDATA[Jeder]]></item>
+		<item name="wcf.acp.user.option.typeData"><![CDATA[Eigenschaften]]></item>
+		<item name="wcf.acp.user.option.outputClass"><![CDATA[PHP-Klasse für Ausgabe]]></item>
+		<item name="wcf.acp.user.option.outputClass.description"><![CDATA[Erlaubt die Angabe einer speziellen PHP-Klasse für die Ausgabeformatierung bei der Anzeige des Feldes.]]></item>
+		<item name="wcf.acp.user.option.outputClass.error.doesNotExist"><![CDATA[Eine Klasse mit dem angegeben Namen existiert nicht.]]></item>
+		<item name="wcf.acp.user.option.error.noCategories"><![CDATA[Bevor du ein Benutzerprofilfeld hinzufügen kannst, musst du eine <a href="{link controller='UserOptionCategoryAdd'}{/link}">Benutzerprofilfeld-Kategorie hinzufügen</a>.]]></item>
+		<item name="wcf.acp.user.search.conditions"><![CDATA[Bedingungen]]></item>
+		<item name="wcf.acp.user.search.conditions.states"><![CDATA[Zustände]]></item>
+		<item name="wcf.acp.user.search.conditions.state.banned"><![CDATA[Gesperrt]]></item>
+		<item name="wcf.acp.user.search.conditions.state.notBanned"><![CDATA[Nicht gesperrt]]></item>
+		<item name="wcf.acp.user.activityPoint.option"><![CDATA[Aktivitätspunkte]]></item>
+		<item name="wcf.acp.user.activityPoint.updateEvents"><![CDATA[Punkte pro Aktivität aktualisieren]]></item>
+		<item name="wcf.acp.user.delete"><![CDATA[Benutzer löschen]]></item>
+		<item name="wcf.acp.user.rank.add"><![CDATA[Benutzerrang hinzufügen]]></item>
+		<item name="wcf.acp.user.rank.cssClassName"><![CDATA[CSS-Klassen]]></item>
+		<item name="wcf.acp.user.rank.cssClassName.description"><![CDATA[Du kannst aus den vorgegebenen Darstellungen wählen oder eine eigene Darstellung durch Angabe einer <abbr title="Cascading Style Sheets">CSS</abbr>-Klasse nutzen.]]></item>
+		<item name="wcf.acp.user.rank.cssClassName.error.invalid"><![CDATA[Die gewählte CSS-Klasse ist ungültig.]]></item>
+		<item name="wcf.acp.user.rank.currentImage"><![CDATA[Aktuelle Ranggrafik]]></item>
+		<item name="wcf.acp.user.rank.delete.sure"><![CDATA[Willst du den Benutzerrang <span class="confirmationObject">{$userRank->rankTitle|language}</span> wirklich löschen?]]></item>
+		<item name="wcf.acp.user.rank.edit"><![CDATA[Benutzerrang bearbeiten]]></item>
+		<item name="wcf.acp.user.rank.image"><![CDATA[Ranggrafik]]></item>
+		<item name="wcf.acp.user.rank.list"><![CDATA[Benutzerränge]]></item>
+		<item name="wcf.acp.user.rank.rankImage.description"><![CDATA[Der Pfad zur Ranggrafik kann relativ zum WCF-Verzeichnis oder absolut angegeben werden.]]></item>
+		<item name="wcf.acp.user.rank.requiredGender.description"><![CDATA[Optional kannst du diesen Benutzerrang auf Benutzer mit einem bestimmten Geschlecht einschränken.]]></item>
+		<item name="wcf.acp.user.rank.requiredPoints"><![CDATA[Punkte]]></item>
+		<item name="wcf.acp.user.rank.requiredPoints.description"><![CDATA[Benötigte Menge an Aktivitätspunkten, die ein Benutzer erreichen muss, um in diesen Rang aufzusteigen.]]></item>
+		<item name="wcf.acp.user.rank.requirement"><![CDATA[Beschränkungen]]></item>
+		<item name="wcf.acp.user.rank.repeatImage"><![CDATA[Wiederholung der Ranggrafik]]></item>
+		<item name="wcf.acp.user.rank.repeatImage.description"><![CDATA[Bestimmt, wie oft die Grafik wiederholt wird.]]></item>
+		<item name="wcf.acp.user.rank.title"><![CDATA[Rangbezeichnung]]></item>
+		<item name="wcf.acp.user.rank.userGroup.description"><![CDATA[Dieser Benutzerrang steht ausschließlich den Mitgliedern der ausgewählten Benutzergruppe zur Verfügung.]]></item>
+		<item name="wcf.acp.user.disableSignature"><![CDATA[Signatur sperren]]></item>
+		<item name="wcf.acp.user.disableSignatureReason"><![CDATA[Begründung]]></item>
+		<item name="wcf.acp.user.disableAvatar"><![CDATA[Avatar sperren]]></item>
+		<item name="wcf.acp.user.disableAvatarReason"><![CDATA[Begründung]]></item>
+		<item name="wcf.acp.user.disableAvatar.expires"><![CDATA[Entsperrung]]></item>
+		<item name="wcf.acp.user.disableAvatar.expires.description"><![CDATA[Der Avatar des Benutzer wird zum festgelegten Zeitpunkt automatisch entsperrt.]]></item>
+		<item name="wcf.acp.user.disableAvatar.neverExpires"><![CDATA[Dauerhafte Sperrung]]></item>
+		<item name="wcf.acp.user.disableSignature.expires"><![CDATA[Entsperrung]]></item>
+		<item name="wcf.acp.user.disableSignature.expires.description"><![CDATA[Die Signatur des Benutzer wird zum festgelegten Zeitpunkt automatisch entsperrt.]]></item>
+		<item name="wcf.acp.user.disableSignature.neverExpires"><![CDATA[Dauerhafte Sperrung]]></item>
+		<item name="wcf.acp.user.disable"><![CDATA[Deaktivieren]]></item>
+		<item name="wcf.acp.user.enable"><![CDATA[Aktivieren]]></item>
+		<item name="wcf.acp.user.quickSearch.disabled"><![CDATA[Nicht aktivierte Benutzer]]></item>
+		<item name="wcf.acp.user.quickSearch.disabledAvatars"><![CDATA[Gesperrte Avatare]]></item>
+		<item name="wcf.acp.user.quickSearch.disabledSignatures"><![CDATA[Gesperrte Signaturen]]></item>
+		<item name="wcf.acp.user.usersAwaitingApprovalInfo"><![CDATA[<a href="{link controller='UserQuickSearch'}mode=disabled{/link}">{#$usersAwaitingApproval} Benutzer</a> {if $usersAwaitingApproval == 1}wartet auf seine{else}warten auf ihre{/if} Aktivierung.]]></item>
+		<item name="wcf.acp.user.search.conditions.state.enabled"><![CDATA[Aktiviert]]></item>
+		<item name="wcf.acp.user.search.conditions.state.disabled"><![CDATA[Nicht aktiviert]]></item>
+		<item name="wcf.acp.user.sendNewPassword.mail.subject"><![CDATA[Neues Kennwort für dein Benutzerkonto auf der Website: {@PAGE_TITLE|language}]]></item>
+		<item name="wcf.acp.user.sendNewPassword.mail.plaintext"><![CDATA[Hallo {@$mailbox->getUser()->username},
+
+ein Administrator hat dein Kennwort zurück gesetzt. Es ist nun
+erforderlich, dass du nun ein neues Kennwort setzt, damit du dein 
+Benutzerkonto {@$mailbox->getUser()->username} auf der Seite {@PAGE_TITLE|language} [URL:{link isEmail=true}{/link}]
+weiterhin verwenden kannst:
+
+    {link controller='NewPassword' object=$mailbox->getUser() isEmail=true}k={@$mailbox->getUser()->lostPasswordKey}{/link} {* this line ends with a space *}
+
+Solltest du diese Nachricht erst nach dem {$mailbox->getUser()->lastLostPasswordRequestTime+86400|plainTime} lesen, ist es
+aus Sicherheitsgründen erforderlich, dass du die Kennwort vergessen-Funktion [URL:{link controller='LostPassword' isEmail=true}{/link}] nutzt.]]></item>
+		<item name="wcf.acp.user.sendNewPassword.mail.html.headline"><![CDATA[Hallo {@$mailbox->getUser()->username},]]></item>
+		<item name="wcf.acp.user.sendNewPassword.mail.html.intro"><![CDATA[
+<p>ein Administrator hat dein Kennwort zurück gesetzt. Es ist nun
+erforderlich, dass du nun ein neues Kennwort setzt, damit du dein 
+Benutzerkonto {@$mailbox->getUser()->username} auf der Seite <a href="{link isEmail=true}{/link}">{@PAGE_TITLE|language}</a>
+weiterhin verwenden kannst:</p>]]></item>
+		<item name="wcf.acp.user.sendNewPassword.mail.html.reset"><![CDATA[Neues Kennwort setzen]]></item>
+		<item name="wcf.acp.user.sendNewPassword.mail.html.outro"><![CDATA[
+<p>Solltest du diese Nachricht erst nach dem {$mailbox->getUser()->lastLostPasswordRequestTime+86400|plainTime} lesen, ist es
+aus Sicherheitsgründen erforderlich, dass du die <a href="{link controller='LostPassword' isEmail=true}{/link}">Kennwort vergessen-Funktion</a> nutzt.</p>]]></item>
+		<item name="wcf.acp.user.sendNewPassword.workerTitle"><![CDATA[Neue Passwörter zusenden]]></item>
+		<item name="wcf.acp.user.authentication.failure.list"><![CDATA[Fehlgeschlagene Anmeldungen]]></item>
+		<item name="wcf.acp.user.authentication.failure.environment"><![CDATA[Umgebung]]></item>
+		<item name="wcf.acp.user.authentication.failure.environment.user"><![CDATA[Benutzer]]></item>
+		<item name="wcf.acp.user.authentication.failure.environment.admin"><![CDATA[Administration]]></item>
+		<item name="wcf.acp.user.authentication.failure.time"><![CDATA[Datum]]></item>
+		<item name="wcf.acp.user.activation.mail.subject"><![CDATA[Dein Benutzerkonto auf der Website: {@PAGE_TITLE|language} wurde freigeschaltet]]></item>
+		<item name="wcf.acp.user.activation.mail.html.headline"><![CDATA[Hallo {$mailbox->getUser()->username},]]></item>
+		<item name="wcf.acp.user.activation.mail.html.text"><![CDATA[
+<p>Dein Benutzerkonto auf der Website: <a href="{link isEmail=true}{/link}">{PAGE_TITLE|language}</a> wurde von einem Administrator
+freigeschaltet. Du kannst die Funktionen deines Benutzerkontos nun in vollem Umfang nutzen.</p>]]></item>
+		<item name="wcf.acp.user.activation.mail.plaintext"><![CDATA[Hallo {@$mailbox->getUser()->username},
+
+Dein Benutzerkonto auf der Website: {@PAGE_TITLE|language} [URL:{link isEmail=true}{/link}] wurde von
+einem Administrator freigeschaltet. Du kannst die Funktionen deines
+Benutzerkontos nun in vollem Umfang nutzen.]]></item>
+		<item name="wcf.acp.user.notificationPresetSettings"><![CDATA[Vorgabewerte für Benachrichtigungen bearbeiten]]></item>
+		<item name="wcf.acp.user.notificationPresetSettings.description"><![CDATA[Du kannst auf dieser Seite die Standardeinstellungen für neue Benutzer festlegen, dies wirkt sich nicht auf bestehende Benutzer aus. Benutzer können abweichende Einstellungen festlegen.]]></item>
+		<item name="wcf.acp.user.notificationPresetSettings.applyChangesToExistingUsers"><![CDATA[Änderungen auch auf bestehende Benutzerkonten anwenden]]></item>
+		<item name="wcf.acp.user.notificationPresetSettings.applyChangesToExistingUsers.description"><![CDATA[Die hier eingestellten Änderungen der Vorgabewerte für Benachrichtigungen werden auch in bestehende Benutzerkonten übernommen. Die entsprechenden Einstellungen der Benutzer werden dabei überschrieben.]]></item>
+		
+		<item name="wcf.acp.user.bulkProcessing"><![CDATA[Benutzer-Massenbearbeitung]]></item>
+		<item name="wcf.acp.user.bulkProcessing.action"><![CDATA[Aktion]]></item>
+		<item name="wcf.acp.user.bulkProcessing.assignToUserGroups"><![CDATA[Benutzergruppen zuweisen]]></item>
+		<item name="wcf.acp.user.bulkProcessing.conditions"><![CDATA[Bedingungen]]></item>
+		<item name="wcf.acp.user.bulkProcessing.delete"><![CDATA[Benutzer löschen]]></item>
+		<item name="wcf.acp.user.bulkProcessing.exportMailAddress"><![CDATA[E-Mail-Adressen exportieren]]></item>
+		<item name="wcf.acp.user.bulkProcessing.removeFromUserGroups"><![CDATA[Aus Benutzergruppen entfernen]]></item>
+		<item name="wcf.acp.user.bulkProcessing.sendMail"><![CDATA[E-Mail an Benutzer senden]]></item>
+		<item name="wcf.acp.user.bulkProcessing.success"><![CDATA[Die gewählte Aktion wurde auf {#$affectedObjectCount} Benutzer ausgeführt.]]></item>
+		<item name="wcf.acp.user.bulkProcessing.warning"><![CDATA[Die Massenbearbeitung von Benutzern führt die unten ausgewählte Aktion <b>ohne zusätzliche Sicherheitsabfrage</b> bei allen Benutzern aus, die unter die eingestellten Bedingungen fallen.]]></item>
+		<item name="wcf.acp.user.profileMenu.sort"><![CDATA[Benutzerprofil-Menü Sortierung]]></item>
+	</category>
+	
+	<category name="wcf.acp.worker">
+		<item name="wcf.acp.worker.abort.confirmMessage"><![CDATA[Willst du die Ausführung wirklich abbrechen?]]></item>
+	</category>
+	
+	<category name="wcf.ajax">
+		<item name="wcf.ajax.error.illegalLink"><![CDATA[Der Server konnte die Anfrage nicht verarbeiten, weil das Ziel unbekannt ist oder nicht mehr zur Verfügung steht.]]></item>
+		<item name="wcf.ajax.error.invalidParameter"><![CDATA[Der Parameter „{$fieldName}“ fehlt oder ist ungültig.]]></item>
+		<item name="wcf.ajax.error.badRequest"><![CDATA[Die Anfrage war unvollständig und konnte nicht verarbeitet werden.]]></item>
+		<item name="wcf.ajax.error.internalError"><![CDATA[Es ist ein Fehler bei der Verarbeitung aufgetreten, bitte versuche es später erneut.]]></item>
+		<item name="wcf.ajax.error.permissionDenied"><![CDATA[Du besitzt leider nicht die notwendigen Zugriffsrechte, um diese Aktion auszuführen.]]></item>
+		<item name="wcf.ajax.error.sessionExpired"><![CDATA[Deine Sitzung ist abgelaufen, bitte lade die Seite neu.]]></item>
+	</category>
+	
+	<category name="wcf.article">
+		<item name="wcf.article.nextArticle"><![CDATA[Nächster Artikel]]></item>
+		<item name="wcf.article.previousArticle"><![CDATA[Vorheriger Artikel]]></item>
+		<item name="wcf.article.relatedArticles"><![CDATA[Verwandte Artikel]]></item>
+		<item name="wcf.article.moreArticles"><![CDATA[Weitere Artikel]]></item>
+		<item name="wcf.article.aboutAuthor"><![CDATA[Über den Autor]]></item>
+		<item name="wcf.article.articleComments"><![CDATA[{#$article->comments} Kommentar{if $article->comments != 1}e{/if}]]></item>
+		<item name="wcf.article.articleViews"><![CDATA[{#$article->views} Mal gelesen]]></item>
+		<item name="wcf.article.recentActivity.likedArticle"><![CDATA[Mag den Artikel <a href="{$article->getLink()}">{$article->getTitle()}</a>.]]></item>
+		<item name="wcf.article.recentActivity.articleComment"><![CDATA[Hat einen Kommentar zum Artikel <a href="{$article->getLink()}#comment{$commentID}">{$article->getTitle()}</a> geschrieben.]]></item>
+		<item name="wcf.article.recentActivity.articleCommentResponse"><![CDATA[Hat auf einen Kommentar von <a href="{link controller='User' object=$commentAuthor}{/link}">{$commentAuthor->username}</a> zum Artikel <a href="{$article->getLink()}#comment{@$commentID}/response{@$responseID}">{$article->getTitle()}</a> geantwortet.]]></item>
+		<item name="wcf.article.search.categories"><![CDATA[Folgende Kategorien durchsuchen]]></item>
+		<item name="wcf.article.articles"><![CDATA[Artikel]]></item>
+		<item name="wcf.article.comment"><![CDATA[Artikel-Kommentar]]></item>
+		<item name="wcf.article.commentResponse"><![CDATA[Antwort auf Artikel-Kommentar]]></item>
+		<item name="wcf.article.sortField.comments"><![CDATA[Kommentare]]></item>
+		<item name="wcf.article.sortField.cumulativeLikes"><![CDATA[Likes]]></item>
+		<item name="wcf.article.sortField.time"><![CDATA[Datum]]></item>
+		<item name="wcf.article.sortField.views"><![CDATA[Zugriffe]]></item>
+		<item name="wcf.article.markAllAsRead"><![CDATA[Alle Artikel als gelesen markieren]]></item>
+	</category>
+	
+	<category name="wcf.attachment">
+		<item name="wcf.attachment.file.info"><![CDATA[({@$attachment->filesize|filesize}, <b>{#$attachment->downloads}</b> Mal heruntergeladen{if $attachment->downloads > 0}, zuletzt: {@$attachment->lastDownloadTime|time}{/if})]]></item>
+		<item name="wcf.attachment.image.info"><![CDATA[{@$attachment->filesize|filesize}, {#$attachment->width}×{#$attachment->height}, {#$attachment->downloads} Mal angesehen]]></item>
+		<item name="wcf.attachment.files"><![CDATA[Dateien]]></item>
+		<item name="wcf.attachment.images"><![CDATA[Bilder]]></item>
+		<item name="wcf.attachment.attachments"><![CDATA[Dateianhänge]]></item>
+		<item name="wcf.attachment.delete.sure"><![CDATA[Willst du diesen Dateianhang wirklich löschen?]]></item>
+		<item name="wcf.attachment.upload.error.invalidExtension"><![CDATA[Die Datei hat eine ungültige Dateiendung.]]></item>
+		<item name="wcf.attachment.upload.error.tooLarge"><![CDATA[Die Datei ist zu groß.]]></item>
+		<item name="wcf.attachment.upload.error.reachedLimit"><![CDATA[Du hast die maximale Anzahl an Dateianhängen erreicht.]]></item>
+		<item name="wcf.attachment.upload.error.reachedRemainingLimit"><![CDATA[Du hast zu viele Dateianhänge ausgewählt, maximal verbleibend: #remaining#.]]></item>
+		<item name="wcf.attachment.upload.error.uploadFailed"><![CDATA[Beim Hochladen der Datei ist ein unbekannter Fehler aufgetreten.]]></item>
+		<item name="wcf.attachment.upload.limits"><![CDATA[Maximale Anzahl an Dateianhängen: {#$attachmentHandler->getMaxCount()}<br>
+Maximale Dateigröße: {@$attachmentHandler->getMaxSize()|filesize}<br>
+Erlaubte Dateiendungen: {', '|implode:$attachmentHandler->getFormattedAllowedExtensions()}]]></item>
+		<item name="wcf.attachment.insert"><![CDATA[In Text einfügen]]></item>
+		<item name="wcf.attachment.insertAll"><![CDATA[Alle einfügen]]></item>
+		<item name="wcf.attachment.insertFull"><![CDATA[Original einfügen]]></item>
+		<item name="wcf.attachment.insertThumbnail"><![CDATA[Vorschau einfügen]]></item>
+		<item name="wcf.attachment.filename"><![CDATA[Dateiname]]></item>
+		<item name="wcf.attachment.uploadTime"><![CDATA[Hochgeladen]]></item>
+		<item name="wcf.attachment.filesize"><![CDATA[Größe]]></item>
+		<item name="wcf.attachment.downloads"><![CDATA[Downloads]]></item>
+		<item name="wcf.attachment.lastDownloadTime"><![CDATA[Letzter Download]]></item>
+		<item name="wcf.attachment.fileType"><![CDATA[Dateityp]]></item>
+		<item name="wcf.attachment.dragAndDrop.dropHere"><![CDATA[Hierhin ziehen und loslassen um Dateien hochzuladen]]></item>
+		<item name="wcf.attachment.dragAndDrop.dropNow"><![CDATA[Jetzt loslassen um Dateien hochzuladen]]></item>
+	</category>
+	
+	<category name="wcf.bbcode">
+		<item name="wcf.bbcode.button.collapse"><![CDATA[Weniger anzeigen]]></item>
+		<item name="wcf.bbcode.button.showAll"><![CDATA[Alles anzeigen]]></item>
+		<item name="wcf.bbcode.code"><![CDATA[Code]]></item>
+		<item name="wcf.bbcode.code.bash.title"><![CDATA[Shell-Script]]></item>
+		<item name="wcf.bbcode.code.c.title"><![CDATA[C]]></item>
+		<item name="wcf.bbcode.code.css.title"><![CDATA[CSS]]></item>
+		<item name="wcf.bbcode.code.diff.title"><![CDATA[Diff]]></item>
+		<item name="wcf.bbcode.code.html.title"><![CDATA[HTML]]></item>
+		<item name="wcf.bbcode.code.java.title"><![CDATA[Java]]></item>
+		<item name="wcf.bbcode.code.js.title"><![CDATA[JavaScript]]></item>
+		<item name="wcf.bbcode.code.perl.title"><![CDATA[Perl]]></item>
+		<item name="wcf.bbcode.code.php.title"><![CDATA[PHP]]></item>
+		<item name="wcf.bbcode.code.plain.title"><![CDATA[Code]]></item>
+		<item name="wcf.bbcode.code.sql.title"><![CDATA[SQL]]></item>
+		<item name="wcf.bbcode.code.python.title"><![CDATA[Python]]></item>
+		<item name="wcf.bbcode.code.tex.title"><![CDATA[TeX]]></item>
+		<item name="wcf.bbcode.code.tpl.title"><![CDATA[Smarty]]></item>
+		<item name="wcf.bbcode.code.xml.title"><![CDATA[XML]]></item>
+		<item name="wcf.bbcode.code.simplified"><![CDATA[(Quelltext, {#$lines} Zeile{if $lines != 1}n{/if})]]></item>
+		<item name="wcf.bbcode.image.source"><![CDATA[Bild-Link]]></item>
+		<item name="wcf.bbcode.quote"><![CDATA[Zitat]]></item>
+		<item name="wcf.bbcode.quote.delete"><![CDATA[Zitat löschen]]></item>
+		<item name="wcf.bbcode.quote.edit"><![CDATA[Zitat bearbeiten]]></item>
+		<item name="wcf.bbcode.quote.edit.author"><![CDATA[Autor]]></item>
+		<item name="wcf.bbcode.quote.edit.link"><![CDATA[Quelle]]></item>
+		<item name="wcf.bbcode.quote.insert"><![CDATA[Zitat einfügen]]></item>
+		<item name="wcf.bbcode.quote.title"><![CDATA[{$quoteAuthor} schrieb:]]></item>
+		<item name="wcf.bbcode.quote.title.clickToSet"><![CDATA[(Klicken um eine Quelle anzugeben)]]></item>
+		<item name="wcf.bbcode.quote.title.javascript"><![CDATA[{literal}{$quoteAuthor} schrieb:{/literal}]]></item>
+		<item name="wcf.bbcode.quote.simplified"><![CDATA[(Zitat{if $cite} von {$cite}{/if})]]></item>
+		<item name="wcf.bbcode.spoiler.hide"><![CDATA[Spoiler ausblenden]]></item>
+		<item name="wcf.bbcode.spoiler.show"><![CDATA[Spoiler anzeigen]]></item>
+		<item name="wcf.bbcode.spoiler.text"><![CDATA[(Versteckter Text)]]></item>
+		<item name="wcf.bbcode.spoiler.simplified"><![CDATA[(Versteckter Text)]]></item>
+	</category>
+	
+	<category name="wcf.captcha">
+		<item name="wcf.captcha.useNoCaptcha"><![CDATA[(Kein Captcha)]]></item>
+		<item name="wcf.captcha.com.woltlab.wcf.recaptcha"><![CDATA[reCAPTCHA]]></item>
+		<item name="wcf.captcha.com.woltlab.wcf.captchaQuestion"><![CDATA[Frage]]></item>
+	</category>
+	
+	<category name="wcf.captcha.question">
+		<item name="wcf.captcha.question.answer.error.false"><![CDATA[Du hast eine falsche Antwort angegeben.]]></item>
+		<item name="wcf.captcha.question.captcha"><![CDATA[Frage]]></item>
+		<item name="wcf.captcha.question.captcha.description"><![CDATA[Bitte beantworte die untenstehende Frage bzw. löse die untenstehende Aufgabe.]]></item>
+	</category>
+	
+	<category name="wcf.captcha.recaptchaV2">
+		<item name="wcf.captcha.recaptchaV2.error.recaptchaString.false"><![CDATA[Bitte bestätige, dass du kein Roboter bist.]]></item>
+	</category>
+	
+	<category name="wcf.captcha.recaptchaInvisible">
+		<item name="wcf.captcha.recaptchaInvisible.error.recaptchaString.false"><![CDATA[Die Überprüfung ist fehlgeschlagen. Bitte sende das Formular erneut ab.]]></item>
+	</category>
+	
+	<category name="wcf.category">
+		<item name="wcf.category.add"><![CDATA[Kategorie hinzufügen]]></item>
+		<item name="wcf.category.button.list"><![CDATA[Kategorien auflisten]]></item>
+		<item name="wcf.category.delete.sure"><![CDATA[Willst du diese Kategorie wirklich löschen? Alle sich in dieser Kategorie befindlichen Unterkategorien werden in die Elternkategorie dieser Kategorie verschoben.]]></item>
+		<item name="wcf.category.edit"><![CDATA[Kategorie bearbeiten]]></item>
+		<item name="wcf.category.isDisabled"><![CDATA[Kategorie deaktivieren]]></item>
+		<item name="wcf.category.list"><![CDATA[Kategorien]]></item>
+		<item name="wcf.category.noneAvailable"><![CDATA[Es wurde noch keine Kategorie hinzugefügt.]]></item>
+		<item name="wcf.category.parentCategoryID"><![CDATA[Übergeordnete Kategorie]]></item>
+		<item name="wcf.category.parentCategoryID.error.invalid"><![CDATA[Die ausgewählte Kategorie existiert nicht.]]></item>
+		<item name="wcf.category.position"><![CDATA[Position]]></item>
+		<item name="wcf.category.description"><![CDATA[Beschreibung]]></item>
+		<item name="wcf.category.title"><![CDATA[Titel]]></item>
+		<item name="wcf.category.button.choose"><![CDATA[Kategorien wählen]]></item>
+	</category>
+	
+	<category name="wcf.cli">
+		<item name="wcf.cli.help.noLongHelp"><![CDATA[Zu dem Parameter "{$topic}" ist keine ausführliche Erklärung verfügbar.]]></item>
+		<item name="wcf.cli.help.language"><![CDATA[Erzwingt die Sprache mit dem angegebenen Sprachcode.]]></item>
+		<item name="wcf.cli.help.version"><![CDATA[Zeigt die Versionsnummer an und beendet das Script.]]></item>
+		<item name="wcf.cli.help.help"><![CDATA[Zeigt diese Hilfe an und beendet das Script.]]></item>
+		<item name="wcf.cli.help.q"><![CDATA[Quiet: Zeigt weniger Informationen an.]]></item>
+		<item name="wcf.cli.help.v"><![CDATA[Verbose: Zeigt mehr Informationen an.]]></item>
+		<item name="wcf.cli.help.disableUpdateCheck"><![CDATA[Nach dem Anmelden wird nicht nach Updates gesucht.]]></item>
+		<item name="wcf.cli.help.exitOnFail"><![CDATA[Das Script wird beendet, sobald ein Fehler aufgetreten ist.]]></item>
+		<item name="wcf.cli.help.exitOnFail.description"><![CDATA[Wenn dieser Parameter gesetzt ist, dann wird die Ausführung des Scriptes abgebrochen, sobald ein Fehler aufgetreten ist.
+Fehler sind beispielsweise:
+- Nicht gefundene Befehle
+- Befehle, welche ihre Aktion nicht erfolgreich ausführen konnten
+- Systemfehler]]></item>
+		<item name="wcf.cli.help.packageID"><![CDATA[Die App mit der angegebenen Paket-ID wird als Standard für diese Sitzung verwendet.]]></item>
+		
+		<item name="wcf.cli.worker.setParameter"><![CDATA[Übergibt einen Parameter an den Worker. Bsp.: --setParameter param=wert]]></item>
+		<item name="wcf.cli.worker.list"><![CDATA[Listet alle Worker auf.]]></item>
+		
+		<item name="wcf.cli.error.help.noArguments"><![CDATA[Der Befehl "{$command}" unterstützt keine Parameter.]]></item>
+		<item name="wcf.cli.error.language.notFound"><![CDATA[Die Sprache mit dem Sprachcode "{$languageCode}" konnte nicht gefunden werden.]]></item>
+		<item name="wcf.cli.error.command.notFound"><![CDATA[Der Befehl "{$command}" konnte nicht gefunden werden. Benutze "commands", um verfügbare Befehle aufzulisten.]]></item>
+	</category>
+	
+	<category name="wcf.clipboard">
+		<item name="wcf.clipboard.item.unmarkAll"><![CDATA[Demarkieren]]></item>
+		
+		<item name="wcf.clipboard.item.com.woltlab.wcf.article.delete"><![CDATA[Löschen ({#$count})]]></item>
+		<item name="wcf.clipboard.item.com.woltlab.wcf.article.delete.confirmMessage"><![CDATA[{if $count == 1}Einen{else}{#$count}{/if} Artikel löschen?]]></item>
+		<item name="wcf.clipboard.item.com.woltlab.wcf.article.publish"><![CDATA[Veröffentlichen ({#$count})]]></item>
+		<item name="wcf.clipboard.item.com.woltlab.wcf.article.restore"><![CDATA[Wiederherstellen ({#$count})]]></item>
+		<item name="wcf.clipboard.item.com.woltlab.wcf.article.setCategory"><![CDATA[Kategorie ändern ({#$count})]]></item>
+		<item name="wcf.clipboard.item.com.woltlab.wcf.article.trash"><![CDATA[Löschen ({#$count})]]></item>
+		<item name="wcf.clipboard.item.com.woltlab.wcf.article.trash.confirmMessage"><![CDATA[Willst du {if $count == 1}einen{else}{#$count}{/if} Artikel wirklich in den Papierkorb verschieben?]]></item>
+		<item name="wcf.clipboard.item.com.woltlab.wcf.article.unpublish"><![CDATA[Veröffentlichung zurückziehen ({#$count})]]></item>
+		
+		<item name="wcf.clipboard.item.com.woltlab.wcf.media.delete"><![CDATA[Löschen ({#$count})]]></item>
+		<item name="wcf.clipboard.item.com.woltlab.wcf.media.delete.confirmMessage"><![CDATA[{if $count == 1}Eine Datei{else}{#$count} Dateien{/if} löschen?]]></item>
+		<item name="wcf.clipboard.item.com.woltlab.wcf.media.insert"><![CDATA[Einfügen ({#$count})]]></item>
+		
+		<item name="wcf.clipboard.item.com.woltlab.wcf.tag.delete"><![CDATA[Löschen ({#$count})]]></item>
+		<item name="wcf.clipboard.item.com.woltlab.wcf.tag.delete.confirmMessage"><![CDATA[{if $count == 1}Einen Tag{else}{#$count} Tag{/if} löschen?]]></item>
+		<item name="wcf.clipboard.item.com.woltlab.wcf.tag.setAsSynonyms"><![CDATA[Als Synonyme verwenden ({#$count})]]></item>
+		
+		<item name="wcf.clipboard.item.com.woltlab.wcf.user.assignToGroup"><![CDATA[Benutzergruppe zuweisen]]></item>
+		<item name="wcf.clipboard.item.com.woltlab.wcf.user.ban"><![CDATA[Sperren ({#$count})]]></item>
+		<item name="wcf.clipboard.item.com.woltlab.wcf.user.delete"><![CDATA[Löschen ({#$count})]]></item>
+		<item name="wcf.clipboard.item.com.woltlab.wcf.user.delete.confirmMessage"><![CDATA[{if $count == 1}Einen{else}{#$count}{/if} Benutzer löschen?]]></item>
+		<item name="wcf.clipboard.item.com.woltlab.wcf.user.enable"><![CDATA[Aktivieren]]></item>
+		<item name="wcf.clipboard.item.com.woltlab.wcf.user.exportMailAddress"><![CDATA[E-Mail-Adressen exportieren]]></item>
+		<item name="wcf.clipboard.item.com.woltlab.wcf.user.merge"><![CDATA[Zusammenfügen]]></item>
+		<item name="wcf.clipboard.item.com.woltlab.wcf.user.revertContentChanges"><![CDATA[Änderungen an Inhalten zurücksetzen]]></item>
+		<item name="wcf.clipboard.item.com.woltlab.wcf.user.sendMail"><![CDATA[E-Mail senden]]></item>
+		<item name="wcf.clipboard.item.com.woltlab.wcf.user.sendNewPassword"><![CDATA[Neues Kennwort senden ({#$count})]]></item>
+		<item name="wcf.clipboard.item.com.woltlab.wcf.user.sendNewPassword.confirmMessage"><![CDATA[Willst du wirklich {if $count == 1}einem Benutzer{else}{#$count} Benutzern{/if} ein neues Kennwort zusenden?]]></item>
+		
+		<item name="wcf.clipboard.label.com.woltlab.wcf.article.marked"><![CDATA[{if $count == 1}Ein{else}{#$count}{/if} Artikel]]></item>
+		<item name="wcf.clipboard.label.com.woltlab.wcf.media.marked"><![CDATA[{if $count == 1}Eine Datei{else}{#$count} Dateien{/if}]]></item>
+		<item name="wcf.clipboard.label.com.woltlab.wcf.tag.marked"><![CDATA[{if $count == 1}Ein Tag{else}{#$count} Tags{/if}]]></item>
+		<item name="wcf.clipboard.label.com.woltlab.wcf.user.marked"><![CDATA[{if $count == 1}Ein{else}{#$count}{/if} Benutzer]]></item>
+	</category>
+	
+	<category name="wcf.comment">
+		<item name="wcf.comment.add"><![CDATA[Kommentar schreiben …]]></item>
+		<item name="wcf.comment.approve"><![CDATA[Freischalten]]></item>
+		<item name="wcf.comment.delete.confirmMessage"><![CDATA[Willst du diesen Kommentar wirklich löschen?]]></item>
+		<item name="wcf.comment.description"><![CDATA[Drücke die Eingabetaste, um abzusenden oder Escape, um abzubrechen.]]></item>
+		<item name="wcf.comment.error.floodControl"><![CDATA[Du hast bereits einen Kommentar innerhalb der letzten {if $__wcf->getSession()->getPermission('user.comment.floodControlTime') > 1}{#$__wcf->getSession()->getPermission('user.comment.floodControlTime')} Sekunden{else}Sekunde{/if} geschrieben. Du kannst erst in {#$lastCommentTime+$__wcf->getSession()->getPermission('user.comment.floodControlTime')-TIME_NOW} Sekunde{if ($lastCommentTime+$__wcf->getSession()->getPermission('user.comment.floodControlTime')-TIME_NOW) != 1}n{/if} einen neuen Kommentar erstellen.]]></item>
+		<item name="wcf.comment.more"><![CDATA[Weitere Kommentare]]></item>
+		<item name="wcf.comment.moderation.info"><![CDATA[Neu erstellte Kommentare unterliegen der Moderation und werden erst sichtbar, wenn sie durch einen Moderator geprüft und freigeschaltet wurden.]]></item>
+		<item name="wcf.comment.moderation.disabledComment"><![CDATA[Dein Kommentar muss zunächst von einem Moderator geprüft und freigeschaltet werden, damit er für alle Benutzer sichtbar wird.]]></item>
+		<item name="wcf.comment.response.add"><![CDATA[Antworten …]]></item>
+		<item name="wcf.comment.response.more"><![CDATA[{literal}{if $count == 1}Eine weitere Antwort{else}{#$count} weitere Antworten{/if}{/literal}]]></item>
+		<item name="wcf.comment.button.response.add"><![CDATA[Antworten]]></item>
+		<item name="wcf.comment.guestDialog.title"><![CDATA[Gastkommentar]]></item>
+		<item name="wcf.comment.sortField.cumulativeLikes"><![CDATA[Likes]]></item>
+		<item name="wcf.comment.sortField.time"><![CDATA[Datum]]></item>
+	</category>
+	
+	<category name="wcf.condition">
+		<item name="wcf.condition.greaterThan"><![CDATA[mehr als]]></item>
+		<item name="wcf.condition.greaterThan.error.lessThan"><![CDATA[Der „weniger als“-Wert und der „mehr als“-Wert sind widersprüchlich.]]></item>
+		<item name="wcf.condition.greaterThan.error.maxValue"><![CDATA[Der „mehr als“-Wert darf nicht größer sein als {#$maxValue}.]]></item>
+		<item name="wcf.condition.greaterThan.error.minValue"><![CDATA[Der „mehr als“-Wert darf nicht kleiner sein als {#$minValue}.]]></item>
+		<item name="wcf.condition.lessThan"><![CDATA[weniger als]]></item>
+		<item name="wcf.condition.lessThan.error.maxValue"><![CDATA[Der „weniger als“-Wert darf nicht größer sein als {#$maxValue}.]]></item>
+		<item name="wcf.condition.lessThan.error.minValue"><![CDATA[Der „weniger als“-Wert darf nicht kleiner sein als {#$minValue}.]]></item>
+		<item name="wcf.condition.timestamp.error.endBeforeStart"><![CDATA[Das Enddatum ist vor dem Startdatum.]]></item>
+		<item name="wcf.condition.timestamp.error.invalidEnd"><![CDATA[Das Enddatum ist ungültig.]]></item>
+		<item name="wcf.condition.timestamp.error.invalidStart"><![CDATA[Das Startdatum ist ungültig.]]></item>
+	</category>
+	
+	<category name="wcf.contact">
+		<item name="wcf.contact.data"><![CDATA[Deine Anfrage]]></item>
+		<item name="wcf.contact.mail.subject"><![CDATA[Neue Nachricht über das Kontakt-Formular]]></item>
+		<item name="wcf.contact.mail.plaintext"><![CDATA[Hallo,
+
+„{@$name}“ hat dir über das Kontakt-Formular auf der Website {@PAGE_TITLE|language} [URL:{link isEmail=true}{/link}] folgende Nachricht gesandt:
+
+{foreach from=$options item=option}
+{@$option['title']}:{if !$option['isMessage']} {@$option['value']}{else}
+{@$option['value']}{/if}
+{/foreach}]]></item>
+		<item name="wcf.contact.mail.html"><![CDATA[<h2>Hallo,</h2>
+
+<p>„{$name}“ hat dir über das Kontakt-Formular auf Website <a href="{link isEmail=true}{/link}">{PAGE_TITLE|language}</a> folgende Nachricht gesandt:</p>
+
+{foreach from=$options item=option}
+<p><strong>{@$option['title']}:</strong>{if !$option['isMessage']} {@$option['value']}{else}
+{@$option['value']|newlineToBreak}{/if}</p>
+{/foreach}]]></item>
+		<item name="wcf.contact.option1"><![CDATA[Betreff]]></item>
+		<item name="wcf.contact.optionDescription1"><![CDATA[Kurze, prägnante Beschreibung der Anfrage.]]></item>
+		<item name="wcf.contact.option2"><![CDATA[Nachricht]]></item>
+		<item name="wcf.contact.options.required"><![CDATA[Benötigte Angaben]]></item>
+		<item name="wcf.contact.recipient.name1"><![CDATA[Administrator]]></item>
+		<item name="wcf.contact.recipientID"><![CDATA[Empfänger]]></item>
+		<item name="wcf.contact.sender"><![CDATA[Absender]]></item>
+		<item name="wcf.contact.sender.information"><![CDATA[Deine Angaben]]></item>
+		<item name="wcf.contact.success"><![CDATA[Ihre Nachricht wurde erfolgreich versandt.]]></item>
+	</category>
+	
+	<category name="wcf.date">
+		<item name="wcf.date.dateFormat"><![CDATA[j. F Y]]></item>
+		<item name="wcf.date.timeFormat"><![CDATA[H:i]]></item>
+		<item name="wcf.date.dateTimeFormat"><![CDATA[%date%, %time%]]></item>
+		<item name="wcf.date.shortDateTimeFormat"><![CDATA[%date%]]></item>
+		
+		<item name="wcf.date.interval.days.past"><![CDATA[Vor {if $days > 1}{#$days} Tagen{else}einem Tag{/if}]]></item>
+		<item name="wcf.date.interval.full.past"><![CDATA[Vor {if $years}{if $years > 1}{#$years} Jahren{else}einem Jahr{/if}{/if}{if $months}{if $firstElement != 'months'}{if $lastElement == 'months'} und {else}, {/if}{/if}{if $months > 1}{#$months} Monaten{else}einem Monat{/if}{/if}{if $weeks}{if $firstElement != 'weeks'}{if $lastElement == 'weeks'} und {else}, {/if}{/if}{if $weeks > 1}{#$weeks} Wochen{else}einer Woche{/if}{/if}{if $days}{if $firstElement != 'days'}{if $lastElement == 'days'} und {else}, {/if}{/if}{if $days > 1}{#$days} Tagen{else}einem Tag{/if}{/if}{if $hours}{if $firstElement != 'hours'}{if $lastElement == 'hours'} und {else}, {/if}{/if}{if $hours > 1}{#$hours} Stunden{else}einer Stunde{/if}{/if}{if $minutes}{if $firstElement != 'minutes' && $lastElement == 'minutes'} und {/if}{if $minutes > 1}{#$minutes} Minuten{else}einer Minute{/if}{/if}]]></item>
+		<item name="wcf.date.interval.hours.past"><![CDATA[Vor {if $hours > 1}{#$hours} Stunden{else}einer Stunde{/if}]]></item>
+		<item name="wcf.date.interval.minutes.past"><![CDATA[Vor {if $minutes > 1}{#$minutes} Minuten{else}einer Minute{/if}]]></item>
+		<item name="wcf.date.interval.months.past"><![CDATA[Vor {if $months > 1}{#$months} Monaten{else}einem Monat{/if}]]></item>
+		<item name="wcf.date.interval.weeks.past"><![CDATA[Vor {if $weeks > 1}{#$weeks} Wochen{else}einer Woche{/if}]]></item>
+		<item name="wcf.date.interval.years.past"><![CDATA[Vor {if $years > 1}{#$years} Jahren{else}einem Jahr{/if}]]></item>
+		
+		<item name="wcf.date.interval.days.past.inSentence"><![CDATA[vor {if $days > 1}{#$days} Tagen{else}einem Tag{/if}]]></item>
+		<item name="wcf.date.interval.full.past.inSentence"><![CDATA[vor {if $years}{if $years > 1}{#$years} Jahren{else}einem Jahr{/if}{/if}{if $months}{if $firstElement != 'months'}{if $lastElement == 'months'} und {else}, {/if}{/if}{if $months > 1}{#$months} Monaten{else}einem Monat{/if}{/if}{if $weeks}{if $firstElement != 'weeks'}{if $lastElement == 'weeks'} und {else}, {/if}{/if}{if $weeks > 1}{#$weeks} Wochen{else}einer Woche{/if}{/if}{if $days}{if $firstElement != 'days'}{if $lastElement == 'days'} und {else}, {/if}{/if}{if $days > 1}{#$days} Tagen{else}einem Tag{/if}{/if}{if $hours}{if $firstElement != 'hours'}{if $lastElement == 'hours'} und {else}, {/if}{/if}{if $hours > 1}{#$hours} Stunden{else}einer Stunde{/if}{/if}{if $minutes}{if $firstElement != 'minutes' && $lastElement == 'minutes'} und {/if}{if $minutes > 1}{#$minutes} Minuten{else}einer Minute{/if}{/if}]]></item>
+		<item name="wcf.date.interval.hours.past.inSentence"><![CDATA[vor {if $hours > 1}{#$hours} Stunden{else}einer Stunde{/if}]]></item>
+		<item name="wcf.date.interval.minutes.past.inSentence"><![CDATA[vor {if $minutes > 1}{#$minutes} Minuten{else}einer Minute{/if}]]></item>
+		<item name="wcf.date.interval.months.past.inSentence"><![CDATA[vor {if $months > 1}{#$months} Monaten{else}einem Monat{/if}]]></item>
+		<item name="wcf.date.interval.weeks.past.inSentence"><![CDATA[vor {if $weeks > 1}{#$weeks} Wochen{else}einer Woche{/if}]]></item>
+		<item name="wcf.date.interval.years.past.inSentence"><![CDATA[vor {if $years > 1}{#$years} Jahren{else}einem Jahr{/if}]]></item>
+		
+		<item name="wcf.date.interval.days.future"><![CDATA[In {if $days > 1}{#$days} Tagen{else}einem Tag{/if}]]></item>
+		<item name="wcf.date.interval.full.future"><![CDATA[In {if $years}{if $years > 1}{#$years} Jahren{else}einem Jahr{/if}{/if}{if $months}{if $firstElement != 'months'}{if $lastElement == 'months'} und {else}, {/if}{/if}{if $months > 1}{#$months} Monaten{else}einem Monat{/if}{/if}{if $weeks}{if $firstElement != 'weeks'}{if $lastElement == 'weeks'} und {else}, {/if}{/if}{if $weeks > 1}{#$weeks} Wochen{else}einer Woche{/if}{/if}{if $days}{if $firstElement != 'days'}{if $lastElement == 'days'} und {else}, {/if}{/if}{if $days > 1}{#$days} Tagen{else}einem Tag{/if}{/if}{if $hours}{if $firstElement != 'hours'}{if $lastElement == 'hours'} und {else}, {/if}{/if}{if $hours > 1}{#$hours} Stunden{else}einer Stunde{/if}{/if}{if $minutes}{if $firstElement != 'minutes' && $lastElement == 'minutes'} und {/if}{if $minutes > 1}{#$minutes} Minuten{else}einer Minute{/if}{/if}]]></item>
+		<item name="wcf.date.interval.hours.future"><![CDATA[In {if $hours > 1}{#$hours} Stunden{else}einer Stunde{/if}]]></item>
+		<item name="wcf.date.interval.minutes.future"><![CDATA[In {if $minutes > 1}{#$minutes} Minuten{else}einer Minute{/if}]]></item>
+		<item name="wcf.date.interval.months.future"><![CDATA[In {if $months > 1}{#$months} Monaten{else}einem Monat{/if}]]></item>
+		<item name="wcf.date.interval.weeks.future"><![CDATA[In {if $weeks > 1}{#$weeks} Wochen{else}einer Woche{/if}]]></item>
+		<item name="wcf.date.interval.years.future"><![CDATA[In {if $years > 1}{#$years} Jahren{else}einem Jahr{/if}]]></item>
+		
+		<item name="wcf.date.interval.days.future.inSentence"><![CDATA[in {if $days > 1}{#$days} Tagen{else}einem Tag{/if}]]></item>
+		<item name="wcf.date.interval.full.future.inSentence"><![CDATA[in {if $years}{if $years > 1}{#$years} Jahren{else}einem Jahr{/if}{/if}{if $months}{if $firstElement != 'months'}{if $lastElement == 'months'} und {else}, {/if}{/if}{if $months > 1}{#$months} Monaten{else}einem Monat{/if}{/if}{if $weeks}{if $firstElement != 'weeks'}{if $lastElement == 'weeks'} und {else}, {/if}{/if}{if $weeks > 1}{#$weeks} Wochen{else}einer Woche{/if}{/if}{if $days}{if $firstElement != 'days'}{if $lastElement == 'days'} und {else}, {/if}{/if}{if $days > 1}{#$days} Tagen{else}einem Tag{/if}{/if}{if $hours}{if $firstElement != 'hours'}{if $lastElement == 'hours'} und {else}, {/if}{/if}{if $hours > 1}{#$hours} Stunden{else}einer Stunde{/if}{/if}{if $minutes}{if $firstElement != 'minutes' && $lastElement == 'minutes'} und {/if}{if $minutes > 1}{#$minutes} Minuten{else}einer Minute{/if}{/if}]]></item>
+		<item name="wcf.date.interval.hours.future.inSentence"><![CDATA[in {if $hours > 1}{#$hours} Stunden{else}einer Stunde{/if}]]></item>
+		<item name="wcf.date.interval.minutes.future.inSentence"><![CDATA[in {if $minutes > 1}{#$minutes} Minuten{else}einer Minute{/if}]]></item>
+		<item name="wcf.date.interval.months.future.inSentence"><![CDATA[in {if $months > 1}{#$months} Monaten{else}einem Monat{/if}]]></item>
+		<item name="wcf.date.interval.weeks.future.inSentence"><![CDATA[in {if $weeks > 1}{#$weeks} Wochen{else}einer Woche{/if}]]></item>
+		<item name="wcf.date.interval.years.future.inSentence"><![CDATA[in {if $years > 1}{#$years} Jahren{else}einem Jahr{/if}]]></item>
+		
+		<item name="wcf.date.interval.days.plain"><![CDATA[{if $days > 1}{#$days} Tage{else}ein Tag{/if}]]></item>
+		<item name="wcf.date.interval.full.plain"><![CDATA[{if $years}{if $years > 1}{#$years} Jahre{else}ein Jahr{/if}{/if}{if $months}{if $firstElement != 'months'}{if $lastElement == 'months'} und {else}, {/if}{/if}{if $months > 1}{#$months} Monate{else}ein Monat{/if}{/if}{if $weeks}{if $firstElement != 'weeks'}{if $lastElement == 'weeks'} und {else}, {/if}{/if}{if $weeks > 1}{#$weeks} Wochen{else}eine Woche{/if}{/if}{if $days}{if $firstElement != 'days'}{if $lastElement == 'days'} und {else}, {/if}{/if}{if $days > 1}{#$days} Tage{else}ein Tag{/if}{/if}{if $hours}{if $firstElement != 'hours'}{if $lastElement == 'hours'} und {else}, {/if}{/if}{if $hours > 1}{#$hours} Stunden{else}eine Stunde{/if}{/if}{if $minutes}{if $firstElement != 'minutes' && $lastElement == 'minutes'} und {/if}{if $minutes > 1}{#$minutes} Minuten{else}eine Minute{/if}{/if}]]></item>
+		<item name="wcf.date.interval.hours.plain"><![CDATA[{if $hours > 1}{#$hours} Stunden{else}eine Stunde{/if}]]></item>
+		<item name="wcf.date.interval.minutes.plain"><![CDATA[{if $minutes > 1}{#$minutes} Minuten{else}eine Minute{/if}]]></item>
+		<item name="wcf.date.interval.months.plain"><![CDATA[{if $months > 1}{#$months} Monate{else}ein Monat{/if}]]></item>
+		<item name="wcf.date.interval.weeks.plain"><![CDATA[{if $weeks > 1}{#$weeks} Wochen{else}eine Woche{/if}]]></item>
+		<item name="wcf.date.interval.years.plain"><![CDATA[{if $years > 1}{#$years} Jahre{else}ein Jahr{/if}]]></item>
+		
+		<!-- variables for time periods -->
+		<item name="wcf.date.period.older"><![CDATA[Älter]]></item>
+		<item name="wcf.date.period.today"><![CDATA[Heute]]></item>
+		<item name="wcf.date.period.yesterday"><![CDATA[Gestern]]></item>
+		
+		<!-- variables for relative datetime -->
+		<item name="wcf.date.relative.now"><![CDATA[Vor einem Moment]]></item>
+		<item name="wcf.date.relative.minutes"><![CDATA[Vor {if $minutes > 1}{#$minutes} Minuten{else}einer Minute{/if}]]></item>
+		<item name="wcf.date.relative.hours"><![CDATA[Vor {if $hours > 1}{#$hours} Stunden{else}einer Stunde{/if}]]></item>
+		<item name="wcf.date.relative.pastDays"><![CDATA[{if $days > 1}{$day}{else}Gestern{/if}, {$time}]]></item>
+		
+		<!-- variables for localized date formats -->
+		<item name="wcf.date.hour"><![CDATA[Stunde]]></item>
+		<item name="wcf.date.minute"><![CDATA[Minute]]></item>
+		
+		<item name="wcf.date.month.january"><![CDATA[Januar]]></item>
+		<item name="wcf.date.month.february"><![CDATA[Februar]]></item>
+		<item name="wcf.date.month.march"><![CDATA[März]]></item>
+		<item name="wcf.date.month.april"><![CDATA[April]]></item>
+		<item name="wcf.date.month.may"><![CDATA[Mai]]></item>
+		<item name="wcf.date.month.june"><![CDATA[Juni]]></item>
+		<item name="wcf.date.month.july"><![CDATA[Juli]]></item>
+		<item name="wcf.date.month.august"><![CDATA[August]]></item>
+		<item name="wcf.date.month.september"><![CDATA[September]]></item>
+		<item name="wcf.date.month.october"><![CDATA[Oktober]]></item>
+		<item name="wcf.date.month.november"><![CDATA[November]]></item>
+		<item name="wcf.date.month.december"><![CDATA[Dezember]]></item>
+		<item name="wcf.date.month.short.jan"><![CDATA[Jan]]></item>
+		<item name="wcf.date.month.short.feb"><![CDATA[Feb]]></item>
+		<item name="wcf.date.month.short.mar"><![CDATA[Mrz]]></item>
+		<item name="wcf.date.month.short.apr"><![CDATA[Apr]]></item>
+		<item name="wcf.date.month.short.may"><![CDATA[Mai]]></item>
+		<item name="wcf.date.month.short.jun"><![CDATA[Jun]]></item>
+		<item name="wcf.date.month.short.jul"><![CDATA[Jul]]></item>
+		<item name="wcf.date.month.short.aug"><![CDATA[Aug]]></item>
+		<item name="wcf.date.month.short.sep"><![CDATA[Sep]]></item>
+		<item name="wcf.date.month.short.oct"><![CDATA[Okt]]></item>
+		<item name="wcf.date.month.short.nov"><![CDATA[Nov]]></item>
+		<item name="wcf.date.month.short.dec"><![CDATA[Dez]]></item>
+		<item name="wcf.date.day.sun"><![CDATA[So]]></item>
+		<item name="wcf.date.day.mon"><![CDATA[Mo]]></item>
+		<item name="wcf.date.day.tue"><![CDATA[Di]]></item>
+		<item name="wcf.date.day.wed"><![CDATA[Mi]]></item>
+		<item name="wcf.date.day.thu"><![CDATA[Do]]></item>
+		<item name="wcf.date.day.fri"><![CDATA[Fr]]></item>
+		<item name="wcf.date.day.sat"><![CDATA[Sa]]></item>
+		
+		<!-- localized days -->
+		<item name="wcf.date.day.sunday"><![CDATA[Sonntag]]></item>
+		<item name="wcf.date.day.monday"><![CDATA[Montag]]></item>
+		<item name="wcf.date.day.tuesday"><![CDATA[Dienstag]]></item>
+		<item name="wcf.date.day.wednesday"><![CDATA[Mittwoch]]></item>
+		<item name="wcf.date.day.thursday"><![CDATA[Donnerstag]]></item>
+		<item name="wcf.date.day.friday"><![CDATA[Freitag]]></item>
+		<item name="wcf.date.day.saturday"><![CDATA[Samstag]]></item>
+		
+		<!-- time zones -->
+		<item name="wcf.date.timezone.pacific.samoa"><![CDATA[(UTC-11:00) Amerikanisch-Samoa, Midway]]></item>
+		<item name="wcf.date.timezone.pacific.honolulu"><![CDATA[(UTC-10:00) Hawaii]]></item>
+		<item name="wcf.date.timezone.america.anchorage"><![CDATA[(UTC-09:00) Alaska]]></item>
+		<item name="wcf.date.timezone.america.los_angeles"><![CDATA[(UTC-08:00) Pacific Zeit, Tijuana]]></item>
+		<item name="wcf.date.timezone.america.phoenix"><![CDATA[(UTC-07:00) Arizona]]></item>
+		<item name="wcf.date.timezone.america.chihuahua"><![CDATA[(UTC-07:00) Chihuahua, La Paz, Mazatlán]]></item>
+		<item name="wcf.date.timezone.america.denver"><![CDATA[(UTC-07:00) Mountain Zeit]]></item>
+		<item name="wcf.date.timezone.america.chicago"><![CDATA[(UTC-06:00) Central Zeit]]></item>
+		<item name="wcf.date.timezone.america.mexico_city"><![CDATA[(UTC-06:00) Guadalajara, Mexiko-Stadt, Monterrey]]></item>
+		<item name="wcf.date.timezone.america.tegucigalpa"><![CDATA[(UTC-06:00) Mittelamerika]]></item>
+		<item name="wcf.date.timezone.america.regina"><![CDATA[(UTC-06:00) Saskatchewan]]></item>
+		<item name="wcf.date.timezone.america.bogota"><![CDATA[(UTC-05:00) Bogotá, Lima, Quito]]></item>
+		<item name="wcf.date.timezone.america.new_york"><![CDATA[(UTC-05:00) Eastern Zeit]]></item>
+		<item name="wcf.date.timezone.america.indiana.indianapolis"><![CDATA[(UTC-05:00) Indiana (Ost)]]></item>
+		<item name="wcf.date.timezone.america.rio_branco"><![CDATA[(UTC-05:00) Rio Branco]]></item>
+		<item name="wcf.date.timezone.america.caracas"><![CDATA[(UTC-04:30) Caracas]]></item>
+		<item name="wcf.date.timezone.america.asuncion"><![CDATA[(UTC-04:00) Asunción]]></item>
+		<item name="wcf.date.timezone.america.halifax"><![CDATA[(UTC-04:00) Atlantic (Kanada)]]></item>
+		<item name="wcf.date.timezone.america.cuiaba"><![CDATA[(UTC-04:00) Cuiabá]]></item>
+		<item name="wcf.date.timezone.america.la_paz"><![CDATA[(UTC-04:00) Georgetown, La Paz, Manaus, San Juan]]></item>
+		<item name="wcf.date.timezone.america.santiago"><![CDATA[(UTC-04:00) Santiago]]></item>
+		<item name="wcf.date.timezone.america.st_johns"><![CDATA[(UTC-03:30) Neufundland]]></item>
+		<item name="wcf.date.timezone.america.sao_paulo"><![CDATA[(UTC-03:00) Brasília]]></item>
+		<item name="wcf.date.timezone.america.argentina.buenos_aires"><![CDATA[(UTC-03:00) Buenos Aires]]></item>
+		<item name="wcf.date.timezone.america.cayenne"><![CDATA[(UTC-03:00) Cayenne, Fortaleza]]></item>
+		<item name="wcf.date.timezone.america.godthab"><![CDATA[(UTC-03:00) Grönland]]></item>
+		<item name="wcf.date.timezone.america.montevideo"><![CDATA[(UTC-03:00) Montevideo]]></item>
+		<item name="wcf.date.timezone.atlantic.south_georgia"><![CDATA[(UTC-02:00) Mittelatlantik]]></item>
+		<item name="wcf.date.timezone.atlantic.azores"><![CDATA[(UTC-01:00) Azoren]]></item>
+		<item name="wcf.date.timezone.atlantic.cape_verde"><![CDATA[(UTC-01:00) Kap Verde]]></item>
+		<item name="wcf.date.timezone.africa.casablanca"><![CDATA[(UTC) Casablanca]]></item>
+		<item name="wcf.date.timezone.europe.london"><![CDATA[(UTC) Dublin, Edinburgh, Lissabon, London]]></item>
+		<item name="wcf.date.timezone.africa.monrovia"><![CDATA[(UTC) Monrovia, Reykjavík]]></item>
+		<item name="wcf.date.timezone.europe.berlin"><![CDATA[(UTC+01:00) Amsterdam, Berlin, Bern, Rom, Stockholm, Wien]]></item>
+		<item name="wcf.date.timezone.europe.belgrade"><![CDATA[(UTC+01:00) Belgrad, Bratislava, Budapest, Ljubljana, Prag]]></item>
+		<item name="wcf.date.timezone.europe.paris"><![CDATA[(UTC+01:00) Brüssel, Kopenhagen, Madrid, Paris]]></item>
+		<item name="wcf.date.timezone.europe.sarajevo"><![CDATA[(UTC+01:00) Sarajevo, Skopje, Warschau, Zagreb]]></item>
+		<item name="wcf.date.timezone.africa.algiers"><![CDATA[(UTC+01:00) West-Zentralafrika]]></item>
+		<item name="wcf.date.timezone.africa.windhoek"><![CDATA[(UTC+01:00) Windhuk]]></item>
+		<item name="wcf.date.timezone.asia.amman"><![CDATA[(UTC+03:00) Amman]]></item>
+		<item name="wcf.date.timezone.europe.athens"><![CDATA[(UTC+02:00) Athen, Bukarest, Istanbul]]></item>
+		<item name="wcf.date.timezone.asia.beirut"><![CDATA[(UTC+02:00) Beirut]]></item>
+		<item name="wcf.date.timezone.asia.damascus"><![CDATA[(UTC+02:00) Damaskus]]></item>
+		<item name="wcf.date.timezone.africa.harare"><![CDATA[(UTC+02:00) Harare, Pretoria]]></item>
+		<item name="wcf.date.timezone.europe.helsinki"><![CDATA[(UTC+02:00) Helsinki, Kiew, Riga, Sofia, Tallinn, Wilna]]></item>
+		<item name="wcf.date.timezone.asia.jerusalem"><![CDATA[(UTC+02:00) Jerusalem]]></item>
+		<item name="wcf.date.timezone.africa.cairo"><![CDATA[(UTC+02:00) Kairo]]></item>
+		<item name="wcf.date.timezone.europe.kaliningrad"><![CDATA[(UTC+02:00) Kaliningrad]]></item>
+		<item name="wcf.date.timezone.europe.minsk"><![CDATA[(UTC+03:00) Minsk]]></item>
+		<item name="wcf.date.timezone.asia.baghdad"><![CDATA[(UTC+03:00) Bagdad]]></item>
+		<item name="wcf.date.timezone.asia.kuwait"><![CDATA[(UTC+03:00) Kuwait, Riad]]></item>
+		<item name="wcf.date.timezone.africa.nairobi"><![CDATA[(UTC+03:00) Nairobi]]></item>
+		<item name="wcf.date.timezone.asia.tehran"><![CDATA[(UTC+03:30) Teheran]]></item>
+		<item name="wcf.date.timezone.asia.muscat"><![CDATA[(UTC+04:00) Abu Dhabi, Muskat]]></item>
+		<item name="wcf.date.timezone.asia.baku"><![CDATA[(UTC+04:00) Baku]]></item>
+		<item name="wcf.date.timezone.asia.yerevan"><![CDATA[(UTC+04:00) Eriwan]]></item>
+		<item name="wcf.date.timezone.europe.moscow"><![CDATA[(UTC+03:00) Moskau, St. Petersburg, Wolgograd]]></item>
+		<item name="wcf.date.timezone.indian.mauritius"><![CDATA[(UTC+04:00) Port Louis]]></item>
+		<item name="wcf.date.timezone.asia.tbilisi"><![CDATA[(UTC+04:00) Tiflis]]></item>
+		<item name="wcf.date.timezone.asia.kabul"><![CDATA[(UTC+04:30) Kabul]]></item>
+		<item name="wcf.date.timezone.asia.karachi"><![CDATA[(UTC+05:00) Islamabad, Karatschi]]></item>
+		<item name="wcf.date.timezone.asia.yekaterinburg"><![CDATA[(UTC+05:00) Jekaterinburg]]></item>
+		<item name="wcf.date.timezone.asia.tashkent"><![CDATA[(UTC+05:00) Taschkent]]></item>
+		<item name="wcf.date.timezone.asia.kolkata"><![CDATA[(UTC+05:30) Chennai, Kolkata, Mumbai, New Delhi]]></item>
+		<item name="wcf.date.timezone.asia.colombo"><![CDATA[(UTC+05:30) Sri Jayawardenepura]]></item>
+		<item name="wcf.date.timezone.asia.katmandu"><![CDATA[(UTC+05:45) Katmandu]]></item>
+		<item name="wcf.date.timezone.asia.almaty"><![CDATA[(UTC+06:00) Astana]]></item>
+		<item name="wcf.date.timezone.asia.dhaka"><![CDATA[(UTC+06:00) Dakka]]></item>
+		<item name="wcf.date.timezone.asia.novosibirsk"><![CDATA[(UTC+06:00) Nowosibirsk]]></item>
+		<item name="wcf.date.timezone.asia.rangoon"><![CDATA[(UTC+06:30) Yangon (Rangun)]]></item>
+		<item name="wcf.date.timezone.asia.bangkok"><![CDATA[(UTC+07:00) Bangkok, Hanoi, Jakarta]]></item>
+		<item name="wcf.date.timezone.asia.krasnoyarsk"><![CDATA[(UTC+07:00) Krasnojarsk]]></item>
+		<item name="wcf.date.timezone.asia.irkutsk"><![CDATA[(UTC+08:00) Irkutsk]]></item>
+		<item name="wcf.date.timezone.asia.kuala_lumpur"><![CDATA[(UTC+08:00) Kuala Lumpur, Singapur]]></item>
+		<item name="wcf.date.timezone.asia.chongqing"><![CDATA[(UTC+08:00) Peking, Chongqing, Hongkong, Ürümqi]]></item>
+		<item name="wcf.date.timezone.australia.perth"><![CDATA[(UTC+08:00) Perth]]></item>
+		<item name="wcf.date.timezone.asia.taipei"><![CDATA[(UTC+08:00) Taipeh]]></item>
+		<item name="wcf.date.timezone.asia.ulaanbaatar"><![CDATA[(UTC+08:00) Ulan-Bator]]></item>
+		<item name="wcf.date.timezone.asia.yakutsk"><![CDATA[(UTC+09:00) Jakutsk]]></item>
+		<item name="wcf.date.timezone.asia.tokyo"><![CDATA[(UTC+09:00) Osaka, Sapporo, Tokio]]></item>
+		<item name="wcf.date.timezone.asia.seoul"><![CDATA[(UTC+09:00) Seoul]]></item>
+		<item name="wcf.date.timezone.australia.adelaide"><![CDATA[(UTC+09:30) Adelaide]]></item>
+		<item name="wcf.date.timezone.australia.darwin"><![CDATA[(UTC+09:30) Darwin]]></item>
+		<item name="wcf.date.timezone.australia.brisbane"><![CDATA[(UTC+10:00) Brisbane]]></item>
+		<item name="wcf.date.timezone.australia.sydney"><![CDATA[(UTC+10:00) Canberra, Melbourne, Sydney]]></item>
+		<item name="wcf.date.timezone.pacific.guam"><![CDATA[(UTC+10:00) Guam, Port Moresby]]></item>
+		<item name="wcf.date.timezone.australia.hobart"><![CDATA[(UTC+10:00) Hobart]]></item>
+		<item name="wcf.date.timezone.asia.vladivostok"><![CDATA[(UTC+10:00) Magadan, Wladiwostok]]></item>
+		<item name="wcf.date.timezone.pacific.noumea"><![CDATA[(UTC+11:00) Salomonen, Neu-Kaledonien]]></item>
+		<item name="wcf.date.timezone.pacific.auckland"><![CDATA[(UTC+12:00) Auckland, Wellington]]></item>
+		<item name="wcf.date.timezone.pacific.fiji"><![CDATA[(UTC+12:00) Fidschi]]></item>
+		<item name="wcf.date.timezone.pacific.tongatapu"><![CDATA[(UTC+13:00) Nuku'alofa]]></item>
+		<item name="wcf.date.timezone.pacific.apia"><![CDATA[(UTC+13:00) Samoa]]></item>
+		
+		<item name="wcf.date.period.start"><![CDATA[von]]></item>
+		<item name="wcf.date.period.end"><![CDATA[bis]]></item>
+		<item name="wcf.date.firstDayOfTheWeek"><![CDATA[1]]></item>
+		<item name="wcf.date.daysOfWeek"><![CDATA[Wochentage]]></item>
+		<item name="wcf.date.time"><![CDATA[Uhrzeit]]></item>
+		<item name="wcf.date.timezone"><![CDATA[Zeitzone]]></item>
+		<item name="wcf.date.timezone.user"><![CDATA[Zeitzone des Benutzers]]></item>
+		<item name="wcf.date.endTime.error.beforeStartTime"><![CDATA[Der Endzeitpunkt muss nach dem Startzeitpunkt liegen.]]></item>
+		<item name="wcf.date.startTime.error.invalid"><![CDATA[Der Startzeitpunkt ist ungültig.]]></item>
+		<item name="wcf.date.endTime.error.invalid"><![CDATA[Der Endzeitpunkt ist ungültig.]]></item>
+	</category>
+	
+	<category name="wcf.edit">
+		<item name="wcf.edit.version"><![CDATA[Version]]></item>
+		<item name="wcf.edit.versions"><![CDATA[Versionen]]></item>
+		<item name="wcf.edit.time"><![CDATA[Änderungszeitpunkt]]></item>
+		<item name="wcf.edit.reason"><![CDATA[Änderungsgrund]]></item>
+		<item name="wcf.edit.currentVersion"><![CDATA[Aktuell]]></item>
+		<item name="wcf.edit.revert"><![CDATA[Wiederherstellen]]></item>
+		<item name="wcf.edit.revert.sure"><![CDATA[Möchtest du die Version von <span class="confirmationObject">{$edit->username}</span> vom <span class="confirmationObject">{$edit->time|plainTime}</span> wirklich wiederherstellen?]]></item>
+		<item name="wcf.edit.reverted"><![CDATA[Wiederhergestellt auf Version von {$edit->username} vom {$edit->time|plainTime}]]></item>
+		<item name="wcf.edit.button.compare"><![CDATA[Vergleichen]]></item>
+		<item name="wcf.edit.button.goToContent"><![CDATA[Zum Inhalt gehen]]></item>
+		<item name="wcf.edit.headline.comparison"><![CDATA[Vergleich]]></item>
+		<item name="wcf.edit.headline.old"><![CDATA[{if $oldID == 'current'}Aktuelle {/if}Version vom {@$old->time|plainTime} ({$old->username})]]></item>
+		<item name="wcf.edit.headline.new"><![CDATA[{if $newID == 'current'}Aktuelle {/if}Version vom {@$new->time|plainTime} ({$new->username})]]></item>
+		<item name="wcf.edit.headline.newOrCurrent"><![CDATA[{if $newID == 'current'}Aktuelle Version{else}Version vom {@$new->time|plainTime}{/if}{if $new->username} ({$new->username}){/if}]]></item>
+	</category>
+	
+	<category name="wcf.editor">
+		<item name="wcf.editor.alignment.center"><![CDATA[Zentrieren]]></item>
+		<item name="wcf.editor.alignment.justify"><![CDATA[Blocksatz]]></item>
+		<item name="wcf.editor.alignment.left"><![CDATA[Linksbündig ausrichten]]></item>
+		<item name="wcf.editor.alignment.right"><![CDATA[Rechtsbündig ausrichten]]></item>
+		
+		<item name="wcf.editor.autosave.discard"><![CDATA[Verwerfen und Editor zurücksetzen]]></item>
+		<item name="wcf.editor.autosave.keep"><![CDATA[Hinweis ausblenden]]></item>
+		<item name="wcf.editor.autosave.restored"><![CDATA[Entwurf wiederhergestellt]]></item>
+		
+		<item name="wcf.editor.button.alignment"><![CDATA[Ausrichtung]]></item>
+		<item name="wcf.editor.button.bold"><![CDATA[Fett]]></item>
+		<item name="wcf.editor.button.code"><![CDATA[Code]]></item>
+		<item name="wcf.editor.button.color"><![CDATA[Schriftfarbe]]></item>
+		<item name="wcf.editor.button.color.removeColor"><![CDATA[Schriftfarbe entfernen]]></item>
+		<item name="wcf.editor.button.font"><![CDATA[Schriftart]]></item>
+		<item name="wcf.editor.button.font.removeFont"><![CDATA[Schriftart entfernen]]></item>
+		<item name="wcf.editor.button.format"><![CDATA[Überschrift]]></item>
+		<item name="wcf.editor.button.fullscreen"><![CDATA[Vollbild]]></item>
+		<item name="wcf.editor.button.html"><![CDATA[Quellcode]]></item>
+		<item name="wcf.editor.button.image"><![CDATA[Bild]]></item>
+		<item name="wcf.editor.button.inlineCode"><![CDATA[Inline-Code]]></item>
+		<item name="wcf.editor.button.italic"><![CDATA[Kursiv]]></item>
+		<item name="wcf.editor.button.link"><![CDATA[Link]]></item>
+		<item name="wcf.editor.button.lists"><![CDATA[Liste]]></item>
+		<item name="wcf.editor.button.media"><![CDATA[Media]]></item>
+		<item name="wcf.editor.button.page"><![CDATA[CMS-Seite]]></item>
+		<item name="wcf.editor.button.quote"><![CDATA[Zitat]]></item>
+		<item name="wcf.editor.button.redo"><![CDATA[Wiederholen]]></item>
+		<item name="wcf.editor.button.size"><![CDATA[Schriftgröße]]></item>
+		<item name="wcf.editor.button.size.removeSize"><![CDATA[Schriftgröße entfernen]]></item>
+		<item name="wcf.editor.button.spoiler"><![CDATA[Spoiler]]></item>
+		<item name="wcf.editor.button.strikethrough"><![CDATA[Durchgestrichen]]></item>
+		<item name="wcf.editor.button.subscript"><![CDATA[Tiefgestellt]]></item>
+		<item name="wcf.editor.button.superscript"><![CDATA[Hochgestellt]]></item>
+		<item name="wcf.editor.button.table"><![CDATA[Tabelle]]></item>
+		<item name="wcf.editor.button.underline"><![CDATA[Unterstrichen]]></item>
+		<item name="wcf.editor.button.undo"><![CDATA[Rückgängig]]></item>
+		<item name="wcf.editor.button.woltlabHtml"><![CDATA[Unsicheres HTML]]></item>
+		
+		<item name="wcf.editor.code.edit"><![CDATA[Code bearbeiten]]></item>
+		<item name="wcf.editor.code.file"><![CDATA[Dateiname]]></item>
+		<item name="wcf.editor.code.file.description"><![CDATA[Optional: Lege einen anzuzeigenden Dateinamen fest.]]></item>
+		<item name="wcf.editor.code.highlighter"><![CDATA[Syntax-Hervorhebung]]></item>
+		<item name="wcf.editor.code.highlighter.description"><![CDATA[Die farbliche Hervorherbung wird im Editor nicht angezeigt.]]></item>
+		<item name="wcf.editor.code.highlighter.detect"><![CDATA[(Automatische Erkennung)]]></item>
+		<item name="wcf.editor.code.line"><![CDATA[Start-Zeilennummer]]></item>
+		<item name="wcf.editor.code.line.description"><![CDATA[Optional: Lege den Wert fest, ab dem die Zeilennummierung startet.]]></item>
+		<item name="wcf.editor.code.title"><![CDATA[{if $highlighter}{$highlighter}{else}Quellcode{/if}{if $file} - {$file}{/if}]]></item>
+		
+		<item name="wcf.editor.format.heading2"><![CDATA[Überschrift 1]]></item>
+		<item name="wcf.editor.format.heading3"><![CDATA[Überschrift 2]]></item>
+		<item name="wcf.editor.format.heading4"><![CDATA[Überschrift 3]]></item>
+		<item name="wcf.editor.format.paragraph"><![CDATA[Normaler Text]]></item>
+		
+		<item name="wcf.editor.html.description"><![CDATA[Der Inhalt wird unverändert ausgegeben.]]></item>
+		<item name="wcf.editor.html.title"><![CDATA[Unsicheres HTML]]></item>
+		
+		<item name="wcf.editor.image.edit"><![CDATA[Bild bearbeiten]]></item>
+		<item name="wcf.editor.image.insert"><![CDATA[Bild einfügen]]></item>
+		<item name="wcf.editor.image.link"><![CDATA[Verlinkung]]></item>
+		<item name="wcf.editor.image.link.error.invalid"><![CDATA[Der eingegebene Link ist ungültig.]]></item>
+		<item name="wcf.editor.image.float"><![CDATA[Textumfluss]]></item>
+		<item name="wcf.editor.image.float.left"><![CDATA[Links]]></item>
+		<item name="wcf.editor.image.float.right"><![CDATA[Rechts]]></item>
+		<item name="wcf.editor.image.source"><![CDATA[Quelle]]></item>
+		<item name="wcf.editor.image.source.error.invalid"><![CDATA[Der eingegebene Link ist ungültig.]]></item>
+		
+		<item name="wcf.editor.link.add"><![CDATA[Link einfügen]]></item>
+		<item name="wcf.editor.link.edit"><![CDATA[Link bearbeiten]]></item>
+		<item name="wcf.editor.link.error.invalid"><![CDATA[Der eingegebene Link ist ungültig.]]></item>
+		<item name="wcf.editor.link.unlink"><![CDATA[Link entfernen]]></item>
+		<item name="wcf.editor.link.url"><![CDATA[Link]]></item>
+		<item name="wcf.editor.link.text"><![CDATA[Text]]></item>
+		
+		<item name="wcf.editor.list.indent"><![CDATA[Einrücken]]></item>
+		<item name="wcf.editor.list.outdent"><![CDATA[Ausrücken]]></item>
+		
+		<item name="wcf.editor.quote.author"><![CDATA[Quelle]]></item>
+		<item name="wcf.editor.quote.edit"><![CDATA[Zitat bearbeiten]]></item>
+		<item name="wcf.editor.quote.title"><![CDATA[{if $author}Zitat von {$author}{else}Zitat{/if}]]></item>
+		<item name="wcf.editor.quote.url"><![CDATA[Link]]></item>
+		<item name="wcf.editor.quote.url.description"><![CDATA[Optional: Gib einen Link zu der Quelle an.]]></item>
+		<item name="wcf.editor.quote.url.error.invalid"><![CDATA[Der eingegebene Link ist ungültig.]]></item>
+		
+		<item name="wcf.editor.source.error.active"><![CDATA[Bitte kehre zum Absenden in die normale Ansicht zurück.]]></item>
+		
+		<item name="wcf.editor.spoiler.label"><![CDATA[Beschriftung]]></item>
+		<item name="wcf.editor.spoiler.label.description"><![CDATA[Optional: Gib eine Beschriftung für den Spoiler-Button ein.]]></item>
+		<item name="wcf.editor.spoiler.edit"><![CDATA[Spoiler bearbeiten]]></item>
+		<item name="wcf.editor.spoiler.title"><![CDATA[Spoiler{if $label}: {$label}{/if}]]></item>
+		
+		<item name="wcf.editor.table.addHead"><![CDATA[Kopfzeile einfügen]]></item>
+		<item name="wcf.editor.table.deleteColumn"><![CDATA[Spalte löschen]]></item>
+		<item name="wcf.editor.table.deleteHead"><![CDATA[Kopfzeile löschen]]></item>
+		<item name="wcf.editor.table.deleteRow"><![CDATA[Zeile löschen]]></item>
+		<item name="wcf.editor.table.deleteTable"><![CDATA[Tabelle löschen]]></item>
+		<item name="wcf.editor.table.insertTable"><![CDATA[Tabelle einfügen]]></item>
+		<item name="wcf.editor.table.insertColumnLeft"><![CDATA[Spalte links einfügen]]></item>
+		<item name="wcf.editor.table.insertColumnRight"><![CDATA[Spalte rechts einfügen]]></item>
+		<item name="wcf.editor.table.insertRowAbove"><![CDATA[Zeile darüber einfügen]]></item>
+		<item name="wcf.editor.table.insertRowBelow"><![CDATA[Zeile darunter einfügen]]></item>
+	</category>
+	
+	<category name="wcf.global">
+		<item name="wcf.global.button.add"><![CDATA[Hinzufügen]]></item>
+		<item name="wcf.global.button.back"><![CDATA[&laquo; Zurück]]></item>
+		<item name="wcf.global.button.cancel"><![CDATA[Abbrechen]]></item>
+		<item name="wcf.global.button.close"><![CDATA[Schließen]]></item>
+		<item name="wcf.global.button.collapsible"><![CDATA[Auf- und Zuklappen]]></item>
+		<item name="wcf.global.button.delete"><![CDATA[Löschen]]></item>
+		<item name="wcf.global.button.disable"><![CDATA[Deaktivieren]]></item>
+		<item name="wcf.global.button.disabledI18n"><![CDATA[einsprachig]]></item>
+		<item name="wcf.global.button.edit"><![CDATA[Bearbeiten]]></item>
+		<item name="wcf.global.button.enable"><![CDATA[Aktivieren]]></item>
+		<item name="wcf.global.button.fullscreen"><![CDATA[Vollbildmodus]]></item>
+		<item name="wcf.global.button.hide"><![CDATA[Ausblenden]]></item>
+		<item name="wcf.global.button.insert"><![CDATA[Einfügen]]></item>
+		<item name="wcf.global.button.next"><![CDATA[Weiter »]]></item>
+		<item name="wcf.global.button.preview"><![CDATA[Vorschau]]></item>
+		<item name="wcf.global.button.refresh"><![CDATA[Aktualisieren]]></item>
+		<item name="wcf.global.button.reply"><![CDATA[Antworten]]></item>
+		<item name="wcf.global.button.reset"><![CDATA[Zurücksetzen]]></item>
+		<item name="wcf.global.button.restore"><![CDATA[Wiederherstellen]]></item>
+		<item name="wcf.global.button.rss"><![CDATA[RSS-Feed]]></item>
+		<item name="wcf.global.button.save"><![CDATA[Speichern]]></item>
+		<item name="wcf.global.button.saveSorting"><![CDATA[Sortierung speichern]]></item>
+		<item name="wcf.global.button.search"><![CDATA[Suche]]></item>
+		<item name="wcf.global.button.submit"><![CDATA[Absenden]]></item>
+		<item name="wcf.global.button.trash"><![CDATA[Löschen]]></item>
+		<item name="wcf.global.button.upload"><![CDATA[Hochladen]]></item>
+		<item name="wcf.global.button.readMore"><![CDATA[Weiterlesen]]></item>
+		<item name="wcf.global.comments"><![CDATA[Kommentare]]></item>
+		<item name="wcf.global.confirmation.cancel"><![CDATA[Abbrechen]]></item>
+		<item name="wcf.global.confirmation.confirm"><![CDATA[OK]]></item>
+		<item name="wcf.global.confirmation.title"><![CDATA[Bestätigung erforderlich]]></item>
+		<item name="wcf.global.date"><![CDATA[Datum]]></item>
+		<item name="wcf.global.decimalPoint"><![CDATA[,]]></item>
+		<item name="wcf.global.description"><![CDATA[Beschreibung]]></item>
+		<item name="wcf.global.error.timeout"><![CDATA[Keine Antwort vom Server erhalten, Anfrage wurde abgebrochen.]]></item>
+		<item name="wcf.global.error.title"><![CDATA[Fehlermeldung]]></item>
+		<item name="wcf.global.exception.explanation"><![CDATA[<p class="exceptionSubtitle">Was ist passiert?</p>
+<p class="exceptionText">Leider ist es bei der Verarbeitung zu einem Fehler gekommen und die Ausführung wurde abgebrochen. Falls möglich, leiten Sie bitte den oben stehenden Fehlercode an den Administrator weiter.</p>
+<p class="exceptionText">&nbsp;</p> <!-- required to ensure spacing after copy & paste -->
+<p class="exceptionText">
+	Administratoren können die vollständige Fehlermeldung mit Hilfe dieses Codes in der Administrationsoberfläche unter „Protokoll » Fehler“ einsehen.
+	Zusätzlich wurden die Informationen in die Protokolldatei <span class="exceptionInlineCodeWrapper"><span class="exceptionInlineCode">{$logFile}</span></span> geschrieben und können beispielsweise mit Hilfe eines FTP-Programms abgerufen werden.
+</p>
+<p class="exceptionText">&nbsp;</p> <!-- required to ensure spacing after copy & paste -->
+<p class="exceptionText">Hinweis: Der Fehlercode wird zufällig generiert, erlaubt keinen Rückschluss auf die Ursache und ist daher für Dritte nutzlos.</p>]]></item>
+		<item name="wcf.global.exception.title"><![CDATA[Ein Fehler ist aufgetreten]]></item>
+		<item name="wcf.global.exception.subtitle"><![CDATA[Interner Fehlercode: <span class="exceptionInlineCodeWrapper"><span class="exceptionInlineCode">{$exceptionID}</span></span>]]></item>
+		<item name="wcf.global.filter.button.clear"><![CDATA[Filter löschen]]></item>
+		<item name="wcf.global.filter.error.noMatches"><![CDATA[Keine Übereinstimmungen gefunden.]]></item>
+		<item name="wcf.global.filter.placeholder"><![CDATA[Nach Name filtern]]></item>
+		<item name="wcf.global.success"><![CDATA[Die Aktion wurde erfolgreich ausgeführt.]]></item>
+		<item name="wcf.global.success.add"><![CDATA[Der Eintrag wurde gespeichert.]]></item>
+		<item name="wcf.global.success.edit"><![CDATA[Die Änderungen wurden gespeichert.]]></item>
+		<item name="wcf.global.language.noSelection"><![CDATA[Keine Auswahl]]></item>
+		<item name="wcf.global.loading"><![CDATA[Lädt …]]></item>
+		<item name="wcf.global.name"><![CDATA[Name]]></item>
+		<item name="wcf.global.objectID"><![CDATA[ID]]></item>
+		<item name="wcf.global.page.next"><![CDATA[Nächste Seite]]></item>
+		<item name="wcf.global.page.pagination"><![CDATA[Navigation]]></item>
+		<item name="wcf.global.page.previous"><![CDATA[Vorherige Seite]]></item>
+		<item name="wcf.global.pageDirection"><![CDATA[ltr]]></item> <!-- system variable; do not translate -->
+		<item name="wcf.global.scrollDown"><![CDATA[Zum Seitenende]]></item>
+		<item name="wcf.global.scrollUp"><![CDATA[Zum Seitenanfang]]></item>
+		<item name="wcf.global.search.enterSearchTerm"><![CDATA[Suchbegriff eingeben]]></item>
+		<item name="wcf.global.showOrder"><![CDATA[Reihenfolge]]></item>
+		<item name="wcf.global.sortOrder.ascending"><![CDATA[aufsteigend]]></item>
+		<item name="wcf.global.sortOrder.descending"><![CDATA[absteigend]]></item>
+		<item name="wcf.global.state.closed"><![CDATA[Geschlossen]]></item>
+		<item name="wcf.global.state.trashed"><![CDATA[Im Papierkorb]]></item>
+		<item name="wcf.global.subject"><![CDATA[Betreff]]></item>
+		<item name="wcf.global.thousandsSeparator"><![CDATA[.]]></item>
+		<item name="wcf.global.title"><![CDATA[Titel]]></item>
+		<item name="wcf.global.jumpToPage"><![CDATA[Zur Seite]]></item>
+		<item name="wcf.global.preview"><![CDATA[Vorschau]]></item>
+		<item name="wcf.global.multiSelect"><![CDATA[Mehrfache Markierungen sind durch zusätzliches Drücken der Taste „Strg/Ctrl“ (Windows) oder „Befehl/Command“ (Mac OS) möglich.]]></item>
+		<item name="wcf.global.noDeclaration"><![CDATA[Keine Angabe]]></item>
+		<item name="wcf.global.defaultValue"><![CDATA[Standard]]></item>
+		<item name="wcf.global.noSelection"><![CDATA[(Keine Auswahl)]]></item>
+		<item name="wcf.global.acp"><![CDATA[Administrationsoberfläche]]></item>
+		<item name="wcf.global.acp.short"><![CDATA[Administration]]></item>
+		<item name="wcf.global.worker.completed"><![CDATA[Aufgabe abgeschlossen]]></item>
+		<item name="wcf.global.worker.executing"><![CDATA[Aufgaben werden ausgeführt …]]></item>
+		<item name="wcf.global.filter"><![CDATA[Filter]]></item>
+		<item name="wcf.global.noItems"><![CDATA[Es wurden keine Einträge gefunden.]]></item>
+		<item name="wcf.global.button.showAll"><![CDATA[Alle anzeigen]]></item>
+		<item name="wcf.global.reason"><![CDATA[Begründung]]></item>
+		<item name="wcf.global.settings"><![CDATA[Einstellungen]]></item>
+		<item name="wcf.global.bulkProcessing.warning"><![CDATA[Die Massenbearbeitung führt die unten ausgewählte Aktion <b>ohne zusätzliche Sicherheitsabfrage</b> aus!]]></item>
+		<item name="wcf.global.search"><![CDATA[Suche]]></item>
+		<item name="wcf.global.select"><![CDATA[Auswählen]]></item>
+		<item name="wcf.global.sorting"><![CDATA[Sortierung]]></item>
+		<item name="wcf.global.fontAwesome.selectIcon"><![CDATA[Icon auswählen]]></item>
+		<item name="wcf.global.button.hideNavigation"><![CDATA[Navigation verbergen]]></item>
+		<item name="wcf.global.button.showNavigation"><![CDATA[Navigation anzeigen]]></item>
+		<item name="wcf.global.button.hideSidebar"><![CDATA[Sidebar verbergen]]></item>
+		<item name="wcf.global.button.showSidebar"><![CDATA[Sidebar anzeigen]]></item>
+	</category>
+	
+	<category name="wcf.global.form">
+		<item name="wcf.global.form.data"><![CDATA[Allgemeine Daten]]></item>
+		<item name="wcf.global.form.error"><![CDATA[Deine Angaben sind ungültig. Bitte überprüfe die markierten Eingabefelder.]]></item>
+		<item name="wcf.global.form.error.empty"><![CDATA[Bitte fülle dieses Eingabefeld aus.]]></item>
+		<item name="wcf.global.form.error.greaterThan"><![CDATA[Der eingegebene Wert muss größer sein als {#$greaterThan}.]]></item>
+		<item name="wcf.global.form.error.lessThan"><![CDATA[Der eingegebene Wert muss kleiner sein als {#$lessThan}.]]></item>
+		<item name="wcf.global.form.error.multilingual"><![CDATA[Bitte fülle dieses Eingabefeld für jede Sprache aus.]]></item>
+		<item name="wcf.global.form.error.noValidSelection"><![CDATA[Wähle eine der angebotenen Optionen aus.]]></item>
+		<item name="wcf.global.form.error.securityToken"><![CDATA[Deine Sitzung ist abgelaufen, bitte sende das Formular erneut ab.]]></item>
+		<item name="wcf.global.form.input.maxItems"><![CDATA[Maximale Anzahl erreicht]]></item>
+		
+		<!-- deprecated since 2.1 -->
+		<item name="wcf.global.form.error.lessThan.javaScript"><![CDATA[{literal}Der eingegebene Wert muss kleiner sein als {#$lessThan}.{/literal}]]></item>
+		<item name="wcf.global.form.error.greaterThan.javaScript"><![CDATA[{literal}Der eingegebene Wert muss größer sein als {#$greaterThan}.{/literal}]]></item>
+		<!-- /deprecated since 2.1 -->
+	</category>
+	
+	<category name="wcf.imageViewer">
+		<item name="wcf.imageViewer.button.enlarge"><![CDATA[Vollbild-Modus]]></item>
+		<item name="wcf.imageViewer.button.full"><![CDATA[Originalversion aufrufen]]></item>
+		<item name="wcf.imageViewer.button.openSlideshow"><![CDATA[Slideshow]]></item>
+		<item name="wcf.imageViewer.seriesIndex"><![CDATA[{literal}{x} von {y}{/literal}]]></item>
+		
+		<item name="wcf.imageViewer.close"><![CDATA[Schließen]]></item>
+		<item name="wcf.imageViewer.counter"><![CDATA[{literal}Bild {x} von {y}{/literal}]]></item>
+		<item name="wcf.imageViewer.enlarge"><![CDATA[Bild direkt anzeigen]]></item>
+		<item name="wcf.imageViewer.next"><![CDATA[Nächstes Bild]]></item>
+		<item name="wcf.imageViewer.previous"><![CDATA[Vorheriges Bild]]></item>
+	</category>
+	
+	<category name="wcf.label">
+		<item name="wcf.label.all"><![CDATA[Alle]]></item>
+		<item name="wcf.label.error.missing"><![CDATA[Du musst ein Label auswählen.]]></item>
+		<item name="wcf.label.error.invalid"><![CDATA[Die Labelauswahl ist ungültig.]]></item>
+		<item name="wcf.label.label"><![CDATA[Label]]></item>
+		<item name="wcf.label.labels"><![CDATA[Labels]]></item>
+		<item name="wcf.label.none"><![CDATA[Keine Auswahl]]></item>
+		<item name="wcf.label.withoutSelection"><![CDATA[Ohne Label]]></item>
+	</category>
+	
+	<category name="wcf.like">
+		<item name="wcf.like.cumulativeLikes"><![CDATA[Likes]]></item>
+		<item name="wcf.like.tooltip"><![CDATA[{if $likes}{#$likes} Like{if $likes != 1}s{/if}{if $dislikes}, {/if}{/if}{if $dislikes}{#$dislikes} Dislike{if $dislikes != 1}s{/if}{/if}]]></item>
+		<item name="wcf.like.jsTooltip"><![CDATA[{literal}{if $likes}{#$likes} Like{if $likes != 1}s{/if}{if $dislikes}, {/if}{/if}{if $dislikes}{#$dislikes} Dislike{if $dislikes != 1}s{/if}{/if}{/literal}]]></item>
+		<item name="wcf.like.button.like"><![CDATA[Gefällt mir]]></item>
+		<item name="wcf.like.button.dislike"><![CDATA[Gefällt mir nicht]]></item>
+		<item name="wcf.like.likesReceived"><![CDATA[Erhaltene Likes]]></item>
+		<item name="wcf.like.showLikesReceived"><![CDATA[Erhaltene Likes von {$user->username}]]></item>
+		<item name="wcf.like.likesGiven"><![CDATA[Vergebene Likes]]></item>
+		<item name="wcf.like.dislikesReceived"><![CDATA[Erhaltene Dislikes]]></item>
+		<item name="wcf.like.dislikesGiven"><![CDATA[Vergebene Dislikes]]></item>
+		<item name="wcf.like.summary"><![CDATA[{literal}{if $others == 0}{@$users.slice(0, -1).join(", ")}{if $users.length > 1} und {/if}{@$users.slice(-1)[0]}{else}{@$users.join(", ")} und {if $others == 1}einem{else}{#$others}{/if} weiteren{/if} gefällt das.{/literal}]]></item>
+		<item name="wcf.like.details"><![CDATA[Details]]></item>
+		<item name="wcf.like.details.like"><![CDATA[Likes]]></item>
+		<item name="wcf.like.details.dislike"><![CDATA[Dislikes]]></item>
+		<item name="wcf.like.objectType.com.woltlab.wcf.comment"><![CDATA[Kommentar]]></item>
+		<item name="wcf.like.objectType.com.woltlab.wcf.comment.response"><![CDATA[Kommentar-Antwort]]></item>
+		<item name="wcf.like.likes.more"><![CDATA[Weitere Likes]]></item>
+		<item name="wcf.like.likes.noMoreEntries"><![CDATA[Keine weiteren Likes]]></item>
+		<item name="wcf.like.dislikes.more"><![CDATA[Weitere Dislikes]]></item>
+		<item name="wcf.like.dislikes.noMoreEntries"><![CDATA[Keine weiteren Dislikes]]></item>
+		<item name="wcf.like.title.com.woltlab.wcf.user.profileComment"><![CDATA[Mag den Kommentar {if $commentAuthor}<a href="{link controller='User' object=$commentAuthor}{/link}">von {$commentAuthor->username}</a>{else}eines Gasts{/if} an der <a href="{link controller='User' object=$user}#wall/comment{@$commentID}{/link}">Pinnwand von {$user->username}</a>{if $like->isDislike()} nicht{/if}.]]></item>
+		<item name="wcf.like.title.com.woltlab.wcf.user.profileComment.response"><![CDATA[Mag die Antwort {if $responseAuthor}<a href="{link controller='User' object=$responseAuthor}{/link}">von {$responseAuthor->username}</a>{else}eines Gasts{/if} zum Kommentar {if $commentAuthor}von <a href="{link controller='User' object=$commentAuthor}{/link}">{$commentAuthor->username}</a>{else}eines Gasts{/if} an der <a href="{link controller='User' object=$user}#wall/comment{@$commentID}/response{@$responseID}{/link}">Pinnwand von {$user->username}</a>{if $like->isDislike()} nicht{/if}.]]></item>
+		<item name="wcf.like.objectType.com.woltlab.wcf.likeableArticle"><![CDATA[Artikel]]></item>
+		<item name="wcf.like.title.com.woltlab.wcf.likeableArticle"><![CDATA[Mag den Artikel <a href="{$article->getLink()}">{$article->getTitle()}</a>{if $like->isDislike()} nicht{/if}.]]></item>
+		<item name="wcf.like.title.com.woltlab.wcf.articleComment"><![CDATA[Mag den Kommentar {if $commentAuthor}von <a href="{link controller='User' object=$commentAuthor}{/link}">{$commentAuthor->username}</a>{else}eines Gasts{/if} zum Artikel <a href="{$articleContent->getLink()}#comments">{$articleContent->getTitle()}</a>{if $like->isDislike()} nicht{/if}.]]></item>
+		<item name="wcf.like.title.com.woltlab.wcf.articleComment.response"><![CDATA[Mag die Antwort {if $responseAuthor}von <a href="{link controller='User' object=$responseAuthor}{/link}">{$responseAuthor->username}</a>{else}eines Gasts{/if} zum Kommentar {if $commentAuthor}von <a href="{link controller='User' object=$commentAuthor}{/link}">{$commentAuthor->username}</a>{else}eines Gasts{/if} zum Artikel <a href="{$articleContent->getLink()}#comments">{$articleContent->getTitle()}</a>{if $like->isDislike()} nicht{/if}.]]></item>
+		<item name="wcf.like.title.com.woltlab.wcf.pageComment"><![CDATA[Mag den Kommentar {if $commentAuthor}von <a href="{link controller='User' object=$commentAuthor}{/link}">{$commentAuthor->username}</a>{else}eines Gasts{/if} zu der Seite <a href="{$page->getLink()}#comments">{$page->getTitle()}</a>{if $like->isDislike()} nicht{/if}.]]></item>
+		<item name="wcf.like.title.com.woltlab.wcf.pageComment.response"><![CDATA[Mag die Antwort {if $responseAuthor}von <a href="{link controller='User' object=$responseAuthor}{/link}">{$responseAuthor->username}</a>{else}eines Gasts{/if} zum Kommentar {if $commentAuthor}von <a href="{link controller='User' object=$commentAuthor}{/link}">{$commentAuthor->username}</a>{else}eines Gasts{/if} zu der Seite <a href="{$page->getLink()}#comments">{$page->getTitle()}</a>{if $like->isDislike()} nicht{/if}.]]></item>
+	</category>
+	
+	<category name="wcf.map">
+		<item name="wcf.map.noLocationSuggestions"><![CDATA[Für den aktuellen Kartenausschnitt liegen keine Ortsvorschläge vor.]]></item>
+		<item name="wcf.map.route.button.calculateRoute"><![CDATA[Route berechnen]]></item>
+		<item name="wcf.map.route.error.not_found"><![CDATA[Die Route konnte nicht berechnet werden.]]></item>
+		<item name="wcf.map.route.error.over_query_limit"><![CDATA[Die Route konnte nicht berechnet werden. Innerhalb des zulässigen Zeitraums wurden zu viele Anfragen an die Google Maps API gesendet.]]></item>
+		<item name="wcf.map.route.error.request_denied"><![CDATA[Die Route konnte nicht berechnet werden. Diese Webseite ist nicht berechtigt ist, den Google Maps Directions-Dienst zu nutzen]]></item>
+		<item name="wcf.map.route.origin"><![CDATA[Startpunkt]]></item>
+		<item name="wcf.map.route.planner"><![CDATA[Routenplaner]]></item>
+		<item name="wcf.map.route.travelMode"><![CDATA[Verkehrsmittel]]></item>
+		<item name="wcf.map.route.travelMode.bicycling"><![CDATA[Fahrrad]]></item>
+		<item name="wcf.map.route.travelMode.driving"><![CDATA[Auto]]></item>
+		<item name="wcf.map.route.travelMode.transit"><![CDATA[Öffentliche Verkehrsmittel]]></item>
+		<item name="wcf.map.route.travelMode.walking"><![CDATA[Zu Fuß]]></item>
+		<item name="wcf.map.route.viewOnGoogleMaps"><![CDATA[Direkt bei Google Maps anschauen]]></item>
+		<item name="wcf.map.showLocationSuggestions"><![CDATA[Orte vorschlagen]]></item>
+		<item name="wcf.map.useLocationSuggestion"><![CDATA[Ort verwenden]]></item>
+	</category>
+	
+	<category name="wcf.media">
+		<item name="wcf.media.altText"><![CDATA[Alternativ-Text]]></item>
+		<item name="wcf.media.button.insert"><![CDATA[Einfügen]]></item>
+		<item name="wcf.media.button.select"><![CDATA[Auswählen]]></item>
+		<item name="wcf.media.caption"><![CDATA[Bildunterschrift]]></item>
+		<item name="wcf.media.category.choose"><![CDATA[Kategorien]]></item>
+		<item name="wcf.media.categoryID"><![CDATA[Kategorie]]></item>
+		<item name="wcf.media.chooseImage"><![CDATA[Bild auswählen]]></item>
+		<item name="wcf.media.delete.confirmMessage"><![CDATA[Möchtest du die Datei <span class="confirmationObject">{$title}</span> wirklich löschen?]]></item>
+		<item name="wcf.media.edit"><![CDATA[Datei bearbeiten]]></item>
+		<item name="wcf.media.filename"><![CDATA[Dateiname]]></item>
+		<item name="wcf.media.filesize"><![CDATA[Dateigröße]]></item>
+		<item name="wcf.media.imageDimensions"><![CDATA[Bildformat]]></item>
+		<item name="wcf.media.imageDimensions.value"><![CDATA[{#$media->width}×{#$media->height}]]></item>
+		<item name="wcf.media.insert"><![CDATA[Datei einfügen]]></item>
+		<item name="wcf.media.insert.imageSize"><![CDATA[Bildgröße]]></item>
+		<item name="wcf.media.insert.imageSize.large"><![CDATA[Großes Vorschaubild]]></item>
+		<item name="wcf.media.insert.imageSize.medium"><![CDATA[Mittleres Vorschaubild]]></item>
+		<item name="wcf.media.insert.imageSize.original"><![CDATA[Original-Bild]]></item>
+		<item name="wcf.media.insert.imageSize.small"><![CDATA[Kleines Vorschaubild]]></item>
+		<item name="wcf.media.isMultilingual"><![CDATA[Mehrsprachigkeit aktivieren]]></item>
+		<item name="wcf.media.languageID"><![CDATA[Sprache]]></item>
+		<item name="wcf.media.manager"><![CDATA[Medien verwalten]]></item>
+		<item name="wcf.media.media"><![CDATA[Medien]]></item>
+		<item name="wcf.media.search.cancel"><![CDATA[Suche abbrechen]]></item>
+		<item name="wcf.media.search.placeholder"><![CDATA[Datei suchen]]></item>
+		<item name="wcf.media.upload.error.noImage"><![CDATA[Die hochgeladene Datei ist kein Bild.]]></item>
+		<item name="wcf.media.upload.success"><![CDATA[Die Datei wurde erfolgreich hochgeladen.]]></item>
+		<item name="wcf.media.uploader"><![CDATA[Hochgeladen von]]></item>
+		<item name="wcf.media.uploadTime"><![CDATA[Datum hochgeladen]]></item>
+		<item name="wcf.media.search.noResults"><![CDATA[Es wurden keine Ergebnisse gefunden.]]></item>
+	</category>
+	
+	<category name="wcf.message">
+		<item name="wcf.message.autosave.prompt"><![CDATA[Gespeicherten Entwurf wiederherstellen?]]></item>
+		<item name="wcf.message.autosave.prompt.confirm"><![CDATA[Entwurf wiederherstellen]]></item>
+		<item name="wcf.message.autosave.prompt.discard"><![CDATA[Entwurf verwerfen]]></item>
+		<item name="wcf.message.autosave.restored"><![CDATA[Entwurf wiederhergestellt]]></item>
+		<item name="wcf.message.autosave.restored.confirm"><![CDATA[Beibehalten]]></item>
+		<item name="wcf.message.autosave.restored.revert"><![CDATA[Verwerfen und Editor leeren]]></item>
+		<item name="wcf.message.autosave.restored.revert.confirmMessage"><![CDATA[Willst du den gespeicherten Entwurf wirklich löschen und den Editor leeren?]]></item>
+		<item name="wcf.message.autosave.restored.version"><![CDATA[Entwurf vom {@$date}]]></item>
+		<item name="wcf.message.autosave.saved"><![CDATA[Entwurf gespeichert]]></item>
+		<item name="wcf.message.bbcode.code.copy"><![CDATA[Inhalt kopieren]]></item>
+		<item name="wcf.message.quote.insertAllQuotes"><![CDATA[Alle Zitate einfügen]]></item>
+		<item name="wcf.message.quote.insertQuote"><![CDATA[Zitat einfügen]]></item>
+		<item name="wcf.message.quote.insertSelectedQuotes"><![CDATA[Markierte Zitate einfügen]]></item>
+		<item name="wcf.message.quote.manageQuotes"><![CDATA[Zitate verwalten]]></item>
+		<item name="wcf.message.quote.quoteSelected"><![CDATA[Zitat speichern]]></item>
+		<item name="wcf.message.quote.quoteAndReply"><![CDATA[Zitat einfügen]]></item>
+		<item name="wcf.message.quote.showQuotes"><![CDATA[Zitate (#count#)]]></item>
+		<item name="wcf.message.quote.quoteMessage"><![CDATA[Zitieren]]></item>
+		<item name="wcf.message.quote.removeAllQuotes"><![CDATA[Alle Zitate entfernen]]></item>
+		<item name="wcf.message.quote.removeSelectedQuotes"><![CDATA[Markierte Zitate entfernen]]></item>
+		<item name="wcf.message.settings"><![CDATA[Einstellungen]]></item>
+		<item name="wcf.message.share"><![CDATA[Teilen]]></item>
+		<item name="wcf.message.share.facebook"><![CDATA[Facebook]]></item>
+		<item name="wcf.message.share.google"><![CDATA[Google+]]></item>
+		<item name="wcf.message.share.permalink"><![CDATA[Permalink]]></item>
+		<item name="wcf.message.share.permalink.bbcode"><![CDATA[BBCode]]></item>
+		<item name="wcf.message.share.permalink.html"><![CDATA[HTML]]></item>
+		<item name="wcf.message.share.reddit"><![CDATA[Reddit]]></item>
+		<item name="wcf.message.share.twitter"><![CDATA[Twitter]]></item>
+		<item name="wcf.message.share.whatsApp"><![CDATA[WhatsApp]]></item>
+		<item name="wcf.message.share.linkedIn"><![CDATA[LinkedIn]]></item>
+		<item name="wcf.message.share.pinterest"><![CDATA[Pinterest]]></item>
+		<item name="wcf.message.share.xing"><![CDATA[XING]]></item>
+		<item name="wcf.message.smilies"><![CDATA[Smileys]]></item>
+		<item name="wcf.message.button.extendedReply"><![CDATA[Erweiterte Antwort]]></item>
+		<item name="wcf.message.button.extendedEdit"><![CDATA[Erweiterte Bearbeitung]]></item>
+		<item name="wcf.message.new"><![CDATA[Neu]]></item>
+		<item name="wcf.message.error.censoredWordsFound"><![CDATA[Deine Nachricht enthält folgende zensierte Wörter: {implode from=$censoredWords key=censoredWord item=number}{$censoredWord}{if $number > 1} ({#$number}×){/if}{/implode}]]></item>
+		<item name="wcf.message.error.disallowedBBCodes"><![CDATA[Deine Nachricht enthält die folgenden BBCodes, die du nicht verwenden darst: {implode from=$disallowedBBCodes item=disallowedBBCode}{$disallowedBBCode}{/implode}]]></item>
+		<item name="wcf.message.error.editorAlreadyInUse"><![CDATA[Der Editor ist bereits aktiv, beende die Bearbeitung bevor du fortfährst.]]></item>
+		<item name="wcf.message.error.tooLong"><![CDATA[Deine Nachricht ist zu lang. Es stehen maximal {#$maxTextLength} Zeichen zur Verfügung.]]></item>
+		<item name="wcf.message.status.deleted"><![CDATA[Gelöscht]]></item>
+		<item name="wcf.message.status.disabled"><![CDATA[Deaktiviert]]></item>
+	</category>
+	
+	<category name="wcf.menu">
+		<!-- category for menus and menu items -->
+		
+		<item name="wcf.menu.page"><![CDATA[Menü]]></item>
+		<item name="wcf.menu.page.location"><![CDATA[Aktueller Ort]]></item>
+		<item name="wcf.menu.page.navigation"><![CDATA[Navigation]]></item>
+		<item name="wcf.menu.page.options"><![CDATA[Optionen]]></item>
+		<item name="wcf.menu.user"><![CDATA[Benutzer-Menü]]></item>
+	</category>
+	
+	<category name="wcf.moderation">
+		<item name="wcf.moderation.assignedUser"><![CDATA[Zugewiesener Benutzer]]></item>
+		<item name="wcf.moderation.assignedUser.change"><![CDATA[Zugewiesenen Benutzer ändern]]></item>
+		<item name="wcf.moderation.assignedUser.error.notAffected"><![CDATA[Dieser Benutzer hat unzureichende Zugriffsrechte]]></item>
+		<item name="wcf.moderation.assignedUser.nobody"><![CDATA[Niemand]]></item>
+		<item name="wcf.moderation.filterByType"><![CDATA[Typ]]></item>
+		<item name="wcf.moderation.filterByUser"><![CDATA[Zugewiesener Benutzer]]></item>
+		<item name="wcf.moderation.filterByUser.allEntries"><![CDATA[Alle Einträge]]></item>
+		<item name="wcf.moderation.filterByUser.myself"><![CDATA[Ich ({$__wcf->getUser()->username})]]></item>
+		<item name="wcf.moderation.filterByUser.nobody"><![CDATA[Niemand]]></item>
+		<item name="wcf.moderation.outstandingItems"><![CDATA[Ausstehende Einträge]]></item>
+		<item name="wcf.moderation.doneItems"><![CDATA[Erledigte Einträge]]></item>
+		<item name="wcf.moderation.lastChangeTime"><![CDATA[Letzte Änderung]]></item>
+		<item name="wcf.moderation.markAllAsRead.confirmMessage"><![CDATA[Willst du wirklich alle Einträge als gelesen markieren?]]></item>
+		<item name="wcf.moderation.moderation"><![CDATA[Moderation]]></item>
+		<item name="wcf.moderation.noMoreItems"><![CDATA[Keine weiteren Einträge]]></item>
+		<item name="wcf.moderation.notification.comment.title"><![CDATA[Neuer Kommentar (Moderation)]]></item>
+		<item name="wcf.moderation.notification.comment.title.stacked"><![CDATA[{#$timesTriggered} neue Kommentare (Moderation)]]></item>
+		<item name="wcf.moderation.notification.comment.message"><![CDATA[{if !$author->userID}Ein Gast{else}{@$author->getAnchorTag()}{/if} hat einen Kommentar zum Moderationseintrag <a href="{@$moderationQueue->getLink()}">{$moderationQueue->getTitle()}</a> verfasst.]]></item>
+		<item name="wcf.moderation.notification.comment.message.stacked"><![CDATA[{if $count < 4}{@$authors[0]->getAnchorTag()}{if $count != 1}{if $count == 2} und {else}, {/if}{@$authors[1]->getAnchorTag()}{if $count == 3} und {@$authors[2]->getAnchorTag()}{/if}{/if}{else}{@$authors[0]->getAnchorTag()} und {#$others} weitere Benutzer{/if} haben Kommentare zum Moderationseintrag <a href="{@$moderationQueue->getLink()}">{$moderationQueue->getTitle()}</a> verfasst.]]></item>
+		<item name="wcf.moderation.notification.comment.mail.plaintext"><![CDATA[{@$authorList} {if $count == 1 && !$guestTimesTriggered}hat einen Kommentar{else}haben Kommentare{/if} zum Moderationseintrag {$notificationContent[variables][moderationQueue]->getTitle()} [URL:{$notificationContent[variables][moderationQueue]->getLink()}] verfasst{if $count == 1 && !$guestTimesTriggered}:{else}.{/if}]]></item>
+		<item name="wcf.moderation.notification.comment.mail.html"><![CDATA[<p>{@$authorList} {if $count == 1 && !$guestTimesTriggered}hat einen Kommentar{else}haben Kommentare{/if} zum Moderationseintrag <a href="{$notificationContent[variables][moderationQueue]->getLink()}">{$notificationContent[variables][moderationQueue]->getTitle()}</a> verfasst:</p>]]></item>
+		<item name="wcf.moderation.notification.commentResponse.title"><![CDATA[Neue Antwort (Moderation)]]></item>
+		<item name="wcf.moderation.notification.commentResponse.title.stacked"><![CDATA[{#$timesTriggered} neue Antworten (Moderation)]]></item>
+		<item name="wcf.moderation.notification.commentResponse.message"><![CDATA[{if !$author->userID}Ein Gast{else}{@$author->getAnchorTag()}{/if} hat eine Antwort zum Kommentar von {if $commentAuthor->userID}<a href="{link controller='User' object=$commentAuthor}{/link}" class="userLink" data-user-id="{@$commentAuthor->userID}">{$commentAuthor->username}</a>{else}{$commentAuthor->username}{/if} zum Moderationseintrag <a href="{@$moderationQueue->getLink()}">{$moderationQueue->getTitle()}</a> verfasst.]]></item>
+		<item name="wcf.moderation.notification.commentResponse.message.stacked"><![CDATA[{if $count < 4}{@$authors[0]->getAnchorTag()}{if $count != 1}{if $count == 2} und {else}, {/if}{@$authors[1]->getAnchorTag()}{if $count == 3}und {@$authors[2]->getAnchorTag()}{/if}{/if}{else}{@$authors[0]->getAnchorTag()} und {#$others} weitere Benutzer{/if} haben Kommentare zum Moderationseintrag <a href="{@$moderationQueue->getLink()}">{$moderationQueue->getTitle()}</a> verfasst.]]></item>
+		<item name="wcf.moderation.notification.commentResponse.mail.plaintext"><![CDATA[{@$authorList} {if $count == 1 && !$guestTimesTriggered}hat eine Antwort{else}haben Antworten{/if} zum Kommentar von {@$notificationContent[variables][commentAuthor]->username}{if $notificationContent[variables][commentAuthor]->userID} [URL:{link controller='User' object=$notificationContent[variables][commentAuthor] isEmail=true}{/link}]{/if} zum Moderationseintrag {$notificationContent[variables][moderationQueue]->getTitle()} [URL:{$notificationContent[variables][moderationQueue]->getLink()}] verfasst{if $count == 1 && !$guestTimesTriggered}:{else}.{/if}]]></item>
+		<item name="wcf.moderation.notification.commentResponse.mail.html"><![CDATA[<p>{@$authorList} {if $count == 1 && !$guestTimesTriggered}hat eine Antwort{else}haben Antworten{/if} zum Kommentar von {if $notificationContent[variables][commentAuthor]->userID}<a href="{link controller='User' object=$notificationContent[variables][commentAuthor] isEmail=true}{/link}">{$notificationContent[variables][commentAuthor]->username}</a>{else}{$notificationContent[variables][commentAuthor]->username}{/if} zum Moderationseintrag <a href="{$notificationContent[variables][moderationQueue]->getLink()}">{$notificationContent[variables][moderationQueue]->getTitle()}</a> verfasst:</p>]]></item>
+		<item name="wcf.moderation.status"><![CDATA[Status]]></item>
+		<item name="wcf.moderation.status.outstanding"><![CDATA[Ausstehend]]></item>
+		<item name="wcf.moderation.status.processing"><![CDATA[In Bearbeitung]]></item>
+		<item name="wcf.moderation.status.done"><![CDATA[Erledigt]]></item>
+		<item name="wcf.moderation.status.confirmed.com.woltlab.wcf.moderation.activation"><![CDATA[Inhalt wurde freigeschaltet]]></item>
+		<item name="wcf.moderation.status.confirmed.com.woltlab.wcf.moderation.report"><![CDATA[Meldung berechtigt, Inhalt wurde gelöscht]]></item>
+		<item name="wcf.moderation.status.rejected.com.woltlab.wcf.moderation.activation"><![CDATA[Freischaltung wurde abgelehnt]]></item>
+		<item name="wcf.moderation.status.rejected.com.woltlab.wcf.moderation.report"><![CDATA[Meldung unberechtigt]]></item>
+		<item name="wcf.moderation.status.rejectedButJustified.com.woltlab.wcf.moderation.report"><![CDATA[Meldung berechtigt]]></item>
+		<item name="wcf.moderation.time"><![CDATA[Datum]]></item>
+		<item name="wcf.moderation.title"><![CDATA[Titel]]></item>
+		<item name="wcf.moderation.type"><![CDATA[Typ]]></item>
+		<item name="wcf.moderation.type.all"><![CDATA[Alle Einträge]]></item>
+		<item name="wcf.moderation.type.com.woltlab.wcf.moderation.activation"><![CDATA[Freischaltung]]></item>
+		<item name="wcf.moderation.type.com.woltlab.wcf.moderation.activation.delayed"><![CDATA[Zeitgesteuerte Freischaltung]]></item>
+		<item name="wcf.moderation.type.com.woltlab.wcf.moderation.report"><![CDATA[Meldung]]></item>
+		<item name="wcf.moderation.type.com.woltlab.wcf.comment.comment"><![CDATA[Kommentar]]></item>
+		<item name="wcf.moderation.type.com.woltlab.wcf.comment.response"><![CDATA[Antwort auf Kommentar]]></item>
+		<item name="wcf.moderation.type.com.woltlab.wcf.user"><![CDATA[Benutzerprofil]]></item>
+		<item name="wcf.moderation.showAll"><![CDATA[Alle Einträge anzeigen]]></item>
+		<item name="wcf.moderation.showDeletedContent"><![CDATA[Gelöschte Inhalte anzeigen]]></item>
+		<item name="wcf.moderation.deletedContent.objectTypes"><![CDATA[Gelöschte Inhalte]]></item>
+		<item name="wcf.moderation.comments.description"><![CDATA[Diese Kommentare sind intern und nur für Moderatoren einsehbar]]></item>
+		<item name="wcf.moderation.jumpToContent"><![CDATA[Zum Inhalt gehen]]></item>
+		<item name="wcf.moderation.markAllAsRead"><![CDATA[Alle Einträge als gelesen markieren]]></item>
+		<item name="wcf.moderation.markAsRead.doubleClick"><![CDATA[Eintrag durch Doppelklick als gelesen markieren]]></item>
+	</category>
+	
+	<category name="wcf.moderation.activation">
+		<item name="wcf.moderation.activation"><![CDATA[Freischaltung]]></item>
+		<item name="wcf.moderation.activation.details"><![CDATA[Informationen]]></item>
+		<item name="wcf.moderation.activation.content"><![CDATA[Freizuschaltender Inhalt]]></item>
+		<item name="wcf.moderation.activation.enableContent"><![CDATA[Inhalt freischalten]]></item>
+		<item name="wcf.moderation.activation.enableContent.confirmMessage"><![CDATA[Willst du diesen Inhalt wirklich freischalten?]]></item>
+		<item name="wcf.moderation.activation.notification.comment.title"><![CDATA[Neuer Kommentar (Freischaltung)]]></item>
+		<item name="wcf.moderation.activation.notification.comment.title.stacked"><![CDATA[{#$timesTriggered} neue Kommentare (Freischaltung)]]></item>
+		<item name="wcf.moderation.activation.notification.comment.message"><![CDATA[{if !$author->userID}Ein Gast{else}{@$author->getAnchorTag()}{/if} hat einen Kommentar zum freizuschaltenden Inhalt <a href="{@$moderationQueue->getLink()}">{$moderationQueue->getTitle()}</a> verfasst.]]></item>
+		<item name="wcf.moderation.activation.notification.comment.message.stacked"><![CDATA[{if $count < 4}{@$authors[0]->getAnchorTag()}{if $count != 1}{if $count == 2} und {else}, {/if}{@$authors[1]->getAnchorTag()}{if $count == 3}und {@$authors[2]->getAnchorTag()}{/if}{/if}{else}{@$authors[0]->getAnchorTag()} und {#$others} weitere Benutzer{/if} haben Kommentare zum freizuschaltenden Inhalt <a href="{@$moderationQueue->getLink()}">{$moderationQueue->getTitle()}</a> verfasst.]]></item>
+		<item name="wcf.moderation.activation.notification.comment.mail.plaintext"><![CDATA[{@$authorList} {if $count == 1 && !$guestTimesTriggered}hat einen Kommentar{else}haben Kommentare{/if} zum freizuschaltenden Inhalt {$notificationContent[variables][moderationQueue]->getTitle()} [URL:{$notificationContent[variables][moderationQueue]->getLink()}] verfasst{if $count == 1 && !$guestTimesTriggered}:{else}.{/if}]]></item>
+		<item name="wcf.moderation.activation.notification.comment.mail.html"><![CDATA[<p>{@$authorList} {if $count == 1 && !$guestTimesTriggered}hat einen Kommentar{else}haben Kommentare{/if} zum freizuschaltenden Inhalt <a href="{$notificationContent[variables][moderationQueue]->getLink()}">{$notificationContent[variables][moderationQueue]->getTitle()}</a> verfasst:</p>]]></item>
+		<item name="wcf.moderation.activation.notification.commentResponse.title"><![CDATA[Neue Antwort (Freischaltung)]]></item>
+		<item name="wcf.moderation.activation.notification.commentResponse.title.stacked"><![CDATA[{#$timesTriggered} neue Antworten (Freischaltung)]]></item>
+		<item name="wcf.moderation.activation.notification.commentResponse.message"><![CDATA[{if !$author->userID}Ein Gast{else}{@$author->getAnchorTag()}{/if} hat eine Antwort zum Kommentar von {if $commentAuthor->userID}<a href="{link controller='User' object=$commentAuthor}{/link}" class="userLink" data-user-id="{@$commentAuthor->userID}">{$commentAuthor->username}</a>{else}{$commentAuthor->username}{/if} zum freizuschaltenden Inhalt <a href="{@$moderationQueue->getLink()}">{$moderationQueue->getTitle()}</a> verfasst.]]></item>
+		<item name="wcf.moderation.activation.notification.commentResponse.message.stacked"><![CDATA[{if $count < 4}{@$authors[0]->getAnchorTag()}{if $count != 1}{if $count == 2} und {else}, {/if}{@$authors[1]->getAnchorTag()}{if $count == 3} und {@$authors[2]->getAnchorTag()}{/if}{/if}{else}{@$authors[0]->getAnchorTag()} und {#$others} weitere Benutzer{/if} haben Antworten zu Kommentare zum freizuschaltenden Inhalt <a href="{@$moderationQueue->getLink()}">{$moderationQueue->getTitle()}</a> verfasst.]]></item>
+		<item name="wcf.moderation.activation.notification.commentResponse.mail.plaintext"><![CDATA[{@$authorList} {if $count == 1 && !$guestTimesTriggered}hat eine Antwort{else}haben Antworten{/if} zum Kommentar von {@$notificationContent[variables][commentAuthor]->username}{if $notificationContent[variables][commentAuthor]->userID} [URL:{link controller='User' object=$notificationContent[variables][commentAuthor] isEmail=true}{/link}]{/if} zum freizuschaltenden Inhalt {$notificationContent[variables][moderationQueue]->getTitle()} [URL:{$notificationContent[variables][moderationQueue]->getLink()}] verfasst{if $count == 1 && !$guestTimesTriggered}:{else}.{/if}]]></item>
+		<item name="wcf.moderation.activation.notification.commentResponse.mail.html"><![CDATA[<p>{@$authorList} {if $count == 1 && !$guestTimesTriggered}hat eine Antwort{else}haben Antworten{/if} zum Kommentar von {if $notificationContent[variables][commentAuthor]->userID}<a href="{link controller='User' object=$notificationContent[variables][commentAuthor] isEmail=true}{/link}">{$notificationContent[variables][commentAuthor]->username}</a>{else}{$notificationContent[variables][commentAuthor]->username}{/if} zum freizuschaltenden Inhalt <a href="{$notificationContent[variables][moderationQueue]->getLink()}">{$notificationContent[variables][moderationQueue]->getTitle()}</a> verfasst:</p>]]></item>
+		<item name="wcf.moderation.activation.removeContent"><![CDATA[Inhalt löschen]]></item>
+		<item name="wcf.moderation.activation.removeContent.confirmMessage"><![CDATA[Willst du diesen Inhalt wirklich löschen?]]></item>
+	</category>
+	
+	<category name="wcf.moderation.report">
+		<item name="wcf.moderation.report"><![CDATA[Meldung]]></item>
+		<item name="wcf.moderation.report.alreadyReported"><![CDATA[Dieser Inhalt wurde bereits gemeldet.]]></item>
+		<item name="wcf.moderation.report.details"><![CDATA[Informationen]]></item>
+		<item name="wcf.moderation.report.notification.comment.title"><![CDATA[Neuer Kommentar (Meldung)]]></item>
+		<item name="wcf.moderation.report.notification.comment.title.stacked"><![CDATA[{#$timesTriggered} neue Kommentare (Meldung)]]></item>
+		<item name="wcf.moderation.report.notification.comment.message"><![CDATA[{if !$author->userID}Ein Gast{else}{@$author->getAnchorTag()}{/if} hat einen Kommentar zur Meldung <a href="{@$moderationQueue->getLink()}">{$moderationQueue->getTitle()}</a> verfasst.]]></item>
+		<item name="wcf.moderation.report.notification.comment.message.stacked"><![CDATA[{if $count < 4}{@$authors[0]->getAnchorTag()}{if $count != 1}{if $count == 2} und {else}, {/if}{@$authors[1]->getAnchorTag()}{if $count == 3} und {@$authors[2]->getAnchorTag()}{/if}{/if}{else}{@$authors[0]->getAnchorTag()} und {#$others} weitere Benutzer{/if} haben Kommentare zur Meldung <a href="{@$moderationQueue->getLink()}">{$moderationQueue->getTitle()}</a> verfasst.]]></item>
+		<item name="wcf.moderation.report.notification.comment.mail.plaintext"><![CDATA[{@$authorList} {if $count == 1 && !$guestTimesTriggered}hat einen Kommentar{else}haben Kommentare{/if} zu der Meldung {$notificationContent[variables][moderationQueue]->getTitle()} [URL:{$notificationContent[variables][moderationQueue]->getLink()}] verfasst{if $count == 1 && !$guestTimesTriggered}:{else}.{/if}]]></item>
+		<item name="wcf.moderation.report.notification.comment.mail.html"><![CDATA[<p>{@$authorList} {if $count == 1 && !$guestTimesTriggered}hat einen Kommentar{else}haben Kommentare{/if} zu der Meldung <a href="{$notificationContent[variables][moderationQueue]->getLink()}">{$notificationContent[variables][moderationQueue]->getTitle()}</a> verfasst:</p>]]></item>
+		<item name="wcf.moderation.report.notification.commentResponse.title"><![CDATA[Neue Antwort (Meldung)]]></item>
+		<item name="wcf.moderation.report.notification.commentResponse.title.stacked"><![CDATA[{#$timesTriggered} neue Antworten (Meldung)]]></item>
+		<item name="wcf.moderation.report.notification.commentResponse.message"><![CDATA[{if !$author->userID}Ein Gast{else}{@$author->getAnchorTag()}{/if} hat eine Antwort zum Kommentar von {if $commentAuthor->userID}<a href="{link controller='User' object=$commentAuthor}{/link}" class="userLink" data-user-id="{@$commentAuthor->userID}">{$commentAuthor->username}</a>{else}{$commentAuthor->username}{/if} zur Meldung <a href="{@$moderationQueue->getLink()}">{$moderationQueue->getTitle()}</a> verfasst.]]></item>
+		<item name="wcf.moderation.report.notification.commentResponse.message.stacked"><![CDATA[{if $count < 4}{@$authors[0]->getAnchorTag()}{if $count != 1}{if $count == 2} und {else}, {/if}{@$authors[1]->getAnchorTag()}{if $count == 3}und {@$authors[2]->getAnchorTag()}{/if}{/if}{else}{@$authors[0]->getAnchorTag()} und {#$others} weitere Benutzer{/if} haben Antworten zu Kommentare zur Meldung <a href="{@$moderationQueue->getLink()}">{$moderationQueue->getTitle()}</a> verfasst.]]></item>
+		<item name="wcf.moderation.report.notification.commentResponse.mail.plaintext"><![CDATA[{@$authorList} {if $count == 1 && !$guestTimesTriggered}hat eine Antwort{else}haben Antworten{/if} zum Kommentar von {@$notificationContent[variables][commentAuthor]->username}{if $notificationContent[variables][commentAuthor]->userID} [URL:{link controller='User' object=$notificationContent[variables][commentAuthor] isEmail=true}{/link}]{/if} zur Meldung {$notificationContent[variables][moderationQueue]->getTitle()} [URL:{$notificationContent[variables][moderationQueue]->getLink()}] verfasst{if $count == 1 && !$guestTimesTriggered}:{else}.{/if}]]></item>
+		<item name="wcf.moderation.report.notification.commentResponse.mail.html"><![CDATA[<p>{@$authorList} {if $count == 1 && !$guestTimesTriggered}hat eine Antwort{else}haben Antworten{/if} zum Kommentar von {if $notificationContent[variables][commentAuthor]->userID}<a href="{link controller='User' object=$notificationContent[variables][commentAuthor] isEmail=true}{/link}">{$notificationContent[variables][commentAuthor]->username}</a>{else}{$notificationContent[variables][commentAuthor]->username}{/if} zur Meldung <a href="{$notificationContent[variables][moderationQueue]->getLink()}">{$notificationContent[variables][moderationQueue]->getTitle()}</a> verfasst:</p>]]></item>
+		<item name="wcf.moderation.report.reason"><![CDATA[Grund der Meldung]]></item>
+		<item name="wcf.moderation.report.reason.description"><![CDATA[Diese Funktion ist ausschließlich zu verwenden bei: Spam, Werbung und anderen problematischen (rassistischen, gewaltverherrlichenden, aggressiven, beleidigenden oder sexistischen) Inhalten.]]></item>
+		<item name="wcf.moderation.report.removeContent"><![CDATA[Inhalt löschen]]></item>
+		<item name="wcf.moderation.report.removeContent.confirmMessage"><![CDATA[Willst du den gemeldeten Inhalt wirklich löschen?]]></item>
+		<item name="wcf.moderation.report.removeContent.reason"><![CDATA[Begründung (optional)]]></item>
+		<item name="wcf.moderation.report.removeReport"><![CDATA[Meldung löschen]]></item>
+		<item name="wcf.moderation.report.removeReport.confirmMessage"><![CDATA[Willst du diese Meldung wirklich löschen?]]></item>
+		<item name="wcf.moderation.report.removeReport.markAsJustified"><![CDATA[Meldung zusätzlich als „Berechtigt“ markieren]]></item>
+		<item name="wcf.moderation.report.reportContent"><![CDATA[Inhalt melden]]></item>
+		<item name="wcf.moderation.report.reportedBy"><![CDATA[Gemeldet von]]></item>
+		<item name="wcf.moderation.report.reportedContent"><![CDATA[Gemeldeter Inhalt]]></item>
+		<item name="wcf.moderation.report.success"><![CDATA[Der Inhalt wurde den Moderatoren gemeldet.]]></item>
+	</category>
+	
+	<category name="wcf.notice">
+		<item name="wcf.notice.button.dismiss"><![CDATA[Hinweis dauerhaft ausblenden]]></item>
+	</category>
+	
+	<category name="wcf.page">
+		<item name="wcf.page.pageNo"><![CDATA[Seite {#$pageNo}]]></item>
+		<item name="wcf.page.offline"><![CDATA[Die Seite befindet sich zurzeit {if OFFLINE_MESSAGE != ''}aus folgenden Gründen im Wartungsmodus:{else}im Wartungsmodus.{/if}]]></item>
+		<item name="wcf.page.mainMenu"><![CDATA[Navigation]]></item>
+		<item name="wcf.page.pagePosition"><![CDATA[Seite {#$pageNo} von {#$pages}]]></item>
+		<item name="wcf.page.javascriptDisabled"><![CDATA[In deinem Webbrowser ist JavaScript deaktiviert. Um alle Funktionen dieser Website nutzen zu können, muss JavaScript aktiviert sein.]]></item>
+		<item name="wcf.page.requestedPage"><![CDATA[Aufgerufene Seite]]></item>
+		<item name="wcf.page.cookiePolicy.info"><![CDATA[Diese Seite verwendet Cookies. Durch die Nutzung unserer Seite erklärst du dich damit einverstanden, dass wir Cookies setzen.]]></item>
+		<item name="wcf.page.cookiePolicy.info.moreInformation"><![CDATA[Weitere Informationen]]></item>
+		<item name="wcf.page.copyright"><![CDATA[<a href="https://www.woltlab.com/de/" rel="nofollow"{if EXTERNAL_LINK_TARGET_BLANK} target="_blank"{/if}>Community-Software: <strong>WoltLab Suite&trade;{if SHOW_VERSION_NUMBER} {@WCF_VERSION}{/if}</strong></a>]]></item>
+		<item name="wcf.page.onlineLocation.com.woltlab.wcf.Article"><![CDATA[Artikel <a href="{$article->getLink()}">{$article->getTitle()}</a>]]></item>
+		<item name="wcf.page.onlineLocation.com.woltlab.wcf.CategoryArticleList"><![CDATA[Artikel-Kategorie <a href="{$category->getLink()}">{$category->getTitle()}</a>]]></item>
+		<item name="wcf.page.onlineLocation.com.woltlab.wcf.User"><![CDATA[Benutzerprofil von <a href="{link controller='User' object=$user}{/link}" class="userLink" data-user-id="{@$user->userID}">{$user->username}</a>]]></item>
+		<item name="wcf.page.availableUpdates"><![CDATA[Es sind <a href="{link controller='PackageUpdate' isACP=true}{/link}">Aktualisierungen für installierte Pakete</a> verfügbar.]]></item>
+		<item name="wcf.page.error.permissionDenied"><![CDATA[Der Zutritt zu dieser Seite ist dir leider verwehrt. Du besitzt nicht die notwendigen Zugriffsrechte, um diese Seite aufrufen zu können.]]></item>
+		<item name="wcf.page.error.permissionDenied.title"><![CDATA[Zugriff verweigert]]></item>
+		<item name="wcf.page.error.illegalLink"><![CDATA[Die von dir angeforderte Seite wurde nicht gefunden. Bitte überprüfe die Adresse oder geh zurück auf die Startseite.]]></item>
+		<item name="wcf.page.error.illegalLink.title"><![CDATA[Seite nicht gefunden]]></item>
+		<item name="wcf.page.error.backward"><![CDATA[Zurück zur vorherigen Seite]]></item>
+		<item name="wcf.page.jumpTo"><![CDATA[Gehe zu Seite]]></item>
+		<item name="wcf.page.jumpTo.description"><![CDATA[Gib einen Wert zwischen „1“ und „#pages#“ ein.]]></item>
+		<item name="wcf.page.redirect.title"><![CDATA[Weiterleitung]]></item>
+		<item name="wcf.page.redirect.url"><![CDATA[Falls die automatische Weiterleitung nicht funktioniert, klicke bitte hier!]]></item>
+		<item name="wcf.page.pageObjectID"><![CDATA[Objekt-ID]]></item>
+		<item name="wcf.page.pageObjectID.com.woltlab.wcf.Article"><![CDATA[ID des Artikels]]></item>
+		<item name="wcf.page.pageObjectID.com.woltlab.wcf.CategoryArticleList"><![CDATA[ID der Kategorie]]></item>
+		<item name="wcf.page.pageObjectID.com.woltlab.wcf.User"><![CDATA[ID des Benutzers]]></item>
+		<item name="wcf.page.pageObjectID.search"><![CDATA[ID suchen]]></item>
+		<item name="wcf.page.pageObjectID.search.com.woltlab.wcf.Article"><![CDATA[Artikeltitel durchsuchen]]></item>
+		<item name="wcf.page.pageObjectID.search.com.woltlab.wcf.CategoryArticleList"><![CDATA[Kategorietitel durchsuchen]]></item>
+		<item name="wcf.page.pageObjectID.search.com.woltlab.wcf.User"><![CDATA[Benutzernamen durchsuchen]]></item>
+		<item name="wcf.page.pageObjectID.search.noResults"><![CDATA[Es wurden keine Ergebnisse gefunden.]]></item>
+		<item name="wcf.page.pageObjectID.search.results"><![CDATA[Suchergebnisse]]></item>
+		<item name="wcf.page.pageObjectID.search.terms"><![CDATA[Durchsuchen]]></item>
+		<item name="wcf.page.search"><![CDATA[Seiten durchsuchen]]></item>
+		<item name="wcf.page.search.error.noResults"><![CDATA[Es wurden keine Ergebnisse gefunden.]]></item>
+		<item name="wcf.page.search.error.tooShort"><![CDATA[Der Suchbegriff ist zu kurz.]]></item>
+		<item name="wcf.page.search.name"><![CDATA[Seitennamen durchsuchen]]></item>
+		<item name="wcf.page.search.results"><![CDATA[Suchergebnisse]]></item>
+		<item name="wcf.page.comment"><![CDATA[Seiten-Kommentar]]></item>
+	</category>
+	
+	<category name="wcf.paidSubscription">
+		<item name="wcf.paidSubscription.availableSubscriptions"><![CDATA[Verfügbare Mitgliedschaften]]></item>
+		<item name="wcf.paidSubscription.purchasedSubscriptions"><![CDATA[Erworbene Mitgliedschaften]]></item>
+		<item name="wcf.paidSubscription.formattedCost"><![CDATA[{$subscription->currency} {$subscription->cost|currency}{if $subscription->subscriptionLength} {if $subscription->subscriptionLength != 1}für{else}pro{/if} {if $subscription->subscriptionLength != 1}{@$subscription->subscriptionLength} {/if}{if $subscription->subscriptionLengthUnit == 'D'}Tag{if $subscription->subscriptionLength != 1}e{/if}{/if}{if $subscription->subscriptionLengthUnit == 'M'}Monat{if $subscription->subscriptionLength != 1}e{/if}{/if}{if $subscription->subscriptionLengthUnit == 'Y'}Jahr{if $subscription->subscriptionLength != 1}e{/if}{/if}{/if}]]></item>
+		<item name="wcf.paidSubscription.expires"><![CDATA[Gültig bis]]></item>
+		<item name="wcf.paidSubscription.returnMessage"><![CDATA[Danke für deine Zahlung. Deine Transaktion wurde abgeschlossen. Sobald deine Zahlung von uns verarbeitet wurde, wird die erworbene Mitgliedschaft aktiviert.]]></item>
+		<item name="wcf.paidSubscription.confirmTOS"><![CDATA[Hiermit bestätige ich mein Einverständnis mit den <a href="{PAID_SUBSCRIPTION_TOS_URL}">Nutzungsbedingungen</a>]]></item>
+		<item name="wcf.paidSubscription.button.moreInformation"><![CDATA[Mehr Informationen]]></item>
+		<item name="wcf.paidSubscription.expiringSubscription.notification.title"><![CDATA[Ablaufende Mitgliedschaft]]></item>
+		<item name="wcf.paidSubscription.expiringSubscription.notification.message"><![CDATA[Deine Mitgliedschaft „{$userNotificationObject->getTitle()}“ läuft {dateInterval start=$notification->time end=$userNotificationObject->endDate format='sentence'} (am {$userNotificationObject->endDate|date:'d. F'}) ab.]]></item>
+		<item name="wcf.paidSubscription.expiringSubscription.notification.mail.plaintext"><![CDATA[Deine Mitgliedschaft „{$subscription->getTitle()}“ läuft {dateInterval start=$notification->time end=$subscription->endDate format='sentence'} (am {$subscription->endDate|date:'d. F'}) ab.]]></item>
+		<item name="wcf.paidSubscription.expiringSubscription.notification.mail.html"><![CDATA[<p>Deine Mitgliedschaft „{$subscription->getTitle()}“ läuft <b>{dateInterval start=$notification->time end=$subscription->endDate format='sentence'}</b> (am {$subscription->endDate|date:'d. F'}) ab.</p>]]></item>
+	</category>
+	
+	<category name="wcf.payment">
+		<item name="wcf.payment.com.woltlab.wcf.payment.method.paypal"><![CDATA[PayPal]]></item>
+		<item name="wcf.payment.paypal.button.purchase"><![CDATA[Via PayPal kaufen]]></item>
+		<item name="wcf.payment.paypal.button.subscribe"><![CDATA[Via PayPal abonnieren]]></item>
+	</category>
+	
+	<category name="wcf.poll">
+		<item name="wcf.poll.button.addOption"><![CDATA[Weitere Antwort hinzufügen]]></item>
+		<item name="wcf.poll.button.removeOption"><![CDATA[Antwort entfernen]]></item>
+		<item name="wcf.poll.button.showParticipants"><![CDATA[Teilnehmer auflisten]]></item>
+		<item name="wcf.poll.button.showResult"><![CDATA[Ergebnis anzeigen]]></item>
+		<item name="wcf.poll.button.showVote"><![CDATA[Zur Abstimmung]]></item>
+		<item name="wcf.poll.button.vote"><![CDATA[Abstimmen]]></item>
+		<item name="wcf.poll.endTime"><![CDATA[Umfrage endet (optional)]]></item>
+		<item name="wcf.poll.endTime.error.invalid"><![CDATA[Du hast ein ungültiges Datum eingegeben.]]></item>
+		<item name="wcf.poll.isChangeable"><![CDATA[Abgegebene Stimmen dürfen verändert werden]]></item>
+		<item name="wcf.poll.isPublic"><![CDATA[Teilnehmer sind sichtbar]]></item>
+		<item name="wcf.poll.management"><![CDATA[Umfrage]]></item>
+		<item name="wcf.poll.maxVotes"><![CDATA[Anzahl erlaubter Antworten]]></item>
+		<item name="wcf.poll.maxVotes.error.invalid"><![CDATA[Die Anzahl der erlaubten Antworten liegt über den tatsächlich verfügbaren Antworten.]]></item>
+		<item name="wcf.poll.multipleVotes"><![CDATA[Du kannst {#$poll->maxVotes} Antwortmöglichkeiten wählen.]]></item>
+		<item name="wcf.poll.noVotes"><![CDATA[Bisher keine Stimmen]]></item>
+		<item name="wcf.poll.options"><![CDATA[Antworten]]></item>
+		<item name="wcf.poll.options.description"><![CDATA[Du kannst die Antworten mittels Drücken und Festhalten in ihrer Reihenfolge ändern. Du kannst {@POLL_MAX_OPTIONS} Antwortmöglichkeiten vorgeben.]]></item>
+		<item name="wcf.poll.question"><![CDATA[Frage]]></item>
+		<item name="wcf.poll.restrictedResult"><![CDATA[Das Ergebnis ist nur für Teilnehmer sichtbar.]]></item>
+		<item name="wcf.poll.resultsRequireVote"><![CDATA[Ergebnis erst nach Abgabe der Stimme sichtbar]]></item>
+		<item name="wcf.poll.resultsRequireVote.description"><![CDATA[Das Ergebnis ist erst mit dem Ablauf der Umfrage oder der Abgabe einer Stimme sichtbar.]]></item>
+		<item name="wcf.poll.sortByVotes"><![CDATA[Ergebnis nach Stimmen sortieren]]></item>
+		<item name="wcf.poll.totalVotes"><![CDATA[Insgesamt {#$poll->votes} Stimme{if $poll->votes != 1}n{/if}]]></item>
+		<item name="wcf.poll.endTimeInfo"><![CDATA[Umfrage endet am {@$poll->endTime|plainTime}]]></item>
+	</category>
+	
+	<category name="wcf.recaptcha">
+		<item name="wcf.recaptcha.title"><![CDATA[Sicherheitsabfrage („reCAPTCHA“)]]></item>
+		<item name="wcf.recaptcha.description"><![CDATA[Bitte gib die untenstehenden Zeichen in das leere Feld ein. Groß- und Kleinschreibung müssen nicht beachtet werden. Solltest du das Bild trotz Neuladen nicht identifizieren können, wende dich an den Administrator.]]></item>
+		<item name="wcf.recaptcha.reload"><![CDATA[Neu laden]]></item>
+		<item name="wcf.recaptcha.audio"><![CDATA[Audio-Version]]></item>
+		<item name="wcf.recaptcha.image"><![CDATA[Bild-Version]]></item>
+		<item name="wcf.recaptcha.help"><![CDATA[Hilfe]]></item>
+		<item name="wcf.recaptcha.error.recaptchaString.false"><![CDATA[Du hast leider nicht die korrekten Zeichen eingegeben. Bitte versuche es erneut!]]></item>
+	</category>
+	
+	<category name="wcf.search">
+		<item name="wcf.search.author"><![CDATA[Suche nach Autor]]></item>
+		<item name="wcf.search.extended"><![CDATA[Erweiterte Suche]]></item>
+		<item name="wcf.search.general"><![CDATA[Allgemeine Suchangaben]]></item>
+		<item name="wcf.search.matchExactly"><![CDATA[Exakter Treffer]]></item>
+		<item name="wcf.search.period"><![CDATA[Im Zeitraum]]></item>
+		<item name="wcf.search.query"><![CDATA[Suche nach Begriff]]></item>
+		<item name="wcf.search.query.description"><![CDATA[Gib einen oder mehrere Begriffe ein. Ein Begriff muss mindestens vier Zeichen lang sein.]]></item>
+		<item name="wcf.search.results.change"><![CDATA[Suche ändern]]></item>
+		<item name="wcf.search.results.description"><![CDATA[Suchergebnisse {#$startIndex}-{#$endIndex} von insgesamt {#$items}{if $query} für „<strong>{$query}</strong>“{/if}.{if $items == 1000} Es gibt noch weitere Suchergebnisse, bitte verfeinere deine Suche.{/if}{if $highlight}<br>Diese Suchbegriffe wurden hervorgehoben: <span class="highlight">{$highlight}</span>{/if}]]></item>
+		<item name="wcf.search.sortBy"><![CDATA[Sortierung]]></item>
+		<item name="wcf.search.sortBy.relevance"><![CDATA[Relevanz]]></item>
+		<item name="wcf.search.sortBy.time"><![CDATA[Datum]]></item>
+		<item name="wcf.search.sortBy.username"><![CDATA[Autor]]></item>
+		<item name="wcf.search.subjectOnly"><![CDATA[Nur Betreff durchsuchen]]></item>
+		<item name="wcf.search.type"><![CDATA[Suche in]]></item>
+		<item name="wcf.search.type.everywhere"><![CDATA[Alles]]></item>
+		<item name="wcf.search.error.noMatches"><![CDATA[Es wurde kein{if !$query|empty} mit deiner Suchanfrage „{$query}“ übereinstimmender{/if} Eintrag gefunden.]]></item>
+		<item name="wcf.search.error.user.noMatches"><![CDATA[Es wurde kein Eintrag von diesem Autor gefunden.]]></item>
+		<item name="wcf.search.object.com.woltlab.wcf.article"><![CDATA[Artikel]]></item>
+		<item name="wcf.search.type.com.woltlab.wcf.article"><![CDATA[Artikel]]></item>
+		<item name="wcf.search.object.com.woltlab.wcf.page"><![CDATA[Seite]]></item>
+		<item name="wcf.search.type.com.woltlab.wcf.page"><![CDATA[Seiten]]></item>
+	</category>
+	
+	<category name="wcf.style">
+		<item name="wcf.style.changeStyle"><![CDATA[Stil ändern]]></item>
+		<item name="wcf.style.colorPicker"><![CDATA[Farbwähler]]></item>
+		<item name="wcf.style.colorPicker.new"><![CDATA[neu]]></item>
+		<item name="wcf.style.colorPicker.current"><![CDATA[aktuell]]></item>
+		<item name="wcf.style.currentStyle"><![CDATA[Aktiver Stil]]></item>
+		<item name="wcf.style.colorPicker.button.apply"><![CDATA[Übernehmen]]></item>
+	</category>
+	
+	<category name="wcf.tagging">
+		<item name="wcf.tagging.tags"><![CDATA[Tags]]></item>
+		<item name="wcf.tagging.tags.add"><![CDATA[Tags]]></item>
+		<item name="wcf.tagging.tags.description"><![CDATA[Mehrere Tags müssen durch ein Komma getrennt werden.]]></item>
+		<item name="wcf.tagging.objectTypes"><![CDATA[Inhalte]]></item>
+		<item name="wcf.tagging.taggedObjects.noResults"><![CDATA[Es wurden keine Einträge mit diesem Tag gefunden.]]></item>
+		<item name="wcf.tagging.objectType.com.woltlab.wcf.article"><![CDATA[Artikel]]></item>
+		<item name="wcf.tagging.taggedObjects.com.woltlab.wcf.article"><![CDATA[Artikel mit dem Tag „{$tag->name}“]]></item>
+	</category>
+	
+	<category name="wcf.user">
+		<item name="wcf.user.confirmEmail"><![CDATA[E-Mail-Adresse wiederholen]]></item>
+		<item name="wcf.user.confirmPassword"><![CDATA[Kennwort wiederholen]]></item>
+		<item name="wcf.user.confirmEmail.error.notEqual"><![CDATA[Die eingegebenen E-Mail-Adressen sind nicht identisch.]]></item>
+		<item name="wcf.user.confirmPassword.error.notEqual"><![CDATA[Die eingegebenen Kennwörter sind nicht identisch.]]></item>
+		<item name="wcf.user.controlPanel"><![CDATA[Kontrollzentrum]]></item>
+		<item name="wcf.user.email"><![CDATA[E-Mail-Adresse]]></item>
+		<item name="wcf.user.email.error.notUnique"><![CDATA[Diese E-Mail-Adresse ist bereits durch einen anderen Benutzer vergeben.]]></item>
+		<item name="wcf.user.email.error.invalid"><![CDATA[Du hast eine ungültige E-Mail-Adresse eingegeben.]]></item>
+		<item name="wcf.user.ipAddress"><![CDATA[IP-Adresse]]></item>
+		<item name="wcf.user.userAgent"><![CDATA[Browser-Kennung]]></item>
+		<item name="wcf.user.login"><![CDATA[Anmeldung]]></item>
+		<item name="wcf.user.login.error.cookieRequired"><![CDATA[Die Anmeldung erfordert den Einsatz von Cookies, bitte aktiviere diese, um die Anmeldung durchzuführen.]]></item>
+		<item name="wcf.user.login.login"><![CDATA[Anmeldung]]></item>
+		<item name="wcf.user.login.register"><![CDATA[Registrierung]]></item>
+		<item name="wcf.user.login.register.teaser"><![CDATA[Du hast noch kein Benutzerkonto auf unserer Seite? <a href="{link controller='Register'}{/link}">Registriere dich kostenlos</a> und nimm an unserer Community teil!]]></item>
+		<item name="wcf.user.login.register.registerNow"><![CDATA[Benutzerkonto erstellen]]></item>
+		<item name="wcf.user.password.error.false"><![CDATA[Dieses Kennwort ist falsch.]]></item>
+		<item name="wcf.user.language"><![CDATA[Sprache]]></item>
+		<item name="wcf.user.language.description"><![CDATA[Sprache der Benutzeroberfläche]]></item>
+		<item name="wcf.user.logout"><![CDATA[Abmelden]]></item>
+		<item name="wcf.user.logout.sure"><![CDATA[Willst du dich wirklich abmelden?]]></item>
+		<item name="wcf.user.password"><![CDATA[Kennwort]]></item>
+		<item name="wcf.user.registrationDate"><![CDATA[Registrierungsdatum]]></item>
+		<item name="wcf.user.visibleLanguages"><![CDATA[Inhaltssprachen]]></item>
+		<item name="wcf.user.visibleLanguages.description"><![CDATA[Zeigt Inhalte in den ausgewählten Sprachen an]]></item>
+		<item name="wcf.user.unknownUser"><![CDATA[Dieser Benutzer existiert nicht oder wurde gelöscht.]]></item>
+		<item name="wcf.user.userID"><![CDATA[Benutzer-ID]]></item>
+		<item name="wcf.user.username"><![CDATA[Benutzername]]></item>
+		<item name="wcf.user.username.placeholder"><![CDATA[Gib einen Benutzernamen ein]]></item>
+		<item name="wcf.user.username.error.acpNotAuthorized"><![CDATA[Dieser Benutzer ist nicht berechtigt sich an der Administrationsoberfläche anzumelden.]]></item>
+		<item name="wcf.user.username.error.notFound"><![CDATA[Der Benutzername {$username} konnte nicht gefunden werden.]]></item>
+		<item name="wcf.user.username.error.notUnique"><![CDATA[Dieser Benutzername ist bereits vergeben.]]></item>
+		<item name="wcf.user.username.error.invalid"><![CDATA[Du hast einen ungültigen Benutzernamen eingegeben.]]></item>
+		<item name="wcf.user.userNote"><![CDATA[{$__wcf->user->username}]]></item>
+		<item name="wcf.user.group"><![CDATA[Benutzergruppe]]></item>
+		<item name="wcf.user.option.error.tooLong"><![CDATA[Der eingegebene Text ist zu lang.]]></item>
+		<item name="wcf.user.option.error.tooShort"><![CDATA[Der eingegebene Text ist zu kurz.]]></item>
+		<item name="wcf.user.option.error.validationFailed"><![CDATA[Du hast einen ungültigen Inhalt eingegeben.]]></item>
+		<item name="wcf.user.option.error.birthdayTooYoung"><![CDATA[Du bist zu jung. Für eine Anmeldung auf dieser Seite musst du mindestens {#REGISTER_MIN_USER_AGE} Jahre alt sein.]]></item>
+		<item name="wcf.user.option.error.censoredWordsFound"><![CDATA[Dein Text enthält folgende zensierte Wörter: {implode from=$censoredWords key=censoredWord item=number}{$censoredWord}{if $number > 1} ({#$number}×){/if}{/implode}]]></item>
+		<item name="wcf.user.error.isBanned"><![CDATA[Dein Benutzeraccount wurde{if $__wcf->user->banExpires != 0} bis zum {@$__wcf->user->banExpires|plainTime}{/if} gesperrt{if $__wcf->user->banReason}: {@$__wcf->user->banReason|newlineToBreak}{else}.{/if}]]></item>
+		<item name="wcf.user.access.everyone"><![CDATA[Jeder]]></item>
+		<item name="wcf.user.access.following"><![CDATA[Benutzer, denen ich folge]]></item>
+		<item name="wcf.user.access.nobody"><![CDATA[Keiner]]></item>
+		<item name="wcf.user.access.registered"><![CDATA[Registrierte Benutzer]]></item>
+		<item name="wcf.user.button.login"><![CDATA[Anmelden]]></item>
+		<item name="wcf.user.button.register"><![CDATA[Registrieren]]></item>
+		<item name="wcf.user.username.error.3rdParty"><![CDATA[Das Benutzerkonto ist mit einem Drittanbieter-Konto verbunden, ein Passwort kann nicht angefordert werden.]]></item>
+		<item name="wcf.user.loginOrRegister"><![CDATA[Anmelden{if !REGISTER_DISABLED} oder registrieren{/if}]]></item>
+		<item name="wcf.user.useCookies"><![CDATA[Dauerhaft angemeldet bleiben]]></item>
+		<item name="wcf.user.usernameOrEmail"><![CDATA[Benutzername oder E-Mail-Adresse]]></item>
+		<item name="wcf.user.gender.male"><![CDATA[Männlich]]></item>
+		<item name="wcf.user.gender.female"><![CDATA[Weiblich]]></item>
+		<item name="wcf.user.members"><![CDATA[Mitglieder]]></item>
+		<item name="wcf.user.members.noMembers"><![CDATA[Es wurden keine Mitglieder gefunden.]]></item>
+		<item name="wcf.user.members.sort"><![CDATA[Sortierung]]></item>
+		<item name="wcf.user.members.sort.letters"><![CDATA[Anfangsbuchstabe]]></item>
+		<item name="wcf.user.members.sort.letters.all"><![CDATA[Alle]]></item>
+		<item name="wcf.user.membersList.registrationDate"><![CDATA[Mitglied seit {@$user->registrationDate|date}]]></item>
+		<item name="wcf.user.membersList.location"><![CDATA[aus {$user->location}]]></item>
+		<item name="wcf.user.myProfile"><![CDATA[Mein Profil]]></item>
+		<item name="wcf.user.editProfile"><![CDATA[Profil bearbeiten]]></item>
+		<item name="wcf.user.profileHits"><![CDATA[Profil-Aufrufe]]></item>
+		<item name="wcf.user.profileHits.hitsPerDay"><![CDATA[{#$user->profileHits/$user->getProfileAge()} Aufrufe pro Tag]]></item>
+		<item name="wcf.user.online"><![CDATA[Online]]></item>
+		<item name="wcf.user.online.title"><![CDATA[{$username} ist online]]></item>
+		<item name="wcf.user.button.follow"><![CDATA[Folgen]]></item>
+		<item name="wcf.user.button.unfollow"><![CDATA[Entfolgen]]></item>
+		<item name="wcf.user.button.ignore"><![CDATA[Blockieren]]></item>
+		<item name="wcf.user.button.unignore"><![CDATA[Nicht mehr blockieren]]></item>
+		<item name="wcf.user.style"><![CDATA[Stile]]></item>
+		<item name="wcf.user.style.description"><![CDATA[Stile der Benutzeroberfläche]]></item>
+		<item name="wcf.user.username.description"><![CDATA[Der Benutzername muss mindestens {REGISTER_USERNAME_MIN_LENGTH} und darf maximal {REGISTER_USERNAME_MAX_LENGTH} Zeichen lang sein.]]></item>
+		<item name="wcf.user.password.description"><![CDATA[{if REGISTER_ENABLE_PASSWORD_SECURITY_CHECK}Das Kennwort muss aus Sicherheitsgründen mindestens {REGISTER_PASSWORD_MIN_LENGTH} Zeichen lang sein{if REGISTER_PASSWORD_MUST_CONTAIN_LOWER_CASE || REGISTER_PASSWORD_MUST_CONTAIN_UPPER_CASE || REGISTER_PASSWORD_MUST_CONTAIN_DIGIT || REGISTER_PASSWORD_MUST_CONTAIN_SPECIAL_CHAR}{*
+		*} und {*
+		*}{if REGISTER_PASSWORD_MUST_CONTAIN_LOWER_CASE}kleine Buchstaben{/if}{*
+		*}{if REGISTER_PASSWORD_MUST_CONTAIN_UPPER_CASE}{if REGISTER_PASSWORD_MUST_CONTAIN_LOWER_CASE}{if REGISTER_PASSWORD_MUST_CONTAIN_DIGIT || REGISTER_PASSWORD_MUST_CONTAIN_SPECIAL_CHAR},{else} und{/if} {/if}große Buchstaben{/if}{*
+		*}{if REGISTER_PASSWORD_MUST_CONTAIN_DIGIT}{if REGISTER_PASSWORD_MUST_CONTAIN_LOWER_CASE || REGISTER_PASSWORD_MUST_CONTAIN_UPPER_CASE}{if REGISTER_PASSWORD_MUST_CONTAIN_SPECIAL_CHAR},{else} und{/if} {/if}Zahlen{/if}{*
+		*}{if REGISTER_PASSWORD_MUST_CONTAIN_SPECIAL_CHAR}{if REGISTER_PASSWORD_MUST_CONTAIN_LOWER_CASE || REGISTER_PASSWORD_MUST_CONTAIN_UPPER_CASE || REGISTER_PASSWORD_MUST_CONTAIN_DIGIT} und {/if}Sonderzeichen{/if} {*
+		*}enthalten{/if}.{else}Ein sicheres Kennwort sollte mindestens 8 Zeichen lang sein.{/if}]]></item>
+		<item name="wcf.user.lostPassword"><![CDATA[Kennwort vergessen]]></item>
+		<item name="wcf.user.lostPassword.description"><![CDATA[Wenn du dein Kennwort vergessen hast, musst du entweder den Benutzernamen oder die E-Mail-Adresse angeben, die du in deinem Profil hinterlegt hast. Du kannst dabei nur eines der beiden Felder ausfüllen. Wenn du beide Daten nicht mehr weißt, wende dich bitte an den Administrator.]]></item>
+		<item name="wcf.user.lostPassword.email.error.notFound"><![CDATA[Es wurde kein Benutzer mit der E-Mail-Adresse: „{$email}“ gefunden.]]></item>
+		<item name="wcf.user.lostPassword.error.tooManyRequests"><![CDATA[Das Kennwort für dieses Benutzerkonto wurde in den letzten 24 Stunden bereits einmal angefordert. Aus Sicherheitsgründen kann das Kennwort eines Benutzers nur einmal pro Tag angefordert werden. Du kannst das Kennwort für dieses Benutzerkonto in {#$hours} Stunde{if $hours != 1}n{/if} erneut anfordern.]]></item>
+		<item name="wcf.user.lostPassword.mail.subject"><![CDATA[Kennwort vergessen auf der Website: {@PAGE_TITLE|language}]]></item>
+		<item name="wcf.user.lostPassword.mail.plaintext"><![CDATA[Hallo {@$mailbox->getUser()->username},
+
+du (oder jemand anders) hat angegeben das Kennwort für das Benutzerkonto
+{@$mailbox->getUser()->username} auf der Seite {@PAGE_TITLE|language} [URL:{link isEmail=true}{/link}] vergessen zu haben. Du kannst dein Kennwort
+nach einem Klick auf den Folgenden Link ändern:
+
+    {link controller='NewPassword' object=$mailbox->getUser() isEmail=true}k={@$mailbox->getUser()->lostPasswordKey}{/link} {* this line ends with a space *}
+
+Wenn du dein Kennwort nicht ändern möchtest, dann wird diese Anfrage
+am {$mailbox->getUser()->lastLostPasswordRequestTime+86400|plainTime} automatisch ablaufen.]]></item>
+		<item name="wcf.user.lostPassword.mail.html.headline"><![CDATA[Hallo {@$mailbox->getUser()->username},]]></item>
+		<item name="wcf.user.lostPassword.mail.html.intro"><![CDATA[
+<p>du (oder jemand anders) hat angegeben das
+Kennwort für das Benutzerkonto {@$mailbox->getUser()->username} auf der Seite <a href="{link isEmail=true}{/link}">{@PAGE_TITLE|language}</a> vergessen zu
+haben:</p>]]></item>
+		<item name="wcf.user.lostPassword.mail.html.reset"><![CDATA[Kennwort ändern]]></item>
+		<item name="wcf.user.lostPassword.mail.html.outro"><![CDATA[
+<p>Wenn du dein Kennwort nicht ändern möchtest,
+dann wird diese Anfrage am {$mailbox->getUser()->lastLostPasswordRequestTime+86400|plainTime} automatisch ablaufen.</p>]]></item>
+		<item name="wcf.user.lostPassword.mail.sent"><![CDATA[Du erhälst in Kürze eine E-Mail mit weiteren Informationen.]]></item>
+		<item name="wcf.user.lostPasswordKey"><![CDATA[Sicherheitsschlüssel]]></item>
+		<item name="wcf.user.lostPasswordKey.error.invalid"><![CDATA[Du hast einen ungültigen Sicherheitsschlüssel angegeben.]]></item>
+		<item name="wcf.user.newPassword"><![CDATA[Neues Kennwort]]></item>
+		<item name="wcf.user.newPassword.info"><![CDATA[Du bist im Begriff das Kennwort des Benutzers „{$user->username}“ zu ändern.]]></item>
+		<item name="wcf.user.newPassword.success"><![CDATA[Das Kennwort des Benutzers „{$user->username}“ wurde erfolgreich geändert. Du kannst dich nun mit dem neuen Kennwort einloggen.]]></item>
+		<item name="wcf.user.userID.error.invalid"><![CDATA[Du hast eine ungültige Benutzer-ID angegeben.]]></item>
+		<item name="wcf.user.accountManagement"><![CDATA[Benutzerkonto-Verwaltung]]></item>
+		<item name="wcf.user.accountManagement.warning"><![CDATA[Du bearbeitest dein eigenes Benutzerkonto. Unbedachte Änderungen können dazu führen, dass du dich nicht mehr anmelden kannst. Bitte sei entsprechend vorsichtig!]]></item>
+		<item name="wcf.user.accountManagement.password.description"><![CDATA[Bitte gib zur Bestätigung dein <u>bisheriges</u> Kennwort ein!]]></item>
+		<item name="wcf.user.changeUsername"><![CDATA[Benutzernamen ändern]]></item>
+		<item name="wcf.user.changeUsername.description"><![CDATA[Du kannst deinen Benutzernamen nur einmal alle {$renamePeriod} Tage ändern. Änderungen von Groß- auf Kleinschreibung und umgekehrt sind jederzeit möglich.
+		{if $__wcf->getUser()->lastUsernameChange}Die letzte Änderung erfolgte am {@$__wcf->getUser()->lastUsernameChange|date}.{/if}]]></item>
+		<item name="wcf.user.changePassword"><![CDATA[Kennwort ändern]]></item>
+		<item name="wcf.user.changeEmail"><![CDATA[E-Mail-Adresse ändern]]></item>
+		<item name="wcf.user.newEmail"><![CDATA[Neue E-Mail-Adresse]]></item>
+		<item name="wcf.user.newUsername"><![CDATA[Neuer Benutzername]]></item>
+		<item name="wcf.user.quit"><![CDATA[Benutzerkonto kündigen]]></item>
+		<item name="wcf.user.quit.sure"><![CDATA[Willst du dein Benutzerkonto mitsamt deiner persönlichen Daten dauerhaft löschen?]]></item>
+		<item name="wcf.user.quit.cancel"><![CDATA[Dein Benutzerkonto wird am {$quitStarted+7*86400|date} gelöscht. Bitte aktiviere diese Option, wenn du die Löschung abbrechen möchtest.]]></item>
+		<item name="wcf.user.quit.description"><![CDATA[Hinweis: Beiträge, Anhänge und ähnliches werden nicht gelöscht.]]></item>
+		<item name="wcf.user.quit.success"><![CDATA[Dein Benutzerkonto wird am {TIME_NOW+7*86400|date} gelöscht. Bis dahin kannst du die Löschung auf dieser Seite abbrechen.]]></item>
+		<item name="wcf.user.quit.cancel.success"><![CDATA[Die Löschung deines Benutzerkontos wurde erfolgreich abgebrochen.]]></item>
+		<item name="wcf.user.emailActivation"><![CDATA[Neue E-Mail-Adresse aktivieren]]></item>
+		<item name="wcf.user.password.error.notSecure"><![CDATA[Das Kennwort muss aus Sicherheitsgründen mindestens {REGISTER_PASSWORD_MIN_LENGTH} Zeichen lang sein{if REGISTER_PASSWORD_MUST_CONTAIN_LOWER_CASE || REGISTER_PASSWORD_MUST_CONTAIN_UPPER_CASE || REGISTER_PASSWORD_MUST_CONTAIN_DIGIT || REGISTER_PASSWORD_MUST_CONTAIN_SPECIAL_CHAR}{*
+		*} und {*
+		*}{if REGISTER_PASSWORD_MUST_CONTAIN_LOWER_CASE}kleine Buchstaben{/if}{*
+		*}{if REGISTER_PASSWORD_MUST_CONTAIN_UPPER_CASE}{if REGISTER_PASSWORD_MUST_CONTAIN_LOWER_CASE}{if REGISTER_PASSWORD_MUST_CONTAIN_DIGIT || REGISTER_PASSWORD_MUST_CONTAIN_SPECIAL_CHAR},{else} und{/if} {/if}große Buchstaben{/if}{*
+		*}{if REGISTER_PASSWORD_MUST_CONTAIN_DIGIT}{if REGISTER_PASSWORD_MUST_CONTAIN_LOWER_CASE || REGISTER_PASSWORD_MUST_CONTAIN_UPPER_CASE}{if REGISTER_PASSWORD_MUST_CONTAIN_SPECIAL_CHAR},{else} und{/if} {/if}Zahlen{/if}{*
+		*}{if REGISTER_PASSWORD_MUST_CONTAIN_SPECIAL_CHAR}{if REGISTER_PASSWORD_MUST_CONTAIN_LOWER_CASE || REGISTER_PASSWORD_MUST_CONTAIN_UPPER_CASE || REGISTER_PASSWORD_MUST_CONTAIN_DIGIT} und {/if}Sonderzeichen{/if} {*
+		*}enthalten{/if}.]]></item>
+		<item name="wcf.user.changeUsername.success"><![CDATA[Dein Benutzername wurde erfolgreich geändert.]]></item>
+		<item name="wcf.user.changeEmail.success"><![CDATA[Deine E-Mail-Adresse wurde erfolgreich geändert.]]></item>
+		<item name="wcf.user.changeEmail.needReactivation"><![CDATA[Deine neue E-Mail-Adresse{if $newEmail|isset} („{$newEmail}“){/if} muss noch aktiviert werden. Dazu wurde eine E-Mail mit einem Aktivierungslink an die neue Adresse gesandt. Du musst diesen Aktivierungslink aufrufen, um die neue E-Mail-Adresse zu aktivieren.]]></item>
+		<item name="wcf.user.changeEmail.needReactivation.mail.subject"><![CDATA[Aktivierung der neuen E-Mail-Adresse auf der Website: {@PAGE_TITLE|language}]]></item>
+		<item name="wcf.user.changeEmail.needReactivation.mail.html.headline"><![CDATA[Hallo {$mailbox->getUser()->username},]]></item>
+		<item name="wcf.user.changeEmail.needReactivation.mail.html.intro"><![CDATA[
+<p>du hast deine E-Mail-Adresse auf der Website: <a href="{link isEmail=true}{/link}">{PAGE_TITLE|language}</a> geändert. 
+Zum Abschließen dieser Änderung musst du einmalig die Gültigkeit der neuen E-Mail-Adresse bestätigen:</p>]]></item>
+		<item name="wcf.user.changeEmail.needReactivation.mail.html.activate"><![CDATA[Neue E-Mail-Adresse aktivieren]]></item>
+		<item name="wcf.user.changeEmail.needReactivation.mail.html.outro"><![CDATA[
+<p>Dein Aktivierungscode lautet: <code>{$mailbox->getUser()->reactivationCode}</code>.</p>
+<p>Wenn du Probleme mit der Aktivierung haben solltest, wende dich bitte an den Administrator:
+<a href="mailto:{MAIL_ADMIN_ADDRESS}">{MAIL_ADMIN_ADDRESS}</a>. Wenn du dich nicht bei uns registriert hast,
+dann kannst du diese E-Mail ignorieren.</p>]]></item>
+		<item name="wcf.user.changeEmail.needReactivation.mail.plaintext"><![CDATA[Hallo {$mailbox->getUser()->username},
+
+du hast deine E-Mail-Adresse auf der Website: {@PAGE_TITLE|language} [URL:{link isEmail=true}{/link}] geändert.
+Zum Abschließen dieser Änderung musst du einmalig die Gültigkeit der neuen E-Mail-Adresse bestätigen:
+
+    {link controller='EmailActivation' isEmail=true}u={@$mailbox->getUser()->userID}&a={@$mailbox->getUser()->reactivationCode}{/link} {* this line ends with a space *}
+
+Dein Aktivierungscode lautet: {@$mailbox->getUser()->reactivationCode} {* this line ends with a space *}
+
+Wenn du Probleme mit der Aktivierung haben solltest, wende dich bitte an den Administrator: {@MAIL_ADMIN_ADDRESS}. Wenn du
+dich nicht bei uns registriert hast, dann kannst du diese E-Mail ignorieren.]]></item>
+		<item name="wcf.user.changePassword.success"><![CDATA[Dein Kennwort wurde erfolgreich geändert.]]></item>
+		<item name="wcf.user.activationCode"><![CDATA[9-stelliger Aktivierungscode]]></item>
+		<item name="wcf.user.newActivationCode"><![CDATA[Neuen Aktivierungscode anfordern]]></item>
+		<item name="wcf.user.registerActivation"><![CDATA[Registrierung abschließen]]></item>
+		<item name="wcf.user.registerActivation.error.userAlreadyEnabled"><![CDATA[Dieser Benutzer ist bereits freigeschaltet.]]></item>
+		<item name="wcf.user.registerActivation.success"><![CDATA[Dein Benutzerkonto wurde erfolgreich freigeschaltet.]]></item>
+		<item name="wcf.user.activationCode.error.invalid"><![CDATA[Du hast einen ungültigen Aktivierungscode eingegeben. Klicke auf den unten stehenden Link, falls du einen neuen Aktivierungscode anfordern möchtest.]]></item>
+		<item name="wcf.user.registerNewActivationCode.email.description"><![CDATA[Optional kannst du hier eine neue E-Mail-Adresse eintragen, an die der neue Aktivierungscode gesendet werden soll. Lasse dieses Feld frei, wenn der Aktivierungscode an die bestehende Adresse geschickt werden soll.]]></item>
+		<item name="wcf.user.newActivationCode.success"><![CDATA[Eine E-Mail mit dem neuen Aktivierungscode wurde an {$email} versendet.]]></item>
+		<item name="wcf.user.emailActivation.error.emailAlreadyEnabled"><![CDATA[Die neue E-Mail-Adresse ist bereits aktiviert.]]></item>
+		<item name="wcf.user.emailActivation.success"><![CDATA[Deine neue E-Mail-Adresse wurde erfolgreich aktiviert.]]></item>
+		<item name="wcf.user.registerActivation.info"><![CDATA[Eine E-Mail mit dem 9-stelligen Aktivierungscode wurde an deine E-Mail-Adresse {$__wcf->user->email} verschickt.]]></item>
+		<item name="wcf.user.username.error.alreadyRenamed"><![CDATA[Der Benutzername wurde innerhalb der letzten {#$__wcf->getSession()->getPermission('user.profile.renamePeriod')} Tage bereits einmal verändert.]]></item>
+		<item name="wcf.user.guest"><![CDATA[Gast]]></item>
+		<item name="wcf.user.signature"><![CDATA[Signatur]]></item>
+		<item name="wcf.user.signature.current"><![CDATA[Aktuelle Signatur]]></item>
+		<item name="wcf.user.signature.error.disabled"><![CDATA[Der Administrator hat{if $__wcf->user->signature} deine derzeitige Signatur gesperrt und{/if} dir die weitere Nutzungsberechtigung der Signatur-Funktion {if !$__wcf->user->disableSignatureReason}entzogen.{else} aus folgenden Gründen entzogen: {$__wcf->user->disableSignatureReason}{/if}]]></item>
+		<item name="wcf.user.activityPoint"><![CDATA[Punkte]]></item>
+		<item name="wcf.user.activityPoint.showActivityPoints"><![CDATA[Punkte von {$user->username} anzeigen]]></item>
+		<item name="wcf.user.activityPoint.objects"><![CDATA[Anzahl]]></item>
+		<item name="wcf.user.activityPoint.objectType"><![CDATA[Art]]></item>
+		<item name="wcf.user.activityPoint.pointsPerObject"><![CDATA[Punkte]]></item>
+		<item name="wcf.user.activityPoint.sum"><![CDATA[Summe]]></item>
+		<item name="wcf.user.usercp"><![CDATA[Benutzerkonto]]></item>
+		<item name="wcf.user.button.mail"><![CDATA[E-Mail senden]]></item>
+		<item name="wcf.user.ignoredUsers.noUsers"><![CDATA[Du blockierst derzeit keine Benutzer.]]></item>
+		<item name="wcf.user.following.noUsers"><![CDATA[Du folgst derzeit keinen Benutzern.]]></item>
+		<item name="wcf.user.userTitle"><![CDATA[Individueller Benutzertitel]]></item>
+		<item name="wcf.user.userTitle.description"><![CDATA[Du kannst dir einen individuellen Benutzertitel geben.]]></item>
+		<item name="wcf.user.userTitle.error.tooLong"><![CDATA[Der eingegebene Titel ist zu lang. Die maximal zulässige Gesamtlänge beträgt {#USER_TITLE_MAX_LENGTH} Zeichen.]]></item>
+		<item name="wcf.user.userTitle.error.forbidden"><![CDATA[Du hast einen ungültigen Benutzertitel eingegeben.]]></item>
+		<item name="wcf.user.birthday.age"><![CDATA[Alter]]></item>
+		<item name="wcf.user.birthday.age.from"><![CDATA[von]]></item>
+		<item name="wcf.user.birthday.age.to"><![CDATA[bis]]></item>
+		<item name="wcf.user.search"><![CDATA[Mitgliedersuche]]></item>
+		<item name="wcf.user.search.error.noMatches"><![CDATA[Zu den angegebenen Kriterien wurde kein Mitglied gefunden.]]></item>
+		<item name="wcf.user.newestMember"><![CDATA[Neuestes Mitglied]]></item>
+		<item name="wcf.user.login.3rdParty"><![CDATA[Anmeldung über Drittanbieter]]></item>
+		<item name="wcf.user.search.results"><![CDATA[Suchergebnisse]]></item>
+		<item name="wcf.user.lastActivityTime"><![CDATA[Letzte Aktivität]]></item>
+		<item name="wcf.user.activityPoint.objectType.com.woltlab.wcf.like.activityPointEvent.receivedLikes"><![CDATA[Erhaltene Likes]]></item>
+		<item name="wcf.user.register.honeyPot"><![CDATA[Bitte ignorieren!]]></item>
+		<item name="wcf.user.register.honeyPot.description"><![CDATA[Falls du dies sehen kannst, fülle bitte die nächsten zwei Eingabefelder <strong>NICHT</strong> aus!]]></item>
+		<item name="wcf.user.searchUserContent"><![CDATA[Inhalte von {$user->username} suchen]]></item>
+		<item name="wcf.user.author"><![CDATA[Autor]]></item>
+		<item name="wcf.user.moderate"><![CDATA[Benutzer moderieren]]></item>
+		<item name="wcf.user.ban"><![CDATA[Benutzer sperren]]></item>
+		<item name="wcf.user.ban.confirmMessage"><![CDATA[Willst du den Benutzer wirklich sperren?]]></item>
+		<item name="wcf.user.ban.expires"><![CDATA[Entsperrung]]></item>
+		<item name="wcf.user.ban.expires.description"><![CDATA[Der Benutzer wird zum festgelegten Zeitpunkt automatisch entsperrt.]]></item>
+		<item name="wcf.user.ban.neverExpires"><![CDATA[Dauerhafte Sperrung]]></item>
+		<item name="wcf.user.ban.reason.description"><![CDATA[Die Begründung wird dem gesperrten Benutzer beim Aufruf der Seite angezeigt.]]></item>
+		<item name="wcf.user.unban"><![CDATA[Benutzer entsperren]]></item>
+		<item name="wcf.user.disableAvatar"><![CDATA[Avatar sperren]]></item>
+		<item name="wcf.user.disableAvatar.confirmMessage"><![CDATA[Willst du den Avatar des Benutzers wirklich sperren?]]></item>
+		<item name="wcf.user.disableAvatar.expires"><![CDATA[Entsperrung]]></item>
+		<item name="wcf.user.disableAvatar.expires.description"><![CDATA[Der Avatar des Benutzer wird zum festgelegten Zeitpunkt automatisch entsperrt.]]></item>
+		<item name="wcf.user.disableAvatar.neverExpires"><![CDATA[Dauerhafte Sperrung]]></item>
+		<item name="wcf.user.enableAvatar"><![CDATA[Avatar entsperren]]></item>
+		<item name="wcf.user.disableSignature"><![CDATA[Signatur sperren]]></item>
+		<item name="wcf.user.disableSignature.confirmMessage"><![CDATA[Willst du die Signatur des Benutzers wirklich sperren?]]></item>
+		<item name="wcf.user.disableSignature.expires"><![CDATA[Entsperrung]]></item>
+		<item name="wcf.user.disableSignature.expires.description"><![CDATA[Die Signatur des Benutzer wird zum festgelegten Zeitpunkt automatisch entsperrt.]]></item>
+		<item name="wcf.user.disableSignature.neverExpires"><![CDATA[Dauerhafte Sperrung]]></item>
+		<item name="wcf.user.enableSignature"><![CDATA[Signatur entsperren]]></item>
+		<item name="wcf.user.edit"><![CDATA[Benutzer bearbeiten]]></item>
+		<item name="wcf.user.birthdayToday"><![CDATA[Hat heute Geburtstag]]></item>
+		<item name="wcf.user.login.blocked"><![CDATA[Aufgrund einer hohen Anzahl von fehlgeschlagenen Anmeldeversuchen durch deine IP-Adresse steht dir die Anmeldung aus Sicherheitsgründen vorübergehend nicht zur Verfügung. Bitte versuche es später erneut!]]></item>
+		<item name="wcf.user.banned"><![CDATA[Der Benutzer {$user->username} wurde{if $user->banExpires != 0} bis zum {@$user->banExpires|date}{/if} gesperrt.]]></item>
+		<item name="wcf.user.panel.markAllAsRead"><![CDATA[Alle als gelesen markieren]]></item>
+		<item name="wcf.user.panel.markAsRead"><![CDATA[Als gelesen markieren]]></item>
+		<item name="wcf.user.panel.settings"><![CDATA[Einstellungen]]></item>
+		<item name="wcf.user.panel.showAll"><![CDATA[Alle anzeigen]]></item>
+		<item name="wcf.user.boxList.description.activityPoints"><![CDATA[{#$boxUser->activityPoints} Punkt{if $boxUser->activityPoints != 1}e{/if}]]></item>
+		<item name="wcf.user.boxList.description.likesReceived"><![CDATA[{#$boxUser->likesReceived} Like{if $boxUser->likesReceived != 1}s{/if}]]></item>
+		<item name="wcf.user.boxList.description.registrationDate"><![CDATA[{@$boxUser->registrationDate|time}]]></item>
+		<item name="wcf.user.mostOnlineUsers"><![CDATA[Meiste Benutzer online]]></item>
+		<item name="wcf.user.sortField.activityPoints"><![CDATA[Punkte]]></item>
+		<item name="wcf.user.sortField.likesReceived"><![CDATA[Erhaltene Likes]]></item>
+		<item name="wcf.user.sortField.registrationDate"><![CDATA[Registrierungsdatum]]></item>
+		<item name="wcf.user.sortField.username"><![CDATA[Benutzername]]></item>
+		<item name="wcf.user.sortField.lastActivityTime"><![CDATA[Letzte Aktivität]]></item>
+	</category>
+	
+	<category name="wcf.user.menu">
+		<item name="wcf.user.menu.community"><![CDATA[Community]]></item>
+		<item name="wcf.user.menu.community.notification"><![CDATA[Benachrichtigungen]]></item>
+		<item name="wcf.user.menu.community.following"><![CDATA[Nutzer, denen du folgst]]></item>
+		<item name="wcf.user.menu.community.ignoredUsers"><![CDATA[Blockierte Nutzer]]></item>
+		<item name="wcf.user.menu.profile"><![CDATA[Benutzerkonto]]></item>
+		<item name="wcf.user.menu.profile.accountManagement"><![CDATA[Verwaltung]]></item>
+		<item name="wcf.user.menu.profile.avatar"><![CDATA[Avatar]]></item>
+		<item name="wcf.user.menu.profile.signature"><![CDATA[Signatur]]></item>
+		<item name="wcf.user.menu.settings"><![CDATA[Einstellungen]]></item>
+		<item name="wcf.user.menu.settings.notification"><![CDATA[Benachrichtigungen]]></item>
+		<item name="wcf.user.menu.settings.paidSubscription"><![CDATA[Bezahlte Mitgliedschaften]]></item>
+	</category>
+	
+	<category name="wcf.user.register">
+		<item name="wcf.user.register"><![CDATA[Registrierung]]></item>
+		
+		<!-- Need Activation -->
+		<item name="wcf.user.register.needActivation"><![CDATA[Dein Benutzerkonto ist noch nicht aktiviert. Du musst den <a href="{link controller='RegisterActivation'}{/link}">Aktivierungsvorgang abschließen</a>, um den vollen Funktionsumfang dieser Seite nutzen zu können.]]></item>
+		<item name="wcf.user.register.needActivation.mail.subject"><![CDATA[Aktivierung der Registrierung auf der Website: {@PAGE_TITLE|language}]]></item>
+		<item name="wcf.user.register.needActivation.mail.html.headline"><![CDATA[Hallo {$mailbox->getUser()->username},]]></item>
+		<item name="wcf.user.register.needActivation.mail.html.intro"><![CDATA[
+<p>vielen Dank für deine Registrierung auf der Website: <a href="{link isEmail=true}{/link}">{PAGE_TITLE|language}</a>. Bevor du dein 
+Benutzerkonto vollständig verwenden kannst, ist es notwendig, dass du einmalig die Gültigkeit deiner E-Mail-Adresse bestätigst:</p>]]></item>
+		<item name="wcf.user.register.needActivation.mail.html.activate"><![CDATA[Benutzerkonto aktivieren]]></item>
+		<item name="wcf.user.register.needActivation.mail.html.outro"><![CDATA[
+<p>Dein Aktivierungscode lautet: <code>{$mailbox->getUser()->activationCode}</code>.</p>
+<p>Wenn du Probleme mit der Aktivierung deines Benutzerkontos hast, dann wende dich bitte an den Administrator
+unter: <a href="mailto:{MAIL_ADMIN_ADDRESS}">{MAIL_ADMIN_ADDRESS}</a>. Wenn du dich nicht bei uns registriert hast,
+dann kannst du diese E-Mail ignorieren.</p>]]></item>
+		<item name="wcf.user.register.needActivation.mail.plaintext"><![CDATA[Hallo {$mailbox->getUser()->username},
+
+vielen Dank für deine Registrierung auf der Website: {@PAGE_TITLE|language} [URL:{link isEmail=true}{/link}].
+Bevor du dein Benutzerkonto vollständig verwenden kannst, ist es notwendig,
+dass du einmalig durch Klicken des Folgenden Links die Gültigkeit deiner
+E-Mail-Adresse bestätigst:
+
+    {link controller='RegisterActivation' isEmail=true}u={@$mailbox->getUser()->userID}&a={@$mailbox->getUser()->activationCode}{/link} {* this line ends with a space *}
+
+Dein Aktivierungscode lautet: {@$mailbox->getUser()->activationCode} {* this line ends with a space *}
+
+Wenn du Probleme mit der Aktivierung Ihres Benutzerkontos hast, dann wende
+dich bitte an den Administrator unter: {@MAIL_ADMIN_ADDRESS}. Wenn du
+dich nicht bei uns registriert hast, dann kannst du diese E-Mail ignorieren.]]></item>
+		
+		<!-- Success Messages -->
+		<item name="wcf.user.register.success"><![CDATA[Vielen Dank für die Registrierung, {$user->username}. Deine Registrierung ist hiermit vollständig abgeschlossen.]]></item>
+		<item name="wcf.user.register.success.needActivation"><![CDATA[Vielen Dank für die Registrierung, {$user->username}.<br>
+Wir haben dir eine E-Mail an {$user->email} geschickt. Die E-Mail enthält einen Link, den du einmalig aufrufen musst, um die Gültigkeit deiner E-Mail-Adresse zu bestätigen und damit deine Registrierung abzuschließen.]]></item>
+		<item name="wcf.user.register.success.awaitActivation"><![CDATA[Vielen Dank für die Registrierung, {$user->username}. Deine Benutzerdaten werden in Kürze von einem Administrator geprüft.<br>
+Sobald dein Benutzerkonto freigeschaltet ist, wirst du per E-Mail darüber in Kenntnis gesetzt.]]></item>
+		
+		<!-- Error Messages -->
+		<item name="wcf.user.register.error.disabled"><![CDATA[Die Registrierung ist momentan deaktiviert.]]></item>
+		
+		<!-- Administrator Notification -->
+		<item name="wcf.user.register.notification.mail"><![CDATA[Hallo Administrator,
+		
+auf der Website {@PAGE_TITLE|language} erfolgte eine neue Benutzeranmeldung durch: {@$user->username} 
+
+Die E-Mail-Adresse des neuen Benutzers lautet: {@$user->email} 
+
+Du erreichst das Benutzerprofil des neuen Benutzers, indem du folgenden Link aufrufst:
+{link controller='User' object=$user isEmail=true}{/link} ]]></item>
+		<item name="wcf.user.register.notification.mail.subject"><![CDATA[Neue Benutzeranmeldung auf der Website: {@PAGE_TITLE|language}]]></item>
+		
+		<!-- Disclaimer -->
+		<item name="wcf.user.register.disclaimer.accept"><![CDATA[Akzeptieren]]></item>
+		<item name="wcf.user.register.disclaimer.decline"><![CDATA[Ablehnen]]></item>
+		<item name="wcf.user.register.disclaimer.text"><![CDATA[<h2>Haftungsbeschränkung für eigene Inhalte</h2>
+<p>Alle Inhalte unseres Internetauftritts wurden mit Sorgfalt und nach bestem Gewissen erstellt. Eine Gewähr für die Aktualität, Vollständigkeit und Richtigkeit sämtlicher Seiten kann jedoch nicht übernommen werden.</p>
+<p><br></p>
+<p>Gemäß § 7 Abs. 1 TMG sind wir als Dienstanbieter für eigene Inhalte auf diesen Seiten nach den allgemeinen Gesetzen verantwortlich, nach den §§ 8 bis 10 TMG jedoch nicht verpflichtet, die übermittelten oder gespeicherten fremden Informationen zu überwachen. Eine umgehende Entfernung dieser Inhalte erfolgt ab dem Zeitpunkt der Kenntnis einer konkreten Rechtsverletzung und wir haften nicht vor dem Zeitpunkt der Kenntniserlangung.</p>
+<h2>Haftungsbeschränkung für externe Links</h2>
+<p>Unsere Website enthält sog. „externe Links“ (Verknüpfungen zu Websites Dritter), auf deren Inhalt wir keinen Einfluss haben und für den wir aus diesem Grund keine Gewähr übernehmen. Für die Inhalte und Richtigkeit der Informationen ist der jeweilige Informationsanbieter der verlinkten Websites verantwortlich. Als die Verlinkung vorgenommen wurde, waren für uns keine Rechtsverstöße erkennbar. Sollte uns eine Rechtsverletzung bekannt werden, wird der jeweilige Link umgehend von uns entfernt.</p>
+<h2>Urheberrecht</h2>
+<p>Die auf dieser Website veröffentlichten Inhalte und Werke unterliegen dem deutschen Urheberrecht. Jede Art der Vervielfältigung, Bearbeitung, Verbreitung und jede Art der Verwertung außerhalb der Grenzen des Urheberrechts bedarf der vorherigen schriftlichen Zustimmung des jeweiligen Urhebers bzw. Autors.</p>
+<h2>Datenschutz</h2>
+<p>Durch den Besuch unseres Internetauftritts können Informationen über den Zugriff (Datum, Uhrzeit, aufgerufene Seite) auf dem Server gespeichert werden. Dies stellt keine Auswertung personenbezogener Daten (z.B. Name, Anschrift oder E-Mail Adresse) dar. Sofern personenbezogene Daten erhoben werden, erfolgt dies – sofern möglich – nur mit dem vorherigen Einverständnis des Nutzers der Website. Eine Weiterleitung der Daten an Dritte findet ohne ausdrückliche Zustimmung des Nutzers nicht statt.</p>
+<p><br></p>
+<p>Wir weisen ausdrücklich darauf hin, dass die Übertragung von Daten im Internet (z.B. per E-Mail) Sicherheitslücken aufweisen kann. Ein lückenloser Schutz der Daten vor dem Zugriff Dritter kann nicht gewährleistet werden. Wir können keine Haftung für die durch solche Sicherheitslücken entstehenden Schäden übernehmen.</p>
+<p><br></p>
+<p>Der Verwendung veröffentlichter Kontaktdaten durch Dritte zum Zwecke von Werbung wird ausdrücklich widersprochen. Wir behalten uns rechtliche Schritte für den Fall der unverlangten Zusendung von Werbeinformationen, z.B. durch Spam-Mails, vor.</p>
+<p><br></p>
+<p><small><em>Quelle: <a href="http://www.mustervorlage.net/disclaimer-muster" class="externalURL">Mustervorlage.net</a></em></small></p>]]></item>
+	</category>
+	
+	<category name="wcf.user.usersOnline">
+		<item name="wcf.user.usersOnline"><![CDATA[Benutzer online]]></item>
+		<item name="wcf.user.usersOnline.detail"><![CDATA[
+{if $usersOnlineList->stats[members] > 0}
+	{#$usersOnlineList->stats[members]} Mitglied{if $usersOnlineList->stats[members] != 1}er{/if}
+{/if} 
+{if $usersOnlineList->stats[invisible] > 0}
+	(davon {#$usersOnlineList->stats[invisible]} unsichtbar)
+{/if}
+{if $usersOnlineList->stats[guests] > 0 && $usersOnlineList->stats[members] > 0}und{/if}
+{if $usersOnlineList->stats[guests] > 0}
+	{#$usersOnlineList->stats[guests]} Besucher
+{/if}]]></item>
+		<item name="wcf.user.usersOnline.invisible"><![CDATA[ (unsichtbar)]]></item>
+		<item name="wcf.user.usersOnline.marking.legend"><![CDATA[Legende]]></item>
+		<item name="wcf.user.usersOnline.guests"><![CDATA[Gäste]]></item>
+		<item name="wcf.user.usersOnline.location"><![CDATA[Ort]]></item>
+		<item name="wcf.user.usersOnline.ipAddress"><![CDATA[IP-Adresse]]></item>
+		<item name="wcf.user.usersOnline.userAgent"><![CDATA[Browser]]></item>
+		<item name="wcf.user.usersOnline.lastActivity"><![CDATA[Letzte Aktivität]]></item>
+		<item name="wcf.user.usersOnline.location.unknown"><![CDATA[Unbekannter Ort]]></item>
+		<item name="wcf.user.usersOnline.robots"><![CDATA[Suchmaschinen-Roboter]]></item>
+		<item name="wcf.user.usersOnline.record"><![CDATA[Rekord: {#USERS_ONLINE_RECORD} Benutzer ({@USERS_ONLINE_RECORD_TIME|time})]]></item>
+		<item name="wcf.user.usersOnline.users"><![CDATA[Benutzer]]></item>
+	</category>
+	
+	<category name="wcf.user.recentActivity">
+		<item name="wcf.user.recentActivity"><![CDATA[Letzte Aktivitäten]]></item>
+		<item name="wcf.user.recentActivity.more"><![CDATA[Weitere Aktivitäten]]></item>
+		<item name="wcf.user.recentActivity.noMoreEntries"><![CDATA[Keine weiteren Aktivitäten]]></item>
+		<item name="wcf.user.recentActivity.noEntries"><![CDATA[Es sind keine Aktivitäten vorhanden.]]></item>
+		<item name="wcf.user.recentActivity.com.woltlab.wcf.user.recentActivityEvent.follow"><![CDATA[Folgen]]></item>
+		<item name="wcf.user.recentActivity.com.woltlab.wcf.user.profileComment.recentActivityEvent"><![CDATA[Pinnwand-Kommentar]]></item>
+		<item name="wcf.user.recentActivity.com.woltlab.wcf.user.profileComment.response.recentActivityEvent"><![CDATA[Pinnwand-Antwort]]></item>
+		<item name="wcf.user.recentActivity.com.woltlab.wcf.likeableArticle.recentActivityEvent"><![CDATA[Like (Artikel)]]></item>
+		<item name="wcf.user.recentActivity.com.woltlab.wcf.articleComment.recentActivityEvent"><![CDATA[Kommentar (Artikel)]]></item>
+		<item name="wcf.user.recentActivity.com.woltlab.wcf.articleComment.response.recentActivityEvent"><![CDATA[Antwort (Artikel)]]></item>
+		<item name="wcf.user.recentActivity.condition.excludedObjectType"><![CDATA[Ausgeschlossene Aktivitäten]]></item>
+		<item name="wcf.user.recentActivity.scope.all"><![CDATA[Aktivitäten aller Benutzer]]></item>
+		<item name="wcf.user.recentActivity.scope.followedUsers"><![CDATA[Aktivitäten von Benutzern, denen du folgst]]></item>
+		<item name="wcf.user.recentActivity.scope.followedUsers.noResults"><![CDATA[Es gibt aktuell keine Aktivitäten von Benutzeren, denen du folgst. Es werden alle Aktivitäten angezeigt.]]></item>
+	</category>
+	
+	<category name="wcf.user.3rdparty">
+		<item name="wcf.user.3rdparty"><![CDATA[Drittanbieter]]></item>
+		<item name="wcf.user.3rdparty.github"><![CDATA[GitHub]]></item>
+		<item name="wcf.user.3rdparty.github.login"><![CDATA[Mit deinem GitHub-Konto anmelden]]></item>
+		<item name="wcf.user.3rdparty.github.login.error.access_denied"><![CDATA[Da du die Berechtigungen verweigert hast, ist die Anmeldung mit GitHub nicht möglich.]]></item>
+		<item name="wcf.user.3rdparty.github.register"><![CDATA[Du erstellst einen Account über <span class="icon icon16 fa-github"></span>&nbsp;GitHub. Der Benutzername und deine E-Mail-Adresse wurden daher bereits ausgefüllt.]]></item>
+		<item name="wcf.user.3rdparty.github.connect"><![CDATA[Mit GitHub-Konto {if $__wcf->session->getVar('__githubUsername')}(„<a href="https://github.com/{$__wcf->session->getVar('__githubUsername')}"{if EXTERNAL_LINK_TARGET_BLANK} target="_blank"{/if}>{$__wcf->session->getVar('__githubUsername')}</a>“){/if} verknüpfen]]></item>
+		<item name="wcf.user.3rdparty.github.connect.success"><![CDATA[Dein Benutzerkonto wurde erfolgreich mit deinem GitHub-Konto verknüpft.]]></item>
+		<item name="wcf.user.3rdparty.github.connect.error.inuse"><![CDATA[Dein GitHub-Konto ist bereits mit einem anderen Benutzerkonto verknüpft.]]></item>
+		<item name="wcf.user.3rdparty.github.disconnect"><![CDATA[Verknüpfung mit GitHub trennen]]></item>
+		<item name="wcf.user.3rdparty.github.disconnect.success"><![CDATA[Die Verknüpfung mit deinem GitHub-Konto wurde erfolgreich getrennt.]]></item>
+		<item name="wcf.user.3rdparty.twitter"><![CDATA[Twitter]]></item>
+		<item name="wcf.user.3rdparty.twitter.login"><![CDATA[Mit deinem Twitter-Konto anmelden]]></item>
+		<item name="wcf.user.3rdparty.twitter.login.error.denied"><![CDATA[Da du die Berechtigungen verweigert hast, ist die Anmeldung mit Twitter nicht möglich.]]></item>
+		<item name="wcf.user.3rdparty.twitter.register"><![CDATA[Du erstellst einen Account über &nbsp;Twitter. Der Benutzername wurde daher bereits ausgefüllt. Gib nun noch deine E-Mail-Adresse an und du kannst sofort loslegen!]]></item>
+		<item name="wcf.user.3rdparty.twitter.connect"><![CDATA[Mit Twitter-Konto {if $__wcf->session->getVar('__twitterUsername')}(„<a href="https://twitter.com/{$__wcf->session->getVar('__twitterUsername')}"{if EXTERNAL_LINK_TARGET_BLANK} target="_blank"{/if}>{$__wcf->session->getVar('__twitterUsername')}</a>“){/if} verknüpfen]]></item>
+		<item name="wcf.user.3rdparty.twitter.connect.success"><![CDATA[Dein Benutzerkonto wurde erfolgreich mit deinem Twitter-Konto verknüpft.]]></item>
+		<item name="wcf.user.3rdparty.twitter.connect.error.inuse"><![CDATA[Dein Twitter-Konto ist bereits mit einem anderen Benutzerkonto verknüpft.]]></item>
+		<item name="wcf.user.3rdparty.twitter.disconnect"><![CDATA[Verknüpfung mit Twitter trennen]]></item>
+		<item name="wcf.user.3rdparty.twitter.disconnect.success"><![CDATA[Die Verknüpfung mit deinem Twitter-Konto wurde erfolgreich getrennt.]]></item>
+		<item name="wcf.user.3rdparty.facebook"><![CDATA[Facebook]]></item>
+		<item name="wcf.user.3rdparty.facebook.login"><![CDATA[Mit deinem Facebook-Konto anmelden]]></item>
+		<item name="wcf.user.3rdparty.facebook.login.error.access_denied"><![CDATA[Da du die Berechtigungen verweigert hast, ist die Anmeldung mit Facebook nicht möglich.]]></item>
+		<item name="wcf.user.3rdparty.facebook.register"><![CDATA[Du erstellst einen Account über <span class="icon icon16 fa-facebook"></span>&nbsp;Facebook. Der Benutzername und deine E-Mail-Adresse wurden daher bereits ausgefüllt.]]></item>
+		<item name="wcf.user.3rdparty.facebook.connect"><![CDATA[Mit Facebook-Konto {if $__wcf->session->getVar('__facebookUsername')}(„{$__wcf->session->getVar('__facebookUsername')}“){/if} verknüpfen]]></item>
+		<item name="wcf.user.3rdparty.facebook.connect.success"><![CDATA[Dein Benutzerkonto wurde erfolgreich mit deinem Facebook-Konto verknüpft.]]></item>
+		<item name="wcf.user.3rdparty.facebook.connect.error.inuse"><![CDATA[Dein Facebook-Konto ist bereits mit einem anderen Benutzerkonto verknüpft.]]></item>
+		<item name="wcf.user.3rdparty.facebook.disconnect"><![CDATA[Verknüpfung mit Facebook trennen]]></item>
+		<item name="wcf.user.3rdparty.facebook.disconnect.success"><![CDATA[Die Verknüpfung mit deinem Facebook-Konto wurde erfolgreich getrennt.]]></item>
+		<item name="wcf.user.3rdparty.google"><![CDATA[Google]]></item>
+		<item name="wcf.user.3rdparty.google.login"><![CDATA[Mit deinem Google-Konto anmelden]]></item>
+		<item name="wcf.user.3rdparty.google.login.error.access_denied"><![CDATA[Da du die Berechtigungen verweigert hast, ist die Anmeldung mit Google nicht möglich.]]></item>
+		<item name="wcf.user.3rdparty.google.register"><![CDATA[Du erstellst einen Account über <span class="icon icon16 fa-google-plus"></span>&nbsp;Google. Der Benutzername und deine E-Mail-Adresse wurden daher bereits ausgefüllt.]]></item>
+		<item name="wcf.user.3rdparty.google.connect"><![CDATA[Mit Google-Konto {if $__wcf->session->getVar('__googleUsername')}(„{$__wcf->session->getVar('__googleUsername')}“){/if} verknüpfen]]></item>
+		<item name="wcf.user.3rdparty.google.connect.success"><![CDATA[Dein Benutzerkonto wurde erfolgreich mit deinem Google-Konto verknüpft.]]></item>
+		<item name="wcf.user.3rdparty.google.connect.error.inuse"><![CDATA[Dein Google-Konto ist bereits mit einem anderen Benutzerkonto verknüpft.]]></item>
+		<item name="wcf.user.3rdparty.google.disconnect"><![CDATA[Verknüpfung mit Google trennen]]></item>
+		<item name="wcf.user.3rdparty.google.disconnect.success"><![CDATA[Die Verknüpfung mit deinem Google-Konto wurde erfolgreich getrennt.]]></item>
+	</category>
+	
+	<category name="wcf.user.avatar">
+		<item name="wcf.user.avatar"><![CDATA[Avatar]]></item>
+		<item name="wcf.user.avatar.edit"><![CDATA[Avatar verwalten]]></item>
+		<item name="wcf.user.avatar.error.disabled"><![CDATA[Der Administrator hat{if $__wcf->user->avatarID || $__wcf->user->enableGravatar} deinen derzeitigen Avatar gesperrt und{/if} dir die weitere Nutzungsberechtigung der Avatar-Funktion {if !$__wcf->user->disableAvatarReason}entzogen.{else} aus folgenden Gründen entzogen: {$__wcf->user->disableAvatarReason}{/if}]]></item>
+		<item name="wcf.user.avatar.type.custom"><![CDATA[Eigenen Avatar hochladen]]></item>
+		<item name="wcf.user.avatar.type.custom.description"><![CDATA[Eigene Avatare dürfen die Dateiendungen {"\n"|str_replace:', ':$__wcf->session->getPermission('user.profile.avatar.allowedFileExtensions')} und maximal eine Dateigröße von {@$__wcf->session->getPermission('user.profile.avatar.maxSize')|filesize} besitzen. Die Mindestgröße für Avatare liegt bei 128×128 Pixel.]]></item>
+		<item name="wcf.user.avatar.type.gravatar"><![CDATA[Gravatar verwenden]]></item>
+		<item name="wcf.user.avatar.type.gravatar.description"><![CDATA[Bei einem Gravatar handelt es sich um einen global verfügbaren Avatar (Global Recognized Avatar), welcher mit deiner E-Mail-Adresse („{$__wcf->user->email}“) verknüpft ist. Auf der folgenden Website kannst du einen Gravatar anlegen: <a href="http://www.gravatar.com" class="externalURL"{if EXTERNAL_LINK_TARGET_BLANK} target="_blank"{/if}>www.gravatar.com</a>]]></item>
+		<item name="wcf.user.avatar.type.gravatar.error.notFound"><![CDATA[Zu deiner E-Mail-Adresse konnte kein Gravatar gefunden werden.]]></item>
+		<item name="wcf.user.avatar.type.none"><![CDATA[Keinen Avatar verwenden]]></item>
+		<item name="wcf.user.avatar.type.none.description"><![CDATA[Bereits hochgeladene Avatare werden bei Auswahl dieser Option gelöscht.]]></item>
+		<item name="wcf.user.avatar.upload.error.badImage"><![CDATA[Du hast kein gültiges Bild hochgeladen.]]></item>
+		<item name="wcf.user.avatar.upload.error.invalidExtension"><![CDATA[Die Datei hat eine ungültige Dateiendung.]]></item>
+		<item name="wcf.user.avatar.upload.error.tooLarge"><![CDATA[Die Datei ist zu groß.]]></item>
+		<item name="wcf.user.avatar.upload.error.tooSmall"><![CDATA[Das Bild ist zu klein.]]></item>
+		<item name="wcf.user.avatar.upload.error.uploadFailed"><![CDATA[Beim Hochladen der Datei ist ein unbekannter Fehler aufgetreten.]]></item>
+		<item name="wcf.user.avatar.upload.success"><![CDATA[Der neue Avatar wurde erfolgreich gespeichert.]]></item>
+	</category>
+	
+	<category name="wcf.user.condition">
+		<item name="wcf.user.condition.activityPoints"><![CDATA[Punkte]]></item>
+		<item name="wcf.user.condition.avatar"><![CDATA[Avatar]]></item>
+		<item name="wcf.user.condition.avatar.avatar"><![CDATA[Eigener Avatar]]></item>
+		<item name="wcf.user.condition.avatar.gravatar"><![CDATA[Gravatar]]></item>
+		<item name="wcf.user.condition.avatar.noAvatar"><![CDATA[Kein Avatar]]></item>
+		<item name="wcf.user.condition.conditionGroup.contents"><![CDATA[Inhalte]]></item>
+		<item name="wcf.user.condition.conditionGroup.general"><![CDATA[Allgemeine Daten]]></item>
+		<item name="wcf.user.condition.conditionGroup.userOptions"><![CDATA[Persönliche Daten]]></item>
+		<item name="wcf.user.condition.groupIDs"><![CDATA[in Benutzergruppen]]></item>
+		<item name="wcf.user.condition.groupIDs.description"><![CDATA[Benutzer müssen in allen ausgewählten Benutzergruppen Mitglied sein.]]></item>
+		<item name="wcf.user.condition.languages"><![CDATA[Sprachen]]></item>
+		<item name="wcf.user.condition.lastActivityTime"><![CDATA[Letzte Aktivität]]></item>
+		<item name="wcf.user.condition.likesReceived"><![CDATA[Erhaltene Likes]]></item>
+		<item name="wcf.user.condition.mobileBrowser"><![CDATA[Mobiler Browser]]></item>
+		<item name="wcf.user.condition.mobileBrowser.usesMobileBrowser"><![CDATA[Verwendet mobilen Browser]]></item>
+		<item name="wcf.user.condition.mobileBrowser.usesMobileBrowser.error.conflict"><![CDATA[„Verwendet mobilen Browser“ und „Verwendet keinen mobilen Browser“ können nicht gleichzeitig ausgewählt werden.]]></item>
+		<item name="wcf.user.condition.mobileBrowser.usesNoMobileBrowser"><![CDATA[Verwendet keinen mobilen Browser]]></item>
+		<item name="wcf.user.condition.notGroupIDs"><![CDATA[nicht in Benutzergruppen]]></item>
+		<item name="wcf.user.condition.notGroupIDs.description"><![CDATA[Benutzer dürfen in keiner der ausgewählten Benutzergruppen Mitglied sein.]]></item>
+		<item name="wcf.user.condition.notGroupIDs.error.groupIDsIntersection"><![CDATA[Die ausgewählten Benutzergruppen in „in Benutzergruppen“ und „nicht in Benutzergruppen“ sind widersprüchlich.]]></item>
+		<item name="wcf.user.condition.registrationDate"><![CDATA[Registrierungsdatum]]></item>
+		<item name="wcf.user.condition.registrationDateInterval"><![CDATA[Tage seit Registrierung]]></item>
+		<item name="wcf.user.condition.state"><![CDATA[Zustand]]></item>
+		<item name="wcf.user.condition.state.isBanned"><![CDATA[Gesperrt]]></item>
+		<item name="wcf.user.condition.state.isBanned.error.conflict"><![CDATA[„Gesperrt“ und „Nicht gesperrt“ können nicht gleichzeitig ausgewählt werden.]]></item>
+		<item name="wcf.user.condition.state.isDisabled"><![CDATA[Nicht aktiviert]]></item>
+		<item name="wcf.user.condition.state.isEnabled"><![CDATA[Aktiviert]]></item>
+		<item name="wcf.user.condition.state.isEnabled.error.conflict"><![CDATA[„Aktiviert“ und „Nicht aktiviert“ können nicht gleichzeitig ausgewählt werden.]]></item>
+		<item name="wcf.user.condition.state.isNotBanned"><![CDATA[Nicht gesperrt]]></item>
+	</category>
+	
+	<category name="wcf.user.notification">
+		<item name="wcf.user.notification.button.confirmed"><![CDATA[OK]]></item>
+		<item name="wcf.user.notification.count"><![CDATA[if (data.returnValues.count == 0) { "Keine Benachrichtigungen" } else if (data.returnValues.count == 1) { "Eine Benachrichtigung" } else { data.returnValues.count + " Benachrichtigungen" }]]></item>
+		<item name="wcf.user.notification.markAllAsConfirmed"><![CDATA[Alle als gelesen markieren]]></item>
+		<item name="wcf.user.notification.markAllAsConfirmed.confirmMessage"><![CDATA[Willst du wirklich alle Benachrichtigungen als gelesen markieren?]]></item>
+		<item name="wcf.user.notification.markAsConfirmed"><![CDATA[Als gelesen markieren]]></item>
+		<item name="wcf.user.notification.noMoreNotifications"><![CDATA[Keine aktuellen Benachrichtigungen]]></item>
+		<item name="wcf.user.notification.noNotifications"><![CDATA[Du hast keine Benachrichtigungen.]]></item>
+		<item name="wcf.user.notification.notifications"><![CDATA[Benachrichtigungen]]></item>
+		<item name="wcf.user.notification.notifications.description"><![CDATA[E-Mail-Benachrichtigungen werden nicht von allen verfügbaren Benachrichtigungen unterstützt.]]></item>
+		<item name="wcf.user.notification.notifications.disabled"><![CDATA[Deaktiviert]]></item>
+		<item name="wcf.user.notification.notifications.enabled"><![CDATA[Aktiviert]]></item>
+		<item name="wcf.user.notification.showAll"><![CDATA[Alle Benachrichtigungen anzeigen]]></item>
+		<item name="wcf.user.notification.mail.disabled"><![CDATA[Die E-Mail-Benachrichtigung wurde erfolgreich abgeschaltet.]]></item>
+		<item name="wcf.user.notification.mailNotificationType.none"><![CDATA[Keine E-Mail-Benachrichtigung]]></item>
+		<item name="wcf.user.notification.mailNotificationType.instant"><![CDATA[Sofortige E-Mail-Benachrichtigung]]></item>
+		<item name="wcf.user.notification.mailNotificationType.daily"><![CDATA[Tägliche E-Mail-Benachrichtigung]]></item>
+		<item name="wcf.user.notification.mailNotificationType.notSupported"><![CDATA[E-Mail-Benachrichtigungen werden nicht unterstützt.]]></item>
+		
+		<!-- Email Wrapper -->
+		<item name="wcf.user.notification.mail.subject"><![CDATA[Neue Benachrichtigung: {@$title}]]></item>
+		<item name="wcf.user.notification.mail.plaintext.intro"><![CDATA[Hallo {@$mailbox->getUser()->username},]]></item>
+		<item name="wcf.user.notification.mail.plaintext.outro"><![CDATA[Diese E-Mail ist eine automatische Benachrichtigung. BITTE ANTWORTE NICHT AUF DIESE E-MAIL.
+		
+Besuche deine Benachrichtigungseinstellungen [URL:{link controller='NotificationSettings' isEmail=true}{/link}], um die
+Benachrichtigungen auf {@PAGE_TITLE|language} [URL:{link isEmail=true}{/link}] nach deinen Wünschen zu konfigurieren.
+
+Wenn du nur diese E-Mail-Benachrichtigung nicht mehr erhalten möchtest, dann kannst du diese direkt abbestellen: {link controller='NotificationDisable' isEmail=true}eventID={@$event->eventID}&userID={@$mailbox->getUser()->userID}&token={@$mailbox->getUser()->notificationMailToken}{/link}.]]></item>
+		<item name="wcf.user.notification.mail.html.intro"><![CDATA[<h2>Hallo {$mailbox->getUser()->username},</h2>]]></item>
+		<item name="wcf.user.notification.mail.html.outro"><![CDATA[<p>Diese E-Mail ist eine automatische Benachrichtigung. <b>Bitte antworte nicht auf diese E-Mail</b>.</p>
+
+<p>Besuche deine <a href="{link controller='NotificationSettings' isEmail=true}{/link}">Benachrichtigungseinstellungen</a>, um die
+Benachrichtigungen auf <a href="{link isEmail=true}{/link}">{PAGE_TITLE|language}</a> nach deinen Wünschen zu konfigurieren.</p>
+
+<p>Wenn du nur diese E-Mail-Benachrichtigung nicht mehr erhalten möchtest, dann kannst du diese direkt <a href="{link controller='NotificationDisable' isEmail=true}eventID={@$event->eventID}&userID={@$mailbox->getUser()->userID}&token={@$mailbox->getUser()->notificationMailToken}{/link}">abbestellen</a>.</p>]]></item>
+		<item name="wcf.user.notification.mail.daily.subject"><![CDATA[{if $count == 1}Neue Benachrichtigung{else}{#$count} neue Benachrichtigungen{/if}]]></item>
+		<item name="wcf.user.notification.mail.daily.plaintext.intro"><![CDATA[Hallo {@$mailbox->getUser()->username},
+
+Du hast derzeit insgesamt {#$notifications|count} ungelesene Benachrichtigungen, die älter als 24 Stunden sind:]]></item>
+		<item name="wcf.user.notification.mail.daily.plaintext.outro"><![CDATA[{if $notifications|count > $maximum}Besuche deine Benachrichtigungs-Übersicht [URL:{link controller='NotificationList' isEmail=true}{/link}], um auch die restlichen {#$remaining} Benachrichtigungen einzusehen.
+
+{/if}Diese E-Mail ist eine automatische Benachrichtigung. BITTE ANTWORTE NICHT AUF DIESE E-MAIL.
+
+Besuche deine Benachrichtigungseinstellungen [URL:{link controller='NotificationSettings' isEmail=true}{/link}], um die
+Benachrichtigungen auf {@PAGE_TITLE|language} [URL:{link isEmail=true}{/link}] nach deinen Wünschen zu konfigurieren.
+
+Wenn du keine E-Mail-Benachrichtigungen mehr erhalten möchtest, dann kannst du diese direkt abbestellen: {link controller='NotificationDisable' isEmail=true}userID={@$mailbox->getUser()->userID}&token={@$mailbox->getUser()->notificationMailToken}{/link}.]]></item>
+		<item name="wcf.user.notification.mail.daily.html.intro"><![CDATA[<h2>Hallo {@$mailbox->getUser()->username},</h2>
+
+<p>Du hast derzeit insgesamt {#$notifications|count} ungelesene Benachrichtigungen, die älter als 24 Stunden sind:</p>]]></item>
+		<item name="wcf.user.notification.mail.daily.html.outro"><![CDATA[{if $notifications|count > $maximum}<p>Besuche <a href="{link controller='NotificationList' isEmail=true}{/link}">deine Benachrichtigungs-Übersicht</a>, um auch die restlichen {#$remaining} Benachrichtigungen einzusehen.</p>{/if}
+
+<p>Diese E-Mail ist eine automatische Benachrichtigung. <b>Bitte antworte nicht auf diese E-Mail</b>.</p>
+
+<p>Besuche deine <a href="{link controller='NotificationSettings' isEmail=true}{/link}">Benachrichtigungseinstellungen</a>, um die
+Benachrichtigungen auf <a href="{link isEmail=true}{/link}">{PAGE_TITLE|language}</a> nach deinen Wünschen zu konfigurieren.</p>
+
+<p>Wenn du keine E-Mail-Benachrichtigungen mehr erhalten möchtest, dann kannst du diese direkt <a href="{link controller='NotificationDisable' isEmail=true}userID={@$mailbox->getUser()->userID}&token={@$mailbox->getUser()->notificationMailToken}{/link}">abbestellen</a>.</p>]]></item>
+		
+		<item name="wcf.user.notification.mail.authorList.plaintext"><![CDATA[{if !$event->getAuthor()->userID}Ein Gast{else}{@$event->getAuthor()->username} [URL:{link controller='User' object=$event->getAuthor() isEmail=true}{/link}]{/if}{if $count > 1 && $count < 4}{if $count == 2 && !$guestTimesTriggered} und {else}, {/if}{@$authors[1]->username} [URL:{link controller='User' object=$authors[1] isEmail=true}{/link}]{if $count == 3}{if !$guestTimesTriggered} und {else}, {/if}{@$authors[2]->username} [URL:{link controller='User' object=$authors[2] isEmail=true}{/link}]{/if}{elseif $count >= 4}{if $guestTimesTriggered},{else} und{/if} {#$count-1} weitere Benutzer{/if}{if $guestTimesTriggered} und {if $guestTimesTriggered == 1}ein Gast{else}{#$guestTimesTriggered} Gäste{/if}{/if}]]></item>
+		<item name="wcf.user.notification.mail.authorList.html"><![CDATA[{if !$event->getAuthor()->userID}Ein Gast{else}<a href="{link controller='User' object=$event->getAuthor() isEmail=true}{/link}">{@$event->getAuthor()->username}</a>{/if}{if $count > 1 && $count < 4}{if $count == 2 && !$guestTimesTriggered} und {else}, {/if}<a href="{link controller='User' object=$authors[1] isEmail=true}{/link}">{@$authors[1]->username}</a>{if $count == 3}{if !$guestTimesTriggered} und {else}, {/if}<a href="{link controller='User' object=$authors[2] isEmail=true}{/link}">{@$authors[2]->username}</a>{/if}{elseif $count >= 4}{if $guestTimesTriggered},{else} und{/if} {#$count-1} weitere Benutzer{/if}{if $guestTimesTriggered} und {if $guestTimesTriggered == 1}ein Gast{else}{#$guestTimesTriggered} Gäste{/if}{/if}]]></item>
+		
+		<!-- Notifications -->
+		<item name="wcf.user.notification.com.woltlab.wcf.user"><![CDATA[Benutzer-Profile]]></item>
+		<item name="wcf.user.notification.com.woltlab.wcf.user.follow.following"><![CDATA[Jemand folgt dir]]></item>
+		<item name="wcf.user.notification.follow.title"><![CDATA[Neuer Follower]]></item>
+		<item name="wcf.user.notification.follow.title.stacked"><![CDATA[{#$count} neue Follower]]></item>
+		<item name="wcf.user.notification.follow.message"><![CDATA[{@$author->getAnchorTag()} folgt dir.]]></item>
+		<item name="wcf.user.notification.follow.message.stacked"><![CDATA[{if $count < 4}{@$authors[0]->getAnchorTag()}{if $count == 2} und {else}, {/if}{@$authors[1]->getAnchorTag()}{if $count == 3} und {@$authors[2]->getAnchorTag()}{/if}{else}{@$authors[0]->getAnchorTag()} und {#$others} weitere{/if} folgen dir.]]></item>
+		<item name="wcf.user.notification.follow.mail.plaintext"><![CDATA[{@$authorList} {if $count == 1}folgt{else}folgen{/if} dir.]]></item>
+		<item name="wcf.user.notification.follow.mail.html"><![CDATA[<p>{@$authorList} {if $count == 1}folgt{else}folgen{/if} dir:</p>]]></item>
+		<item name="wcf.user.notification.comment.title"><![CDATA[Neuer Kommentar (Pinnwand)]]></item>
+		<item name="wcf.user.notification.comment.title.stacked"><![CDATA[{#$timesTriggered} neue Kommentare (Pinnwand)]]></item>
+		<item name="wcf.user.notification.comment.message"><![CDATA[{if !$author->userID}Ein Gast{else}{@$author->getAnchorTag()}{/if} hat einen Kommentar an <a href="{link controller='User' object=$__wcf->getUser()}#wall/comment{@$commentID}{/link}">deiner Pinnwand</a> verfasst.]]></item>
+		<item name="wcf.user.notification.comment.message.stacked"><![CDATA[{if $count < 4}{@$authors[0]->getAnchorTag()}{if $count != 1}{if $count == 2 && !$guestTimesTriggered} und {else}, {/if}{@$authors[1]->getAnchorTag()}{if $count == 3}{if !$guestTimesTriggered} und {else}, {/if} {@$authors[2]->getAnchorTag()}{/if}{/if}{if $guestTimesTriggered} und {if $guestTimesTriggered == 1}ein Gast{else}Gäste{/if}{/if}{else}{@$authors[0]->getAnchorTag()}{if $guestTimesTriggered},{else} und{/if} {#$others} weitere Benutzer {if $guestTimesTriggered}und {if $guestTimesTriggered == 1}ein Gast{else}Gäste{/if}{/if}{/if} haben Kommentare an <a href="{link controller='User' object=$__wcf->getUser()}#wall/comment{@$commentID}{/link}">deiner Pinnwand</a> verfasst.]]></item>
+		<item name="wcf.user.notification.comment.mail.plaintext"><![CDATA[{@$authorList} {if $count == 1 && !$guestTimesTriggered}hat einen Kommentar{else}haben Kommentare{/if} an deiner Pinnwand [URL:{link controller='User' object=$notificationContent[variables][owner] isEmail=true}#wall/comment{@$commentID}{/link}] verfasst{if $count == 1 && !$guestTimesTriggered}:{else}.{/if}]]></item>
+		<item name="wcf.user.notification.comment.mail.html"><![CDATA[<p>{@$authorList} {if $count == 1 && !$guestTimesTriggered}hat einen Kommentar{else}haben Kommentare{/if} an <a href="{link controller='User' object=$notificationContent[variables][owner] isEmail=true}#wall/comment{@$commentID}{/link}">deiner Pinnwand</a> verfasst:</p>]]></item>
+		<item name="wcf.user.notification.comment.like.title"><![CDATA[Gefällt ein Kommentar (Pinnwand)]]></item>
+		<item name="wcf.user.notification.comment.like.title.stacked"><![CDATA[{#$count} Benutzern gefällt dein Kommentar (Pinnwand)]]></item>
+		<item name="wcf.user.notification.comment.like.message"><![CDATA[{@$author->getAnchorTag()} gefällt dein Kommentar an {if $owner === null}<a href="{link controller='User' object=$__wcf->getUser()}#wall/comment{@$commentID}{/link}">deiner Pinnwand</a>{else}der <a href="{link controller='User' object=$owner}#wall/comment{@$commentID}{/link}">Pinnwand von {$owner->username}</a>{/if}.]]></item>
+		<item name="wcf.user.notification.comment.like.message.stacked"><![CDATA[{if $count < 4}{@$authors[0]->getAnchorTag()}{if $count == 2} und {else}, {/if}{@$authors[1]->getAnchorTag()}{if $count == 3} und {@$authors[2]->getAnchorTag()}{/if}{else}{@$authors[0]->getAnchorTag()} und {#$others} weiteren{/if} gefällt dein Kommentar an {if $owner === null}<a href="{link controller='User' object=$__wcf->getUser()}#wall/comment{@$commentID}{/link}">deiner Pinnwand</a>{else}der <a href="{link controller='User' object=$owner}#wall/comment{@$commentID}{/link}">Pinnwand von {$owner->username}</a>{/if}.]]></item>
+		<item name="wcf.user.notification.commentResponse.title"><![CDATA[Neue Antwort (Pinnwand)]]></item>
+		<item name="wcf.user.notification.commentResponse.title.stacked"><![CDATA[{#$timesTriggered} neue Antworten (Pinnwand)]]></item>
+		<item name="wcf.user.notification.commentResponse.message"><![CDATA[{if !$author->userID}Ein Gast{else}{@$author->getAnchorTag()}{/if} hat eine Antwort zu deinem Kommentar an {if $owner->userID == $__wcf->getUser()->userID}<a href="{link controller='User' object=$owner}#wall/comment{@$commentID}/response{@$responseID}{/link}">deiner Pinnwand</a>{else}der <a href="{link controller='User' object=$owner}#wall/comment{@$commentID}/response{@$responseID}{/link}">Pinnwand von {$owner->username}</a>{/if} verfasst.]]></item>
+		<item name="wcf.user.notification.commentResponse.message.stacked"><![CDATA[{if $count < 4}{@$authors[0]->getAnchorTag()}{if $count != 1}{if $count == 2 && !$guestTimesTriggered} und {else}, {/if}{@$authors[1]->getAnchorTag()}{if $count == 3}{if !$guestTimesTriggered} und {else}, {/if} {@$authors[2]->getAnchorTag()}{/if}{/if}{if $guestTimesTriggered} und {if $guestTimesTriggered == 1}ein Gast{else}Gäste{/if}{/if}{else}{@$authors[0]->getAnchorTag()}{if $guestTimesTriggered},{else} und{/if} {#$others} weitere Benutzer {if $guestTimesTriggered}und {if $guestTimesTriggered == 1}ein Gast{else}Gäste{/if}{/if}{/if} haben auf deinen Kommentar an {if $owner->userID == $__wcf->getUser()->userID}<a href="{link controller='User' object=$owner}#wall/comment{@$commentID}/response{@$responseID}{/link}">deiner Pinnwand</a>{else}der <a href="{link controller='User' object=$owner}#wall/comment{@$commentID}/response{@$responseID}{/link}">Pinnwand von {$owner->username}</a>{/if} geantwortet.]]></item>
+		<item name="wcf.user.notification.commentResponse.mail.plaintext"><![CDATA[{@$authorList} {if $count == 1 && !$guestTimesTriggered}hat eine Antwort{else}haben Antworten{/if} auf deinen Kommentar an{if $mailbox->getUser()->userID == $notificationContent[variables][owner]->userID}deiner Pinnwand{else}der Pinnwand von {@$notificationContent[variables][owner]->username}{/if} [URL:{link controller='User' object=$notificationContent[variables][owner] isEmail=true}#wall/comment{@$commentID}/response{@$responseID}{/link}] verfasst{if $count == 1 && !$guestTimesTriggered}:{else}.{/if}]]></item>
+		<item name="wcf.user.notification.commentResponse.mail.html"><![CDATA[<p>{@$authorList} {if $count == 1 && !$guestTimesTriggered}hat eine Antwort{else}haben Antworten{/if} zu deinem Kommentar an {if $mailbox->getUser()->userID == $notificationContent[variables][owner]->userID}<a href="{link controller='User' object=$notificationContent[variables][owner] isEmail=true}#wall/comment{@$commentID}/response{@$responseID}{/link}">deiner Pinnwand</a>{else}der <a href="{link controller='User' object=$notificationContent[variables][owner] isEmail=true}#wall/comment{@$commentID}/response{@$responseID}{/link}">Pinnwand von {$notificationContent[variables][owner]->username}</a>{/if} verfasst:</p>]]></item>
+		<item name="wcf.user.notification.commentResponse.like.title"><![CDATA[Gefällt die Antwort auf einen Kommentar (Pinnwand)]]></item>
+		<item name="wcf.user.notification.commentResponse.like.title.stacked"><![CDATA[{#$count} Benutzern gefällt deine Antwort auf einen Kommentar (Pinnwand)]]></item>
+		<item name="wcf.user.notification.commentResponse.like.message"><![CDATA[{@$author->getAnchorTag()} gefällt deine Antwort auf einen Kommentar an {if $owner === null}<a href="{link controller='User' object=$__wcf->getUser()}#wall/comment{@$commentID}/response{@$responseID}{/link}">deiner Pinnwand</a>{else}der <a href="{link controller='User' object=$owner}#wall/comment{@$commentID}/response{@$responseID}{/link}">Pinnwand von {$owner->username}</a>{/if}.]]></item>
+		<item name="wcf.user.notification.commentResponse.like.message.stacked"><![CDATA[{if $count < 4}{@$authors[0]->getAnchorTag()}{if $count == 2} und {else}, {/if}{@$authors[1]->getAnchorTag()}{if $count == 3} und {@$authors[2]->getAnchorTag()}{/if}{else}{@$authors[0]->getAnchorTag()} und {#$others} weiteren{/if} gefällt deine Antwort auf einen Kommentar an {if $owner === null}<a href="{link controller='User' object=$__wcf->getUser()}#wall/comment{@$commentID}/response{@$responseID}{/link}">deiner Pinnwand</a>{else}der <a href="{link controller='User' object=$owner}#wall/comment{@$commentID}/response{@$responseID}{/link}">Pinnwand von {$owner->username}</a>{/if}.]]></item>
+		<item name="wcf.user.notification.commentResponseOwner.title"><![CDATA[Neue Antwort (Pinnwand)]]></item>
+		<item name="wcf.user.notification.commentResponseOwner.title.stacked"><![CDATA[{#$timesTriggered} neue Antworten (Pinnwand)]]></item>
+		<item name="wcf.user.notification.commentResponseOwner.message"><![CDATA[{if !$author->userID}ein Gast{else}{@$author->getAnchorTag()}{/if} hat eine Antwort zum Kommentar von {if $commentAuthor->userID}<a href="{link controller='User' object=$commentAuthor}{/link}" class="userLink" data-user-id="{@$commentAuthor->userID}">{$commentAuthor->username}</a>{else}{$commentAuthor->username}{/if} an <a href="{link controller='User' object=$__wcf->getUser()}#wall/comment{@$commentID}/response{@$responseID}{/link}">deiner Pinnwand</a> verfasst.]]></item>
+		<item name="wcf.user.notification.commentResponseOwner.message.stacked"><![CDATA[{if $count < 4}{@$authors[0]->getAnchorTag()}{if $count != 1}{if $count == 2 && !$guestTimesTriggered} und {else}, {/if}{@$authors[1]->getAnchorTag()}{if $count == 3}{if !$guestTimesTriggered} und {else}, {/if} {@$authors[2]->getAnchorTag()}{/if}{/if}{if $guestTimesTriggered} und {if $guestTimesTriggered == 1}ein Gast{else}Gäste{/if}{/if}{else}{@$authors[0]->getAnchorTag()}{if $guestTimesTriggered},{else} und{/if} {#$others} weitere Benutzer {if $guestTimesTriggered}und {if $guestTimesTriggered == 1}ein Gast{else}Gäste{/if}{/if}{/if} haben auf den Kommentar von {if $author->userID}<a href="{link controller='User' object=$author}{/link}" class="userLink" data-user-id="{@$author->userID}">{$author->username}</a>{else}{$author->username}{/if} an <a href="{link controller='User' object=$__wcf->getUser()}#wall/comment{@$commentID}/response{@$responseID}{/link}">deiner Pinnwand</a> geantwortet.]]></item>
+		<item name="wcf.user.notification.commentResponseOwner.mail.plaintext"><![CDATA[{@$authorList} {if $count == 1 && !$guestTimesTriggered}hat eine Antwort{else}haben Antworten{/if} zum Kommentar von {@$notificationContent[variables][commentAuthor]->username}{if $notificationContent[variables][commentAuthor]->userID} [URL:{link controller='User' object=$notificationContent[variables][commentAuthor] isEmail=true}{/link}]{/if} an deiner Pinnwand [URL:{link controller='User' object=$notificationContent[variables][owner] isEmail=true}#wall/comment{@$commentID}/response{@$responseID}{/link}] verfasst{if $count == 1 && !$guestTimesTriggered}:{else}.{/if}]]></item>
+		<item name="wcf.user.notification.commentResponseOwner.mail.html"><![CDATA[<p>{@$authorList} {if $count == 1 && !$guestTimesTriggered}hat eine Antwort{else}haben Antworten{/if} zum Kommentar von {if $notificationContent[variables][commentAuthor]->userID}<a href="{link controller='User' object=$notificationContent[variables][commentAuthor] isEmail=true}{/link}">{$notificationContent[variables][commentAuthor]->username}</a>{else}{$notificationContent[variables][commentAuthor]->username}{/if} an <a href="{link controller='User' object=$notificationContent[variables][owner] isEmail=true}#wall/comment{@$commentID}/response{@$responseID}{/link}">deiner Pinnwand</a> verfasst:</p>]]></item>
+		<item name="wcf.user.notification.com.woltlab.wcf.user.profileComment.notification.comment"><![CDATA[Neuer Kommentar an deiner Pinnwand]]></item>
+		<item name="wcf.user.notification.com.woltlab.wcf.user.profileComment.response.notification.commentResponse"><![CDATA[Neue Antwort auf einen Kommentar von dir]]></item>
+		<item name="wcf.user.notification.com.woltlab.wcf.user.profileComment.response.notification.commentResponseOwner"><![CDATA[Neue Antwort auf einen Kommentar an deiner Pinnwand]]></item>
+		<item name="wcf.user.notification.com.woltlab.wcf.user.profileComment.like.notification.like"><![CDATA[Jemandem gefällt dein Kommentar]]></item>
+		<item name="wcf.user.notification.com.woltlab.wcf.user.profileComment.response.like.notification.like"><![CDATA[Jemandem gefällt deine Antwort auf einen Kommentar]]></item>
+		<item name="wcf.user.notification.com.woltlab.wcf.paidSubscription.user.expiring"><![CDATA[Eine deiner Mitgliedschaft läuft bald ab]]></item>
+		
+		<item name="wcf.user.notification.com.woltlab.wcf.moderation"><![CDATA[Moderation]]></item>
+		<item name="wcf.user.notification.com.woltlab.wcf.moderation.queue.notification.comment"><![CDATA[Neuer Kommentar in der Moderation]]></item>
+		<item name="wcf.user.notification.com.woltlab.wcf.moderation.queue.response.notification.commentResponse"><![CDATA[Neue Antwort auf einen Kommentar in der Moderation]]></item>
+	</category>
+	
+	<category name="wcf.user.profile">
+		<item name="wcf.user.profile.content.about.noPublicData"><![CDATA[{if $userID == $__wcf->getUser()->userID}Du hast noch keine sichtbaren Informationen hinterlegt.{else}Der Benutzer hat noch keine für dich sichtbaren Informationen hinterlegt.{/if}]]></item>
+		<item name="wcf.user.profile.content.recentActivity.noEntries"><![CDATA[Es sind keine anzeigbaren Aktivitäten vorhanden.]]></item>
+		<item name="wcf.user.profile.followers"><![CDATA[{$user->username} folgen]]></item>
+		<item name="wcf.user.profile.following"><![CDATA[{$user->username} folgt]]></item>
+		<item name="wcf.user.profile.menu.about"><![CDATA[Über mich]]></item>
+		<item name="wcf.user.profile.menu.recentActivity"><![CDATA[Letzte Aktivitäten]]></item>
+		<item name="wcf.user.profile.oldUsername"><![CDATA[Hieß früher {$user->getOldUsername()}]]></item>
+		<item name="wcf.user.profile.recentActivity.follow"><![CDATA[Folgt nun <a href="{link controller='User' object=$user}{/link}">{$user->username}</a>.]]></item>
+		<item name="wcf.user.profile.visitors"><![CDATA[Profil-Besucher]]></item>
+		<item name="wcf.user.profile.content.wall.comment"><![CDATA[Kommentar an der Pinnwand]]></item>
+		<item name="wcf.user.profile.content.wall.commentResponse"><![CDATA[Antwort auf einen Pinnwand-Kommentar]]></item>
+		<item name="wcf.user.profile.content.wall.noEntries"><![CDATA[Es wurden noch keine Einträge an der Pinnwand verfasst.]]></item>
+		<item name="wcf.user.profile.menu.wall"><![CDATA[Pinnwand]]></item>
+		<item name="wcf.user.profile.menu.likes"><![CDATA[Likes]]></item>
+		<item name="wcf.user.profile.recentActivity.profileComment"><![CDATA[Hat einen Kommentar an die <a href="{link controller='User' object=$user}{/link}#wall/comment{@$commentID}">Pinnwand von {$user->username}</a> geschrieben.]]></item>
+		<item name="wcf.user.profile.recentActivity.profileCommentResponse"><![CDATA[Hat auf einen Kommentar von <a href="{link controller='User' object=$commentAuthor}{/link}">{$commentAuthor->username}</a> an der <a href="{link controller='User' object=$user}{/link}#wall/comment{@$commentID}/response{@$responseID}">Pinnwand von {$user->username}</a> geantwortet.]]></item>
+		<item name="wcf.user.profile.report"><![CDATA[Benutzerprofil melden]]></item>
+		<item name="wcf.user.profile.protected"><![CDATA[Der Benutzer hat den Zugriff auf sein vollständiges Profil eingeschränkt.]]></item>
+		<item name="wcf.user.profile.user"><![CDATA[Benutzer]]></item>
+		<item name="wcf.user.profile.management"><![CDATA[Verwaltung]]></item>
+		<item name="wcf.user.profile.customization"><![CDATA[Anpassung]]></item>
+	</category>
+	
+	<category name="wcf.user.objectWatch">
+		<item name="wcf.user.objectWatch.manageSubscription"><![CDATA[Abonnement verwalten]]></item>
+	</category>
+	
+	<category name="wcf.user.option">
+		<item name="wcf.user.option.aboutMe"><![CDATA[Über mich]]></item>
+		<item name="wcf.user.option.adminCanMail"><![CDATA[E-Mails der Administration akzeptieren]]></item>
+		<item name="wcf.user.option.adminComment"><![CDATA[Kommentar (intern)]]></item>
+		<item name="wcf.user.option.birthday"><![CDATA[Geburtstag]]></item>
+		<item name="wcf.user.option.birthdayShowYear"><![CDATA[Geburtsjahr im Profil anzeigen]]></item>
+		<item name="wcf.user.option.birthdayShowYear.description"><![CDATA[Mitglieder können dadurch dein Alter sehen.]]></item>
+		<item name="wcf.user.option.canMail"><![CDATA[Kann E-Mails senden]]></item>
+		<item name="wcf.user.option.canViewEmailAddress"><![CDATA[Kann E-Mail-Adresse sehen]]></item>
+		<item name="wcf.user.option.canViewOnlineStatus"><![CDATA[Kann Online-Status sehen]]></item>
+		<item name="wcf.user.option.canViewProfile"><![CDATA[Kann Benutzerprofil sehen]]></item>
+		
+		<item name="wcf.user.option.category.profile"><![CDATA[Persönliche Daten]]></item>
+		<item name="wcf.user.option.category.profile.aboutMe"><![CDATA[Über mich]]></item>
+		<item name="wcf.user.option.category.profile.contact"><![CDATA[Kontaktmöglichkeiten]]></item>
+		<item name="wcf.user.option.category.profile.personal"><![CDATA[Persönliche Informationen]]></item>
+		<item name="wcf.user.option.category.settings"><![CDATA[Einstellungen]]></item>
+		<item name="wcf.user.option.category.settings.general"><![CDATA[Allgemein]]></item>
+		<item name="wcf.user.option.category.settings.general.date"><![CDATA[Datum &amp; Zeit]]></item>
+		<item name="wcf.user.option.category.settings.general.appearance"><![CDATA[Anzeige]]></item>
+		<item name="wcf.user.option.category.settings.general.interface"><![CDATA[Bedienung]]></item>
+		<item name="wcf.user.option.category.settings.privacy"><![CDATA[Privatsphäre]]></item>
+		<item name="wcf.user.option.category.settings.privacy.content"><![CDATA[Inhalt]]></item>
+		<item name="wcf.user.option.category.settings.privacy.messaging"><![CDATA[Kommunikation]]></item>
+		
+		<item name="wcf.user.option.gender"><![CDATA[Geschlecht]]></item>
+		<item name="wcf.user.option.hobbies"><![CDATA[Hobbys]]></item>
+		<item name="wcf.user.option.homepage"><![CDATA[Website]]></item>
+		<item name="wcf.user.option.location"><![CDATA[Wohnort]]></item>
+		<item name="wcf.user.option.occupation"><![CDATA[Beruf]]></item>
+		<item name="wcf.user.option.showSignature"><![CDATA[Persönliche Signatur anderer Mitglieder anzeigen]]></item>
+		<item name="wcf.user.option.timezone"><![CDATA[Zeitzone]]></item>
+		<item name="wcf.user.option.icq"><![CDATA[ICQ]]></item>
+		<item name="wcf.user.option.skype"><![CDATA[Skype]]></item>
+		<item name="wcf.user.option.facebook"><![CDATA[Facebook]]></item>
+		<item name="wcf.user.option.twitter"><![CDATA[Twitter]]></item>
+		<item name="wcf.user.option.googlePlus"><![CDATA[Google+]]></item>
+		<item name="wcf.user.option.googlePlus.description"><![CDATA[21-stellige Google-Plus-ID, Google-Plus Benutzername (+Benutzername) oder URL zum Google-Plus-Profil]]></item>
+		<item name="wcf.user.option.canWriteProfileComments"><![CDATA[Kann Pinnwand-Kommentare schreiben]]></item>
+		
+		<item name="wcf.user.option.searchRadioButtonOption"><![CDATA[Auswahl des Benutzers bei „{lang}wcf.user.option.{$option->optionName}{/lang}“:]]></item>
+		<item name="wcf.user.option.searchTextOption"><![CDATA[„{lang}wcf.user.option.{$option->optionName}{/lang}“ enthält:]]></item>
+	</category>
+	
+	<category name="wcf.user.mail">
+		<item name="wcf.user.mail.information"><![CDATA[Informationen]]></item>
+		<item name="wcf.user.mail.mail.subject"><![CDATA[Nachricht von {@$username}: {@$subject}]]></item>
+		<item name="wcf.user.mail.mail.plaintext"><![CDATA[Hallo {@$mailbox->getUser()->username},
+
+„{@$username}“ hat dir über die Website {@PAGE_TITLE|language} [URL:{link isEmail=true}{/link}] folgende Nachricht gesandt:
+
+{@$message}]]></item>
+		<item name="wcf.user.mail.mail.html"><![CDATA[<h2>Hallo {$mailbox->getUser()->username},</h2>
+
+<p>„{$username}“ hat dir über die Website <a href="{link isEmail=true}{/link}">{PAGE_TITLE|language}</a> folgende Nachricht gesandt:</p>
+
+<p>{@$message|newlineToBreak}</p>]]></item>
+		<item name="wcf.user.mail.message"><![CDATA[Nachricht]]></item>
+		<item name="wcf.user.mail.senderEmail"><![CDATA[Deine E-Mail-Adresse]]></item>
+		<item name="wcf.user.mail.sent"><![CDATA[Deine Nachricht an {$user->username} wurde erfolgreich versandt.]]></item>
+		<item name="wcf.user.mail.showAddress"><![CDATA[Meine E-Mail-Adresse als Absender-Adresse benutzen. Der Empfänger kann direkt auf die Nachricht antworten.]]></item>
+		<item name="wcf.user.mail.subject"><![CDATA[Betreff]]></item>
+	</category>
+	
+	<category name="wcf.user.rank">
+		<item name="wcf.user.rank.administrator"><![CDATA[Administrator]]></item>
+		<item name="wcf.user.rank.moderator"><![CDATA[Moderator]]></item>
+		<item name="wcf.user.rank.user0"><![CDATA[Anfänger]]></item>
+		<item name="wcf.user.rank.user1"><![CDATA[Schüler]]></item>
+		<item name="wcf.user.rank.user2"><![CDATA[Fortgeschrittener]]></item>
+		<item name="wcf.user.rank.user3"><![CDATA[Profi]]></item>
+		<item name="wcf.user.rank.user4"><![CDATA[Meister]]></item>
+		<item name="wcf.user.rank.user5"><![CDATA[Erleuchteter]]></item>
+	</category>
+	
+	<!-- i18n categories -->
+	<category name="wcf.smiley" />
+</language>

--- a/wcfsetup/install/lang/de.xml
+++ b/wcfsetup/install/lang/de.xml
@@ -680,6 +680,9 @@
 		<item name="wcf.acp.language.multilingualism.enable.description"><![CDATA[{if LANGUAGE_USE_INFORMAL_VARIANT}Hast du{else}Haben Sie{/if} mehrere Sprachen installiert, können sich {if LANGUAGE_USE_INFORMAL_VARIANT}deine{else}Ihre{/if} Mitglieder die Programmoberfläche in diesen Sprachen anzeigen lassen. Erstellte Inhalte werden durch die aktivierte Mehrsprachigkeit außerdem einer Sprache zugeordnet. Die Benutzer können in ihrem Profil auswählen, ob ausschließlich Inhalte bestimmter Sprachen angezeigt werden. Bei der Erstellung von Inhalten ist standardmäßig die aktive Oberflächensprache voreingestellt.]]></item>
 		<item name="wcf.acp.language.multilingualism.languages"><![CDATA[Inhalte in folgenden Sprachen zulassen]]></item>
 		<item name="wcf.acp.language.multilingualism.languages.error.empty"><![CDATA[Um die Mehrsprachigkeit zu nutzen, {if LANGUAGE_USE_INFORMAL_VARIANT}musst du{else}müssen Sie{/if} mindestens zwei Sprachen auswählen.]]></item>
+		<item name="wcf.acp.language.parent"><![CDATA[Übergeordnete Sprache]]></item>
+		<item name="wcf.acp.language.parent.description"><![CDATA[Die hier angegebene Sprache wird als Fallback verwendet, falls in der eigentlichen Sprache eine Sprachvariable nicht vorhanden ist.]]></item>
+		<item name="wcf.acp.language.parent.error.parentsItself"><![CDATA[Eine Sprache kann nicht ihre eigene übergeordnete Sprache sein.]]></item>
 		<item name="wcf.acp.language.setAsDefault"><![CDATA[Zur Standardsprache machen]]></item>
 		<item name="wcf.acp.language.variables"><![CDATA[Variablen]]></item>
 		<item name="wcf.acp.language.users"><![CDATA[Verwendet von]]></item>

--- a/wcfsetup/install/lang/en.xml
+++ b/wcfsetup/install/lang/en.xml
@@ -663,6 +663,9 @@
 		<item name="wcf.acp.language.multilingualism.enable.description"><![CDATA[Enabling multilingualism provides the ability to associate user-generated content with a specific language; Newly created content is automatically associated with the user’s interface language. Users can filter content for specific languages through their settings.]]></item>
 		<item name="wcf.acp.language.multilingualism.languages"><![CDATA[Available Languages]]></item>
 		<item name="wcf.acp.language.multilingualism.languages.error.empty"><![CDATA[You need to select at least two languages.]]></item>
+		<item name="wcf.acp.language.parent"><![CDATA[Parent Language]]></item>
+		<item name="wcf.acp.language.parent.description"><![CDATA[The selected language will be used as fallback if a language is not set within the real language.]]></item>
+		<item name="wcf.acp.language.parent.error.parentsItself"><![CDATA[A Language can't be parent of itself.]]></item>
 		<item name="wcf.acp.language.setAsDefault"><![CDATA[Set As Default]]></item>
 		<item name="wcf.acp.language.variables"><![CDATA[Phrases]]></item>
 		<item name="wcf.acp.language.users"><![CDATA[Used by]]></item>

--- a/wcfsetup/setup/db/install.sql
+++ b/wcfsetup/setup/db/install.sql
@@ -568,6 +568,7 @@ CREATE TABLE wcf1_language (
 	isDefault TINYINT(1) NOT NULL DEFAULT 0,
 	hasContent TINYINT(1) NOT NULL DEFAULT 0,
 	isDisabled TINYINT(1) NOT NULL DEFAULT 0,
+	parentID INT(10),
 	UNIQUE KEY languageCode (languageCode)
 );
 
@@ -1805,6 +1806,8 @@ ALTER TABLE wcf1_edit_history_entry ADD FOREIGN KEY (userID) REFERENCES wcf1_use
 ALTER TABLE wcf1_edit_history_entry ADD FOREIGN KEY (obsoletedByUserID) REFERENCES wcf1_user (userID) ON DELETE SET NULL;
 
 ALTER TABLE wcf1_event_listener ADD FOREIGN KEY (packageID) REFERENCES wcf1_package (packageID) ON DELETE CASCADE;
+
+ALTER TABLE wcf1_language ADD FOREIGN KEY (parentID) REFERENCES wcf1_language (languageID) ON DELETE SET NULL;
 
 ALTER TABLE wcf1_language_item ADD FOREIGN KEY (languageID) REFERENCES wcf1_language (languageID) ON DELETE CASCADE;
 ALTER TABLE wcf1_language_item ADD FOREIGN KEY (languageCategoryID) REFERENCES wcf1_language_category (languageCategoryID) ON DELETE CASCADE;


### PR DESCRIPTION
This feature enables inheritance of languages.
E.g.: You translated German into informal German. If some items of informal German are missing, they will be fetched from it's parent language "German". Same with e.g. en-us and en-gb or the Chinese language variants. Event if you translate English into some different languages you could have a fallback to the English language instead of ugly language item strings.
By this change the user will also be able to decide whether she/he prefers formal or informal German.

Basically the request creates a new column at `wcf1_language` and then calls the parent language's method within `Language::get()` and `Language::getDynamicVariable()`. This feature won't cause big performance-issues because the fallback is used only! if the language item does not exist and that shouldn't be often (but useful if some plugins don't support the specific language and you just don't realize that).

The request also adds a fallback for article contents and page contents.