### PR TITLE
Improved pasting from clipboard into the editor

### DIFF
--- a/wcfsetup/install/files/js/3rdParty/redactor2/plugins/WoltLabPaste.js
+++ b/wcfsetup/install/files/js/3rdParty/redactor2/plugins/WoltLabPaste.js
@@ -153,16 +153,6 @@ $.Redactor.prototype.WoltLabPaste = function() {
 					// prevent page scrolling
 					this.tmpScrollTop = undefined;
 					
-					// DEBUG CODE TO VERIFY PASTE HANDLING -- REMOVE BEFORE RELEASE
-					var box = elBySel('.redactor-box');
-					var p = box.nextSibling;
-					if (p === null || p.nodeName !== 'P') {
-						p = elCreate('p');
-						box.parentNode.insertBefore(p, box.nextSibling);
-					}
-					
-					p.textContent = WCF.getUUID();
-					
 					return pastedHtml || pastedPlainText;
 				}
 				

--- a/wcfsetup/install/files/js/3rdParty/redactor2/plugins/WoltLabPaste.js
+++ b/wcfsetup/install/files/js/3rdParty/redactor2/plugins/WoltLabPaste.js
@@ -84,11 +84,11 @@ $.Redactor.prototype.WoltLabPaste = function() {
 			
 			var mpGetPasteBoxCode = this.paste.getPasteBoxCode;
 			this.paste.getPasteBoxCode = (function (pre) {
-				if (pastedHtml !== null) {
-					return pastedHtml;
-				}
-				else if (pastedPlainText) {
-					return pastedPlainText;
+				if (pastedHtml !== null || pastedPlainText !== null) {
+					// prevent page scrolling
+					this.tmpScrollTop = undefined;
+					
+					return pastedHtml || pastedPlainText;
 				}
 				
 				var returnValue = mpGetPasteBoxCode.call(this, pre);

--- a/wcfsetup/install/files/js/3rdParty/redactor2/plugins/WoltLabPaste.js
+++ b/wcfsetup/install/files/js/3rdParty/redactor2/plugins/WoltLabPaste.js
@@ -62,7 +62,7 @@ $.Redactor.prototype.WoltLabPaste = function() {
 						
 						// remove document fragments
 						if (pastedHtml.match(/^<html>[\s\S]*?<body>([\s\S]+)<\/body>\s*<\/html>$/)) {
-							pastedHtml = RegExp.$1;
+							pastedHtml = RegExp.$1.replace(/^\s*(?:<!--StartFragment-->)(.+)(?:<!--EndFragment-->)?\s*$/, '$1');
 						}
 					}
 				}
@@ -166,6 +166,20 @@ $.Redactor.prototype.WoltLabPaste = function() {
 					
 					if (!clipboard.items || !clipboard.items.length) {
 						return;
+					}
+					
+					if (this.detect.isWebkit()) {
+						var item, hasFile = false, hasHtml = false;
+						for (var i = 0, length = clipboard.items.length; i < length; i++) {
+							item = clipboard.items[i];
+							if (item.kind === 'string' && item.type === 'text/html') hasHtml = true;
+							else if (item.kind === 'file') hasFile = true;
+						}
+						
+						// pasted an `<img>` element from clipboard
+						if (hasFile && hasHtml) {
+							return false;
+						}
 					}
 					
 					var cancelPaste = false;


### PR DESCRIPTION
* Uses the native clipboard API to process text and HTML in all major browsers.
* Better cross-browser detection of pasted images for both URLs (using `<img src="…">`) and plain image data.
* Uses the legacy implementation for Internet Explorer 11 (ancient API) and iOS Safari (incomplete and broken API).
* Works-around the ~1s second paste delay in Chrome for Android.
* Almost entirely avoids page movement on paste in iOS Safari.