### PR TITLE
New group type "Owner"

### DIFF
--- a/wcfsetup/install/files/acp/style/layout.scss
+++ b/wcfsetup/install/files/acp/style/layout.scss
@@ -441,3 +441,26 @@ $wcfAcpSubMenuWidth: 300px;
 		width: 100% !important;
 	}
 }
+
+/* Owner Group */
+#wscMissingOwnerGroup {
+	background-color: rgb(248, 215, 218);
+	border-top: 5px solid red;
+	bottom: 0;
+	color: rgb(114, 28, 36);
+	left: 0;
+	padding: 10px;
+	position: fixed;
+	text-align: center;
+	right: 0;
+	z-index: 9999;
+	
+	@include screen-md-up {
+		padding: 20px;
+	}
+	
+	> a {
+		color: inherit;
+		text-decoration: underline;
+	}
+}

--- a/wcfsetup/install/files/acp/templates/footer.tpl
+++ b/wcfsetup/install/files/acp/templates/footer.tpl
@@ -8,6 +8,10 @@
 
 {if $__isRescueMode|empty}{include file='pageMenuMobile'}{/if}
 
+{if !$__wscMissingOwnerGroup|empty}
+	<div id="wscMissingOwnerGroup" role="alert">{lang}wcf.acp.group.missingOwnerGroup{/lang}</div>
+{/if}
+
 {event name='footer'}
 
 <!-- JAVASCRIPT_RELOCATE_POSITION -->

--- a/wcfsetup/install/files/acp/templates/optionFieldList.tpl
+++ b/wcfsetup/install/files/acp/templates/optionFieldList.tpl
@@ -1,4 +1,5 @@
 {if !$isGuestGroup|isset}{assign var=isGuestGroup value=false}{/if}
+{if !$groupIsOwner|isset}{assign var=groupIsOwner value=false}{/if}
 {foreach from=$options item=optionData}
 	{assign var=option value=$optionData[object]}
 	{if $errorType|is_array && $errorType[$option->optionName]|isset}
@@ -7,7 +8,16 @@
 		{assign var=error value=''}
 	{/if}
 	<dl class="{$option->optionName}Input{if $error} formError{/if}">
-		<dt{if $optionData[cssClassName]} class="{$optionData[cssClassName]}"{/if}>{if $isSearchMode|empty || !$optionData[hideLabelInSearch]}<label for="{$option->optionName}">{if VISITOR_USE_TINY_BUILD && $isGuestGroup && $option->excludedInTinyBuild}<span class="icon icon16 fa-bolt red jsTooltip" title="{lang}wcf.acp.group.excludedInTinyBuild{/lang}"></span> {/if}{lang}{@$langPrefix}{$option->optionName}{/lang}</label>{/if}</dt>
+		<dt{if $optionData[cssClassName]} class="{$optionData[cssClassName]}"{/if}>
+			{if $isSearchMode|empty || !$optionData[hideLabelInSearch]}
+				<label for="{$option->optionName}">
+					{if VISITOR_USE_TINY_BUILD && $isGuestGroup && $option->excludedInTinyBuild}<span class="icon icon16 fa-bolt red jsTooltip" title="{lang}wcf.acp.group.excludedInTinyBuild{/lang}"></span> {/if}
+					{if $groupIsOwner && $option->optionName|in_array:$ownerGroupPermissions}<span class="icon icon16 fa-shield jsTooltip" title="{lang}wcf.acp.group.ownerGroupPermission{/lang}"></span> {/if}
+					
+					{lang}{@$langPrefix}{$option->optionName}{/lang}
+				</label>
+			{/if}
+		</dt>
 		<dd>{@$optionData[html]}
 			{if $error}
 				<small class="innerError">

--- a/wcfsetup/install/files/acp/templates/userAdd.tpl
+++ b/wcfsetup/install/files/acp/templates/userAdd.tpl
@@ -602,4 +602,28 @@
 	</div>
 </form>
 
+{if $action === 'edit' && $ownerGroupID}
+	<script data-relocate="true">
+		(function() {
+			var input = elBySel('input[name="groupIDs[]"][value="{@$ownerGroupID}"]');
+			if (input) {
+				var icon = elCreate('span');
+				icon.className = 'icon icon16 fa-shield jsTooltip';
+				icon.title = '{lang}wcf.acp.group.type.owner{/lang}';
+				input.parentNode.appendChild(icon);
+				
+				{if $user->userID == $__wcf->user->userID}
+					var shadow = elCreate('input');
+					shadow.name = input.name;
+					shadow.type = 'hidden';
+					shadow.value = input.value;
+					
+					input.parentNode.appendChild(shadow);
+					input.disabled = true;
+				{/if}
+			}
+		})();
+	</script>
+{/if}
+
 {include file='footer'}

--- a/wcfsetup/install/files/acp/templates/userGroupAdd.tpl
+++ b/wcfsetup/install/files/acp/templates/userGroupAdd.tpl
@@ -71,6 +71,10 @@
 	<p class="warning">{lang}wcf.acp.group.excludedInTinyBuild.notice{/lang}</p>
 {/if}
 
+{if $action == 'edit' && $group->isOwner()}
+	<p class="info"><span class="icon icon16 fa-shield"></span> {lang}wcf.acp.group.type.owner.description{/lang}</p>
+{/if}
+
 {if $warningSelfEdit|isset}
 	<p class="warning">{lang}wcf.acp.group.edit.warning.selfIsMember{/lang}</p>
 {/if}
@@ -218,5 +222,41 @@
 		{@SECURITY_TOKEN_INPUT_TAG}
 	</div>
 </form>
