### PR TITLE
support the license-tag within the package.xml

### DIFF
--- a/XSD/package.xsd
+++ b/XSD/package.xsd
@@ -97,6 +97,16 @@
 					</xs:simpleContent>
 				</xs:complexType>
 			</xs:element>
+			<xs:element name="license" minOccurs="0" maxOccurs="unbounded">
+				<xs:complexType>
+					<xs:simpleContent>
+						<xs:extension base="xs:string">
+							<xs:attribute name="language" type="xs:string" />
+							<xs:attribute name="url" type="xs:string" />
+						</xs:extension>
+					</xs:simpleContent>
+				</xs:complexType>
+			</xs:element>
 			<xs:element name="applicationdirectory" type="woltlab_varchar" minOccurs="0" maxOccurs="1" />
 			<xs:element name="packageurl" type="xs:anyURI" minOccurs="0" maxOccurs="1" />
 			<xs:element name="isapplication" type="woltlab_boolean" minOccurs="0" maxOccurs="1" />

--- a/wcfsetup/install/files/acp/templates/package.tpl
+++ b/wcfsetup/install/files/acp/templates/package.tpl
@@ -75,6 +75,18 @@
 				<dt>{lang}wcf.acp.package.author{/lang}</dt>
 				<dd>{if $package->authorURL}<a href="{@$__wcf->getPath()}acp/dereferrer.php?url={$package->authorURL|rawurlencode}" class="externalURL">{$package->author}</a>{else}{$package->author}{/if}</dd>
 			</dl>
+			{if $package->license != ''}
+				<dl>
+					<dt>{lang}wcf.acp.package.license{/lang}</dt>
+					<dd>
+						{if $package->licenseURL != ''}
+							<a href="{@$__wcf->getPath()}acp/dereferrer.php?url={$package->licenseURL|rawurlencode}" class="externalURL">{$package->license}</a>
+						{else}
+							{$package->license}
+						{/if}
+					</dd>
+				</dl>
+			{/if}
 			{if $pluginStoreFileID}
 				{capture assign=_storeUrl}https://pluginstore.woltlab.com/file/{$pluginStoreFileID}/{/capture}
 				<dl>

--- a/wcfsetup/install/files/acp/templates/packageInstallationConfirm.tpl
+++ b/wcfsetup/install/files/acp/templates/packageInstallationConfirm.tpl
@@ -48,11 +48,24 @@
 		<dt>{lang}wcf.acp.package.packageDate{/lang}</dt>
 		<dd>{@$archive->getPackageInfo('date')|date}</dd>
 	</dl>
-	
+
 	{if $archive->getPackageInfo('packageURL') != ''}
 		<dl>
 			<dt>{lang}wcf.acp.package.url{/lang}</dt>
 			<dd><a href="{@$__wcf->getPath()}acp/dereferrer.php?url={$archive->getPackageInfo('packageURL')|rawurlencode}" class="externalURL">{$archive->getPackageInfo('packageURL')}</a></dd>
+		</dl>
+	{/if}
+
+	{if $archive->getLocalizedPackageInfo('license') != ''}
+		<dl>
+			<dt>{lang}wcf.acp.package.license{/lang}</dt>
+			<dd>
+				{if $archive->getLocalizedPackageInfo('licenseURL') != ''}
+					<a href="{@$__wcf->getPath()}acp/dereferrer.php?url={$archive->getLocalizedPackageInfo('licenseURL')|rawurlencode}" class="externalURL">{$archive->getLocalizedPackageInfo('license')}</a>
+				{else}
+					{$archive->getLocalizedPackageInfo('license')}
+				{/if}
+			</dd>
 		</dl>
 	{/if}
 	

--- a/wcfsetup/install/files/lib/system/package/PackageArchive.class.php
+++ b/wcfsetup/install/files/lib/system/package/PackageArchive.class.php
@@ -195,6 +195,7 @@ class PackageArchive {
 					$name = $element->tagName;
 					if ($name == 'packagename') $name = 'packageName';
 					else if ($name == 'packagedescription') $name = 'packageDescription';
+					else if ($name == 'license' && $element->hasAttribute('url')) $this->packageInfo['licenseURL'][$languageCode] = $element->getAttribute('url');
 					
 					$this->packageInfo[$name][$languageCode] = $element->nodeValue;
 				break;

--- a/wcfsetup/install/files/lib/system/package/PackageInstallationNodeBuilder.class.php
+++ b/wcfsetup/install/files/lib/system/package/PackageInstallationNodeBuilder.class.php
@@ -418,6 +418,8 @@ class PackageInstallationNodeBuilder {
 				'isApplication' => $this->installation->getArchive()->getPackageInfo('isApplication'),
 				'author' => $this->installation->getArchive()->getAuthorInfo('author'),
 				'authorURL' => $this->installation->getArchive()->getAuthorInfo('authorURL') !== null ? $this->installation->getArchive()->getAuthorInfo('authorURL') : '',
+				'license' => $this->installation->getArchive()->getLocalizedPackageInfo('license'),
+				'licenseURL' => $this->installation->getArchive()->getLocalizedPackageInfo('licenseURL') !== null ? $this->installation->getArchive()->getLocalizedPackageInfo('licenseURL') : '',
 				'installDate' => TIME_NOW,
 				'updateDate' => TIME_NOW,
 				'requirements' => $this->requirements

--- a/wcfsetup/setup/db/install.sql
+++ b/wcfsetup/setup/db/install.sql
@@ -869,6 +869,8 @@ CREATE TABLE wcf1_package (
 	isApplication TINYINT(1) NOT NULL DEFAULT 0,
 	author VARCHAR(255) NOT NULL DEFAULT '',
 	authorURL VARCHAR(255) NOT NULL DEFAULT '',
+	license VARCHAR(255) NOT NULL DEFAULT '',
+	licenseURL VARCHAR(255) NOT NULL DEFAULT '',
 	KEY package (package)
 );
 


### PR DESCRIPTION
multilingual license-tag within the packageinformation-tag, containing the attribute `url` with an URL.
example:
```xml
	<packageinformation>
		<packagename>Test-Paket</packagename>
		<version>1.0.0 Alpha 1</version>
		<date>2017-10-05</date>
		<license url="https://www.mysterycode.de/licenses/kostenlose-plugins/">Kostenlose Plugins</license>
	</packageinformation>
```
or multilingual:
```xml
	<packageinformation>
		<packagename>Test-Paket</packagename>
		<version>1.0.0 Alpha 1</version>
		<date>2017-10-05</date>
		<license language="de" url="https://www.mysterycode.de/licenses/kostenlose-plugins/">Kostenlose Plugins</license>
	</packageinformation>
```

The license will be shown on the detail-page of a package and on the confirm-form before the installation.