### PR TITLE
Performance Optimizations

### DIFF
--- a/wcfsetup/install.php
+++ b/wcfsetup/install.php
@@ -528,6 +528,10 @@ function handleError($errorNo, $message, $filename, $lineNo) {
 	}
 }
 
+if (!function_exists('is_countable')) {
+	function is_countable($var) { return is_array($var) || $var instanceof Countable || $var instanceof ResourceBundle || $var instanceof SimpleXmlElement; }
+}
+
 /** @noinspection PhpMultipleClassesDeclarationsInOneFile */
 /**
  * BasicFileUtil contains file-related functions.

--- a/wcfsetup/install/files/lib/core.functions.php
+++ b/wcfsetup/install/files/lib/core.functions.php
@@ -88,6 +88,10 @@ namespace {
 	if (@ini_get('zlib.output_compression')) {
 		@ini_set('zlib.output_compression', '0');
 	}
+	
+	if (!function_exists('is_countable')) {
+		function is_countable($var) { return is_array($var) || $var instanceof Countable || $var instanceof ResourceBundle || $var instanceof SimpleXmlElement; }
+	}
 }
 
 // @codingStandardsIgnoreStart

--- a/wcfsetup/install/files/lib/data/language/Language.class.php
+++ b/wcfsetup/install/files/lib/data/language/Language.class.php
@@ -3,6 +3,7 @@ namespace wcf\data\language;
 use wcf\data\DatabaseObject;
 use wcf\system\language\LanguageFactory;
 use wcf\system\WCF;
+use wcf\util\StringUtil;
 
 /**
  * Represents a language.
@@ -168,6 +169,31 @@ class Language extends DatabaseObject {
 		}
 		
 		return $staticItem;
+	}
+	
+	/**
+	 * Shortcut method to reduce the code repetition in the compiled template code.
+	 * 
+	 * @param string $item
+	 * @param mixed[] $tagStackData
+	 * @return string
+	 * @since 5.2
+	 */
+	public function tplGet($item, array &$tagStackData) {
+		$optional = !empty($tagStackData['__optional']);
+		
+		if (!empty($tagStackData['__literal'])) {
+			$value = $this->get($item, $optional);
+		}
+		else {
+			$value = $this->getDynamicVariable($item, $tagStackData, $optional);
+		}
+		
+		if (!empty($tagStackData['__encode'])) {
+			return StringUtil::encodeHTML($value);
+		}
+		
+		return $value;
 	}
 	
 	/**

--- a/wcfsetup/install/files/lib/system/SingletonFactory.class.php
+++ b/wcfsetup/install/files/lib/system/SingletonFactory.class.php
@@ -49,13 +49,15 @@ abstract class SingletonFactory {
 	 * @throws	SystemException
 	 */
 	public static final function getInstance() {
-		$className = get_called_class();
-		if (!array_key_exists($className, self::$__singletonObjects)) {
-			self::$__singletonObjects[$className] = null;
+		$className = static::class;
+		if (!isset(self::$__singletonObjects[$className])) {
+			// The previously used `null` value forced us into using `array_key_exists()` which has a bad performance,
+			// especially with the growing list of derived classes that are used today. Saves a few ms on every request.
+			self::$__singletonObjects[$className] = false;
 			self::$__singletonObjects[$className] = new $className();
 		}
-		else if (self::$__singletonObjects[$className] === null) {
-			throw new SystemException("Infinite loop detected while trying to retrieve object for '".$className."'");
+		else if (self::$__singletonObjects[$className] === false) {
+			throw new SystemException("Infinite loop detected while trying to retrieve object for '" . $className . "'");
 		}
 		
 		return self::$__singletonObjects[$className];

--- a/wcfsetup/install/files/lib/system/WCF.class.php
+++ b/wcfsetup/install/files/lib/system/WCF.class.php
@@ -789,9 +789,10 @@ class WCF {
 			}
 			if (isset(self::$autoloadDirectories[$applicationPrefix])) {
 				$classPath = self::$autoloadDirectories[$applicationPrefix] . implode('/', $namespaces) . '.class.php';
-				if (file_exists($classPath)) {
-					require_once($classPath);
-				}
+				
+				// PHP will implicitly check if the file exists when including it, which means that we can save a
+				// redundant syscall/fs access by not checking for existence ourselves. Do not use require_once()!
+				@include_once($classPath);
 			}
 		}
 	}

--- a/wcfsetup/install/files/lib/system/template/plugin/LangCompilerTemplatePlugin.class.php
+++ b/wcfsetup/install/files/lib/system/template/plugin/LangCompilerTemplatePlugin.class.php
@@ -23,7 +23,7 @@ class LangCompilerTemplatePlugin implements ICompilerTemplatePlugin {
 		
 		$tagArgs = $compiler::makeArgString($tagArgs);
 		return "<?php
-			\$this->tagStack[] = array('lang', array_merge(\$this->v, array($tagArgs)));
+			\$this->tagStack[] = ['lang', array_merge(\$this->v, [$tagArgs])];
 			ob_start();
 			?>";
 	}
@@ -34,36 +34,7 @@ class LangCompilerTemplatePlugin implements ICompilerTemplatePlugin {
 	public function executeEnd(TemplateScriptingCompiler $compiler) {
 		$compiler->popTag('lang');
 		return "<?php
-			\$__langCompilerTemplatePluginOutput = (
-				!empty(\$this->tagStack[count(\$this->tagStack) - 1][1]['__literal'])
-				?
-				wcf\system\WCF::getLanguage()->get(
-					ob_get_clean(),
-					(
-						isset(\$this->tagStack[count(\$this->tagStack) - 1][1]['__optional'])
-						?
-						\$this->tagStack[count(\$this->tagStack) - 1][1]['__optional']
-						:
-						false
-					)
-				)
-				:
-				wcf\system\WCF::getLanguage()->getDynamicVariable(
-					ob_get_clean(),
-					\$this->tagStack[count(\$this->tagStack) - 1][1],
-					(
-						isset(\$this->tagStack[count(\$this->tagStack) - 1][1]['__optional'])
-						?
-						\$this->tagStack[count(\$this->tagStack) - 1][1]['__optional']
-						:
-						false
-					)
-				)
-			);
-			
-			if (!empty(\$this->tagStack[count(\$this->tagStack) - 1][1]['__encode'])) \$__langCompilerTemplatePluginOutput = wcf\util\StringUtil::encodeHTML(\$__langCompilerTemplatePluginOutput);
-			echo \$__langCompilerTemplatePluginOutput;
-			
+			echo wcf\system\WCF::getLanguage()->tplGet(ob_get_clean(), \$this->tagStack[count(\$this->tagStack) - 1][1]);
 			array_pop(\$this->tagStack); ?>";
 	}
 }

--- a/wcfsetup/install/files/lib/util/StringUtil.class.php
+++ b/wcfsetup/install/files/lib/util/StringUtil.class.php
@@ -119,20 +119,8 @@ final class StringUtil {
 	 * @return	string
 	 */
 	public static function encodeJS($string) {
-		// unify newlines
 		$string = self::unifyNewlines($string);
-		
-		// escape backslash
-		$string = str_replace("\\", "\\\\", $string);
-		
-		// escape singe quote
-		$string = str_replace("'", "\'", $string);
-		
-		// escape new lines
-		$string = str_replace("\n", '\n', $string);
-		
-		// escape slashes
-		$string = str_replace("/", '\/', $string);
+		$string = str_replace(["\\", "'", "\n", "/"], ["\\\\", "\'", '\n', '\/'], $string);
 		
 		return $string;
 	}


### PR DESCRIPTION
These changes improve the overall site performance by around 5-15 percent, depending on the actual content, with performance gains increasing with the code complexity. The changes were tested with both the built in benchmark (100 runs each) and using Xdebug's profiler.

However, these are rather conservative changes that aim to improve the performance of existing code, rather than rewriting things in order to gain more performance. All changes yield a performance delta of above 1%, the size of the compiled templates is reduced by 10% on average.