### PR TITLE
Remove deprecated/removed permissions

### DIFF
--- a/wcfsetup/install/files/lib/action/FacebookAuthAction.class.php
+++ b/wcfsetup/install/files/lib/action/FacebookAuthAction.class.php
@@ -147,7 +147,7 @@ class FacebookAuthAction extends AbstractAction {
 		// start auth by redirecting to facebook
 		$token = StringUtil::getRandomID();
 		WCF::getSession()->register('__facebookInit', $token);
-		HeaderUtil::redirect("https://www.facebook.com/dialog/oauth?client_id=".StringUtil::trim(FACEBOOK_PUBLIC_KEY). "&redirect_uri=".rawurlencode($callbackURL)."&state=".$token."&scope=email,user_about_me,user_birthday,user_location,user_website");
+		HeaderUtil::redirect("https://www.facebook.com/dialog/oauth?client_id=".StringUtil::trim(FACEBOOK_PUBLIC_KEY). "&redirect_uri=".rawurlencode($callbackURL)."&state=".$token."&scope=email,user_birthday,user_location");
 		$this->executed();
 		exit;
 	}

--- a/wcfsetup/install/files/lib/form/RegisterForm.class.php
+++ b/wcfsetup/install/files/lib/form/RegisterForm.class.php
@@ -361,18 +361,7 @@ class RegisterForm extends UserAddForm {
 							list($month, $day, $year) = explode('/', $facebookData['birthday']);
 							$saveOptions[User::getUserOptionID('birthday')] = $year.'-'.$month.'-'.$day;
 						}
-						if (isset($facebookData['about']) && User::getUserOptionID('aboutMe') !== null) $saveOptions[User::getUserOptionID('aboutMe')] = $facebookData['about'];
 						if (isset($facebookData['location']) && User::getUserOptionID('location') !== null) $saveOptions[User::getUserOptionID('location')] = $facebookData['location']['name'];
-						if (isset($facebookData['website']) && User::getUserOptionID('website') !== null) {
-							$urls = preg_split('/[\s,;]/', $facebookData['website'], -1, PREG_SPLIT_NO_EMPTY);
-							if (!empty($urls)) {
-								if (!Regex::compile('^https?://')->match($urls[0])) {
-									$urls[0] = 'http://' . $urls[0];
-								}
-								
-								$saveOptions[User::getUserOptionID('homepage')] = $urls[0];
-							}
-						}
 						
 						// avatar
 						if (isset($facebookData['picture']) && !$facebookData['picture']['data']['is_silhouette']) {


### PR DESCRIPTION
As of April 4, 2018 the permissions `user_about_me` and `user_website` have been deprecated (see https://developers.facebook.com/docs/graph-api/changelog/breaking-changes/#4-4-2018).

App developers will see a notice, that they should update their app to no longer request these permissions. 

Since there isn't any alternative (or i havent found any), it can be completely removed.