### PR TITLE
[Optimization] Replace strstr with strpos because it’s faster

### DIFF
--- a/wcfsetup/install/files/lib/action/PaypalCallbackAction.class.php
+++ b/wcfsetup/install/files/lib/action/PaypalCallbackAction.class.php
@@ -43,7 +43,7 @@ class PaypalCallbackAction extends AbstractAction {
 				throw new SystemException('connection to paypal.com failed: ' . $e->getMessage());
 			}
 			
-			if (strstr($content, "VERIFIED") === false) {
+			if (strpos($content, "VERIFIED") === false) {
 				throw new SystemException('request not validated');
 			}
 			

--- a/wcfsetup/install/files/lib/system/WCF.class.php
+++ b/wcfsetup/install/files/lib/system/WCF.class.php
@@ -279,8 +279,8 @@ class WCF {
 			// we'll just gzip the output of the exception to prevent them from tampering.
 			// This part is copied from `HeaderUtil` in order to isolate the exception handler!
 			if (HTTP_ENABLE_GZIP && !defined('HTTP_DISABLE_GZIP')) {
-				if (function_exists('gzcompress') && !@ini_get('zlib.output_compression') && !@ini_get('output_handler') && isset($_SERVER['HTTP_ACCEPT_ENCODING']) && strstr($_SERVER['HTTP_ACCEPT_ENCODING'], 'gzip')) {
-					if (strstr($_SERVER['HTTP_ACCEPT_ENCODING'], 'x-gzip')) {
+				if (function_exists('gzcompress') && !@ini_get('zlib.output_compression') && !@ini_get('output_handler') && isset($_SERVER['HTTP_ACCEPT_ENCODING']) && strpos($_SERVER['HTTP_ACCEPT_ENCODING'], 'gzip') !== false) {
+					if (strpos($_SERVER['HTTP_ACCEPT_ENCODING'], 'x-gzip') !== false) {
 						@header('Content-Encoding: x-gzip');
 					}
 					else {

--- a/wcfsetup/install/files/lib/util/HeaderUtil.class.php
+++ b/wcfsetup/install/files/lib/util/HeaderUtil.class.php
@@ -64,10 +64,10 @@ final class HeaderUtil {
 		}
 		
 		if (HTTP_ENABLE_GZIP && !defined('HTTP_DISABLE_GZIP')) {
-			if (function_exists('gzcompress') && !@ini_get('zlib.output_compression') && !@ini_get('output_handler') && isset($_SERVER['HTTP_ACCEPT_ENCODING']) && strstr($_SERVER['HTTP_ACCEPT_ENCODING'], 'gzip')) {
+			if (function_exists('gzcompress') && !@ini_get('zlib.output_compression') && !@ini_get('output_handler') && isset($_SERVER['HTTP_ACCEPT_ENCODING']) && strpos($_SERVER['HTTP_ACCEPT_ENCODING'], 'gzip') !== false) {
 				self::$enableGzipCompression = true;
 				
-				if (strstr($_SERVER['HTTP_ACCEPT_ENCODING'], 'x-gzip')) {
+				if (strpos($_SERVER['HTTP_ACCEPT_ENCODING'], 'x-gzip') !== false) {
 					@header('Content-Encoding: x-gzip');
 				}
 				else {

--- a/wcfsetup/install/files/lib/util/ImageUtil.class.php
+++ b/wcfsetup/install/files/lib/util/ImageUtil.class.php
@@ -26,7 +26,7 @@ final class ImageUtil {
 		$content = str_replace('description', '', $content);
 		
 		// search for javascript
-		if (strstr($content, 'script') || strstr($content, 'javascript') || strstr($content, 'expression(')) return false;
+		if (strpos($content, 'script') !== false || strpos($content, 'javascript') !== false || strpos($content, 'expression(') !== false) return false;
 		
 		return true;
 	}


### PR DESCRIPTION
As mentioned from @dtdesign in the commit fef5bd1f21876de170d181e7c81b92ff893efa6f (see comments) this little pr replaces all `strstr` calls with `strpos` because the docs for the strstr function (https://secure.php.net/manual/en/function.strstr.php) says that it is better to use strpos if you only want to determine if a string is in another string. I think doesn't brings so much performance, but actually on all other checks of this type strpos is already used, so why don't "optimize" the last few findings?

Signed-off-by: Lukas Kämmerling <kontakt@lukas-kaemmerling.de>