### PR TITLE
array with clipboard-actions which require a page-reload after execution

### DIFF
--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Controller/Clipboard.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Controller/Clipboard.js
@@ -365,6 +365,11 @@ define(
 			if (fireEvent) {
 				triggerEvent();
 			}
+
+			//noinspection JSUnresolvedVariable
+			if (data.parameters.refreshPageAfterExecution === 'true') {
+				window.location.reload();
+			}
 		},
 		
 		/**
@@ -410,6 +415,11 @@ define(
 				
 				this._loadMarkedItems();
 			}).bind(this));
+
+			//noinspection JSUnresolvedVariable
+			if (data.parameters.refreshPageAfterExecution === 'true') {
+				window.location.reload();
+			}
 		},
 		
 		/**

--- a/wcfsetup/install/files/lib/system/clipboard/action/AbstractClipboardAction.class.php
+++ b/wcfsetup/install/files/lib/system/clipboard/action/AbstractClipboardAction.class.php
@@ -34,6 +34,12 @@ abstract class AbstractClipboardAction implements IClipboardAction {
 	protected $supportedActions = [];
 	
 	/**
+	 * list of clipboard actions which need a reload of the page after execution
+	 * @var	string[]
+	 */
+	protected $refreshPageActions = [];
+	
+	/**
 	 * @inheritDoc
 	 */
 	public function execute(array $objects, ClipboardAction $action) {
@@ -50,6 +56,7 @@ abstract class AbstractClipboardAction implements IClipboardAction {
 		if (in_array($action->actionName, $this->actionClassActions)) {
 			$item->addParameter('actionName', $action->actionName);
 			$item->addParameter('className', $this->getClassName());
+			$item->addParameter('refreshPageAfterExecution', in_array($action->actionName, $this->refreshPageActions) ? 'true' : 'false');
 		}
 		
 		// validate objects if relevant method exists and set valid object ids


### PR DESCRIPTION
`wcf\system\clipboard\action\AbstractClipboardAction::$refreshPageActions`
this makes it more easy to provide simple clipboard-actions without the need of special JavaScript which handles the marking after delete/enable/disable etc.