### PR TITLE
Fix displayed day for timestamps (WCF 2.1)

### DIFF
--- a/wcfsetup/install/files/js/WCF.js
+++ b/wcfsetup/install/files/js/WCF.js
@@ -3682,8 +3682,10 @@ WCF.Date.Time = Class.extend({
 	_refresh: function() {
 		this._date = new Date();
 		this._timestamp = (this._date.getTime() - this._date.getMilliseconds()) / 1000;
+		// initialize server / client time offset in minute granularity
 		if (this._offset === null) {
 			this._offset = this._timestamp - TIME_NOW;
+			this._offset = (this._offset >= 0 ? Math.floor(this._offset / 60) : Math.ceil(this._offset / 60)) * 60;
 		}
 		
 		this._elements.each($.proxy(this._refreshElement, this));


### PR DESCRIPTION
If the server time compared to the users system time is off by some seconds, the displayed day for timestamps could be incorrect.
Only affected timestamps at/near midnight.
See https://community.woltlab.com/thread/264879-fehlerhafte-sprechende-zeitangaben/