### PR TITLE
Add missing data-identifier to mobile menu

### DIFF
--- a/com.woltlab.wcf/templates/pageMenuMobile.tpl
+++ b/com.woltlab.wcf/templates/pageMenuMobile.tpl
@@ -3,7 +3,7 @@
 	<ol class="menuOverlayItemList" data-title="{lang}wcf.menu.page{/lang}">
 		<li class="menuOverlayTitle">{lang}wcf.menu.page.navigation{/lang}</li>
 		{foreach from=$__wcf->getBoxHandler()->getBoxByIdentifier('com.woltlab.wcf.MainMenu')->getMenu()->getMenuItemNodeList() item=menuItemNode}
-			<li class="menuOverlayItem">
+			<li class="menuOverlayItem" data-identifier="{@$menuItemNode->identifier}">
 				{assign var=__outstandingItems value=$menuItemNode->getOutstandingItems()}
 				<a href="{$menuItemNode->getURL()}" class="menuOverlayItemLink{if $__outstandingItems} menuOverlayItemBadge{/if}{if $menuItemNode->isActiveNode()} active{/if}"{if $menuItemNode->isExternalLink() && EXTERNAL_LINK_TARGET_BLANK} target="_blank"{/if}>
 					<span class="menuOverlayItemTitle">{lang}{$menuItemNode->title}{/lang}</span>


### PR DESCRIPTION
All menus items contain their identifier as data attribute.
This allows admins to easily add css specific to those links (like icons etc).
see: https://github.com/WoltLab/WCF/blob/master/com.woltlab.wcf/templates/__menu.tpl#L6
This is missing on the mobile menu version and added with this pull request.