+
+{if $action === 'edit'}
+	<script>
+		(function () {
+			{if $groupIsOwner}
+				elBySelAll('input[name="values[admin.user.accessibleGroups][]"]', undefined, function(input) {
+					var shadow = elCreate('input');
+					shadow.type = 'hidden';
+					shadow.name = input.name;
+					shadow.value = input.value;
+					
+					input.parentNode.appendChild(shadow);
+					
+					input.disabled = true;
+				});
+				
+				var permissions = [{implode from=$ownerGroupPermissions item=$_ownerPermission}'{$_ownerPermission|encodeJS}'{/implode}];
+				permissions.forEach(function(permission) {
+					elBySelAll('input[name="values[' + permission + ']"]', undefined, function (input) {
+						if (input.value === '1') {
+							input.checked = true;
+						}
+						else {
+							input.disabled = true;
+						}
+					});
+				});
+			{elseif $ownerGroupID}
+				var input = elBySel('input[name="values[admin.user.accessibleGroups][]"][value="{$ownerGroupID}"]');
+				if (input) {
+					elRemove(input.closest('label'));
+				}
+			{/if}
+		})();
+	</script>
+{/if}
 
 {include file='footer'}

--- a/wcfsetup/install/files/acp/templates/userGroupAdd.tpl
+++ b/wcfsetup/install/files/acp/templates/userGroupAdd.tpl
@@ -250,7 +250,7 @@
 					});
 				});
 			{elseif $ownerGroupID}
-				var input = elBySel('input[name="values[admin.user.accessibleGroups][]"][value="{$ownerGroupID}"]');
+				var input = elBySel('input[name="values[admin.user.accessibleGroups][]"][value="{@$ownerGroupID}"]');
 				if (input) {
 					elRemove(input.closest('label'));
 				}

--- a/wcfsetup/install/files/acp/templates/userGroupList.tpl
+++ b/wcfsetup/install/files/acp/templates/userGroupList.tpl
@@ -69,6 +69,9 @@
 						{else}
 							{lang}{$group->groupName}{/lang}
 						{/if}
+						{if $group->isOwner()}
+							<span class="icon icon16 fa-shield jsTooltip" title="{lang}wcf.acp.group.type.owner{/lang}"></span>
+						{/if}
 					</td>
 					<td class="columnDigits columnMembers">
 						{if $group->groupType == 1 ||$group->groupType == 2}

--- a/wcfsetup/install/files/acp/templates/userGroupOption.tpl
+++ b/wcfsetup/install/files/acp/templates/userGroupOption.tpl
@@ -55,7 +55,6 @@
 			{if $userGroupOption->optionName === 'admin.user.accessibleGroups'}
 				elBySelAll('dl[data-group-id]', container, function(dl) {
 					var groupId = parseInt(elData(dl, 'group-id'), 10);
-					console.log("Group", groupId);
 					
 					elBySelAll('input[name="values[' + groupId + '][]"', undefined, function(input) {
 						if (groupId === {@$ownerGroupID}) {

--- a/wcfsetup/install/files/acp/templates/userGroupOption.tpl
+++ b/wcfsetup/install/files/acp/templates/userGroupOption.tpl
@@ -50,6 +50,42 @@
 				elHide(bbcodeHtml);
 			});
 		});
+		
+		{if $ownerGroupID}
+			{if $userGroupOption->optionName === 'admin.user.accessibleGroups'}
+				elBySelAll('dl[data-group-id]', container, function(dl) {
+					var groupId = parseInt(elData(dl, 'group-id'), 10);
+					console.log("Group", groupId);
+					
+					elBySelAll('input[name="values[' + groupId + '][]"', undefined, function(input) {
+						if (groupId === {@$ownerGroupID}) {
+							var shadow = elCreate('input');
+							shadow.type = 'hidden';
+							shadow.name = input.name;
+							shadow.value = input.value;
+							
+							input.parentNode.appendChild(shadow);
+							
+							input.disabled = true;
+						}
+						else {
+							if (parseInt(input.value, 10) === {@$ownerGroupID}) {
+								elRemove(input.closest('label'));
+							}
+						}
+					});
+				});
+			{elseif $userGroupOption->optionName|in_array:$ownerGroupPermissions}
+				elBySelAll('input[name="values[{@$ownerGroupID}]"]', undefined, function (input) {
+					if (input.value === '1') {
+						input.checked = true;
+					}
+					else {
+						input.disabled = true;
+					}
+				});
+			{/if}
+		{/if}
 	})();
 </script>
 
@@ -86,7 +122,11 @@
 		
 		{foreach from=$groups item=group}
 			<dl data-group-id="{@$group->groupID}">
-				<dt>{if VISITOR_USE_TINY_BUILD && $guestGroupID == $group->groupID && $userGroupOption->excludedInTinyBuild}<span class="icon icon16 fa-bolt red jsTooltip" title="{lang}wcf.acp.group.excludedInTinyBuild{/lang}"></span> {/if}<label for="userGroupOption{@$group->groupID}">{lang}{$group->groupName}{/lang}</label></dt>
+				<dt>
+					{if VISITOR_USE_TINY_BUILD && $guestGroupID == $group->groupID && $userGroupOption->excludedInTinyBuild}<span class="icon icon16 fa-bolt red jsTooltip" title="{lang}wcf.acp.group.excludedInTinyBuild{/lang}"></span> {/if}
+					{if $ownerGroupID == $group->groupID && $userGroupOption->optionName|in_array:$ownerGroupPermissions}<span class="icon icon16 fa-shield jsTooltip" title="{lang}wcf.acp.group.ownerGroupPermission{/lang}"></span> {/if}
+					<label for="userGroupOption{@$group->groupID}">{lang}{$group->groupName}{/lang}</label>
+				</dt>
 				<dd>
 					{@$formElements[$group->groupID]}
 					

