### PR TITLE
Improve information in the system tab on the admin panel index even more

### DIFF
--- a/wcfsetup/install/files/acp/templates/index.tpl
+++ b/wcfsetup/install/files/acp/templates/index.tpl
@@ -159,6 +159,13 @@
 			</dl>
 			
 			<dl>
+				<dt>upload_max_filesize</dt>
+				<dd>
+					{$server[uploadMaxFilesize]}
+				</dd>
+			</dl>
+			
+			<dl>
 				<dt>{lang}wcf.acp.index.system.php.sslSupport{/lang}</dt>
 				<dd>
 					{if $server[sslSupport]}{lang}wcf.acp.index.system.php.sslSupport.available{/lang}{else}{lang}wcf.acp.index.system.php.sslSupport.notAvailable{/lang}{/if}

--- a/wcfsetup/install/files/acp/templates/index.tpl
+++ b/wcfsetup/install/files/acp/templates/index.tpl
@@ -200,9 +200,9 @@
 					<ul class="inlineList commaSeparated">
 						<li>Tim D&uuml;sterhus</li>
 						<li>Alexander Ebert</li>
+						<li>Max Mader</li>
 						<li>Joshua R&uuml;sweg</li>
 						<li>Matthias Schmidt</li>
-						<li>Max Mader</li>
 						<li>Marcel Werk</li>
 					</ul>
 				</dd>

--- a/wcfsetup/install/files/acp/templates/index.tpl
+++ b/wcfsetup/install/files/acp/templates/index.tpl
@@ -195,6 +195,7 @@
 						<li>Alexander Ebert</li>
 						<li>Joshua R&uuml;sweg</li>
 						<li>Matthias Schmidt</li>
+						<li>Max Mader</li>
 						<li>Marcel Werk</li>
 					</ul>
 				</dd>

--- a/wcfsetup/install/files/lib/acp/page/IndexPage.class.php
+++ b/wcfsetup/install/files/lib/acp/page/IndexPage.class.php
@@ -36,6 +36,7 @@ class IndexPage extends AbstractPage {
 			'load' => '',
 			'memoryLimit' => @ini_get('memory_limit'),
 			'postMaxSize' => @ini_get('post_max_size'),
+			'uploadMaxFilesize' => @ini_get('upload_max_filesize'),
 			'sslSupport' => RemoteFile::supportsSSL()
 		];
 		


### PR DESCRIPTION
Displaying some important PHP settings directly on the index page (d473e26) is a nice idea. However, i would recommend to display the value of `upload_max_filesize` as well, next to `post_max_size`, which is already there.

Furthermore, the list of developers is incomplete. The latest developer is missing here.