### PR TITLE
Be more accurate with benchmark

### DIFF
--- a/wcfsetup/install/files/lib/system/benchmark/Benchmark.class.php
+++ b/wcfsetup/install/files/lib/system/benchmark/Benchmark.class.php
@@ -20,7 +20,7 @@ class Benchmark extends SingletonFactory {
 	 * general benchmark start time
 	 * @var	float
 	 */
-	protected $startTime = $_SERVER['REQUEST_TIME_FLOAT'];
+	protected $startTime = 0;
 	
 	/**
 	 * benchmark items
@@ -39,6 +39,13 @@ class Benchmark extends SingletonFactory {
 	 * @var	float
 	 */
 	protected $queryTime = 0;
+	
+	/**
+	 * Creates a new Benchmark object.
+	 */
+	protected function init() {
+		$this->startTime = $_SERVER['REQUEST_TIME_FLOAT'];
+	}
 	
 	/**
 	 * Starts a benchmark.

--- a/wcfsetup/install/files/lib/system/benchmark/Benchmark.class.php
+++ b/wcfsetup/install/files/lib/system/benchmark/Benchmark.class.php
@@ -20,7 +20,7 @@ class Benchmark extends SingletonFactory {
 	 * general benchmark start time
 	 * @var	float
 	 */
-	protected $startTime = 0;
+	protected $startTime = $_SERVER['REQUEST_TIME_FLOAT'];
 	
 	/**
 	 * benchmark items
@@ -39,13 +39,6 @@ class Benchmark extends SingletonFactory {
 	 * @var	float
 	 */
 	protected $queryTime = 0;
-	
-	/**
-	 * Creates a new Benchmark object.
-	 */
-	protected function init() {
-		$this->startTime = self::getMicrotime();
-	}
 	
 	/**
 	 * Starts a benchmark.


### PR DESCRIPTION
Measure once the request has been received, and not when it has been already handled.

Especially noticeable on development environments with slower hard disk drives.