### PR TITLE
Update RegisterForm.class.php

### DIFF
--- a/wcfsetup/install/files/lib/form/RegisterForm.class.php
+++ b/wcfsetup/install/files/lib/form/RegisterForm.class.php
@@ -178,7 +178,7 @@ class RegisterForm extends UserAddForm {
 		
 		if (BLACKLIST_SFS_ENABLE) {
 			$this->blacklistMatches = BlacklistEntry::getMatches($this->username, $this->email, UserUtil::getIpAddress());
-			if (BLACKLIST_SFS_ACTION === 'block') {
+			if (!empty($this->blacklistMatches) && BLACKLIST_SFS_ACTION === 'block') {
 				throw new NamedUserException('wcf.user.register.error.blacklistMatches');
 			}
 		}


### PR DESCRIPTION
Currently, users are unable to register, if `BLACKLIST_SFS_ACTION` is set to `block`, because of a missing `if` statement (`!empty($this->blacklistMatches)`).