### PR TITLE
Delete firstVisit = true, userID = 0 sessions after processing backgr…

### DIFF
--- a/wcfsetup/install/files/lib/action/BackgroundQueuePerformAction.class.php
+++ b/wcfsetup/install/files/lib/action/BackgroundQueuePerformAction.class.php
@@ -1,6 +1,7 @@
 <?php
 namespace wcf\action;
 use wcf\system\background\BackgroundQueueHandler;
+use wcf\system\WCF;
 
 /**
  * Performs background queue jobs.
@@ -32,6 +33,9 @@ class BackgroundQueuePerformAction extends AbstractAction {
 			}
 		}
 		echo BackgroundQueueHandler::getInstance()->getRunnableCount();
+		if (WCF::getSession()->isFirstVisit() && !WCF::getUser()->userID) {
+			WCF::getSession()->delete();
+		}
 		exit;
 	}
 }

--- a/wcfsetup/install/files/lib/action/BackgroundQueuePerformAction.class.php
+++ b/wcfsetup/install/files/lib/action/BackgroundQueuePerformAction.class.php
@@ -33,9 +33,7 @@ class BackgroundQueuePerformAction extends AbstractAction {
 			}
 		}
 		echo BackgroundQueueHandler::getInstance()->getRunnableCount();
-		if (WCF::getSession()->isFirstVisit() && !WCF::getUser()->userID) {
-			WCF::getSession()->delete();
-		}
+		WCF::getSession()->deleteIfNew();
 		exit;
 	}
 }

--- a/wcfsetup/install/files/lib/system/session/SessionHandler.class.php
+++ b/wcfsetup/install/files/lib/system/session/SessionHandler.class.php
@@ -990,6 +990,25 @@ class SessionHandler extends SingletonFactory {
 	}
 	
 	/**
+	 * Deletes this session if:
+	 * - it is newly created in this request, and
+	 * - it belongs to a guest.
+	 * 
+	 * This method is useful if you have controllers that are likely to be
+	 * accessed by a user agent that is not going to re-use sessions (e.g.
+	 * curl in a cronjob). It immediately remove the session that was created
+	 * just for that request and that is not going to be used ever again.
+	 * 
+	 * @since 5.2
+	 */
+	public function deleteIfNew() {
+		if (!$this->isFirstVisit()) return;
+		if ($this->getUser()->userID) return;
+		
+		$this->delete();
+	}
+	
+	/**
 	 * Returns currently active language id.
 	 * 
 	 * @return	integer

--- a/wcfsetup/install/files/lib/system/session/SessionHandler.class.php
+++ b/wcfsetup/install/files/lib/system/session/SessionHandler.class.php
@@ -1002,10 +1002,9 @@ class SessionHandler extends SingletonFactory {
 	 * @since 5.2
 	 */
 	public function deleteIfNew() {
-		if (!$this->isFirstVisit()) return;
-		if ($this->getUser()->userID) return;
-		
-		$this->delete();
+		if ($this->isFirstVisit() && !$this->getUser()->userID) {
+			$this->delete();
+		}
 	}
 	
 	/**


### PR DESCRIPTION
…ound queue

These sessions most likely stem from a script / cronjob that is set-up
to regularly request the background queue to ensure it does not fill up
in periods of low user activity. They “fill up” the session table, skew
the user online statistics and are not going to be re-used.