### PR TITLE
accept .gz, .tar and .tgz only for package installation/upload

### DIFF
--- a/wcfsetup/install/files/acp/templates/packageStartInstall.tpl
+++ b/wcfsetup/install/files/acp/templates/packageStartInstall.tpl
@@ -80,7 +80,7 @@
 				<dl{if $errorField == 'uploadPackage'} class="formError"{/if}>
 					<dt><label for="uploadPackage">{lang}wcf.acp.package.source.upload{/lang}</label></dt>
 					<dd>
-						<input type="file" id="uploadPackage" name="uploadPackage" value="">
+						<input type="file" id="uploadPackage" name="uploadPackage" value="" accept="application/x-tar,application/gzip,application/tar+gzip">
 						{if $errorField == 'uploadPackage'}
 							<small class="innerError">
 								{if $errorType == 'empty'}


### PR DESCRIPTION
Prevent new user's from selecting the zip file containing the first-installation-tool