--- a/wcfsetup/install/files/acp/templates/userGroupPromoteOwner.tpl
+++ b/wcfsetup/install/files/acp/templates/userGroupPromoteOwner.tpl
@@ -1,0 +1,13 @@
+{include file='header' pageTitle='wcf.acp.group.promoteOwner'}
+
+<header class="contentHeader">
+	<div class="contentHeaderTitle">
+		<h1 class="contentTitle">{lang}wcf.acp.group.promoteOwner{/lang}</h1>
+	</div>
+</header>
+
+<div class="warning">{lang}wcf.acp.group.promoteOwner.warning{/lang}</div>
+
+{@$form->getHtml()}
+
+{include file='footer'}

--- a/wcfsetup/install/files/lib/acp/form/UserEditForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/UserEditForm.class.php
@@ -274,7 +274,8 @@ class UserEditForm extends UserAddForm {
 			'disableCoverPhoto' => $this->disableCoverPhoto,
 			'disableCoverPhotoReason' => $this->disableCoverPhotoReason,
 			'disableCoverPhotoExpires' => $this->disableCoverPhotoExpires,
-			'deleteCoverPhoto' => $this->deleteCoverPhoto
+			'deleteCoverPhoto' => $this->deleteCoverPhoto,
+			'ownerGroupID' => UserGroup::getOwnerGroupID(),
 		]);
 	}
 	
