### PR TITLE
Add Privacy Policy Consent

### DIFF
--- a/com.woltlab.wcf/templates/commentAddGuestDialog.tpl
+++ b/com.woltlab.wcf/templates/commentAddGuestDialog.tpl
@@ -15,6 +15,20 @@
 				{/if}
 			</dd>
 		</dl>
+		
+		<dl{if $errorType[privacyPolicyConsent]|isset} class="formError"{/if}>
+			<dt><label for="privacyPolicyConsent">{lang}wcf.comment.privacyPolicyConsent.title{/lang}</label></dt>
+			<dd>
+				<label><input type="checkbox" id="privacyPolicyConsent" name="privacyPolicyConsent" value="1"> {lang}wcf.comment.privacyPolicyConsent.text{/lang}</label>
+				{if $errorType[privacyPolicyConsent]|isset}
+					<small class="innerError">
+						{if $errorType[privacyPolicyConsent] == 'empty'}
+							{lang}wcf.global.form.error.empty{/lang}
+						{/if}
+					</small>
+				{/if}
+			</dd>
+		</dl>
 	</div>
 	
 	{include file='captcha'}

--- a/com.woltlab.wcf/templates/contact.tpl
+++ b/com.woltlab.wcf/templates/contact.tpl
@@ -70,6 +70,20 @@
 		{include file='customOptionFieldList'}
 		
 		{event name='optionFields'}
+		
+		<dl{if $errorField == 'privacyPolicyConsent'} class="formError"{/if}>
+			<dt><label for="privacyPolicyConsent">{lang}wcf.contact.privacyPolicyConsent.title{/lang}</label> <span class="customOptionRequired">*</span></dt>
+			<dd>
+				<label><input type="checkbox" id="privacyPolicyConsent" name="privacyPolicyConsent" value="1"> {lang}wcf.contact.privacyPolicyConsent.text{/lang}</label>
+				{if $errorField == 'privacyPolicyConsent'}
+					<small class="innerError">
+						{if $errorType == 'empty'}
+							{lang}wcf.global.form.error.empty{/lang}
+						{/if}
+					</small>
+				{/if}
+			</dd>
+		</dl>
 	</section>
 	
 	{event name='sections'}

--- a/wcfsetup/install/files/lib/data/comment/CommentAction.class.php
+++ b/wcfsetup/install/files/lib/data/comment/CommentAction.class.php
@@ -293,6 +293,7 @@ class CommentAction extends AbstractDatabaseObjectAction implements IMessageInli
 		
 		if (!$this->parameters['requireGuestDialog']) {
 			$this->validateUsername();
+			$this->validatePrivacyPolicyConsent();
 			$this->validateCaptcha();
 		}
 		
@@ -440,6 +441,7 @@ class CommentAction extends AbstractDatabaseObjectAction implements IMessageInli
 		
 		if (!$this->parameters['requireGuestDialog']) {
 			$this->validateUsername();
+			$this->validatePrivacyPolicyConsent();
 			$this->validateCaptcha();
 		}
 		
@@ -1129,6 +1131,20 @@ class CommentAction extends AbstractDatabaseObjectAction implements IMessageInli
 		}
 		if ($this->response === null || !$this->response->responseID) {
 			throw new UserInputException('responseID');
+		}
+	}
+	
+	/**
+	 * Validates the privacy policy consent.
+	 */
+	protected function validatePrivacyPolicyConsent() {
+		if (WCF::getUser()->userID) return;
+		
+		try {
+			$this->readInteger('privacyPolicyConsent', false, 'data');
+		}
+		catch (UserInputException $e) {
+			$this->validationErrors['privacyPolicyConsent'] = $e->getType();
 		}
 	}
 	

