### PR TITLE
Add new "SameSite"-cookie-attribute

### DIFF
--- a/com.woltlab.wcf/option.xml
+++ b/com.woltlab.wcf/option.xml
@@ -618,8 +618,7 @@ private:wcf.acp.option.exception_privacy.private</selectoptions>
 				<optiontype>select</optiontype>
 				<defaultvalue>none</defaultvalue>
 				<selectoptions>none:wcf.acp.option.cookie_same_site_attribute.none
-					lax:wcf.acp.option.cookie_same_site_attribute.lax
-					strict:wcf.acp.option.cookie_same_site_attribute.strict</selectoptions>
+lax:wcf.acp.option.cookie_same_site_attribute.lax</selectoptions>
 			</option>
 			<!-- /general.system.cookie-->
 			

--- a/com.woltlab.wcf/option.xml
+++ b/com.woltlab.wcf/option.xml
@@ -613,6 +613,14 @@ private:wcf.acp.option.exception_privacy.private</selectoptions>
 				<defaultvalue>wsc31_</defaultvalue>
 				<validationpattern>.+</validationpattern>
 			</option>
+			<option name="cookie_same_site_attribute">
+				<categoryname>general.system.cookie</categoryname>
+				<optiontype>select</optiontype>
+				<defaultvalue>none</defaultvalue>
+				<selectoptions>none:wcf.acp.option.cookie_same_site_attribute.none
+					lax:wcf.acp.option.cookie_same_site_attribute.lax
+					strict:wcf.acp.option.cookie_same_site_attribute.strict</selectoptions>
+			</option>
 			<!-- /general.system.cookie-->
 			
 			<!-- general.system.http -->

--- a/constants.php
+++ b/constants.php
@@ -67,6 +67,7 @@ define('IMAGE_ADAPTER_TYPE', 'gd');
 define('SEARCH_ENGINE', 'mysql');
 define('EXCEPTION_PRIVACY', 'public');
 define('COOKIE_PREFIX', 'wcf21_');
+define('COOKIE_SAME_SITE_ATTRIBUTE', 'none');
 define('HTTP_SEND_X_FRAME_OPTIONS', 1);
 define('HTTP_ENABLE_GZIP', 1);
 define('PACKAGE_SERVER_AUTH_CODE', '');

--- a/wcfsetup/install/files/lib/util/HeaderUtil.class.php
+++ b/wcfsetup/install/files/lib/util/HeaderUtil.class.php
@@ -49,8 +49,7 @@ final class HeaderUtil {
 		}
 		
 		$sameSitePolicy = '';
