### PR TITLE
fixed logged IP-address of authentication failure while logging is disabled

### DIFF
--- a/wcfsetup/install/files/lib/acp/form/LoginForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/LoginForm.class.php
@@ -151,7 +151,7 @@ class LoginForm extends AbstractCaptchaForm {
 						'userID' => $user->userID ?: null,
 						'username' => $this->username,
 						'time' => TIME_NOW,
-						'ipAddress' => UserUtil::getIpAddress(),
+						'ipAddress' => LOG_IP_ADDRESS ? UserUtil::getIpAddress() : '',
 						'userAgent' => UserUtil::getUserAgent()
 					]
 				]);


### PR DESCRIPTION
maybe we should add a notice that in case the IPs are not logged this security feature get's useless