### PR TITLE
Fix xsd filenames in pip gui

### DIFF
--- a/wcfsetup/install/files/lib/system/package/plugin/ACPMenuPackageInstallationPlugin.class.php
+++ b/wcfsetup/install/files/lib/system/package/plugin/ACPMenuPackageInstallationPlugin.class.php
@@ -49,6 +49,14 @@ class ACPMenuPackageInstallationPlugin extends AbstractMenuPackageInstallationPl
 	 * @inheritDoc
 	 * @since	5.2
 	 */
+	protected function getXsdFilename() {
+		return 'acpMenu';
+	}
+	
+	/**
+	 * @inheritDoc
+	 * @since	5.2
+	 */
 	protected function addFormFields(IFormDocument $form) {
 		parent::addFormFields($form);
 		

--- a/wcfsetup/install/files/lib/system/package/plugin/ACPSearchProviderPackageInstallationPlugin.class.php
+++ b/wcfsetup/install/files/lib/system/package/plugin/ACPSearchProviderPackageInstallationPlugin.class.php
@@ -143,6 +143,14 @@ class ACPSearchProviderPackageInstallationPlugin extends AbstractXMLPackageInsta
 	 * @inheritDoc
 	 * @since	5.2
 	 */
+	protected function getXsdFilename() {
+		return 'acpSearchProvider';
+	}
+	
+	/**
+	 * @inheritDoc
+	 * @since	5.2
+	 */
 	protected function addFormFields(IFormDocument $form) {
 		/** @var FormContainer $dataContainer */
 		$dataContainer = $form->getNodeById('data');

--- a/wcfsetup/install/files/lib/system/package/plugin/BBCodePackageInstallationPlugin.class.php
+++ b/wcfsetup/install/files/lib/system/package/plugin/BBCodePackageInstallationPlugin.class.php
@@ -320,6 +320,14 @@ class BBCodePackageInstallationPlugin extends AbstractXMLPackageInstallationPlug
 	 * @inheritDoc
 	 * @since	5.2
 	 */
+	protected function getXsdFilename() {
+		return 'bbcode';
+	}
+	
+	/**
+	 * @inheritDoc
+	 * @since	5.2
+	 */
 	protected function addFormFields(IFormDocument $form) {
 		/** @var FormContainer $dataContainer */
 		$dataContainer = $form->getNodeById('data');


### PR DESCRIPTION
The pip gui generates the following xsd filenames automatically:

- `aCPMenu`
- `aCPSearchProvider`
- `bBCode`
