### PR TITLE
Fix applicationDirectory index during WSC-Updates

### DIFF
--- a/wcfsetup/install/files/lib/system/package/PackageInstallationDispatcher.class.php
+++ b/wcfsetup/install/files/lib/system/package/PackageInstallationDispatcher.class.php
@@ -432,8 +432,11 @@ class PackageInstallationDispatcher {
 		}
 		unset($nodeData['requirements']);
 		
-		$applicationDirectory = $nodeData['applicationDirectory'];
-		unset($nodeData['applicationDirectory']);
+		$applicationDirectory = '';
+		if (isset($nodeData['applicationDirectory'])) {
+			$applicationDirectory = $nodeData['applicationDirectory'];
+			unset($nodeData['applicationDirectory']);
+		}
 		
 		// update package
 		if ($this->queue->packageID) {
@@ -534,15 +537,13 @@ class PackageInstallationDispatcher {
 			}
 		}
 		
-		if ($this->getPackage()->isApplication && $this->getPackage()->package != 'com.woltlab.wcf' && $this->getAction() == 'install') {
-			if (empty($this->getPackage()->packageDir)) {
-				$document = $this->promptPackageDir($applicationDirectory);
-				if ($document !== null && $document instanceof FormDocument) {
-					$installationStep->setDocument($document);
-				}
-				
-				$installationStep->setSplitNode();
+		if ($this->getPackage()->isApplication && $this->getPackage()->package != 'com.woltlab.wcf' && $this->getAction() == 'install' && empty($this->getPackage()->packageDir)) {
+			$document = $this->promptPackageDir($applicationDirectory);
+			if ($document !== null && $document instanceof FormDocument) {
+				$installationStep->setDocument($document);
 			}
+
+			$installationStep->setSplitNode();
 		}
 		
 		return $installationStep;


### PR DESCRIPTION
Some apps - including the WSC - do not provide an application directory within the package.xml-file.
We have to check whether this index exists - otherwise we wouldn't need to prompt it at lines541ff.

Not changing this behaviour will cause errors during the upgrade WSC 3.1 to WSC 5.2.