### PR TITLE
use `PreparedStatement#fetchSingleColumn` where possible

### DIFF
--- a/wcfsetup/install/files/lib/acp/form/DevtoolsProjectAddForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/DevtoolsProjectAddForm.class.php
@@ -96,7 +96,7 @@ class DevtoolsProjectAddForm extends AbstractForm {
 		$statement = WCF::getDB()->prepareStatement($sql);
 		$statement->execute([$this->name]);
 		
-		if ($statement->fetchColumn()) {
+		if ($statement->fetchSingleColumn()) {
 			throw new UserInputException('name', 'notUnique');
 		}
 	}
@@ -111,7 +111,7 @@ class DevtoolsProjectAddForm extends AbstractForm {
 		$statement = WCF::getDB()->prepareStatement($sql);
 		$statement->execute([$this->path]);
 		
-		if ($statement->fetchColumn()) {
+		if ($statement->fetchSingleColumn()) {
 			throw new UserInputException('path', 'notUnique');
 		}
 	}

--- a/wcfsetup/install/files/lib/acp/form/DevtoolsProjectEditForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/DevtoolsProjectEditForm.class.php
@@ -59,7 +59,7 @@ class DevtoolsProjectEditForm extends DevtoolsProjectAddForm {
 		$statement = WCF::getDB()->prepareStatement($sql);
 		$statement->execute([$this->name, $this->objectID]);
 		
-		if ($statement->fetchColumn()) {
+		if ($statement->fetchSingleColumn()) {
 			throw new UserInputException('name', 'notUnique');
 		}
 	}
@@ -76,7 +76,7 @@ class DevtoolsProjectEditForm extends DevtoolsProjectAddForm {
 		$statement = WCF::getDB()->prepareStatement($sql);
 		$statement->execute([$this->path, $this->objectID]);
 		
-		if ($statement->fetchColumn()) {
+		if ($statement->fetchSingleColumn()) {
 			throw new UserInputException('path', 'notUnique');
 		}
 	}

--- a/wcfsetup/install/files/lib/acp/page/UserListPage.class.php
+++ b/wcfsetup/install/files/lib/acp/page/UserListPage.class.php
@@ -224,7 +224,7 @@ class UserListPage extends SortablePage {
 		$statement = WCF::getDB()->prepareStatement($sql);
 		$statement->execute($this->conditions->getParameters());
 		
-		return $statement->fetchColumn();
+		return $statement->fetchSingleColumn();
 	}
 	
 	/**

--- a/wcfsetup/install/files/lib/data/acp/session/virtual/ACPSessionVirtual.class.php
+++ b/wcfsetup/install/files/lib/data/acp/session/virtual/ACPSessionVirtual.class.php
@@ -65,6 +65,6 @@ class ACPSessionVirtual extends DatabaseObject {
 		$statement = WCF::getDB()->prepareStatement($sql);
 		$statement->execute([$sessionID]);
 		
-		return $statement->fetchColumn();
+		return $statement->fetchSingleColumn();
 	}
 }

--- a/wcfsetup/install/files/lib/data/ad/AdEditor.class.php
+++ b/wcfsetup/install/files/lib/data/ad/AdEditor.class.php
@@ -35,7 +35,7 @@ class AdEditor extends DatabaseObjectEditor implements IEditableCachedObject {
 			FROM	wcf".WCF_N."_ad";
 		$statement = WCF::getDB()->prepareStatement($sql);
 		$statement->execute();
-		$maxShowOrder = $statement->fetchColumn();
+		$maxShowOrder = $statement->fetchSingleColumn();
 		if (!$maxShowOrder) $maxShowOrder = 0;
 		
 		if (!$showOrder || $showOrder > $maxShowOrder) {

--- a/wcfsetup/install/files/lib/data/label/LabelEditor.class.php
+++ b/wcfsetup/install/files/lib/data/label/LabelEditor.class.php
@@ -63,7 +63,7 @@ class LabelEditor extends DatabaseObjectEditor implements IEditableCachedObject 
 			WHERE	groupID = ?";
 		$statement = WCF::getDB()->prepareStatement($sql);
 		$statement->execute([$groupID]);
-		$maxShowOrder = $statement->fetchColumn() ?: 0;
+		$maxShowOrder = $statement->fetchSingleColumn() ?: 0;
 		
 		if (!$showOrder || $showOrder > $maxShowOrder) {
 			$showOrder = $maxShowOrder + 1;

--- a/wcfsetup/install/files/lib/data/like/LikeAction.class.php
+++ b/wcfsetup/install/files/lib/data/like/LikeAction.class.php
@@ -242,7 +242,7 @@ class LikeAction extends AbstractDatabaseObjectAction implements IGroupedUserLis
 			$this->parameters['data']['objectID'],
 			$this->objectType->objectTypeID
 		]);
-		$pageCount = ceil($statement->fetchColumn() / 20);
+		$pageCount = ceil($statement->fetchSingleColumn() / 20);
 		
 		$sql = "SELECT		userID, likeValue
 			FROM		wcf".WCF_N."_like

--- a/wcfsetup/install/files/lib/data/notice/NoticeEditor.class.php
+++ b/wcfsetup/install/files/lib/data/notice/NoticeEditor.class.php
@@ -35,7 +35,7 @@ class NoticeEditor extends DatabaseObjectEditor implements IEditableCachedObject
 			FROM	wcf".WCF_N."_notice";
 		$statement = WCF::getDB()->prepareStatement($sql);
 		$statement->execute();
-		$maxShowOrder = $statement->fetchColumn();
+		$maxShowOrder = $statement->fetchSingleColumn();
 		if (!$maxShowOrder) $maxShowOrder = 0;
 		
 		if (!$showOrder || $showOrder > $maxShowOrder) {

--- a/wcfsetup/install/files/lib/data/page/PageEditor.class.php
+++ b/wcfsetup/install/files/lib/data/page/PageEditor.class.php
@@ -66,7 +66,7 @@ class PageEditor extends DatabaseObjectEditor implements IEditableCachedObject {
 				AND applicationPackageID = ?";
 		$statement = WCF::getDB()->prepareStatement($sql);
 		$statement->execute([$customURL, $packageID]);
-		if ($statement->fetchColumn()) {
+		if ($statement->fetchSingleColumn()) {
 			return false;
 		}
 		
@@ -81,7 +81,7 @@ class PageEditor extends DatabaseObjectEditor implements IEditableCachedObject {
 				)";
 		$statement = WCF::getDB()->prepareStatement($sql);
 		$statement->execute([$customURL, $packageID]);
-		if ($statement->fetchColumn()) {
+		if ($statement->fetchSingleColumn()) {
 			return false;
 		}
 		

--- a/wcfsetup/install/files/lib/data/paid/subscription/PaidSubscriptionEditor.class.php
+++ b/wcfsetup/install/files/lib/data/paid/subscription/PaidSubscriptionEditor.class.php
@@ -33,7 +33,7 @@ class PaidSubscriptionEditor extends DatabaseObjectEditor implements IEditableCa
 			FROM	wcf".WCF_N."_paid_subscription";
 		$statement = WCF::getDB()->prepareStatement($sql);
 		$statement->execute();
-		$maxShowOrder = $statement->fetchColumn();
+		$maxShowOrder = $statement->fetchSingleColumn();
 		if (!$maxShowOrder) $maxShowOrder = 0;
 		
 		if (!$showOrder || $showOrder > $maxShowOrder) {

--- a/wcfsetup/install/files/lib/data/user/authentication/failure/UserAuthenticationFailure.class.php
+++ b/wcfsetup/install/files/lib/data/user/authentication/failure/UserAuthenticationFailure.class.php
@@ -44,7 +44,7 @@ class UserAuthenticationFailure extends DatabaseObject {
 		$statement = WCF::getDB()->prepareStatement($sql);
 		$statement->execute([$ipAddress, TIME_NOW - USER_AUTHENTICATION_FAILURE_TIMEOUT]);
 		
-		return $statement->fetchColumn();
+		return $statement->fetchSingleColumn();
 	}
 	
 	/**
@@ -61,6 +61,6 @@ class UserAuthenticationFailure extends DatabaseObject {
 		$statement = WCF::getDB()->prepareStatement($sql);
 		$statement->execute([$userID, TIME_NOW - USER_AUTHENTICATION_FAILURE_TIMEOUT]);
 		
-		return $statement->fetchColumn();
+		return $statement->fetchSingleColumn();
 	}
 }

--- a/wcfsetup/install/files/lib/data/user/group/UserGroupEditor.class.php
+++ b/wcfsetup/install/files/lib/data/user/group/UserGroupEditor.class.php
@@ -127,8 +127,7 @@ class UserGroupEditor extends DatabaseObjectEditor implements IEditableCachedObj
 			WHERE	optionName = ?";
 		$statement = WCF::getDB()->prepareStatement($sql);
 		$statement->execute(['admin.user.accessibleGroups']);
-		$optionID = $statement->fetchColumn();
-		$statement->closeCursor();
+		$optionID = $statement->fetchSingleColumn();
 		
 		if (!$optionID) throw new SystemException("Unable to find 'admin.user.accessibleGroups' user option");
 		

--- a/wcfsetup/install/files/lib/system/box/BoxHandler.class.php
+++ b/wcfsetup/install/files/lib/system/box/BoxHandler.class.php
@@ -280,6 +280,6 @@ class BoxHandler extends SingletonFactory {
 		$statement = WCF::getDB()->prepareStatement($sql);
 		$statement->execute([$pageID]);
 		
-		return $statement->fetchColumn() > 0;
+		return $statement->fetchSingleColumn() > 0;
 	}
 }

--- a/wcfsetup/install/files/lib/system/cli/command/ImportCLICommand.class.php
+++ b/wcfsetup/install/files/lib/system/cli/command/ImportCLICommand.class.php
@@ -139,7 +139,7 @@ class ImportCLICommand implements ICLICommand {
 			FROM	wcf".WCF_N."_import_mapping";
 		$statement = WCF::getDB()->prepareStatement($sql);
 		$statement->execute();
-		if ($statement->fetchColumn()) {
+		if ($statement->fetchSingleColumn()) {
 			CLIWCF::getReader()->println(StringUtil::stripHTML(WCF::getLanguage()->get('wcf.acp.dataImport.existingMapping.notice')));
 			CLIWCF::getReader()->println(WCF::getLanguage()->get('wcf.acp.dataImport.existingMapping.confirmMessage') . ' [YN]');
 			

--- a/wcfsetup/install/files/lib/system/language/LanguageFactory.class.php
+++ b/wcfsetup/install/files/lib/system/language/LanguageFactory.class.php
@@ -354,6 +354,6 @@ class LanguageFactory extends SingletonFactory {
 		$statement = WCF::getDB()->prepareStatement($sql, 1);
 		$statement->execute([TIME_NOW - 86400 * 7]);
 		
-		return $statement->fetchColumn();
+		return $statement->fetchSingleColumn();
 	}
 }

--- a/wcfsetup/install/files/lib/system/moderation/queue/ModerationQueueReportManager.class.php
+++ b/wcfsetup/install/files/lib/system/moderation/queue/ModerationQueueReportManager.class.php
@@ -68,7 +68,7 @@ class ModerationQueueReportManager extends AbstractModerationQueueManager {
 			ModerationQueue::STATUS_PROCESSING
 		]);
 		
-		return $statement->fetchColumn() > 0;
+		return $statement->fetchSingleColumn() > 0;
 	}
 	
 	/**

--- a/wcfsetup/install/files/lib/system/package/plugin/ACLOptionPackageInstallationPlugin.class.php
+++ b/wcfsetup/install/files/lib/system/package/plugin/ACLOptionPackageInstallationPlugin.class.php
@@ -271,7 +271,7 @@ class ACLOptionPackageInstallationPlugin extends AbstractOptionPackageInstallati
 					)";
 			$statement = WCF::getDB()->prepareStatement($sql, 1);
 			$statement->execute([$optionType]);
-			$objectTypeID = $statement->fetchColumn();
+			$objectTypeID = $statement->fetchSingleColumn();
 			if ($objectTypeID === false) {
 				throw new SystemException("unknown object type '".$optionType."' given");
 			}

--- a/wcfsetup/install/files/lib/system/stat/AbstractCommentStatDailyHandler.class.php
+++ b/wcfsetup/install/files/lib/system/stat/AbstractCommentStatDailyHandler.class.php
@@ -51,7 +51,7 @@ abstract class AbstractCommentStatDailyHandler extends AbstractStatDailyHandler 
 			$date,
 			$date + 86399
 		]);
-		$counter = $statement->fetchColumn();
+		$counter = $statement->fetchSingleColumn();
 		
 		$sql = "SELECT (
 				SELECT	COUNT(*)
@@ -73,7 +73,7 @@ abstract class AbstractCommentStatDailyHandler extends AbstractStatDailyHandler 
 			$objectTypeID,
 			$date + 86400
 		]);
-		$total = $statement->fetchColumn();
+		$total = $statement->fetchSingleColumn();
 		
 		return [
 			'counter' => $counter,

--- a/wcfsetup/install/files/lib/system/stat/AbstractDiskUsageStatDailyHandler.class.php
+++ b/wcfsetup/install/files/lib/system/stat/AbstractDiskUsageStatDailyHandler.class.php
@@ -34,7 +34,7 @@ abstract class AbstractDiskUsageStatDailyHandler extends AbstractStatDailyHandle
 		$statement = WCF::getDB()->prepareStatement($sql);
 		$statement->execute($conditionBuilder->getParameters());
 		
-		return $statement->fetchColumn();
+		return $statement->fetchSingleColumn();
 	}
 	
 	/**
@@ -52,7 +52,7 @@ abstract class AbstractDiskUsageStatDailyHandler extends AbstractStatDailyHandle
 		$statement = WCF::getDB()->prepareStatement($sql);
 		$statement->execute($conditionBuilder->getParameters());
 		
-		return $statement->fetchColumn();
+		return $statement->fetchSingleColumn();
 	}
 	
 	/**

--- a/wcfsetup/install/files/lib/system/stat/AbstractStatDailyHandler.class.php
+++ b/wcfsetup/install/files/lib/system/stat/AbstractStatDailyHandler.class.php
@@ -32,7 +32,7 @@ abstract class AbstractStatDailyHandler implements IStatDailyHandler {
 		$statement = WCF::getDB()->prepareStatement($sql);
 		$statement->execute($conditionBuilder->getParameters());
 		
-		return $statement->fetchColumn();
+		return $statement->fetchSingleColumn();
 	}
 	
 	/**
@@ -55,7 +55,7 @@ abstract class AbstractStatDailyHandler implements IStatDailyHandler {
 		$statement = WCF::getDB()->prepareStatement($sql);
 		$statement->execute($conditionBuilder->getParameters());
 		
-		return $statement->fetchColumn();
+		return $statement->fetchSingleColumn();
 	}
 	
 	/**

--- a/wcfsetup/install/files/lib/system/stat/LikeStatDailyHandler.class.php
+++ b/wcfsetup/install/files/lib/system/stat/LikeStatDailyHandler.class.php
@@ -24,7 +24,7 @@ class LikeStatDailyHandler extends AbstractStatDailyHandler {
 				AND likeValue = ?";
 		$statement = WCF::getDB()->prepareStatement($sql);
 		$statement->execute([$date, $date + 86399, $this->likeValue]);
-		$counter = intval($statement->fetchColumn());
+		$counter = intval($statement->fetchSingleColumn());
 		
 		$sql = "SELECT	COUNT(*)
 			FROM	wcf".WCF_N."_like
@@ -32,7 +32,7 @@ class LikeStatDailyHandler extends AbstractStatDailyHandler {
 				AND likeValue = ?";
 		$statement = WCF::getDB()->prepareStatement($sql);
 		$statement->execute([$date + 86400, $this->likeValue]);
-		$total = intval($statement->fetchColumn());
+		$total = intval($statement->fetchSingleColumn());
 		
 		return [
 			'counter' => $counter,

--- a/wcfsetup/install/files/lib/system/version/VersionTracker.class.php
+++ b/wcfsetup/install/files/lib/system/version/VersionTracker.class.php
@@ -105,7 +105,7 @@ class VersionTracker extends SingletonFactory implements IAJAXInvokeAction {
 		$statement = WCF::getDB()->prepareStatement($sql);
 		$statement->execute([$objectID]);
 		
-		return $statement->fetchColumn();
+		return $statement->fetchSingleColumn();
 	}
 	
 	/**

--- a/wcfsetup/install/files/lib/system/worker/StatDailyRebuildDataWorker.class.php
+++ b/wcfsetup/install/files/lib/system/worker/StatDailyRebuildDataWorker.class.php
@@ -90,6 +90,6 @@ class StatDailyRebuildDataWorker extends AbstractRebuildDataWorker {
 			FROM	wcf".WCF_N."_user";
 		$statement = WCF::getDB()->prepareStatement($sql);
 		$statement->execute();
-		$this->startDate = $statement->fetchColumn();
+		$this->startDate = $statement->fetchSingleColumn();
 	}
 }


### PR DESCRIPTION
As far as I know, it frees up the connection for that statement, and makes the connection itself more stable.