### PR TITLE
Allow modification of visible/editable parameters

### DIFF
--- a/wcfsetup/install/files/lib/data/user/option/UserOption.class.php
+++ b/wcfsetup/install/files/lib/data/user/option/UserOption.class.php
@@ -192,4 +192,22 @@ class UserOption extends Option {
 		
 		return true;
 	}
+
+	/**
+	 * Allows modifications of editable option.
+	 *
+	 * @param int   $editableOption
+	 */
+	public function modifyEditableOption($editableOption) {
+		$this->data['editable'] = $editableOption;
+	}
+
+	/**
+	 * Allows modifications of visible option.
+	 *
+	 * @param int   $visibleOption
+	 */
+	public function modifyVisibleOption($visibleOption) {
+		$this->data['visible'] = $visibleOption;
+	}
 }


### PR DESCRIPTION
Right now it's not possible, to edit those values.
I tried to submit a plugin to the pluginstore and it was denied, cause I changed the values of `$userOption->visible/editable` directly, which would lead to PHP create a new "outside" (not in `data`) attribute.

@TimWolla Agreed, that those two new methods would solve the problem.

https://github.com/WoltLab/WCF/blob/master/wcfsetup/install/files/lib/data/option/Option.class.php#L224-L231 also edits the internal `data` attribute, so I don't see any arguments against those changes :)

Please also merge that to the 3.0 branch, otherwise my plugin would only work in 3.1 :(