### PR TITLE
`new Date().getTime` to `Date.now()`

### DIFF
--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Date/Util.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Date/Util.js
@@ -244,7 +244,7 @@ define(['Language'], function(Language) {
 			elData(time, 'time', formattedTime);
 			elData(time, 'offset', date.getTimezoneOffset() * 60); // PHP returns minutes, JavaScript returns seconds
 			
-			if (date.getTime() > new Date().getTime()) {
+			if (date.getTime() > Date.now()) {
 				elData(time, 'is-future-date', 'true');
 				
 				time.textContent = Language.get('wcf.date.dateTimeFormat').replace('%time%', formattedTime).replace('%date%', formattedDate);


### PR DESCRIPTION
code cleanup

Supported by IE 8+