### PR TITLE
Add possibility to change sidebar open/close labels per page

### DIFF
--- a/com.woltlab.wcf/templates/footer.tpl
+++ b/com.woltlab.wcf/templates/footer.tpl
@@ -43,7 +43,13 @@
 			{/capture}
 				
 			{if $__sidebarRightContent|trim}
-				<aside class="sidebar boxesSidebarRight" data-show-sidebar="{lang}wcf.global.button.showSidebar{/lang}" data-hide-sidebar="{lang}wcf.global.button.hideSidebar{/lang}">
+				{if !$sidebarRightShow|isset}
+					{assign var='sidebarRightShow' value='wcf.global.button.showSidebar'|language}
+				{/if}
+				{if !$sidebarRightHide|isset}
+					{assign var='sidebarRightHide' value='wcf.global.button.hideSidebar'|language}
+				{/if}
+				<aside class="sidebar boxesSidebarRight" data-show-sidebar="{$sidebarRightShow}" data-hide-sidebar="{$sidebarRightHide}">
 					<div class="boxContainer">
 						{if MODULE_WCF_AD && $__disableAds|empty && $__wcf->getAdHandler()->getAds('com.woltlab.wcf.sidebar.top')}
 							<div class="box boxBorderless">

--- a/com.woltlab.wcf/templates/header.tpl
+++ b/com.woltlab.wcf/templates/header.tpl
@@ -74,7 +74,13 @@
 	<section id="main" class="main" role="main"{if !$__mainItemScope|empty} {@$__mainItemScope}{/if}>
 		<div class="layoutBoundary">
 			{hascontent}
-				<aside class="sidebar boxesSidebarLeft{if !$__sidebarLeftHasMenu|empty || $__wcf->getBoxHandler()->sidebarLeftHasMenu()} boxesSidebarLeftHasMenu{/if}" data-show-sidebar="{lang}wcf.global.button.showSidebar{/lang}" data-hide-sidebar="{lang}wcf.global.button.hideSidebar{/lang}" data-show-navigation="{lang}wcf.global.button.showNavigation{/lang}" data-hide-navigation="{lang}wcf.global.button.hideNavigation{/lang}">
+				{if !$sidebarLeftShow|isset}
+					{assign var='sidebarLeftShow' value='wcf.global.button.showSidebar'|language}
+				{/if}
+				{if !$sidebarLeftHide|isset}
+					{assign var='sidebarLeftHide' value='wcf.global.button.hideSidebar'|language}
+				{/if}
+				<aside class="sidebar boxesSidebarLeft{if !$__sidebarLeftHasMenu|empty || $__wcf->getBoxHandler()->sidebarLeftHasMenu()} boxesSidebarLeftHasMenu{/if}" data-show-sidebar="{$sidebarLeftShow}" data-hide-sidebar="{$sidebarLeftHide}" data-show-navigation="{lang}wcf.global.button.showNavigation{/lang}" data-hide-navigation="{lang}wcf.global.button.hideNavigation{/lang}">
 					<div class="boxContainer">
 						{content}
 							{event name='boxesSidebarLeftTop'}


### PR DESCRIPTION
A sidebar for example could contain a contact form. Instead of "Show sidebar" you want to show an explicit action label like "Contact us". This pull request makes that possible:

```
{capture assign='sidebarRightShow'}Contact us{/capture}
{capture assign='sidebarRightHide'}Close contact form{/capture}
```