### PR TITLE
Replace hard-coded bg-color of hovered table rows

### DIFF
--- a/wcfsetup/install/files/style/ui/tabularBox.scss
+++ b/wcfsetup/install/files/style/ui/tabularBox.scss
@@ -260,7 +260,7 @@
 	
 	tr {
 		&:hover > td {
-			background-color: rgb(242, 242, 242);
+			background-color: $wcfTabularBoxBackgroundActive;
 		}
 		
 		&:not(:last-child) > td {


### PR DESCRIPTION
Replace the hard-coded background color of hovered table rows with the correct style variable.