### PR TITLE
Fix background queue repetition logic in JavaScript

### DIFF
--- a/wcfsetup/install/files/js/WoltLabSuite/Core/BackgroundQueue.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/BackgroundQueue.js
@@ -37,7 +37,6 @@ define(['Ajax'], function(Ajax) {
 			
 			if (_isBusy) return;
 			
-			_invocations = 0;
 			_isBusy = true;
 			
 			Ajax.api(this);
@@ -48,10 +47,14 @@ define(['Ajax'], function(Ajax) {
 			
 			// invoke the queue up to 5 times in a row
 			if (data > 0 && _invocations < 5) {
-				window.setTimeout(this.invoke.bind(this), 1000);
+				window.setTimeout(function () {
+					_isBusy = false;
+					this.invoke();
+				}.bind(this), 1000);
 			}
 			else {
 				_isBusy = false;
+				_invocations = 0;
 			}
 		},
 		


### PR DESCRIPTION
This is not yet tested, therefore marking as WIP.

The incorrect reset of the `_isBusy` flag prevented the timer from doing anything useful. This change attempts to induce the intended behaviour (resetting `_invocations` instead of `_isBusy` once the “chain” ends).