### PR TITLE
Restore default browser behavior

### DIFF
--- a/wcfsetup/install/files/images/favicon/default.manifest.json
+++ b/wcfsetup/install/files/images/favicon/default.manifest.json
@@ -14,5 +14,5 @@
     ],
     "theme_color": "#ffffff",
     "background_color": "#ffffff",
-    "display": "standalone"
+    "display": "browser"
 }


### PR DESCRIPTION
See https://community.woltlab.com/thread/265668-mobile-version-rc-2-ohne-adresszeile-im-chrome-browser

Imho, displaying a webpage as standalone web app is nice in some cases, but the default behavior should be the browser mode.