### PR TITLE
Add possiblity to force deactivation of opcache

### DIFF
--- a/wcfsetup/install/files/lib/system/WCF.class.php
+++ b/wcfsetup/install/files/lib/system/WCF.class.php
@@ -973,7 +973,7 @@ class WCF {
 		if (self::$zendOpcacheEnabled === null) {
 			self::$zendOpcacheEnabled = false;
 			
-			if (extension_loaded('Zend Opcache') && @ini_get('opcache.enable')) {
+			if (!defined('DISABLE_ZEND_OPCACHE') && extension_loaded('Zend Opcache') && @ini_get('opcache.enable')) {
 				self::$zendOpcacheEnabled = true;
 			}
 			


### PR DESCRIPTION
This quite simple, suggested change would make it possible to support this Suite being hosted by hosting companies that aren't able to isolate the environments, but still claim to provide the `Zend Opcache`.

I decided against an option in the ACP to prevent misuse by inexperienced users. 

ref https://community.woltlab.com/thread/275439-fehler-bei-der-installation-opcache-invalidate-has-been-disabled/