### PR TITLE
Change the DefaultAvatar’s size to 128x128 pixels

### DIFF
--- a/wcfsetup/install/files/lib/data/user/avatar/DefaultAvatar.class.php
+++ b/wcfsetup/install/files/lib/data/user/avatar/DefaultAvatar.class.php
@@ -56,7 +56,7 @@ class DefaultAvatar implements IUserAvatar {
 			
 			// the <path> is basically a shorter version of a <rect>
 			$svg = <<<SVG
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill="#{$backgroundColor}" d="M0 0h16v16H0z"/><text x="8" y="8" fill="#{$textColor}" text-anchor="middle" dy=".3em" font-family="Arial" font-size="7">{$text}</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="128" height="128"><path fill="#{$backgroundColor}" d="M0 0h16v16H0z"/><text x="8" y="8" fill="#{$textColor}" text-anchor="middle" dy=".3em" font-family="Arial" font-size="7">{$text}</text></svg>
 SVG;
 			
 			$this->src = "data:image/svg+xml;base64," . base64_encode($svg);


### PR DESCRIPTION
Change the DefaultAvatar’s size to a more reasonable size of 128x128 pixels.
Throughout the Suite Core avatars are usually embedded via the `getImageTag` function
but when using the direct avatar URL a larger image is usually wanted.

Firefox for example does not upscale images used in `window.Notification`
thus the avatar would be rendered as a tiny 16x16 image in this case.
This change allows to downscale accordingly in this case.