### PR TITLE
Detection of plain links, CSS for embedded content

### DIFF
--- a/wcfsetup/install/files/lib/system/html/input/node/HtmlInputNodeProcessor.class.php
+++ b/wcfsetup/install/files/lib/system/html/input/node/HtmlInputNodeProcessor.class.php
@@ -3,6 +3,7 @@ namespace wcf\system\html\input\node;
 use wcf\system\bbcode\BBCodeHandler;
 use wcf\system\event\EventHandler;
 use wcf\system\html\node\AbstractHtmlNodeProcessor;
+use wcf\system\html\node\HtmlNodePlainLink;
 use wcf\system\html\node\IHtmlNode;
 use wcf\util\DOMUtil;
 use wcf\util\StringUtil;
@@ -30,12 +31,12 @@ class HtmlInputNodeProcessor extends AbstractHtmlNodeProcessor {
 			'messageFloatObjectLeft', 'messageFloatObjectRight',
 			
 			// built-in
-			'smiley', 'woltlabAttachment', 'woltlabSuiteMedia'
+			'smiley', 'woltlabAttachment', 'woltlabSuiteMedia',
 		],
 		'li' => ['text-center', 'text-justify', 'text-right'],
 		'p' => ['text-center', 'text-justify', 'text-right'],
 		'pre' => ['woltlabHtml'],
