### PR TITLE
Don't truncate cronjob descriptions

### DIFF
--- a/wcfsetup/install/files/acp/templates/cronjobList.tpl
+++ b/wcfsetup/install/files/acp/templates/cronjobList.tpl
@@ -86,9 +86,9 @@
 							<td class="columnDate columnStartDow">{$cronjob->startDow|truncate:30}</td>
 							<td class="columnText columnDescription" title="{$cronjob->description|language}">
 								{if $cronjob->isEditable()}
-									<a title="{lang}wcf.acp.cronjob.edit{/lang}" href="{link controller='CronjobEdit' id=$cronjob->cronjobID}{/link}">{$cronjob->description|language|truncate:50}</a>
+									<a title="{lang}wcf.acp.cronjob.edit{/lang}" href="{link controller='CronjobEdit' id=$cronjob->cronjobID}{/link}">{$cronjob->description|language}</a>
 								{else}
-									{$cronjob->description|language|truncate:50}
+									{$cronjob->description|language}
 								{/if}
 							</td>
 							<td class="columnDate columnNextExec">


### PR DESCRIPTION
Truncating after 50 chars is very ugly for high resolution displays like there is 4cm text and 15cm white space.
No matter which resolution, the text will be cut off after three lines, which makes it possible to display the full description on large screens but prevent large text blocks on mobile/small screens.

Before:
![image](https://user-images.githubusercontent.com/1749344/47856270-0f610300-dde7-11e8-8d84-f5beb5add11a.png)

After:
![image](https://user-images.githubusercontent.com/1749344/47856169-d163df00-dde6-11e8-986d-8be00c71fcf7.png)