-		$sameSiteOption = COOKIE_SAME_SITE_ATTRIBUTE;
-		if ($sameSiteOption != 'none') {
+		if (COOKIE_SAME_SITE_ATTRIBUTE != 'none') {
 			$sameSitePolicy = '; SameSite='.COOKIE_SAME_SITE_ATTRIBUTE;
 		}
 		

--- a/wcfsetup/install/files/lib/util/HeaderUtil.class.php
+++ b/wcfsetup/install/files/lib/util/HeaderUtil.class.php
@@ -8,7 +8,7 @@ use wcf\system\WCF;
 
 /**
  * Contains header-related functions.
- * 
+ *
  * @author	Marcel Werk
  * @copyright	2001-2018 WoltLab GmbH
  * @license	GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
@@ -35,7 +35,7 @@ final class HeaderUtil {
 	
 	/**
 	 * Alias to php setcookie() function.
-	 * 
+	 *
 	 * @param	string		$name
 	 * @param	string		$value
 	 * @param	integer		$expire
@@ -47,8 +47,15 @@ final class HeaderUtil {
 		if ($addDomain && strpos($cookieDomain, ':') !== false) {
 			$cookieDomain = explode(':', $cookieDomain, 2)[0];
 		}
+	    
+	    	$sameSitePolicy = "";
+	    	$sameSiteOption = COOKIE_SAME_SITE_ATTRIBUTE;
+	    	if ($sameSiteOption != "none") {
+	    		$sameSitePolicy = "; SameSite=".COOKIE_SAME_SITE_ATTRIBUTE;
+		}
 		
-		@header('Set-Cookie: '.rawurlencode(COOKIE_PREFIX.$name).'='.rawurlencode($value).($expire ? '; expires='.gmdate('D, d-M-Y H:i:s', $expire).' GMT; max-age='.($expire - TIME_NOW) : '').'; path=/'.($addDomain ? '; domain='.$cookieDomain : '').(RouteHandler::secureConnection() ? '; secure' : '').'; HttpOnly', false);
+		
+		@header('Set-Cookie: '.rawurlencode(COOKIE_PREFIX.$name).'='.rawurlencode($value).($expire ? '; expires='.gmdate('D, d-M-Y H:i:s', $expire).' GMT; max-age='.($expire - TIME_NOW) : '').'; path=/'.($addDomain ? '; domain='.$cookieDomain : '').(RouteHandler::secureConnection() ? '; secure' : '').'; HttpOnly'.$sameSitePolicy, false);
 	}
 	
 	/**
@@ -107,7 +114,7 @@ final class HeaderUtil {
 	
 	/**
 	 * Parses the rendered output.
-	 * 
+	 *
 	 * @param	string		$output
 	 * @return	string
 	 */
@@ -156,10 +163,10 @@ final class HeaderUtil {
 	
 	/**
 	 * Redirects the user agent to given location.
-	 * 
+	 *
 	 * @param	string		$location
 	 * @param	boolean		$sendStatusCode
-	 * @param	boolean		$temporaryRedirect 
+	 * @param	boolean		$temporaryRedirect
 	 */
 	public static function redirect($location, $sendStatusCode = false, $temporaryRedirect = true) {
 		if ($sendStatusCode) {
@@ -172,7 +179,7 @@ final class HeaderUtil {
 	
 	/**
 	 * Does a delayed redirect.
-	 * 
+	 *
 	 * @param	string		$location
 	 * @param	string		$message
 	 * @param	integer		$delay

--- a/wcfsetup/install/files/lib/util/HeaderUtil.class.php
+++ b/wcfsetup/install/files/lib/util/HeaderUtil.class.php
@@ -47,13 +47,12 @@ final class HeaderUtil {
 		if ($addDomain && strpos($cookieDomain, ':') !== false) {
 			$cookieDomain = explode(':', $cookieDomain, 2)[0];
 		}
-	    
-	    	$sameSitePolicy = "";
-	    	$sameSiteOption = COOKIE_SAME_SITE_ATTRIBUTE;
-	    	if ($sameSiteOption != "none") {
-	    		$sameSitePolicy = "; SameSite=".COOKIE_SAME_SITE_ATTRIBUTE;
-		}
 		
+		$sameSitePolicy = "";
+		$sameSiteOption = COOKIE_SAME_SITE_ATTRIBUTE;
+		if ($sameSiteOption != "none") {
+			$sameSitePolicy = "; SameSite=".COOKIE_SAME_SITE_ATTRIBUTE;
+		}
 		
 		@header('Set-Cookie: '.rawurlencode(COOKIE_PREFIX.$name).'='.rawurlencode($value).($expire ? '; expires='.gmdate('D, d-M-Y H:i:s', $expire).' GMT; max-age='.($expire - TIME_NOW) : '').'; path=/'.($addDomain ? '; domain='.$cookieDomain : '').(RouteHandler::secureConnection() ? '; secure' : '').'; HttpOnly'.$sameSitePolicy, false);
 	}

--- a/wcfsetup/install/files/lib/util/HeaderUtil.class.php
+++ b/wcfsetup/install/files/lib/util/HeaderUtil.class.php
@@ -8,7 +8,7 @@ use wcf\system\WCF;
 
 /**
  * Contains header-related functions.
- *
+ * 
  * @author	Marcel Werk
  * @copyright	2001-2018 WoltLab GmbH
  * @license	GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
@@ -35,7 +35,7 @@ final class HeaderUtil {
 	
 	/**
 	 * Alias to php setcookie() function.
-	 *
+	 * 
 	 * @param	string		$name
 	 * @param	string		$value
 	 * @param	integer		$expire
@@ -48,10 +48,10 @@ final class HeaderUtil {
 			$cookieDomain = explode(':', $cookieDomain, 2)[0];
 		}
 		
-		$sameSitePolicy = "";
+		$sameSitePolicy = '';
 		$sameSiteOption = COOKIE_SAME_SITE_ATTRIBUTE;
-		if ($sameSiteOption != "none") {
-			$sameSitePolicy = "; SameSite=".COOKIE_SAME_SITE_ATTRIBUTE;
+		if ($sameSiteOption != 'none') {
+			$sameSitePolicy = '; SameSite='.COOKIE_SAME_SITE_ATTRIBUTE;
 		}
 		
 		@header('Set-Cookie: '.rawurlencode(COOKIE_PREFIX.$name).'='.rawurlencode($value).($expire ? '; expires='.gmdate('D, d-M-Y H:i:s', $expire).' GMT; max-age='.($expire - TIME_NOW) : '').'; path=/'.($addDomain ? '; domain='.$cookieDomain : '').(RouteHandler::secureConnection() ? '; secure' : '').'; HttpOnly'.$sameSitePolicy, false);
@@ -113,7 +113,7 @@ final class HeaderUtil {
 	
 	/**
 	 * Parses the rendered output.
-	 *
+	 * 
 	 * @param	string		$output
 	 * @return	string
 	 */
@@ -162,7 +162,7 @@ final class HeaderUtil {
 	
 	/**
 	 * Redirects the user agent to given location.
-	 *
+	 * 
 	 * @param	string		$location
 	 * @param	boolean		$sendStatusCode
 	 * @param	boolean		$temporaryRedirect
@@ -178,7 +178,7 @@ final class HeaderUtil {
 	
 	/**
 	 * Does a delayed redirect.
-	 *
+	 * 
 	 * @param	string		$location
 	 * @param	string		$message
 	 * @param	integer		$delay

--- a/wcfsetup/install/files/options.inc.php
+++ b/wcfsetup/install/files/options.inc.php
@@ -17,6 +17,7 @@ define('COOKIE_PREFIX', $prefix);
 
 define('COOKIE_PATH', '');
 define('COOKIE_DOMAIN', '');
+define('COOKIE_SAME_SITE_ATTRIBUTE', 'none');
 
 define('HTTP_ENABLE_GZIP', 0);
 define('HTTP_GZIP_LEVEL', 1);

--- a/wcfsetup/install/lang/de.xml
+++ b/wcfsetup/install/lang/de.xml
@@ -1051,6 +1051,11 @@
 		<item name="wcf.acp.option.cookie_path"><![CDATA[Cookiepfad]]></item>
 		<item name="wcf.acp.option.cookie_path.description"><![CDATA[Der Cookiepfad wird absolut zum Document Root angegeben - also z.B. "/forum" für https://www.woltlab.de/forum.]]></item>
 		<item name="wcf.acp.option.cookie_prefix"><![CDATA[Präfix für Cookienamen]]></item>
+		<item name="wcf.acp.option.cookie_same_site_attribute"><![CDATA[Cookies vor externen Zugriffen schützen]]></item>
+		<item name="wcf.acp.option.cookie_same_site_attribute.description"><![CDATA[Fügt beim Setzen von Cookies zusätzlich das <a href="{@$__wcf->getPath()}acp/dereferrer.php?url={'https://en.wikipedia.org/wiki/HTTP_cookie#SameSite_cookie|rawurlencode}" class="externalURL">„SameSite“</a> Attribut hinzu, um das Nutzen der Cookies bei externer Referenzierung dieser Seite zu verhindern.]]></item>
+		<item name="wcf.acp.option.cookie_same_site_attribute.none"><![CDATA[Deaktiviert]]></item>
+		<item name="wcf.acp.option.cookie_same_site_attribute.lax"><![CDATA[Locker]]></item>
+		<item name="wcf.acp.option.cookie_same_site_attribute.strict"><![CDATA[Strikt]]></item>
 		<item name="wcf.acp.option.error.controllerReplacementCollision"><![CDATA[Das Alias „{$urlControllerReplacementError}“ kollidiert mit einem real existierenden Controller und ist daher unzulässig.]]></item>
 		<item name="wcf.acp.option.error.controllerReplacementDuplicateAlias"><![CDATA[Das Alias „{$urlControllerReplacementError}“ wird bereits verwendet.]]></item>
 		<item name="wcf.acp.option.error.controllerReplacementDuplicateController"><![CDATA[Dem Controller „{$urlControllerReplacementError}“ wurde bereits ein Alias zugewiesen.]]></item>

--- a/wcfsetup/install/lang/de.xml
+++ b/wcfsetup/install/lang/de.xml
@@ -1055,7 +1055,6 @@
 		<item name="wcf.acp.option.cookie_same_site_attribute.description"><![CDATA[Fügt beim Setzen von Cookies zusätzlich das <a href="{@$__wcf->getPath()}acp/dereferrer.php?url={'https://en.wikipedia.org/wiki/HTTP_cookie#SameSite_cookie|rawurlencode}" class="externalURL">„SameSite“</a> Attribut hinzu, um das Nutzen der Cookies bei externer Referenzierung dieser Seite zu verhindern.]]></item>
 		<item name="wcf.acp.option.cookie_same_site_attribute.none"><![CDATA[Deaktiviert]]></item>
 		<item name="wcf.acp.option.cookie_same_site_attribute.lax"><![CDATA[Locker]]></item>
-		<item name="wcf.acp.option.cookie_same_site_attribute.strict"><![CDATA[Strikt]]></item>
 		<item name="wcf.acp.option.error.controllerReplacementCollision"><![CDATA[Das Alias „{$urlControllerReplacementError}“ kollidiert mit einem real existierenden Controller und ist daher unzulässig.]]></item>
 		<item name="wcf.acp.option.error.controllerReplacementDuplicateAlias"><![CDATA[Das Alias „{$urlControllerReplacementError}“ wird bereits verwendet.]]></item>
 		<item name="wcf.acp.option.error.controllerReplacementDuplicateController"><![CDATA[Dem Controller „{$urlControllerReplacementError}“ wurde bereits ein Alias zugewiesen.]]></item>

--- a/wcfsetup/install/lang/de.xml
+++ b/wcfsetup/install/lang/de.xml
@@ -1054,7 +1054,7 @@
 		<item name="wcf.acp.option.cookie_same_site_attribute"><![CDATA[Cookies vor externen Zugriffen schützen]]></item>
 		<item name="wcf.acp.option.cookie_same_site_attribute.description"><![CDATA[Fügt beim Setzen von Cookies zusätzlich das <a href="{@$__wcf->getPath()}acp/dereferrer.php?url={'https://en.wikipedia.org/wiki/HTTP_cookie#SameSite_cookie|rawurlencode}" class="externalURL">„SameSite“</a> Attribut hinzu, um das Nutzen der Cookies bei externer Referenzierung dieser Seite zu verhindern.]]></item>
 		<item name="wcf.acp.option.cookie_same_site_attribute.none"><![CDATA[Deaktiviert]]></item>
-		<item name="wcf.acp.option.cookie_same_site_attribute.lax"><![CDATA[Locker]]></item>
+		<item name="wcf.acp.option.cookie_same_site_attribute.lax"><![CDATA[Lasch (Lax)]]></item>
 		<item name="wcf.acp.option.error.controllerReplacementCollision"><![CDATA[Das Alias „{$urlControllerReplacementError}“ kollidiert mit einem real existierenden Controller und ist daher unzulässig.]]></item>
 		<item name="wcf.acp.option.error.controllerReplacementDuplicateAlias"><![CDATA[Das Alias „{$urlControllerReplacementError}“ wird bereits verwendet.]]></item>
 		<item name="wcf.acp.option.error.controllerReplacementDuplicateController"><![CDATA[Dem Controller „{$urlControllerReplacementError}“ wurde bereits ein Alias zugewiesen.]]></item>

--- a/wcfsetup/install/lang/en.xml
+++ b/wcfsetup/install/lang/en.xml
@@ -1033,6 +1033,11 @@
 		<item name="wcf.acp.option.cookie_path"><![CDATA[Cookie Path]]></item>
 		<item name="wcf.acp.option.cookie_path.description"><![CDATA[Value should be absolute to Document Root, e.g. “/forum” for “https://www.woltlab.com/forum”.]]></item>
 		<item name="wcf.acp.option.cookie_prefix"><![CDATA[Cookie Prefix]]></item>
+		<item name="wcf.acp.option.cookie_same_site_attribute"><![CDATA[Protect cookies against external access]]></item>
+		<item name="wcf.acp.option.cookie_same_site_attribute.description"><![CDATA[Appends the <a href="{@$__wcf->getPath()}acp/dereferrer.php?url={'https://en.wikipedia.org/wiki/HTTP_cookie#SameSite_cookie|rawurlencode}" class="externalURL">„SameSite“</a> attribute to new cookies, to prevent the cross-site usage of cookies.]]></item>
+		<item name="wcf.acp.option.cookie_same_site_attribute.none"><![CDATA[Deactivated]]></item>
+		<item name="wcf.acp.option.cookie_same_site_attribute.lax"><![CDATA[Lax]]></item>
+		<item name="wcf.acp.option.cookie_same_site_attribute.strict"><![CDATA[Strict]]></item>
 		<item name="wcf.acp.option.error.controllerReplacementCollision"><![CDATA[The alias “{$urlControllerReplacementError}” equals an existing controller and cannot be used.]]></item>
 		<item name="wcf.acp.option.error.controllerReplacementDuplicateAlias"><![CDATA[The alias “{$urlControllerReplacementError}” is already in use.]]></item>
 		<item name="wcf.acp.option.error.controllerReplacementDuplicateController"><![CDATA[The controller “{$urlControllerReplacementError}” has already been aliased.]]></item>

--- a/wcfsetup/install/lang/en.xml
+++ b/wcfsetup/install/lang/en.xml
@@ -1037,7 +1037,6 @@
 		<item name="wcf.acp.option.cookie_same_site_attribute.description"><![CDATA[Appends the <a href="{@$__wcf->getPath()}acp/dereferrer.php?url={'https://en.wikipedia.org/wiki/HTTP_cookie#SameSite_cookie|rawurlencode}" class="externalURL">„SameSite“</a> attribute to new cookies, to prevent the cross-site usage of cookies.]]></item>
 		<item name="wcf.acp.option.cookie_same_site_attribute.none"><![CDATA[Deactivated]]></item>
 		<item name="wcf.acp.option.cookie_same_site_attribute.lax"><![CDATA[Lax]]></item>
-		<item name="wcf.acp.option.cookie_same_site_attribute.strict"><![CDATA[Strict]]></item>
 		<item name="wcf.acp.option.error.controllerReplacementCollision"><![CDATA[The alias “{$urlControllerReplacementError}” equals an existing controller and cannot be used.]]></item>
 		<item name="wcf.acp.option.error.controllerReplacementDuplicateAlias"><![CDATA[The alias “{$urlControllerReplacementError}” is already in use.]]></item>
 		<item name="wcf.acp.option.error.controllerReplacementDuplicateController"><![CDATA[The controller “{$urlControllerReplacementError}” has already been aliased.]]></item>


### PR DESCRIPTION
Hey,

this adds the "[SameSite](https://www.owasp.org/index.php/SameSite)"-cookie-attribute. This attribute was already accepted (and implemented) by Chrome, Firefox and Opera (at least). It was added to effectively tackle a few CSRF vulnerabilities by not sending cookies on sub-requests or only sending them under specific circumstances.

I added this to the HeaderUtil-setCookie utility, so it's easy to maintain and I also included a config option for the different operation modes, aswell as the "off", to retain backwards-compatibility.

This is my first PR to this project, so I expect I gotta correct a few things for this getting merged, I am, however, willing to make those adjustments, as I'm really looking forward to having this within my favourite framework! :)