### PR TITLE
Append REQUEST_URI to database queries

### DIFF
--- a/com.woltlab.wcf/option.xml
+++ b/com.woltlab.wcf/option.xml
@@ -411,6 +411,11 @@
 				<optiontype>boolean</optiontype>
 				<defaultvalue>0</defaultvalue>
 			</option>
+			<option name="enable_production_debug_mode">
+				<categoryname>module.development</categoryname>
+				<optiontype>boolean</optiontype>
+				<defaultvalue>1</defaultvalue>
+			</option>
 			<option name="enable_benchmark">
 				<categoryname>module.development</categoryname>
 				<optiontype>boolean</optiontype>

--- a/wcfsetup/install/files/lib/system/database/Database.class.php
+++ b/wcfsetup/install/files/lib/system/database/Database.class.php
@@ -252,8 +252,8 @@ abstract class Database {
 				if (isset($_REQUEST['className']) && isset($_REQUEST['actionName'])) {
 					$requestInformation .= ' ('.$_REQUEST['className'].':'.$_REQUEST['actionName'].')';
 				}
+				$requestInformation = substr($requestInformation, 0, 180);
 			}
-			$requestInformation = substr($requestInformation, 0, 180);
 			
 			$pdoStatement = $this->pdo->prepare($statement.($requestInformation ? " -- ".$this->pdo->quote($requestInformation) : ''));
 			

--- a/wcfsetup/install/files/lib/system/database/Database.class.php
+++ b/wcfsetup/install/files/lib/system/database/Database.class.php
@@ -247,7 +247,7 @@ abstract class Database {
 			//       useful. Thus the code to retrieve the request information
 			//       must be absolutely lightweight.
 			$requestInformation = '';
-			if (isset($_SERVER['REQUEST_URI'])) {
+			if (ENABLE_PRODUCTION_DEBUG_MODE && isset($_SERVER['REQUEST_URI'])) {
 				$requestInformation = substr($_SERVER['REQUEST_URI'], 0, 90);
 				if (isset($_REQUEST['className']) && isset($_REQUEST['actionName'])) {
 					$requestInformation .= ' ('.$_REQUEST['className'].':'.$_REQUEST['actionName'].')';
@@ -255,7 +255,7 @@ abstract class Database {
 			}
 			$requestInformation = substr($requestInformation, 0, 180);
 			
-			$pdoStatement = $this->pdo->prepare($statement." -- ".$this->pdo->quote($requestInformation));
+			$pdoStatement = $this->pdo->prepare($statement.($requestInformation ? " -- ".$this->pdo->quote($requestInformation) : ''));
 			
 			return new $this->preparedStatementClassName($this, $pdoStatement, $statement);
 		}

--- a/wcfsetup/install/lang/de.xml
+++ b/wcfsetup/install/lang/de.xml
@@ -1162,6 +1162,8 @@
 		<item name="wcf.acp.option.show_version_number"><![CDATA[Versionsnummer der Software im Copyright-Hinweis anzeigen]]></item>
 		<item name="wcf.acp.option.enable_debug_mode"><![CDATA[Debug-Modus aktivieren]]></item>
 		<item name="wcf.acp.option.enable_debug_mode.description"><![CDATA[Aktiviert ausführliche Fehlerberichte. Diese Option sollte im Live-Betrieb abgeschaltet werden.]]></item>
+		<item name="wcf.acp.option.enable_production_debug_mode"><![CDATA[Problemanalyse im Live-Betrieb]]></item>
+		<item name="wcf.acp.option.enable_production_debug_mode.description"><![CDATA[Hängt die aktuelle URL an Datenbankabfragen an, um diese im Log des Datenbankservers einfacher identifizieren zu können.]]></item>
 		<item name="wcf.acp.option.external_link_rel_nofollow"><![CDATA[Externe Links mit dem Attribut „rel="nofollow"“ versehen]]></item>
 		<item name="wcf.acp.option.external_link_rel_nofollow.description"><![CDATA[Das Attribut „rel="nofollow"“ weist Suchmaschinen an, einen bestimmten Link auf einer Seite zu ignorieren.]]></item>
 		<item name="wcf.acp.option.external_link_target_blank"><![CDATA[Externe Links in neuem Fenster öffnen]]></item>

--- a/wcfsetup/install/lang/en.xml
+++ b/wcfsetup/install/lang/en.xml
@@ -1144,6 +1144,8 @@
 		<item name="wcf.acp.option.show_version_number"><![CDATA[Display version number in copyright notice]]></item>
 		<item name="wcf.acp.option.enable_debug_mode"><![CDATA[Enable debug mode]]></item>
 		<item name="wcf.acp.option.enable_debug_mode.description"><![CDATA[Enables extensive error messages, it should always be disabled in production environments!]]></item>
+		<item name="wcf.acp.option.enable_production_debug_mode"><![CDATA[Problem analysis in production environments]]></item>
+		<item name="wcf.acp.option.enable_production_debug_mode.description"><![CDATA[Appends the current URL to database queries to assist looking them up in the database server’s log files.]]></item>
 		<item name="wcf.acp.option.external_link_rel_nofollow"><![CDATA[Append the attribute “rel="nofollow"” to all external links]]></item>
 		<item name="wcf.acp.option.external_link_rel_nofollow.description"><![CDATA[The attribute “rel="nofollow"” tells search engines to disregard external links.]]></item>
 		<item name="wcf.acp.option.external_link_target_blank"><![CDATA[Open external links in a new window]]></item>


### PR DESCRIPTION
This is a first proof of concept commit to discuss whether we want something like this. I opted to directly access `$_SERVER['REQUEST_URI']` to keep the enhancement lightweight – it is a debugging feature for production after all.

----
This might come in handy to debug long running queries in
production.

Idea stolen from: https://chris-lamb.co.uk/projects/django-append-url-to-sql

![image](https://user-images.githubusercontent.com/209270/43526204-e6be960a-95a3-11e8-9f6c-9524560f8bc1.png)