@@ -483,6 +484,14 @@ class UserEditForm extends UserAddForm {
 	 * @inheritDoc
 	 */
 	public function validate() {
+		if ($this->user->userID == WCF::getUser()->userID && WCF::getUser()->hasOwnerAccess()) {
+			$ownerGroupID = UserGroup::getOwnerGroupID();
+			if ($ownerGroupID && !in_array($ownerGroupID, $this->groupIDs)) {
+				// Members of the owner group cannot remove themselves.
+				throw new PermissionDeniedException();
+			}
+		}
+		
 		$this->validateAvatar();
 		
 		parent::validate();

--- a/wcfsetup/install/files/lib/acp/form/UserGroupAssignmentAddForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/UserGroupAssignmentAddForm.class.php
@@ -82,7 +82,8 @@ class UserGroupAssignmentAddForm extends AbstractForm {
 		$this->userGroups = UserGroup::getGroupsByType([], [
 			UserGroup::EVERYONE,
 			UserGroup::GUESTS,
-			UserGroup::USERS
+			UserGroup::OWNER,
+			UserGroup::USERS,
 		]);
 		foreach ($this->userGroups as $key => $userGroup) {
 			if (!$userGroup->isAccessible()) {

--- a/wcfsetup/install/files/lib/acp/form/UserGroupEditForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/UserGroupEditForm.class.php
@@ -122,8 +122,6 @@ class UserGroupEditForm extends UserGroupAddForm {
 			$ownerGroupPermissions[] = 'admin.user.accessibleGroups';
 		}
 		
-		$ownerGroup = UserGroup::getGroupByType(UserGroup::OWNER);
-		
 		WCF::getTPL()->assign([
 			'groupID' => $this->group->groupID,
 			'group' => $this->group,
@@ -135,7 +133,7 @@ class UserGroupEditForm extends UserGroupAddForm {
 			'groupIsOwner' => $this->group->isOwner(),
 			'isUnmentionableGroup' => $this->isUnmentionableGroup ? 1 : 0,
 			'ownerGroupPermissions' => $ownerGroupPermissions,
-			'ownerGroupID' => $ownerGroup ? $ownerGroup->groupID : null,
+			'ownerGroupID' => UserGroup::getOwnerGroupID(),
 		]);
 		
 		// add warning when the initiator is in the group

--- a/wcfsetup/install/files/lib/acp/form/UserGroupEditForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/UserGroupEditForm.class.php
@@ -116,6 +116,14 @@ class UserGroupEditForm extends UserGroupAddForm {
 		
 		I18nHandler::getInstance()->assignVariables(!empty($_POST));
 		
+		$ownerGroupPermissions = [];
+		if ($this->group->isOwner()) {
+			$ownerGroupPermissions = UserGroup::getOwnerPermissions();
+			$ownerGroupPermissions[] = 'admin.user.accessibleGroups';
+		}
+		
+		$ownerGroup = UserGroup::getGroupByType(UserGroup::OWNER);
+		
 		WCF::getTPL()->assign([
 			'groupID' => $this->group->groupID,
 			'group' => $this->group,
@@ -124,7 +132,10 @@ class UserGroupEditForm extends UserGroupAddForm {
 			'groupIsEveryone' => $this->group->groupType == UserGroup::EVERYONE,
 			'groupIsGuest' => $this->group->groupType == UserGroup::GUESTS,
 			'groupIsUsers' => $this->group->groupType == UserGroup::USERS,
+			'groupIsOwner' => $this->group->isOwner(),
 			'isUnmentionableGroup' => $this->isUnmentionableGroup ? 1 : 0,
+			'ownerGroupPermissions' => $ownerGroupPermissions,
+			'ownerGroupID' => $ownerGroup ? $ownerGroup->groupID : null,
 		]);
 		
 		// add warning when the initiator is in the group

--- a/wcfsetup/install/files/lib/acp/form/UserGroupOptionForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/UserGroupOptionForm.class.php
@@ -251,7 +251,7 @@ class UserGroupOptionForm extends AbstractForm {
 	public function assignVariables() {
 		parent::assignVariables();
 		
-		$everyoneGroupID = $guestGroupID = $userGroupID = 0;
+		$everyoneGroupID = $guestGroupID = $ownerGroupID = $userGroupID = 0;
 		foreach ($this->groups as $group) {
 			if ($group->groupType == UserGroup::EVERYONE) {
 				$everyoneGroupID = $group->groupID;
@@ -259,9 +259,18 @@ class UserGroupOptionForm extends AbstractForm {
 			else if ($group->groupType == UserGroup::GUESTS) {
 				$guestGroupID = $group->groupID;
 			}
+			else if ($group->groupType == UserGroup::OWNER) {
+				$ownerGroupID = $group->groupID;
+			}
 			else if ($group->groupType == UserGroup::USERS) {
 				$userGroupID = $group->groupID;
 			}
+		}
+		
+		$ownerGroupPermissions = [];
+		if ($ownerGroupID) {
+			$ownerGroupPermissions = UserGroup::getOwnerPermissions();
+			$ownerGroupPermissions[] = 'admin.user.accessibleGroups';
 		}
 		
 		WCF::getTPL()->assign([
@@ -272,7 +281,9 @@ class UserGroupOptionForm extends AbstractForm {
 			'values' => $this->values,
 			'everyoneGroupID' => $everyoneGroupID,
 			'guestGroupID' => $guestGroupID,
-			'userGroupID' => $userGroupID
+			'userGroupID' => $userGroupID,
+			'ownerGroupID' => $ownerGroupID,
+			'ownerGroupPermissions' => $ownerGroupPermissions,
 		]);
 	}
 	

--- a/wcfsetup/install/files/lib/acp/form/UserGroupPromoteOwnerForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/UserGroupPromoteOwnerForm.class.php
@@ -1,0 +1,119 @@
+<?php
+namespace wcf\acp\form;
+use wcf\data\user\group\UserGroup;
+use wcf\data\user\group\UserGroupAction;
+use wcf\form\AbstractForm;
+use wcf\system\form\builder\container\FormContainer;
+use wcf\system\form\builder\field\RadioButtonFormField;
+use wcf\system\form\builder\FormDocument;
+use wcf\system\form\builder\IFormDocument;
+use wcf\system\request\LinkHandler;
+use wcf\system\WCF;
+use wcf\util\HeaderUtil;
+
+/**
+ * Promotes a user group to be the owner group.
+ * 
+ * @author      ALexander Ebert
+ * @copyright   2001-2019 WoltLab GmbH
+ * @license     GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @package     WoltLabSuite\Core\Acp\Form
+ * @since       5.2
+ */
+class UserGroupPromoteOwnerForm extends AbstractForm {
+	/**
+	 * @inheritDoc
+	 */
+	public $activeMenuItem = 'wcf.acp.menu.link.group.list';
+	
+	/**
+	 * @var IFormDocument
+	 */
+	public $form;
+	
+	/**
+	 * @var UserGroup
+	 */
+	public $groups = [];
+	
+	/**
+	 * @inheritDoc
+	 */
+	public $neededPermissions = ['admin.configuration.package.canInstallPackage'];
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function readParameters() {
+		parent::readParameters();
+		
+		$this->groups = UserGroup::getGroupsByType([UserGroup::OTHER]);
+		$this->groups = array_filter($this->groups, function (UserGroup $group) {
+			return $group->isAdminGroup();
+		});
+		uasort($this->groups, function(UserGroup $a, UserGroup $b) {
+			return $a->getName() <=> $b->getName();
+		});
+		
+		$this->form = FormDocument::create('promoteGroup')
+			->appendChild(
+				FormContainer::create('groupSection')
+					->appendChild(
+						RadioButtonFormField::create('groupID')
+							->label('wcf.acp.group.promoteOwner.group')
+							->required()
+							->options($this->groups)
+					)
+			);
+		$this->form->action(LinkHandler::getInstance()->getLink('UserGroupPromoteOwner'));
+		$this->form->build();
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function readFormParameters() {
+		parent::readFormParameters();
+		
+		$this->form->readValues();
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function validate() {
+		parent::validate();
+		
+		$this->form->validate();
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function save() {
+		parent::save();
+		
+		$groupID = $this->form->getData()['data']['groupID'];
+		
+		$this->objectAction = new UserGroupAction([$this->groups[$groupID]], 'promoteOwner');
+		$this->objectAction->executeAction();
+		
+		$this->saved();
+		
+		HeaderUtil::redirect(LinkHandler::getInstance()->getLink());
+		exit;
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function assignVariables() {
+		parent::assignVariables();
+		
+		WCF::getTPL()->assign([
+			'form' => $this->form,
+			// Hide the notice on this page only.
+			'__wscMissingOwnerGroup' => false,
+		]);
+	}
+}

--- a/wcfsetup/install/files/lib/acp/form/UserGroupPromoteOwnerForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/UserGroupPromoteOwnerForm.class.php
@@ -57,6 +57,12 @@ class UserGroupPromoteOwnerForm extends AbstractForm {
 		$this->groups = array_filter($this->groups, function (UserGroup $group) {
 			return $group->isAdminGroup();
 		});
+		
+		if (empty($this->groups)) {
+			// fallback for broken installations without an admin group
+			$this->groups = UserGroup::getGroupsByType([UserGroup::OTHER]);
+		}
+		
 		uasort($this->groups, function(UserGroup $a, UserGroup $b) {
 			return $a->getName() <=> $b->getName();
 		});

--- a/wcfsetup/install/files/lib/acp/form/UserGroupPromoteOwnerForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/UserGroupPromoteOwnerForm.class.php
@@ -3,11 +3,10 @@ namespace wcf\acp\form;
 use wcf\data\user\group\UserGroup;
 use wcf\data\user\group\UserGroupAction;
 use wcf\form\AbstractForm;
+use wcf\form\AbstractFormBuilderForm;
 use wcf\system\exception\IllegalLinkException;
 use wcf\system\form\builder\container\FormContainer;
 use wcf\system\form\builder\field\RadioButtonFormField;
-use wcf\system\form\builder\FormDocument;
-use wcf\system\form\builder\IFormDocument;
 use wcf\system\request\LinkHandler;
 use wcf\system\WCF;
 use wcf\util\HeaderUtil;
@@ -21,16 +20,11 @@ use wcf\util\HeaderUtil;
  * @package     WoltLabSuite\Core\Acp\Form
  * @since       5.2
  */
-class UserGroupPromoteOwnerForm extends AbstractForm {
+class UserGroupPromoteOwnerForm extends AbstractFormBuilderForm {
 	/**
 	 * @inheritDoc
 	 */
 	public $activeMenuItem = 'wcf.acp.menu.link.group.list';
-	
-	/**
-	 * @var IFormDocument
-	 */
-	public $form;
 	
 	/**
 	 * @var UserGroup
@@ -66,51 +60,37 @@ class UserGroupPromoteOwnerForm extends AbstractForm {
 		uasort($this->groups, function(UserGroup $a, UserGroup $b) {
 			return $a->getName() <=> $b->getName();
 		});
-		
-		$this->form = FormDocument::create('promoteGroup')
-			->appendChild(
-				FormContainer::create('groupSection')
-					->appendChild(
-						RadioButtonFormField::create('groupID')
-							->label('wcf.acp.group.promoteOwner.group')
-							->required()
-							->options($this->groups)
-					)
-			);
-		$this->form->action(LinkHandler::getInstance()->getLink('UserGroupPromoteOwner'));
-		$this->form->build();
 	}
 	
 	/**
 	 * @inheritDoc
 	 */
-	public function readFormParameters() {
-		parent::readFormParameters();
+	protected function createForm() {
+		parent::createForm();
 		
-		$this->form->readValues();
-	}
-	
-	/**
-	 * @inheritDoc
-	 */
-	public function validate() {
-		parent::validate();
-		
-		$this->form->validate();
+		$this->form->appendChild(
+			FormContainer::create('groupSection')
+				->appendChild(
+					RadioButtonFormField::create('groupID')
+						->label('wcf.acp.group.promoteOwner.group')
+						->required()
+						->options($this->groups)
+				)
+		);
 	}
 	
 	/**
 	 * @inheritDoc
 	 */
 	public function save() {
-		parent::save();
+		AbstractForm::save();
 		
 		$groupID = $this->form->getData()['data']['groupID'];
 		
 		$this->objectAction = new UserGroupAction([$this->groups[$groupID]], 'promoteOwner');
 		$this->objectAction->executeAction();
 		
-		$this->saved();
+		AbstractForm::saved();
 		
 		HeaderUtil::redirect(LinkHandler::getInstance()->getLink());
 		exit;
@@ -123,7 +103,6 @@ class UserGroupPromoteOwnerForm extends AbstractForm {
 		parent::assignVariables();
 		
 		WCF::getTPL()->assign([
-			'form' => $this->form,
 			// Hide the notice on this page only.
 			'__wscMissingOwnerGroup' => false,
 		]);

--- a/wcfsetup/install/files/lib/acp/form/UserGroupPromoteOwnerForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/UserGroupPromoteOwnerForm.class.php
@@ -3,6 +3,7 @@ namespace wcf\acp\form;
 use wcf\data\user\group\UserGroup;
 use wcf\data\user\group\UserGroupAction;
 use wcf\form\AbstractForm;
+use wcf\system\exception\IllegalLinkException;
 use wcf\system\form\builder\container\FormContainer;
 use wcf\system\form\builder\field\RadioButtonFormField;
 use wcf\system\form\builder\FormDocument;
@@ -46,6 +47,11 @@ class UserGroupPromoteOwnerForm extends AbstractForm {
 	 */
 	public function readParameters() {
 		parent::readParameters();
+		
+		// owner user groups cannot be modified
+		if (UserGroup::getOwnerGroupID() !== null) {
+			throw new IllegalLinkException();
+		}
 		
 		$this->groups = UserGroup::getGroupsByType([UserGroup::OTHER]);
 		$this->groups = array_filter($this->groups, function (UserGroup $group) {

--- a/wcfsetup/install/files/lib/data/user/User.class.php
+++ b/wcfsetup/install/files/lib/data/user/User.class.php
@@ -478,8 +478,7 @@ final class User extends DatabaseObject implements IRouteController, IUserConten
 			$this->hasAdministrativePermissions = false;
 			
 			if ($this->userID) {
-				foreach ($this->getGroupIDs() as $groupID) {
-					$group = UserGroup::getGroupByID($groupID);
+				foreach (UserGroup::getGroupsByIDs($this->getGroupIDs()) as $group) {
 					if ($group->isAdminGroup()) {
 						$this->hasAdministrativePermissions = true;
 						break;
@@ -489,6 +488,29 @@ final class User extends DatabaseObject implements IRouteController, IUserConten
 		}
 		
 		return $this->hasAdministrativePermissions;
+	}
+	
+	/**
+	 * Returns true, if this user is a member of the owner group.
+	 * 
+	 * @return bool
+	 * @since 5.2
+	 */
+	public function hasOwnerAccess() {
+		static $isOwner;
+		
+		if ($isOwner === null) {
+			$isOwner = false;
+			
+			foreach (UserGroup::getGroupsByIDs($this->getGroupIDs()) as $group) {
+				if ($group->isOwner()) {
+					$isOwner = true;
+					break;
+				}
+			}
+		}
+		
+		return $isOwner;
 	}
 	
 	/**

--- a/wcfsetup/install/files/lib/data/user/group/UserGroup.class.php
+++ b/wcfsetup/install/files/lib/data/user/group/UserGroup.class.php
@@ -75,6 +75,11 @@ class UserGroup extends DatabaseObject implements ITitledObject {
 	protected static $accessibleGroups = null;
 	
 	/**
+	 * @var UserGroup|null
+	 */
+	protected static $ownerGroup = false;
+	
+	/**
 	 * group options of this group
 	 * @var	mixed[][]
 	 */
@@ -497,5 +502,19 @@ class UserGroup extends DatabaseObject implements ITitledObject {
 			'admin.user.canEditUser',
 			'admin.user.canSearchUser',
 		];
+	}
+	
+	/**
+	 * Returns the owner group's id unless no group was promoted yet due to backwards compatibility.
+	 * 
+	 * @return int|null
+	 * @since 5.2
+	 */
+	public static function getOwnerGroupID() {
+		if (self::$ownerGroup === false) {
+			self::$ownerGroup = self::getGroupByType(self::OWNER);
+		}
+		
+		return self::$ownerGroup ? self::$ownerGroup->groupID : null;
 	}
 }

--- a/wcfsetup/install/files/lib/data/user/group/UserGroup.class.php
+++ b/wcfsetup/install/files/lib/data/user/group/UserGroup.class.php
@@ -60,7 +60,7 @@ class UserGroup extends DatabaseObject implements ITitledObject {
 	 * the owner group is always an administrator group
 	 * @var int
 	 */
-	const OWNER = 5;
+	const OWNER = 9;
 	
 	/**
 	 * group cache

--- a/wcfsetup/install/files/lib/data/user/group/UserGroupAction.class.php
+++ b/wcfsetup/install/files/lib/data/user/group/UserGroupAction.class.php
@@ -212,4 +212,20 @@ class UserGroupAction extends AbstractDatabaseObjectAction {
 			])
 		];
 	}
+	
+	public function promoteOwner() {
+		if (UserGroup::getOwnerGroupID() !== null) {
+			throw new \LogicException('There is already an owner group.');
+		}
+		else if (count($this->objects) !== 1) {
+			throw new \InvalidArgumentException('Only a single group can be promoted to be the owner group.');
+		}
+		
+		$groupEditor = reset($this->objects);
+		$groupEditor->update([
+			'groupType' => UserGroup::OWNER,
+		]);
+		
+		UserGroupEditor::resetCache();
+	}
 }

--- a/wcfsetup/install/files/lib/system/WCF.class.php
+++ b/wcfsetup/install/files/lib/system/WCF.class.php
@@ -483,7 +483,7 @@ class WCF {
 		}
 		
 		// handle banned users
-		if (self::getUser()->userID && self::getUser()->banned) {
+		if (self::getUser()->userID && self::getUser()->banned && !self::getUser()->hasOwnerAccess()) {
 			if ($isAjax) {
 				throw new AJAXException(self::getLanguage()->getDynamicVariable('wcf.user.error.isBanned'), AJAXException::INSUFFICIENT_PERMISSIONS);
 			}

--- a/wcfsetup/install/files/lib/system/WCFACP.class.php
+++ b/wcfsetup/install/files/lib/system/WCFACP.class.php
@@ -4,6 +4,7 @@ use wcf\acp\form\MasterPasswordForm;
 use wcf\acp\form\MasterPasswordInitForm;
 use wcf\data\menu\Menu;
 use wcf\data\menu\MenuCache;
+use wcf\data\user\group\UserGroup;
 use wcf\system\application\ApplicationHandler;
 use wcf\system\cache\builder\ACPSearchProviderCacheBuilder;
 use wcf\system\event\EventHandler;
@@ -175,6 +176,10 @@ class WCFACP extends WCF {
 				// force debug mode if in ACP and authenticated
 				self::$overrideDebugMode = true;
 			}
+		}
+		
+		if (PACKAGE_ID && WCF::getUser()->userID && WCF::getSession()->getPermission('admin.configuration.package.canInstallPackage') && UserGroup::getOwnerGroupID() === null) {
+			self::getTPL()->assign(['__wscMissingOwnerGroup' => true]);
 		}
 	}
 	

--- a/wcfsetup/install/files/lib/system/bulk/processing/user/AbstractUserBulkProcessingAction.class.php
+++ b/wcfsetup/install/files/lib/system/bulk/processing/user/AbstractUserBulkProcessingAction.class.php
@@ -43,9 +43,18 @@ abstract class AbstractUserBulkProcessingAction extends AbstractBulkProcessingAc
 		$statement->execute($conditionBuilder->getParameters());
 		$groupIDs = $statement->fetchMap('userID', 'groupID', false);
 		
+		$ownerGroupID = UserGroup::getOwnerGroupID();
+		
 		$users = [];
 		foreach ($userList as $user) {
-			if (empty($groupIDs[$user->userID]) || UserGroup::isAccessibleGroup($groupIDs[$user->userID])) {
+			if (empty($groupIDs[$user->userID])) {
+				$users[$user->userID] = $user;
+			}
+			else if ($ownerGroupID && in_array($ownerGroupID, $groupIDs[$user->userID])) {
+				// Bulk actions can never affect members of the owner group.
+				continue;
+			}
+			else if (UserGroup::isAccessibleGroup($groupIDs[$user->userID])) {
 				$users[$user->userID] = $user;
 			}
 		}

--- a/wcfsetup/install/files/lib/system/bulk/processing/user/AbstractUserGroupsUserBulkProcessingAction.class.php
+++ b/wcfsetup/install/files/lib/system/bulk/processing/user/AbstractUserGroupsUserBulkProcessingAction.class.php
@@ -45,7 +45,7 @@ abstract class AbstractUserGroupsUserBulkProcessingAction extends AbstractUserBu
 	public function __construct(DatabaseObject $object) {
 		parent::__construct($object);
 		
-		$this->availableUserGroups = UserGroup::getAccessibleGroups([], [UserGroup::GUESTS, UserGroup::EVERYONE, UserGroup::USERS]);
+		$this->availableUserGroups = UserGroup::getAccessibleGroups([], [UserGroup::GUESTS, UserGroup::EVERYONE, UserGroup::OWNER, UserGroup::USERS]);
 		
 		uasort($this->availableUserGroups, function(UserGroup $groupA, UserGroup $groupB) {
 			return strcmp($groupA->getName(), $groupB->getName());

--- a/wcfsetup/install/lang/de.xml
+++ b/wcfsetup/install/lang/de.xml
@@ -883,6 +883,10 @@ Das Fehlerprotokoll enthält {$data[count]} neue Einträge. Die ersten drei, in 
 		<item name="wcf.acp.group.type.owner"><![CDATA[Besitzer]]></item>
 		<item name="wcf.acp.group.type.owner.description"><![CDATA[Die Besitzer-Gruppe verfügt über nicht entziehbare Berechtigungen und kann von anderen Gruppen nicht bearbeitet werden, diese Gruppe kann nur durch die Besitzer-Gruppe selbst bearbeitet werden. Mitglieder dieser Benutzer können andere Benutzer zu dieser Gruppe hinzufügen, sich aber selbst nicht daraus entfernen.]]></item>
 		<item name="wcf.acp.group.ownerGroupPermission"><![CDATA[Die Besitzer-Gruppe verfügt immer über diese Berechtigung, sie kann nicht entzogen werden.]]></item>
+		<item name="wcf.acp.group.missingOwnerGroup"><![CDATA[Es wurde noch keine Besitzer-Gruppe festgelegt, <a href="{link controller='UserGroupPromoteOwner'}{/link}">bitte {if LANGUAGE_USE_INFORMAL_VARIANT}lege{else}legen Sie{/if} diese umgehend fest</a>.]]></item>
+		<item name="wcf.acp.group.promoteOwner"><![CDATA[Besitzer-Gruppe festlegen]]></item>
+		<item name="wcf.acp.group.promoteOwner.group"><![CDATA[Besitzer-Gruppe auswählen]]></item>
+		<item name="wcf.acp.group.promoteOwner.warning"><![CDATA[Die Besitzer-Gruppe kann, einmal festgelegt, nicht mehr geändert werden. Diese Gruppe verfügt über besondere Berechtigungen und wird vor Änderungen durch andere Gruppen geschützt, Mitglieder dieser Gruppe können nicht mehr gesperrt werden.]]></item>
 	</category>
 	<category name="wcf.acp.index">
 		<item name="wcf.acp.index.credits"><![CDATA[Über WoltLab Suite&trade;]]></item>

--- a/wcfsetup/install/lang/de.xml
+++ b/wcfsetup/install/lang/de.xml
@@ -880,6 +880,9 @@ Das Fehlerprotokoll enthält {$data[count]} neue Einträge. Die ersten drei, in 
 		<item name="wcf.acp.group.option.user.contactForm.attachment.maxCount"><![CDATA[Maximale Dateianhänge pro Nachricht]]></item>
 		<item name="wcf.acp.group.option.user.profile.canEditUserProfile"><![CDATA[Kann eigenes Profil bearbeiten]]></item>
 		<item name="wcf.acp.group.allowMention"><![CDATA[Benutzergruppe kann erwähnt werden]]></item>
+		<item name="wcf.acp.group.type.owner"><![CDATA[Besitzer]]></item>
+		<item name="wcf.acp.group.type.owner.description"><![CDATA[Die Besitzer-Gruppe verfügt über nicht entziehbare Berechtigungen und kann von anderen Gruppen nicht bearbeitet werden, diese Gruppe kann nur durch die Besitzer-Gruppe selbst bearbeitet werden. Mitglieder dieser Benutzer können andere Benutzer zu dieser Gruppe hinzufügen, sich aber selbst nicht daraus entfernen.]]></item>
+		<item name="wcf.acp.group.ownerGroupPermission"><![CDATA[Die Besitzer-Gruppe verfügt immer über diese Berechtigung, sie kann nicht entzogen werden.]]></item>
 	</category>
 	<category name="wcf.acp.index">
 		<item name="wcf.acp.index.credits"><![CDATA[Über WoltLab Suite&trade;]]></item>

--- a/wcfsetup/install/lang/en.xml
+++ b/wcfsetup/install/lang/en.xml
@@ -860,6 +860,11 @@ This protocol file contains {$data[count]} new entries. The first three error me
 		<item name="wcf.acp.group.type.owner"><![CDATA[Owner]]></item>
 		<item name="wcf.acp.group.type.owner.description"><![CDATA[The owner group features a few irrevocable permissions and is protected from edits by other groups, only the owner group can edit itself. Members of this group can add other users to this group, but cannot remove themselves.]]></item>
 		<item name="wcf.acp.group.ownerGroupPermission"><![CDATA[The owner group always has this permission, it cannot be revoked.]]></item>
+		
+		<item name="wcf.acp.group.missingOwnerGroup"><![CDATA[No owner group has been configured yet, <a href="{link controller='UserGroupPromoteOwner'}{/link}">please set it up now</a>.]]></item>
+		<item name="wcf.acp.group.promoteOwner"><![CDATA[Set Up the Owner Group]]></item>
+		<item name="wcf.acp.group.promoteOwner.group"><![CDATA[Select the owner group]]></item>
+		<item name="wcf.acp.group.promoteOwner.warning"><![CDATA[The owner group cannot be modified once it has been set up. This group has special privileges and is protected from modifications by any other group, its members cannot be banned.]]></item>
 	</category>
 	<category name="wcf.acp.index">
 		<item name="wcf.acp.index.credits"><![CDATA[About WoltLab Suite&trade;]]></item>

--- a/wcfsetup/install/lang/en.xml
+++ b/wcfsetup/install/lang/en.xml
@@ -857,6 +857,9 @@ This protocol file contains {$data[count]} new entries. The first three error me
 		<item name="wcf.acp.group.option.user.contactForm.attachment.maxCount"><![CDATA[Maximum Attachments per Message]]></item>
 		<item name="wcf.acp.group.option.user.profile.canEditUserProfile"><![CDATA[Can edit their profile]]></item>
 		<item name="wcf.acp.group.allowMention"><![CDATA[User group can be mentioned]]></item>
+		<item name="wcf.acp.group.type.owner"><![CDATA[Owner]]></item>
+		<item name="wcf.acp.group.type.owner.description"><![CDATA[The owner group features a few irrevocable permissions and is protected from edits by other groups, only the owner group can edit itself. Members of this group can add other users to this group, but cannot remove themselves.]]></item>
+		<item name="wcf.acp.group.ownerGroupPermission"><![CDATA[The owner group always has this permission, it cannot be revoked.]]></item>
 	</category>
 	<category name="wcf.acp.index">
 		<item name="wcf.acp.index.credits"><![CDATA[About WoltLab Suite&trade;]]></item>

--- a/wcfsetup/setup/db/install.sql
+++ b/wcfsetup/setup/db/install.sql
@@ -2224,7 +2224,7 @@ ALTER TABLE wcf1_notice_dismissed ADD FOREIGN KEY (userID) REFERENCES wcf1_user 
 INSERT INTO wcf1_user_group (groupID, groupName, groupType) VALUES (1, 'wcf.acp.group.group1', 1); -- Everyone
 INSERT INTO wcf1_user_group (groupID, groupName, groupType) VALUES (2, 'wcf.acp.group.group2', 2); -- Guests
 INSERT INTO wcf1_user_group (groupID, groupName, groupType) VALUES (3, 'wcf.acp.group.group3', 3); -- Registered Users
-INSERT INTO wcf1_user_group (groupID, groupName, groupType) VALUES (4, 'wcf.acp.group.group4', 4); -- Administrators
+INSERT INTO wcf1_user_group (groupID, groupName, groupType) VALUES (4, 'wcf.acp.group.group4', 5); -- Administrators
 INSERT INTO wcf1_user_group (groupID, groupName, groupType) VALUES (5, 'wcf.acp.group.group5', 4); -- Moderators
 
 -- default user group options

--- a/wcfsetup/setup/db/install.sql
+++ b/wcfsetup/setup/db/install.sql
@@ -2224,7 +2224,7 @@ ALTER TABLE wcf1_notice_dismissed ADD FOREIGN KEY (userID) REFERENCES wcf1_user 
 INSERT INTO wcf1_user_group (groupID, groupName, groupType) VALUES (1, 'wcf.acp.group.group1', 1); -- Everyone
 INSERT INTO wcf1_user_group (groupID, groupName, groupType) VALUES (2, 'wcf.acp.group.group2', 2); -- Guests
 INSERT INTO wcf1_user_group (groupID, groupName, groupType) VALUES (3, 'wcf.acp.group.group3', 3); -- Registered Users
-INSERT INTO wcf1_user_group (groupID, groupName, groupType) VALUES (4, 'wcf.acp.group.group4', 5); -- Administrators
+INSERT INTO wcf1_user_group (groupID, groupName, groupType) VALUES (4, 'wcf.acp.group.group4', 9); -- Administrators
 INSERT INTO wcf1_user_group (groupID, groupName, groupType) VALUES (5, 'wcf.acp.group.group5', 4); -- Moderators
 
 -- default user group options


### PR DESCRIPTION
The high amount of flexibility of the user group system allows for very sophisticated setups, but the concept of an administrator group has been quite an issue for a lot of users. In particular, it's somewhat difficult to set up groups that act as day-to-day maintenace, without giving away too many permissions. Additionally, the administrator group could be crippled by revoking permissions, despite several safe-guards being in place.

The owner group is a special type (`groupType = 9` / `UserGroup::OWNER` ) that combines a few key concepts:
1. The owner group has several hardcoded permissions that cannot be revoked and are always present, effectively granting the ability to obtain any permission they want.
2. The owner group can only be ever edited by members of the group itself, no other group can ever be granted the permission to edit them.
3. Members of the owner group cannot be banned, a ban has no effect on them.
4. Members of the owner group cannot remove themselves from the owner group, only other members of this group can do this. This is a security measure to prevent users from accidentially removing themselves.
5. The owner group cannot be the target of automatic assignments and cannot be targeted through the bulk processing. In fact, the user bulk processing will skip every user that is a member of the owner group, regardless of the conditions.

For new installations, the built-in administrators group is defined as the owner group. Installations upgraded from earlier versions are prompted to pick a group that is then promoted to be the owner group. There can only be one owner group.