### PR TITLE
Improve plain/text formatting of anchor tags and smilies

### DIFF
--- a/wcfsetup/install/files/lib/system/html/output/node/HtmlOutputNodeA.class.php
+++ b/wcfsetup/install/files/lib/system/html/output/node/HtmlOutputNodeA.class.php
@@ -53,16 +53,29 @@ class HtmlOutputNodeA extends AbstractHtmlOutputNode {
 			}
 			
 			$value = StringUtil::trim($element->textContent);
-			if (!empty($value) && $value === $href && mb_strlen($value) > 60) {
-				while ($element->childNodes->length) {
-					DOMUtil::removeNode($element->childNodes->item(0));
+			
+			if ($this->outputType === 'text/html' || $this->outputType === 'text/simplified-html') {
+				if (!empty($value) && $value === $href && mb_strlen($value) > 60) {
+					while ($element->childNodes->length) {
+						DOMUtil::removeNode($element->childNodes->item(0));
+					}
+					
+					$element->appendChild(
+						$element->ownerDocument->createTextNode(
+							mb_substr($value, 0, 30) . StringUtil::HELLIP . mb_substr($value, -25)
+						)
+					);
 				}
-				
-				$element->appendChild(
-					$element->ownerDocument->createTextNode(
-						mb_substr($value, 0, 30) . StringUtil::HELLIP . mb_substr($value, -25)
-					)
-				);
+			}
+			else if ($this->outputType === 'text/plain') {
+				if (!empty($value) && $value !== $href) {
+					$text = $value . ' [URL:' . $href . ']';
+				}
+				else {
+					$text = $href;
+				}
+
+				$htmlNodeProcessor->replaceElementWithText($element, $text, false);
 			}
 		}
 	}

--- a/wcfsetup/install/files/lib/system/html/output/node/HtmlOutputNodeImg.class.php
+++ b/wcfsetup/install/files/lib/system/html/output/node/HtmlOutputNodeImg.class.php
@@ -40,10 +40,9 @@ class HtmlOutputNodeImg extends AbstractHtmlOutputNode {
 				
 				/** @var Smiley $smiley */
 				$smiley = SmileyCache::getInstance()->getSmileyByCode($code);
-				if ($smiley === null) {
+				if ($smiley === null || $this->outputType === 'text/plain') {
 					// output as raw code instead
-					$element->parentNode->insertBefore($element->ownerDocument->createTextNode($code), $element);
-					$element->parentNode->removeChild($element);
+					$htmlNodeProcessor->replaceElementWithText($element, ' ' . $code . ' ', false);
 				}
 				else {
 					// enforce database values for src, srcset and style


### PR DESCRIPTION
Truncating URLs in `plain/text` mode leads to obvious problems, this behavior has been switched off.
Also smilies are converted to the appropriate smiley code in `plain/text` now, previously they would have been completely omitted.