### PR TITLE
3rd party auth improvements

### DIFF
--- a/wcfsetup/install/files/acp/templates/userAdd.tpl
+++ b/wcfsetup/install/files/acp/templates/userAdd.tpl
@@ -122,6 +122,13 @@
 						<h2 class="sectionTitle">{lang}wcf.user.3rdparty{/lang}</h2>
 						
 						<div class="info">{lang}wcf.user.3rdparty.connect.info{/lang}</div>
+						
+						<dl>
+							<dt></dt>
+							<dd>
+								<label><input type="checkbox" name="disconnect3rdParty" value="1"> {lang}wcf.user.3rdparty.{$user->getAuthProvider()}.disconnect{/lang}</label>
+							</dd>
+						</dl>
 					</section>
 				{else}
 					<section class="section">

--- a/wcfsetup/install/files/acp/templates/userAdd.tpl
+++ b/wcfsetup/install/files/acp/templates/userAdd.tpl
@@ -117,39 +117,47 @@
 			{/if}
 			
 			{if $action == 'add' || $__wcf->session->getPermission('admin.user.canEditPassword')}
-				<section class="section">
-					<h2 class="sectionTitle">{lang}wcf.user.password{/lang}</h2>
-					
-					<dl{if $errorType.password|isset} class="formError"{/if}>
-						<dt><label for="password">{lang}wcf.user.password{/lang}</label></dt>
-						<dd>
-							<input type="password" id="password" name="password" value="{$password}" class="medium" autocomplete="off">
-							{if $errorType.password|isset}
-								<small class="innerError">
-									{if $errorType.password == 'empty'}
-										{lang}wcf.global.form.error.empty{/lang}
-									{else}
-										{lang}wcf.user.password.error.{@$errorType.password}{/lang}
-									{/if}
-								</small>
-							{/if}
-						</dd>
-					</dl>
-					
-					<dl{if $errorType.confirmPassword|isset} class="formError"{/if}>
-						<dt><label for="confirmPassword">{lang}wcf.user.confirmPassword{/lang}</label></dt>
-						<dd>
-							<input type="password" id="confirmPassword" name="confirmPassword" value="{$confirmPassword}" class="medium" autocomplete="off">
-							{if $errorType.confirmPassword|isset}
-								<small class="innerError">
-									{lang}wcf.user.confirmPassword.error.{@$errorType.confirmPassword}{/lang}
-								</small>
-							{/if}
-						</dd>
-					</dl>
-					
-					{event name='passwordFields'}
-				</section>
+				{if $action == 'edit' && !$user->authData|empty}
+					<section class="section">
+						<h2 class="sectionTitle">{lang}wcf.user.3rdparty{/lang}</h2>
+						
+						<div class="info">{lang}wcf.user.3rdparty.connect.info{/lang}</div>
+					</section>
+				{else}
+					<section class="section">
+						<h2 class="sectionTitle">{lang}wcf.user.password{/lang}</h2>
+						
+						<dl{if $errorType.password|isset} class="formError"{/if}>
+							<dt><label for="password">{lang}wcf.user.password{/lang}</label></dt>
+							<dd>
+								<input type="password" id="password" name="password" value="{$password}" class="medium" autocomplete="off">
+								{if $errorType.password|isset}
+									<small class="innerError">
+										{if $errorType.password == 'empty'}
+											{lang}wcf.global.form.error.empty{/lang}
+										{else}
+											{lang}wcf.user.password.error.{@$errorType.password}{/lang}
+										{/if}
+									</small>
+								{/if}
+							</dd>
+						</dl>
+						
+						<dl{if $errorType.confirmPassword|isset} class="formError"{/if}>
+							<dt><label for="confirmPassword">{lang}wcf.user.confirmPassword{/lang}</label></dt>
+							<dd>
+								<input type="password" id="confirmPassword" name="confirmPassword" value="{$confirmPassword}" class="medium" autocomplete="off">
+								{if $errorType.confirmPassword|isset}
+									<small class="innerError">
+										{lang}wcf.user.confirmPassword.error.{@$errorType.confirmPassword}{/lang}
+									</small>
+								{/if}
+							</dd>
+						</dl>
+						
+						{event name='passwordFields'}
+					</section>
+				{/if}
 			{/if}
 			
 			{if $action == 'edit' && $__wcf->session->getPermission('admin.user.canBanUser') && $__wcf->user->userID != $userID}

