### PR TITLE
fix fatal error when ImageMagick is not found during installation

### DIFF
--- a/wcfsetup/setup/template/stepShowSystemRequirements.tpl
+++ b/wcfsetup/setup/template/stepShowSystemRequirements.tpl
@@ -140,7 +140,7 @@
 				<dl class="col-xs-12 col-md-6">
 					<dt>{lang}wcf.global.systemRequirements.element.yours{/lang}</dt>
 					<dd>
-						<span class="badge {if !$system.imagick.result}red{elseif !$system.imagick.supportsAnimatedGIFs}yellow{else}green{/if}">{$system.imagick.value}</span>
+						<span class="badge {if !$system.imagick.result}red{elseif !$system.imagick.supportsAnimatedGIFs}yellow{else}green{/if}">{if !$system.imagick.result}{lang}wcf.global.systemRequirements.notActive{/lang}{else}{$system.imagick.value}{/if}</span>
 						{if !$system.imagick.result}<small>{lang}wcf.global.systemRequirements.imagick.description{/lang}</small>{/if}
 					</dd>
 				</dl>


### PR DESCRIPTION
trying to show the found version fails since the version get's assigned only in case the extension was found