### PR TITLE
TMultipleFormField::getMaximumMultiples() returns -1 erroneously

### DIFF
--- a/wcfsetup/install/files/lib/system/form/builder/field/TMultipleFormField.class.php
+++ b/wcfsetup/install/files/lib/system/form/builder/field/TMultipleFormField.class.php
@@ -51,7 +51,7 @@ trait TMultipleFormField {
 	 * @return	int	maximum number of values
 	 */
 	public function getMaximumMultiples() {
-		return $this->maximumMultiples;
+		return $this->allowsMultiple() ? $this->maximumMultiples : 1;
 	}
 	
 	/**


### PR DESCRIPTION
should return 1 if field do es not allow multiple values
Otherwise it would be necessary to check for `::allowsMultiple()` and catch this by an additional if-case in template (or other) code.
used over here for example:
https://github.com/WoltLab/WCF/blob/6c85a381d857b063265ddb9e122c0df8a2672f18/wcfsetup/install/files/acp/templates/__userFormField.tpl#L14-L18