-		'td' => ['text-center', 'text-justify', 'text-right']
+		'td' => ['text-center', 'text-justify', 'text-right'],
 	];
 	
 	/**
@@ -48,7 +49,7 @@ class HtmlInputNodeProcessor extends AbstractHtmlNodeProcessor {
 	 * @var string[]
 	 */
 	public static $allowedStyleElements = [
-		'span'
+		'span',
 	];
 	
 	/**
@@ -71,8 +72,13 @@ class HtmlInputNodeProcessor extends AbstractHtmlNodeProcessor {
 		'ul', 'ol', 'li',
 		
 		// other
-		'a', 'kbd', 'woltlab-quote', 'woltlab-spoiler', 'pre', 'sub', 'sup'
+		'a', 'kbd', 'woltlab-quote', 'woltlab-spoiler', 'pre', 'sub', 'sup',
 	];
+	
+	/**
+	 * @var HtmlNodePlainLink[]
+	 */
+	public $plainLinks = [];
 	
 	/**
 	 * list of embedded content grouped by type
@@ -89,6 +95,8 @@ class HtmlInputNodeProcessor extends AbstractHtmlNodeProcessor {
 	 * @inheritDoc
 	 */
 	public function process() {
+		$this->plainLinks = [];
+		
 		EventHandler::getInstance()->fireAction($this, 'beforeProcess');
 		
 		// fix invalid html such as metacode markers outside of block elements
@@ -156,6 +164,8 @@ class HtmlInputNodeProcessor extends AbstractHtmlNodeProcessor {
 		
 		// extract embedded content
 		$this->processEmbeddedContent();
+		
+		$this->convertPlainLinks();
 		
 		EventHandler::getInstance()->fireAction($this, 'afterProcess');
 	}
@@ -415,7 +425,7 @@ class HtmlInputNodeProcessor extends AbstractHtmlNodeProcessor {
 			'font' => 'woltlab-size',
 			'size' => 'woltlab-size',
 			'spoiler' => 'woltlab-spoiler',
-			'url' => 'a'
+			'url' => 'a',
 		];
 		
 		foreach ($customTags as $bbcode => $tagName) {
@@ -504,7 +514,7 @@ class HtmlInputNodeProcessor extends AbstractHtmlNodeProcessor {
 	}
 	
 	/**
-	 * Parses embedded content containedin metacode elements.
+	 * Parses embedded content contained in metacode elements.
 	 */
 	protected function parseEmbeddedContent() {
 		// handle `woltlab-metacode`
@@ -540,5 +550,78 @@ class HtmlInputNodeProcessor extends AbstractHtmlNodeProcessor {
 		$element->setAttribute('data-attributes', base64_encode(json_encode($attributes)));
 		
 		return $element;
+	}
+	
+	/**
+	 * Detects links that contain nothing but their link target. Additionally, standalone links, i. e.
+	 * those that are the only content in their line, are offered separately.
+	 * 
+	 * @since 5.2
+	 */
+	protected function convertPlainLinks() {
+		/** @var HtmlNodePlainLink[] $links */
+		$links = [];
+		
+		/** @var \DOMElement $link */
+		foreach ($this->getDocument()->getElementsByTagName('a') as $link) {
+			$href = $link->getAttribute('href');
+			if ($href !== $link->textContent) {
+				continue;
+			}
+			
+			$plainLink = new HtmlNodePlainLink($link, $href);
+			
+			// Check if the line appears to only contain the link text.
+			$parent = $link;
+			while ($parent->parentNode->nodeName !== 'body') {
+				$parent = $parent->parentNode;
+			}
+			
+			if ($parent->nodeName === 'p' && $parent->textContent === $link->textContent) {
+				// The line may contain nothing but the link, exceptions include basic formatting
+				// and up to a single `<br>` element.
+				$mayContainOtherContent = false;
+				$linebreaks = 0;
+				/** @var \DOMElement $element */
+				foreach ($parent->getElementsByTagName('*') as $element) {
+					switch ($element->nodeName) {
+						case 'br':
+							$linebreaks++;
+							break;
+							
+						case 'span':
+							if ($element->getAttribute('class')) {
+								$mayContainOtherContent = true;
+								break 2;
+							}
+							
+							// `<span>` is used to hold text formatting.
+							break;
+							
+						case 'a':
+						case 'b':
+						case 'em':
+						case 'i':
+						case 'strong':
+						case 'u':
+							// These elements are perfectly fine.
+							break;
+							
+						default:
+							$mayContainOtherContent = true;
+							break 2;
+					}
+				}
+				
+				if (!$mayContainOtherContent || $linebreaks > 1) {
+					$this->plainLinks[] = $plainLink->setIsStandalone($parent);
+					continue;
+				}
+			}
+			
+			$this->plainLinks[] = $plainLink->setIsInline();
+		}
+		
+		EventHandler::getInstance()->fireAction($this, 'convertPlainLinks');
 	}
 }

--- a/wcfsetup/install/files/lib/system/html/input/node/HtmlInputNodeProcessor.class.php
+++ b/wcfsetup/install/files/lib/system/html/input/node/HtmlInputNodeProcessor.class.php
@@ -162,10 +162,11 @@ class HtmlInputNodeProcessor extends AbstractHtmlNodeProcessor {
 		
 		EventHandler::getInstance()->fireAction($this, 'beforeEmbeddedProcess');
 		
+		$this->convertPlainLinks();
+		
 		// extract embedded content
 		$this->processEmbeddedContent();
 		
-		$this->convertPlainLinks();
 		
 		EventHandler::getInstance()->fireAction($this, 'afterProcess');
 	}
@@ -613,7 +614,7 @@ class HtmlInputNodeProcessor extends AbstractHtmlNodeProcessor {
 					}
 				}
 				
-				if (!$mayContainOtherContent || $linebreaks > 1) {
+				if (!$mayContainOtherContent || $linebreaks <= 1) {
 					$this->plainLinks[] = $plainLink->setIsStandalone($parent);
 					continue;
 				}

--- a/wcfsetup/install/files/lib/system/html/input/node/HtmlInputNodeProcessor.class.php
+++ b/wcfsetup/install/files/lib/system/html/input/node/HtmlInputNodeProcessor.class.php
@@ -167,7 +167,6 @@ class HtmlInputNodeProcessor extends AbstractHtmlNodeProcessor {
 		// extract embedded content
 		$this->processEmbeddedContent();
 		
-		
 		EventHandler::getInstance()->fireAction($this, 'afterProcess');
 	}
 	

--- a/wcfsetup/install/files/lib/system/html/node/HtmlNodePlainLink.class.php
+++ b/wcfsetup/install/files/lib/system/html/node/HtmlNodePlainLink.class.php
@@ -1,0 +1,103 @@
+<?php
+namespace wcf\system\html\node;
+
+use wcf\data\bbcode\BBCode;
+use wcf\data\ITitledObject;
+use wcf\system\Regex;
+use wcf\util\DOMUtil;
+use wcf\util\JSON;
+
+class HtmlNodePlainLink {
+	protected $href = '';
+	
+	/**
+	 * @var \DOMElement
+	 */
+	protected $link;
+	protected $objectID = 0;
+	protected $pristine = true;
+	protected $standalone = false;
+	
+	/**
+	 * @var \DOMElement
+	 */
+	protected $topLevelParent;
+	
+	public function __construct(\DOMElement $link, $href) {
+		$this->link = $link;
+		$this->href = $href;
+	}
+	
+	public function setIsInline() {
+		$this->standalone = false;
+		$this->topLevelParent = null;
+		
+		return $this;
+	}
+	
+	public function setIsStandalone(\DOMElement $topLevelParent) {
+		$this->standalone = true;
+		$this->topLevelParent = $topLevelParent;
+		
+		return $this;
+	}
+	
+	public function isPristine() {
+		return $this->pristine;
+	}
+	
+	public function isStandalone() {
+		return $this->standalone;
+	}
+	
+	public function detectObjectID(Regex $regex) {
+		if ($regex->match($this->href, true)) {
+			$this->objectID = $regex->getMatches()[2][0];
+		}
+		
+		return $this->objectID;
+	}
+	
+	public function getObjectID() {
+		return $this->objectID;
+	}
+	
+	public function setTitle(ITitledObject $object) {
+		$this->markAsTainted();
+		
+		$this->link->nodeValue = '';
+		$this->link->appendChild($this->link->ownerDocument->createTextNode($object->getTitle()));
+	}
+	
+	public function replaceWithBBCode(BBCode $bbcode) {
+		$this->markAsTainted();
+		
+		if ($this->objectID === 0) {
+			throw new \UnexpectedValueException('The objectID must not be null.');
+		}
+		
+		$metacodeElement = $this->link->ownerDocument->createElement('woltlab-metacode');
+		$metacodeElement->setAttribute('data-name', $bbcode->bbcodeTag);
+		$metacodeElement->setAttribute('data-attributes', base64_encode(JSON::encode([$this->objectID])));
+		
+		if ($bbcode->isBlockElement) {
+			if (!$this->isStandalone()) {
+				throw new \LogicException('Cannot inject a block bbcode in an inline context.');
+			}
+			
+			// Replace the top level parent with the link itself, which will be replaced with the bbcode afterwards.
+			$this->topLevelParent->insertBefore($this->link, $this->topLevelParent);
+			DOMUtil::removeNode($this->topLevelParent);
+		}
+		
+		DOMUtil::replaceElement($this->link, $metacodeElement, false);
+	}
+	
+	protected function markAsTainted() {
+		if (!$this->pristine) {
+			throw new \RuntimeException('This link has already been modified.');
+		}
+		
+		$this->pristine = false;
+	}
+}

--- a/wcfsetup/install/files/lib/system/html/node/HtmlNodePlainLink.class.php
+++ b/wcfsetup/install/files/lib/system/html/node/HtmlNodePlainLink.class.php
@@ -144,7 +144,7 @@ class HtmlNodePlainLink {
 		$this->markAsTainted();
 		
 		if ($this->objectID === 0) {
-			throw new \UnexpectedValueException('The objectID must not be null.');
+			throw new \UnexpectedValueException('The objectID must not be zero.');
 		}
 		
 		$metacodeElement = $this->link->ownerDocument->createElement('woltlab-metacode');

--- a/wcfsetup/install/files/lib/system/html/output/HtmlOutputProcessor.class.php
+++ b/wcfsetup/install/files/lib/system/html/output/HtmlOutputProcessor.class.php
@@ -16,11 +16,11 @@ use wcf\system\message\embedded\object\MessageEmbeddedObjectManager;
  */
 class HtmlOutputProcessor extends AbstractHtmlProcessor {
 	/**
-	 * generate the table of contents
-	 * @var bool
+	 * Generate the table of contents, implicitly enable this for certain object types on demand.
+	 * @var bool|null
 	 * @since	5.2
 	 */
-	public $enableToc = false;
+	public $enableToc;
 	
 	/**
 	 * Removes any link contained inside the message text.
@@ -96,7 +96,9 @@ class HtmlOutputProcessor extends AbstractHtmlProcessor {
 		
 		MessageEmbeddedObjectManager::getInstance()->setActiveMessage($objectType, $objectID, $this->languageID);
 		$objectType = ObjectTypeCache::getInstance()->getObjectTypeByName('com.woltlab.wcf.message', $objectType);
-		$this->enableToc = (!empty($objectType->additionalData['enableToc']));
+		if ($this->enableToc === null) {
+			$this->enableToc = (!empty($objectType->additionalData['enableToc']));
+		}
 	}
 	
 	/**

--- a/wcfsetup/install/files/style/ui/embeddedContent.scss
+++ b/wcfsetup/install/files/style/ui/embeddedContent.scss
@@ -1,0 +1,73 @@
+.embeddedContent {
+	background-color: $wcfContentBackground;
+	border: 1px solid $wcfContentBorderInner;
+	border-radius: 3px;
+	margin: 10px 0;
+}
+
+.embeddedContentLink {
+	display: block;
+	padding: 10px;
+}
+
+.embeddedContentCategory {
+	color: $wcfContentDimmedText;
+	text-transform: uppercase;
+	
+	@include wcfFontSmall;
+}
+
+.embeddedContentTitle {
+	color: $wcfContentHeadlineText;
+	margin-bottom: 20px;
+	
+	@include wcfFontHeadline;
+	@include wcfFontBold;
+}
+
+.embeddedContentDescription {
+	color: $wcfContentText;
+	max-height: 120px;
+	overflow: hidden;
+	position: relative;
+}
+.embeddedContentDescription::after {
+	background-image: linear-gradient(to top, $wcfContentBackground, transparent);
+	bottom: 0;
+	content: "";
+	left: 0;
+	position: absolute;
+	right: 0;
+	top: 100px;
+}
+
+.embeddedContentMeta {
+	align-items: center;
+	border-top: 1px solid $wcfContentBorderInner;
+	color: $wcfContentDimmedText;
+	display: flex;
+	padding: 10px;
+	
+	@include wcfFontSmall;
+}
+
+.embeddedContentMetaImage {
+	flex: 0 auto;
+	margin-right: 10px;
+}
+
+.embeddedContentMetaContent {
+	flex: 1 auto;
+}
+
+.embeddedContentMetaAuthor {
+	color: $wcfContentText;
+	
+	> a {
+		color: inherit;
+		
+		&:hover {
+			text-decoration: underline;
+		}
+	}
+}


### PR DESCRIPTION
Plain links are `<a>` elements that use their `href` value as text content, the detection also determines if the link is "standalone", which means that it is the only content in a dedicated line.