### PR TITLE
Add width/height properties for default avatars

### DIFF
--- a/wcfsetup/install/files/lib/data/user/avatar/DefaultAvatar.class.php
+++ b/wcfsetup/install/files/lib/data/user/avatar/DefaultAvatar.class.php
@@ -79,7 +79,7 @@ SVG;
 	public function getImageTag($size = null) {
 		if ($size === null) $size = $this->size;
 		
-		return '<img src="'.StringUtil::encodeHTML($this->getURL($size)).'" style="width: '.$size.'px; height: '.$size.'px" alt="" class="userAvatarImage">';
+		return '<img src="'.StringUtil::encodeHTML($this->getURL($size)).'" style="width: '.$size.'px; height: '.$size.'px" width="'.$size.'" height="'.$size.'" alt="" class="userAvatarImage">';
 	}
 	
 	/**

--- a/wcfsetup/install/files/lib/data/user/avatar/DefaultAvatar.class.php
+++ b/wcfsetup/install/files/lib/data/user/avatar/DefaultAvatar.class.php
@@ -79,7 +79,7 @@ SVG;
 	public function getImageTag($size = null) {
 		if ($size === null) $size = $this->size;
 		
-		return '<img src="'.StringUtil::encodeHTML($this->getURL($size)).'" style="width: '.$size.'px; height: '.$size.'px" width="'.$size.'" height="'.$size.'" alt="" class="userAvatarImage">';
+		return '<img src="'.StringUtil::encodeHTML($this->getURL($size)).'" width="'.$size.'" height="'.$size.'" alt="" class="userAvatarImage">';
 	}
 	
 	/**


### PR DESCRIPTION
Under certain circumstances*, it is possible, that the style tag will be stripped from from SVG images. This leads to a display of very tiny avatar images as shown below:

![image](https://user-images.githubusercontent.com/81188/38629520-8fc2df38-3db4-11e8-9429-cdf7bf95ce90.png)

Since `width` and `height` are valid properties and respected by every browser, it's not the worst idea to include them.

* = An example scenario is the Mirage option from Cloudflare.