### PR TITLE
Fix password comparison

### DIFF
--- a/wcfsetup/install/files/lib/util/PasswordUtil.class.php
+++ b/wcfsetup/install/files/lib/util/PasswordUtil.class.php
@@ -588,7 +588,7 @@ final class PasswordUtil {
 	 * @return	boolean
 	 */
 	protected static function wcf2($username, $password, $salt, $dbHash) {
-		return CryptoUtil::secureCompare($dbHash, self::getDoubleSaltedHash($password, $salt));
+		return CryptoUtil::secureCompare($dbHash, self::getDoubleSaltedHash($password, $dbHash));
 	}
 	
 	/**


### PR DESCRIPTION
The password comparison for WCF 2 / WSC does not work, from what i've experienced. Instead of providing the (empty) `$salt`, `$dbHash` needs to be provided to the `getDoubleSaltedHash` method.

To test this, simply prepend `wcf2:` to the password in the DB and try to log in. It will fail, while it works after applying the proposed change.