### PR TITLE
Improved the UX and the DOM markup of reactions

### DIFF
--- a/com.woltlab.wcf/templates/articleListItems.tpl
+++ b/com.woltlab.wcf/templates/articleListItems.tpl
@@ -53,13 +53,6 @@
 				</div>
 				
 				<div class="contentItemMetaIcons">
-					{if MODULE_LIKE && $__wcf->getSession()->getPermission('user.like.canViewLike') && ($article->likes || $article->dislikes || $article->neutralReactions)}
-						<div class="contentItemMetaIcon reputationCounter {if $article->cumulativeLikes > 0}positive{elseif $article->cumulativeLikes < 0}negative{else}neutral{/if}">
-							<span aria-label="{lang cumulativeLikes=$article->cumulativeLikes}wcf.like.reputation.label{/lang}">
-								{if $article->cumulativeLikes > 0}+{elseif $article->cumulativeLikes == 0}±{/if}{#$article->cumulativeLikes}
-							</span>
-						</div>
-					{/if}
 					<div class="contentItemMetaIcon">
 						<span class="icon icon16 fa-comments"></span>
 						<span aria-label="{$article->getDiscussionProvider()->getDiscussionCountPhrase()}">

--- a/com.woltlab.wcf/templates/reactionSummaryList.tpl
+++ b/com.woltlab.wcf/templates/reactionSummaryList.tpl
@@ -1,9 +1,16 @@
 {if $__wcf->session->getPermission('user.like.canViewLike')}
-	<ul class="reactionSummaryList{if $isTiny|isset && $isTiny} reactionSummaryListTiny{/if} jsOnly" data-object-type="{$objectType}" data-object-id="{$objectID}">
-		{if $reactionData[$objectID]|isset && $reactionData[$objectID]->getReactions()|is_array}
-			{foreach from=$reactionData[$objectID]->getReactions() key=reactionTypeID item=reaction}
-				<li class="reactCountButton jsTooltip" data-reaction-type-id="{$reactionTypeID}" title="{lang}wcf.reactions.summary.listReactions{/lang}"><span class="reactionCount">{$reaction[reactionCount]|shortUnit}</span> {@$reaction[renderedReactionIcon]}</li>
+	{assign var='_reactionSummaryListReactions' value=null}
+        {if $reactionData[$objectID]|isset}
+		{assign var='_reactionSummaryListReactions' value=$reactionData[$objectID]->getReactions()}
+	{/if}
+	<a href="#" class="reactionSummaryList{if $isTiny|isset && $isTiny} reactionSummaryListTiny{/if} jsOnly jsTooltip" data-object-type="{$objectType}" data-object-id="{$objectID}" title="{lang}wcf.reactions.summary.listReactions{/lang}"{if $_reactionSummaryListReactions|empty} style="display: none;"{/if}>
+		{if !$_reactionSummaryListReactions|empty}
+			{foreach from=$_reactionSummaryListReactions key=reactionTypeID item=reaction}
+				<span class="reactCountButton" data-reaction-type-id="{@$reactionTypeID}">
+					{@$reaction[renderedReactionIcon]}
+					<span class="reactionCount">{$reaction[reactionCount]|shortUnit}</span>
+				</span>
 			{/foreach}
 		{/if}
-	</ul>
+	</a>
 {/if}

--- a/com.woltlab.wcf/templates/reactionTypeImage.tpl
+++ b/com.woltlab.wcf/templates/reactionTypeImage.tpl
@@ -2,4 +2,4 @@
 	src="{@$__wcf->getPath()}images/reaction/{$reactionType->iconFile}"
 	class="reactionType"
 	data-reaction-type-id="{$reactionType->reactionTypeID}"
-/>
+>

--- a/wcfsetup/install/files/acp/templates/reactionTypeImage.tpl
+++ b/wcfsetup/install/files/acp/templates/reactionTypeImage.tpl
@@ -3,4 +3,4 @@
 	style="width:24px;height:24px"
 	class="reactionType"
 	data-reaction-type-id="{$reactionType->reactionTypeID}"
-/>
+>

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Reaction/Handler.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Reaction/Handler.js
@@ -40,7 +40,6 @@ define(
 				}
 				
 				this._containers = new Dictionary();
-				this._details = new ObjectMap();
 				this._objectType = objectType;
 				this._cache = new Dictionary();
 				this._objects = new Dictionary();
@@ -81,25 +80,24 @@ define(
 						continue;
 					}
 					
+					objectId = ~~elData(element, 'object-id');
 					elementData = {
 						reactButton: null,
-						objectId: ~~elData(element, 'object-id'),
+						objectId: objectId,
 						element: element
 					};
 					
 					this._containers.set(DomUtil.identify(element), elementData);
 					this._initReactButton(element, elementData);
-					
-					if (!this._objects.has(~~elData(element, 'object-id'))) {
-						var objects = [];
-					}
-					else {
-						var objects = this._objects.get(~~elData(element, 'object-id'));
+
+					var objects = [];
+					if (this._objects.has(objectId)) {
+						objects = this._objects.get(objectId);
 					}
 					
 					objects.push(elementData);
 					
-					this._objects.set(~~elData(element, 'object-id'), objects);
+					this._objects.set(objectId, objects);
 					
 					triggerChange = true;
 				}
@@ -122,11 +120,13 @@ define(
 				}
 				
 				if (elementData.reactButton === null || elementData.reactButton.length === 0) {
-					// the element may have no react button 
+					// The element may have no react button. 
 					return;
 				}
 				
+				//noinspection JSUnresolvedVariable
 				if (Object.keys(REACTION_TYPES).length === 1) {
+					//noinspection JSUnresolvedVariable
 					var reaction = REACTION_TYPES[Object.keys(REACTION_TYPES)[0]];
 					elementData.reactButton.title = reaction.title;
 					var textSpan = elBySel('.invisible', elementData.reactButton);
@@ -190,7 +190,8 @@ define(
 						if (reactionTypeID) {
 							elementData.reactButton.classList.add('active');
 							elData(elementData.reactButton, 'reaction-type-id', reactionTypeID);
-						} else {
+						}
+						else {
 							elData(elementData.reactButton, 'reaction-type-id', 0);
 							elementData.reactButton.classList.remove('active');
 						}
@@ -199,25 +200,24 @@ define(
 			},
 			
 			_markReactionAsActive: function() {
-				var reactionTypeID;
+				var reactionTypeID = null;
 				this._objects.get(this._popoverCurrentObjectId).forEach(function (element) {
 					if (element.reactButton !== null) {
-						reactionTypeID = elData(element.reactButton, 'reaction-type-id');
+						reactionTypeID = ~~elData(element.reactButton, 'reaction-type-id');
 					}
 				});
 				
-				if (reactionTypeID === undefined) {
+				if (reactionTypeID === null) {
 					throw new Error("Unable to find react button for current popover.");
 				}
 				
-				//  clear old active state
-				var elements = elBySelAll('.reactionTypeButton.active', this._getPopover());
-				for (var i = 0, length = elements.length; i < length; i++) {
-					elements[i].classList.remove('active');
-				}
+				//  Clear the old active state.
+				elBySelAll('.reactionTypeButton.active', this._getPopover(), function(element) {
+					element.classList.remove('active');
+				});
 				
-				if (reactionTypeID != 0) {
-					elBySel('.reactionTypeButton[data-reaction-type-id="'+reactionTypeID+'"]', this._getPopover()).classList.add('active');
+				if (reactionTypeID) {
+					elBySel('.reactionTypeButton[data-reaction-type-id="' + reactionTypeID + '"]', this._getPopover()).classList.add('active');
 				}
 			},
 			
@@ -226,14 +226,17 @@ define(
 			 * 
 			 * @param       {int}           objectId
 			 * @param       {Element}       element
+			 * @param       {?Event}        event
 			 */
 			_toggleReactPopover: function(objectId, element, event) {
 				if (event !== null) {
 					event.preventDefault();
 					event.stopPropagation();
 				}
-				
+
+				//noinspection JSUnresolvedVariable
 				if (Object.keys(REACTION_TYPES).length === 1) {
+					//noinspection JSUnresolvedVariable
 					var reaction = REACTION_TYPES[Object.keys(REACTION_TYPES)[0]];
 					this._popoverCurrentObjectId = objectId;
 					
@@ -256,7 +259,6 @@ define(
 			 * @param       {Element}	element 		container element
 			 */
 			_openReactPopover: function(objectId, element) {
-				// first close old popover, if exists 
 				if (this._popoverCurrentObjectId !== 0) {
 					this._closePopover();
 				}
@@ -271,9 +273,7 @@ define(
 				});
 				
 				if (this._options.isButtonGroupNavigation) {
-					// find nav element
-					var nav = element.closest('nav');
-					nav.style.opacity = "1";
+					element.closest('nav').style.setProperty('opacity', '1', '');
 				}
 				
 				this._getPopover().classList.remove('forceHide');
@@ -311,7 +311,8 @@ define(
 						var reactionTypeItemSpan = elCreate('span');
 						reactionTypeItemSpan.classList = 'reactionTypeButtonTitle';
 						reactionTypeItemSpan.innerHTML = reactionType.title;
-						
+
+						//noinspection JSUnresolvedVariable
 						reactionTypeItem.innerHTML = reactionType.renderedIcon;
 						
 						reactionTypeItem.appendChild(reactionTypeItemSpan);
@@ -346,13 +347,18 @@ define(
 				var sortedReactionTypes = [];
 				
 				// convert our reaction type object to an array
+				//noinspection JSUnresolvedVariable
 				for (var key in REACTION_TYPES) {
-					if (!REACTION_TYPES.hasOwnProperty(key)) continue;
-					sortedReactionTypes.push(REACTION_TYPES[key]);
+					//noinspection JSUnresolvedVariable
+					if (REACTION_TYPES.hasOwnProperty(key)) {
+						//noinspection JSUnresolvedVariable
+						sortedReactionTypes.push(REACTION_TYPES[key]);
+					}
 				}
 				
 				// sort the array
 				sortedReactionTypes.sort(function (a, b) {
+					//noinspection JSUnresolvedVariable
 					return a.showOrder - b.showOrder;
 				});
 				
@@ -395,9 +401,9 @@ define(
 			},
 			
 			_ajaxSuccess: function(data) {
+				//noinspection JSUnresolvedVariable
 				this.countButtons.updateCountButtons(data.returnValues.objectID, data.returnValues.reactions);
 				
-				// update react button status
 				this._updateReactButton(data.returnValues.objectID, data.returnValues.reactionTypeID);
 			},
 			

--- a/wcfsetup/install/files/lib/data/reaction/ReactionAction.class.php
+++ b/wcfsetup/install/files/lib/data/reaction/ReactionAction.class.php
@@ -52,25 +52,25 @@ class ReactionAction extends AbstractDatabaseObjectAction {
 	 * likeable object
 	 * @var	ILikeObject
 	 */
-	public $likeableObject = null;
+	public $likeableObject;
 	
 	/**
 	 * object type object
 	 * @var	ObjectType
 	 */
-	public $objectType = null;
+	public $objectType;
 	
 	/**
 	 * like object type provider object
 	 * @var	ILikeObjectTypeProvider
 	 */
-	public $objectTypeProvider = null;
+	public $objectTypeProvider;
 	
 	/**
 	 * reaction type for the reaction
 	 * @var	ReactionType
 	 */
-	public $reactionType = null;
+	public $reactionType;
 	
 	/**
 	 * Validates parameters to fetch like details.

--- a/wcfsetup/install/files/style/ui/message.scss
+++ b/wcfsetup/install/files/style/ui/message.scss
@@ -504,14 +504,14 @@
 	flex-wrap: wrap;
 	
 	&:not(:first-child) {
-		> .likesSummary,
+		> .reactionSummaryList,
 		> .messageFooterButtons,
 		> .messageFooterButtonsExtra {
 			margin-top: 20px;
 		}
 	}
 	
-	> .likesSummary {
+	> .reactionSummaryList {
 		flex: 0 1 auto;
 		
 		@include wcfFontSmall;

--- a/wcfsetup/install/files/style/ui/reactions.scss
+++ b/wcfsetup/install/files/style/ui/reactions.scss
@@ -25,14 +25,38 @@
 	}
 }
 
-img.reactionType {
-	width: 24px;
-	height: 24px;
+.reactionType {
+	width: 20px;
+	height: 20px;
 }
 
 .reactionSummaryList {
-	span.reactionCount::after {
-		content: ' × ';
+	display: flex;
+	flex-wrap: wrap;
+	margin: -5px -5px 0 0;
+	
+	.reactionCount{
+		@include wcfFontSmall;
+		
+		&::before {
+			content: ' × ';
+		}
+	}
+	
+	&.reactionSummaryListTiny .reactionType {
+		width: 16px;
+		height: 16px;
+	}
+}
+
+.reactCountButton {
+	color: $wcfContentDimmedText;
+	flex: 0 0 auto;
+	margin: 5px 5px 0 0;
+	white-space: nowrap;
+	
+	&:hover {
+		color: $wcfContentText;
 	}
 }
 
@@ -59,10 +83,10 @@ img.reactionType {
 	}
 	
 	@include screen-md-down {
-		padding: 5px 0px;
+		padding: 5px 0;
 		
 		> ul > li.reactionTypeButton {
-			margin: 0px;
+			margin: 0;
 			display: block;
 			padding: 5px 25px;
 		}
@@ -106,21 +130,9 @@ img.reactionType {
 		}
 		
 		> ul > li.reactionTypeButton:first-child {
-			margin-left: 0px;
+			margin-left: 0;
 		}
 	}
-}
-
-li.reactCountButton {
-	display: inline;
-	padding: 5px;
-	cursor: pointer;
-	color: $wcfContentDimmedText;
-	white-space: nowrap;
-}
-
-li.reactCountButton:hover {
-	color: $wcfContentText;
 }
 
 .reputationCounter {
@@ -150,24 +162,6 @@ li.reactCountButton:hover {
 	
 	&:empty {
 		display: none;	
-	}
-}
-
-.reactionSummaryListTiny {
-	display: inline;
-	
-	li.reactCountButton > img {
-		width: 16px;
-		height: 16px;
-	}
-	
-	span.reactionCount {
-		@include wcfFontSmall;
-	}
-	
-	li.reactCountButton {
-		background-color: transparent;
-		padding: 0px;
 	}
 }
 


### PR DESCRIPTION
Updated visuals for the reaction summary and rebuild the DOM to improve a11y.

Also removed the visual presentation of cumulative likes, they don't really play well with the concept of a 
reaction system. The use of cumulative likes has always been a bit wonky, considering that it's a non-uniform UI element across communities when dislikes are enabled/disabled. The new star ratings for reviews in WoltLab Suite Filebase strenghtens the need for more specialized solutions when an actual rating is required, there is no "one size fits all" when it comes to ratings.

Nevertheless, cumulative likes are tracked in the background and can be enabled through custom templates at the admin's discretion.