--- a/wcfsetup/install/files/lib/form/ContactForm.class.php
+++ b/wcfsetup/install/files/lib/form/ContactForm.class.php
@@ -33,6 +33,12 @@ class ContactForm extends AbstractCaptchaForm {
 	public $name = '';
 	
 	/**
+	 * privacy policy consent acceptance
+	 * @var string
+	 */
+	public $privacyPolicyConsent = 0;
+	
+	/**
 	 * @inheritDoc
 	 */
 	public $neededModules = ['MODULE_CONTACT_FORM'];
@@ -81,6 +87,7 @@ class ContactForm extends AbstractCaptchaForm {
 		
 		if (isset($_POST['email'])) $this->email = StringUtil::trim($_POST['email']);
 		if (isset($_POST['name'])) $this->name = StringUtil::trim($_POST['name']);
+		if (isset($_POST['privacyPolicyConsent'])) $this->privacyPolicyConsent = 1;
 		if (isset($_POST['recipientID'])) $this->recipientID = intval($_POST['recipientID']);
 	}
 	
@@ -111,6 +118,10 @@ class ContactForm extends AbstractCaptchaForm {
 		
 		if (empty($this->name)) {
 			throw new UserInputException('name');
+		}
+		
+		if (empty($this->privacyPolicyConsent)) {
+			throw new UserInputException('privacyPolicyConsent');
 		}
 		
 		$recipients = $this->recipientList->getObjects();

--- a/wcfsetup/install/lang/de.xml
+++ b/wcfsetup/install/lang/de.xml
@@ -2509,6 +2509,8 @@ Fehler sind beispielsweise:
 		<item name="wcf.comment.guestDialog.title"><![CDATA[Gastkommentar]]></item>
 		<item name="wcf.comment.sortField.cumulativeLikes"><![CDATA[Likes]]></item>
 		<item name="wcf.comment.sortField.time"><![CDATA[Datum]]></item>
+		<item name="wcf.comment.privacyPolicyConsent.title"><![CDATA[Einwilligungserklärung Datenschutz]]></item>
+		<item name="wcf.comment.privacyPolicyConsent.text"><![CDATA[Mit Setzen dieses Häkchens im nebenstehenden Kontrollkästchen {if LANGUAGE_USE_INFORMAL_VARIANT}erklärst du dich{else}erklären Sie sich{/if} einverstanden, dass die von Ihnen angegebenen Daten elektronisch erhoben und gespeichert werden. Diese Einwilligung {if LANGUAGE_USE_INFORMAL_VARIANT}kannst du{else}können Sie{/if} jederzeit durch Nachricht an uns widerrufen. Im Falle des Widerrufs werden Ihre Daten umgehend gelöscht. Weitere Informationen {if LANGUAGE_USE_INFORMAL_VARIANT}kannst du der{else}entnehmen Sie der{/if} <a href="{page}com.woltlab.wcf.PrivacyPolicy{/page}">Datenschutzerklärung</a>{if LANGUAGE_USE_INFORMAL_VARIANT} entnehmen{/if}.]]></item>
 	</category>
 	
 	<category name="wcf.condition">

--- a/wcfsetup/install/lang/de.xml
+++ b/wcfsetup/install/lang/de.xml
@@ -2555,6 +2555,8 @@ E-Mail-Adresse: {@$emailAddress} {* this line ends with a space *}
 		<item name="wcf.contact.recipientID"><![CDATA[Empfänger]]></item>
 		<item name="wcf.contact.sender"><![CDATA[Absender]]></item>
 		<item name="wcf.contact.sender.information"><![CDATA[{if LANGUAGE_USE_INFORMAL_VARIANT}Deine{else}Ihre{/if} Angaben]]></item>
+		<item name="wcf.contact.privacyPolicyConsent.title"><![CDATA[Einwilligungserklärung Datenschutz]]></item>
+		<item name="wcf.contact.privacyPolicyConsent.text"><![CDATA[Mit Setzen dieses Häkchens im nebenstehenden Kontrollkästchen {if LANGUAGE_USE_INFORMAL_VARIANT}erklärst du dich{else}erklären Sie sich{/if} einverstanden, dass die von Ihnen angegebenen Daten elektronisch erhoben und gespeichert werden. {if LANGUAGE_USE_INFORMAL_VARIANT}Deine{else}Ihre{/if} Daten werden dabei nur streng zweckgebunden zur Bearbeitung und Beantwortung {if LANGUAGE_USE_INFORMAL_VARIANT}deiner{else}Ihrer{/if} Anfrage genutzt. Diese Einwilligung {if LANGUAGE_USE_INFORMAL_VARIANT}kannst du{else}können Sie{/if} jederzeit durch Nachricht an uns widerrufen. Im Falle des Widerrufs werden Ihre Daten umgehend gelöscht. Weitere Informationen {if LANGUAGE_USE_INFORMAL_VARIANT}kannst du der{else}entnehmen Sie der{/if} <a href="{page}com.woltlab.wcf.PrivacyPolicy{/page}">Datenschutzerklärung</a>{if LANGUAGE_USE_INFORMAL_VARIANT} entnehmen{/if}.]]></item>
 		<item name="wcf.contact.success"><![CDATA[Ihre Nachricht wurde erfolgreich versandt.]]></item>
 	</category>
 	

--- a/wcfsetup/install/lang/en.xml
+++ b/wcfsetup/install/lang/en.xml
@@ -2443,6 +2443,8 @@ Errors are:
 		<item name="wcf.comment.guestDialog.title"><![CDATA[Guest Comment]]></item>
 		<item name="wcf.comment.sortField.cumulativeLikes"><![CDATA[Likes]]></item>
 		<item name="wcf.comment.sortField.time"><![CDATA[Date]]></item>
+		<item name="wcf.comment.privacyPolicyConsent.title"><![CDATA[Privacy Policy Consent]]></item>
+		<item name="wcf.comment.privacyPolicyConsent"><![CDATA[By ticking the adjacent box, you agree to the electronic recording and storage of your data. You can revoke this agreement at any time by sending us a message. In the event of revocation, data will be deleted immediately. For further information, please refer to the <a href="{page}com.woltlab.wcf.PrivacyPolicy{/page}">privacy policy</a>.]]></item>
 	</category>
 	
 	<category name="wcf.condition">

--- a/wcfsetup/install/lang/en.xml
+++ b/wcfsetup/install/lang/en.xml
@@ -2489,6 +2489,8 @@ Email: {@$emailAddress} {* this line ends with a space *}
 		<item name="wcf.contact.recipientID"><![CDATA[Recipient]]></item>
 		<item name="wcf.contact.sender"><![CDATA[Sender]]></item>
 		<item name="wcf.contact.sender.information"><![CDATA[Your Inquiry]]></item>
+		<item name="wcf.contact.privacyPolicyConsent.title"><![CDATA[Privacy Policy Consent]]></item>
+		<item name="wcf.contact.privacyPolicyConsent.text"><![CDATA[By ticking the adjacent box, you agree to the electronic recording and storage of your data. Your data will only be used for processing and responding to your enquiry. You can revoke this agreement at any time by sending us a message. In the event of revocation, data will be deleted immediately. For further information, please refer to the <a href="{page}com.woltlab.wcf.PrivacyPolicy{/page}">privacy policy</a>.]]></item>
 		<item name="wcf.contact.success"><![CDATA[Message has been sent.]]></item>
 	</category>
 	


### PR DESCRIPTION
The upcoming GDPR requires, that users agree to the electronic recording and storage of their data after submitting a form.

WSC 3.1 contains at least two components, where a consent could/should be placed:

1. Guest Comments Dialog
2. Contact Form

However, the contact form could also be extended via plugin, so integrating it into the core is not neccessary, but desired.

On the other hand, it's higly recommended to have it in the comments dialog for guests. 
Not least due to the fact, that there's no suitable event we could use to create a plugin.

While there might be some more places in commercial products (e.g. WSF), this PR should cover the most critical functions in the core (maybe consider adding the consent to the registration form, too).