### PR TITLE
Fix installation

### DIFF
--- a/wcfsetup/install/files/lib/data/language/Language.class.php
+++ b/wcfsetup/install/files/lib/data/language/Language.class.php
@@ -80,7 +80,7 @@ class Language extends DatabaseObject {
 	 * @return	string
 	 */
 	public function get($item, $optional = false) {
-		if (ENABLE_DEBUG_MODE && ENABLE_DEVELOPER_TOOLS && is_array($optional) && !empty($optional)) {
+		if (ENABLE_DEBUG_MODE && defined('ENABLE_DEVELOPER_TOOLS') && ENABLE_DEVELOPER_TOOLS && is_array($optional) && !empty($optional)) {
 			throw new \InvalidArgumentException("The second parameter of Language::get() does not support non-empty arrays. Did you mean to use Language::getDynamicVariable()?");
 		}
 		


### PR DESCRIPTION
597f120 broke the WSC installation process by not checking, if `ENABLE_DEVELOPER_TOOLS` is defined.