### PR TITLE
Support pluginStoreFileID tag from third party servers

### DIFF
--- a/wcfsetup/install/files/lib/system/package/PackageUpdateDispatcher.class.php
+++ b/wcfsetup/install/files/lib/system/package/PackageUpdateDispatcher.class.php
@@ -321,10 +321,8 @@ class PackageUpdateDispatcher extends SingletonFactory {
 				break;
 				
 				case 'pluginStoreFileID':
-					if ($updateServer->isWoltLabStoreServer()) {
-						$packageInfo['pluginStoreFileID'] = intval($element->nodeValue);
-					}
-					break;
+					$packageInfo['pluginStoreFileID'] = intval($element->nodeValue);
+				break;
 			}
 		}
 		


### PR DESCRIPTION
Remove the restriction to WoltLab's servers, since there is no good reason for a restriction.
In case anyone has stupid thoughts (simulating it's a checked/other package from the official plugin store or whatever) in his mind, he'd get what he want's anyway. And most or all _known_ third party developers are reliable.