### PR TITLE
fix php 7.2 compatibility problem

### DIFF
--- a/com.woltlab.wcf/templates/article.tpl
+++ b/com.woltlab.wcf/templates/article.tpl
@@ -263,7 +263,7 @@
 	</div>
 {/if}
 
-{if $relatedArticles|count}
+{if !$relatedArticles|empty}
 	<section class="section relatedArticles">
 		<h2 class="sectionTitle">{lang}wcf.article.relatedArticles{/lang}</h2>
 		

--- a/com.woltlab.wcf/templates/article.tpl
+++ b/com.woltlab.wcf/templates/article.tpl
@@ -263,7 +263,7 @@
 	</div>
 {/if}
 
-{if !$relatedArticles|empty}
+{if $relatedArticles !== null && $relatedArticles|count}
 	<section class="section relatedArticles">
 		<h2 class="sectionTitle">{lang}wcf.article.relatedArticles{/lang}</h2>
 		


### PR DESCRIPTION
happens when there were no tags entered but the module is activated. (`count(null)` is a bad idea):
https://github.com/WoltLab/WCF/blob/93f181958dcd0e88e54d0686712aecc50979cde4/wcfsetup/install/files/lib/page/AbstractArticlePage.class.php#L131-L160