--- a/wcfsetup/install/files/lib/acp/form/UserEditForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/UserEditForm.class.php
@@ -422,7 +422,7 @@ class UserEditForm extends UserAddForm {
 		// reset password
 		$this->password = $this->confirmPassword = '';
 		
-		// reload user when deleting the cover photo or disconneting from 3rd party auth provider
+		// reload user when deleting the cover photo or disconnecting from 3rd party auth provider
 		if ($this->deleteCoverPhoto || $this->disconnect3rdParty) $this->user = new User($this->userID);
 		
 		// show success message

--- a/wcfsetup/install/files/lib/acp/form/UserEditForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/UserEditForm.class.php
@@ -128,6 +128,12 @@ class UserEditForm extends UserAddForm {
 	public $deleteCoverPhoto = 0;
 	
 	/**
+	 * true to delete the current auth data
+	 * @var	boolean
+	 */
+	public $disconnect3rdParty = 0;
+	
+	/**
 	 * @inheritDoc
 	 */
 	public function readParameters() {
@@ -186,6 +192,8 @@ class UserEditForm extends UserAddForm {
 				if (isset($_POST['disableCoverPhotoExpires'])) $this->disableCoverPhotoExpires = @strtotime(StringUtil::trim($_POST['disableCoverPhotoExpires']));
 			}
 		}
+		
+		if (WCF::getSession()->getPermission('admin.user.canEditPassword') && isset($_POST['disconnect3rdParty'])) $this->disconnect3rdParty = 1;
 	}
 	
 	/**
@@ -319,6 +327,10 @@ class UserEditForm extends UserAddForm {
 		
 		$this->additionalFields = array_merge($this->additionalFields, $avatarData);
 		
+		if ($this->disconnect3rdParty) {
+			$this->additionalFields['authData'] = '';
+		}
+		
 		// add default groups
 		$defaultGroups = UserGroup::getAccessibleGroups([UserGroup::GUESTS, UserGroup::EVERYONE, UserGroup::USERS]);
 		$oldGroupIDs = $this->user->getGroupIDs();
@@ -410,8 +422,8 @@ class UserEditForm extends UserAddForm {
 		// reset password
 		$this->password = $this->confirmPassword = '';
 		
-		// reload user when deleting the cover photo
-		if ($this->deleteCoverPhoto) $this->user = new User($this->userID);
+		// reload user when deleting the cover photo or disconneting from 3rd party auth provider
+		if ($this->deleteCoverPhoto || $this->disconnect3rdParty) $this->user = new User($this->userID);
 		
 		// show success message
 		WCF::getTPL()->assign('success', true);

--- a/wcfsetup/install/files/lib/acp/form/UserEditForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/UserEditForm.class.php
@@ -159,7 +159,7 @@ class UserEditForm extends UserAddForm {
 	public function readFormParameters() {
 		parent::readFormParameters();
 		
-		if (!WCF::getSession()->getPermission('admin.user.canEditPassword')) $this->password = $this->confirmPassword = '';
+		if (!WCF::getSession()->getPermission('admin.user.canEditPassword') || !empty($this->user->authData)) $this->password = $this->confirmPassword = '';
 		if (!WCF::getSession()->getPermission('admin.user.canEditMailAddress')) $this->email = $this->confirmEmail = $this->user->email;
 		
 		if (!empty($_POST['banned'])) $this->banned = 1;

--- a/wcfsetup/install/files/lib/data/user/User.class.php
+++ b/wcfsetup/install/files/lib/data/user/User.class.php
@@ -377,6 +377,20 @@ final class User extends DatabaseObject implements IRouteController, IUserConten
 	}
 	
 	/**
+	 * Returns 3rd party auth provider name.
+	 *
+	 * @return	string
+	 * @since       5.2
+	 */
+	public function getAuthProvider() {
+		if (!$this->authData) {
+			return '';
+		}
+		
+		return mb_substr($this->authData, 0, mb_strpos($this->authData, ':'));
+	}
+	
+	/**
 	 * Returns true if this user is marked.
 	 * 
 	 * @return	boolean

--- a/wcfsetup/install/files/lib/data/user/UserProfile.class.php
+++ b/wcfsetup/install/files/lib/data/user/UserProfile.class.php
@@ -939,11 +939,7 @@ class UserProfile extends DatabaseObjectDecorator implements ITitledLinkObject {
 	 * @return	string
 	 */
 	public function getAuthProvider() {
-		if (!$this->authData) {
-			return '';
-		}
-		
-		return mb_substr($this->authData, 0, mb_strpos($this->authData, ':'));
+		return $this->getDecoratedObject()->getAuthProvider();
 	}
 	
 	/**

--- a/wcfsetup/install/files/lib/form/LostPasswordForm.class.php
+++ b/wcfsetup/install/files/lib/form/LostPasswordForm.class.php
@@ -80,9 +80,12 @@ class LostPasswordForm extends AbstractCaptchaForm {
 			}
 		}
 		
-		// check if using 3rd party @author dtdesign
+		// check if using 3rd party
 		if ($this->user->authData) {
-			throw new UserInputException('username', '3rdParty');
+			HeaderUtil::delayedRedirect(LinkHandler::getInstance()->getLink(ucfirst($this->user->getAuthProvider()) . 'Auth'), WCF::getLanguage()->getDynamicVariable('wcf.user.username.error.3rdParty.redirect', [
+				'provider' => WCF::getLanguage()->get('wcf.user.3rdparty.'. $this->user->getAuthProvider())
+			]),5, 'info');
+			exit;
 		}
 		
 		// check whether a lost password request was sent in the last 24 hours

--- a/wcfsetup/install/files/lib/form/LostPasswordForm.class.php
+++ b/wcfsetup/install/files/lib/form/LostPasswordForm.class.php
@@ -84,7 +84,7 @@ class LostPasswordForm extends AbstractCaptchaForm {
 		if ($this->user->authData) {
 			HeaderUtil::delayedRedirect(LinkHandler::getInstance()->getLink(ucfirst($this->user->getAuthProvider()) . 'Auth'), WCF::getLanguage()->getDynamicVariable('wcf.user.username.error.3rdParty.redirect', [
 				'provider' => WCF::getLanguage()->get('wcf.user.3rdparty.'. $this->user->getAuthProvider())
-			]),5, 'info');
+			]), 5, 'info');
 			exit;
 		}
 		

--- a/wcfsetup/install/files/lib/system/clipboard/action/UserClipboardAction.class.php
+++ b/wcfsetup/install/files/lib/system/clipboard/action/UserClipboardAction.class.php
@@ -2,6 +2,7 @@
 namespace wcf\system\clipboard\action;
 use wcf\data\clipboard\action\ClipboardAction;
 use wcf\data\user\group\UserGroup;
+use wcf\data\user\User;
 use wcf\data\user\UserAction;
 use wcf\system\database\util\PreparedStatementConditionBuilder;
 use wcf\system\request\LinkHandler;
@@ -171,7 +172,13 @@ class UserClipboardAction extends AbstractClipboardAction {
 			return [];
 		}
 		
-		return $this->__validateAccessibleGroups(array_keys($this->objects));
+		$userIDs = [];
+		/** @var User $user */
+		foreach ($this->objects as $user) {
+			if (empty($user->authData)) $userIDs[] = $user->userID;
+		}
+		
+		return $this->__validateAccessibleGroups($userIDs);
 	}
 	
 	/**

--- a/wcfsetup/install/lang/de.xml
+++ b/wcfsetup/install/lang/de.xml
@@ -4422,6 +4422,7 @@ Dateianhänge:
 		<item name="wcf.user.button.login"><![CDATA[Anmelden]]></item>
 		<item name="wcf.user.button.register"><![CDATA[Registrieren]]></item>
 		<item name="wcf.user.username.error.3rdParty"><![CDATA[Das Benutzerkonto ist mit einem Drittanbieter-Konto verbunden, ein Passwort kann nicht angefordert werden.]]></item>
+		<item name="wcf.user.username.error.3rdParty.redirect"><![CDATA[Das Benutzerkonto ist mit {$provider} verbunden, ein Passwort kann nicht angefordert werden. Sie werden jetzt zur Anmeldung mit {$provider} weitergeleitet.]]></item>
 		<item name="wcf.user.loginOrRegister"><![CDATA[Anmelden{if !REGISTER_DISABLED} oder registrieren{/if}]]></item>
 		<item name="wcf.user.useCookies"><![CDATA[Dauerhaft angemeldet bleiben]]></item>
 		<item name="wcf.user.usernameOrEmail"><![CDATA[Benutzername oder E-Mail-Adresse]]></item>

--- a/wcfsetup/install/lang/de.xml
+++ b/wcfsetup/install/lang/de.xml
@@ -4845,6 +4845,7 @@ Die E-Mail-Adresse des neuen Benutzers lautet: {@$user->email}
 		<item name="wcf.user.3rdparty.google.connect.error.inuse"><![CDATA[{if LANGUAGE_USE_INFORMAL_VARIANT}Dein{else}Ihr{/if} Google-Konto ist bereits mit einem anderen Benutzerkonto verknüpft.]]></item>
 		<item name="wcf.user.3rdparty.google.disconnect"><![CDATA[Verknüpfung mit Google trennen]]></item>
 		<item name="wcf.user.3rdparty.google.disconnect.success"><![CDATA[Die Verknüpfung mit {if LANGUAGE_USE_INFORMAL_VARIANT}deinem{else}Ihrem{/if} Google-Konto wurde erfolgreich getrennt.]]></item>
+		<item name="wcf.user.3rdparty.connect.info"><![CDATA[Der Benutzer ist mit {lang}wcf.user.3rdparty.{$user->getAuthProvider()}{/lang} verknüpft.]]></item>
 	</category>
 	<category name="wcf.user.avatar">
 		<item name="wcf.user.avatar"><![CDATA[Avatar]]></item>

--- a/wcfsetup/install/lang/de.xml
+++ b/wcfsetup/install/lang/de.xml
@@ -4846,7 +4846,7 @@ Die E-Mail-Adresse des neuen Benutzers lautet: {@$user->email}
 		<item name="wcf.user.3rdparty.google.connect.error.inuse"><![CDATA[{if LANGUAGE_USE_INFORMAL_VARIANT}Dein{else}Ihr{/if} Google-Konto ist bereits mit einem anderen Benutzerkonto verknüpft.]]></item>
 		<item name="wcf.user.3rdparty.google.disconnect"><![CDATA[Verknüpfung mit Google trennen]]></item>
 		<item name="wcf.user.3rdparty.google.disconnect.success"><![CDATA[Die Verknüpfung mit {if LANGUAGE_USE_INFORMAL_VARIANT}deinem{else}Ihrem{/if} Google-Konto wurde erfolgreich getrennt.]]></item>
-		<item name="wcf.user.3rdparty.connect.info"><![CDATA[Der Benutzer ist mit {lang}wcf.user.3rdparty.{$user->getAuthProvider()}{/lang} verknüpft.]]></item>
+		<item name="wcf.user.3rdparty.connect.info"><![CDATA[Der Benutzer ist mit {"wcf.user.3rdparty."|concat:$user->getAuthProvider()|language} verknüpft.]]></item>
 	</category>
 	<category name="wcf.user.avatar">
 		<item name="wcf.user.avatar"><![CDATA[Avatar]]></item>

--- a/wcfsetup/install/lang/en.xml
+++ b/wcfsetup/install/lang/en.xml
@@ -4841,6 +4841,7 @@ Open the link below to access the user profile:
 		<item name="wcf.user.3rdparty.google.connect.error.inuse"><![CDATA[Your Google account is already connected to a different user.]]></item>
 		<item name="wcf.user.3rdparty.google.disconnect"><![CDATA[Cancel connection with Google]]></item>
 		<item name="wcf.user.3rdparty.google.disconnect.success"><![CDATA[Your account is no longer connected with Google.]]></item>
+		<item name="wcf.user.3rdparty.connect.info"><![CDATA[The user is connected with {lang}wcf.user.3rdparty.{$user->getAuthProvider()}{/lang}.]]></item>
 	</category>
 	<category name="wcf.user.avatar">
 		<item name="wcf.user.avatar"><![CDATA[Avatar]]></item>

--- a/wcfsetup/install/lang/en.xml
+++ b/wcfsetup/install/lang/en.xml
@@ -4424,6 +4424,7 @@ Attachments:
 		<item name="wcf.user.button.login"><![CDATA[Login]]></item>
 		<item name="wcf.user.button.register"><![CDATA[Register]]></item>
 		<item name="wcf.user.username.error.3rdParty"><![CDATA[Account is connected with a 3rd party website, password cannot be requested.]]></item>
+		<item name="wcf.user.username.error.3rdParty.redirect"><![CDATA[Account is connected with {$provider}, password cannot be requested. You will now be redirected to the login with {$provider}.]]></item>
 		<item name="wcf.user.loginOrRegister"><![CDATA[Login{if !REGISTER_DISABLED} or register{/if}]]></item>
 		<item name="wcf.user.useCookies"><![CDATA[Remain logged in]]></item>
 		<item name="wcf.user.usernameOrEmail"><![CDATA[Username or Email Address]]></item>

--- a/wcfsetup/install/lang/en.xml
+++ b/wcfsetup/install/lang/en.xml
@@ -4842,7 +4842,7 @@ Open the link below to access the user profile:
 		<item name="wcf.user.3rdparty.google.connect.error.inuse"><![CDATA[Your Google account is already connected to a different user.]]></item>
 		<item name="wcf.user.3rdparty.google.disconnect"><![CDATA[Cancel connection with Google]]></item>
 		<item name="wcf.user.3rdparty.google.disconnect.success"><![CDATA[Your account is no longer connected with Google.]]></item>
-		<item name="wcf.user.3rdparty.connect.info"><![CDATA[The user is connected with {lang}wcf.user.3rdparty.{$user->getAuthProvider()}{/lang}.]]></item>
+		<item name="wcf.user.3rdparty.connect.info"><![CDATA[The user is connected with {"wcf.user.3rdparty."|concat:$user->getAuthProvider()|language}.]]></item>
 	</category>
 	<category name="wcf.user.avatar">
 		<item name="wcf.user.avatar"><![CDATA[Avatar]]></item>


### PR DESCRIPTION
* [x] The administrator is unable to review the authentication method, it is simply not visible that a user has registered themselves through a 3rd party site.
* [x] Offer an option to decouple the account at the place of the password (if the user, for example, no longer has access to the account, for whatever obscure reason).
* [x] Remove the password field for administrators for accounts registered through third parties.
* [x] Requesting a password yields an error message that denies the request, because the account is attached to a third party service. While this is correct, it is a poor UX in terms of the workflow. Instead, the message should tell the user that their account is connected with service X and present the user with a button to initiate the process.