### PR TITLE
Add UA detection for Firefox on iOS

### DIFF
--- a/wcfsetup/install/files/lib/data/user/online/UserOnline.class.php
+++ b/wcfsetup/install/files/lib/data/user/online/UserOnline.class.php
@@ -185,7 +185,7 @@ class UserOnline extends UserProfile {
 		}
 		
 		// firefox mobile
-		if (preg_match('~(mobile.*firefox|fxios)/([\d\.]+)|fennec/([\d\.]+)~i', $this->userAgent, $match)) {
+		if (preg_match('~(?:mobile.*firefox|fxios)/([\d\.]+)|fennec/([\d\.]+)~i', $this->userAgent, $match)) {
 			return 'Firefox Mobile '.(isset($match[2]) ? $match[2] : $match[1]);
 		}
 		

--- a/wcfsetup/install/files/lib/data/user/online/UserOnline.class.php
+++ b/wcfsetup/install/files/lib/data/user/online/UserOnline.class.php
@@ -195,7 +195,7 @@ class UserOnline extends UserProfile {
 		}
 		
 		// firefox
-		if (preg_match('~firefox/([\d\.]+)~i', $this->userAgent, $match)) {
+		if (preg_match('~(?:firefox|fxios)/([\d\.]+)~i', $this->userAgent, $match)) {
 			return 'Firefox '.$match[1];
 		}
 		

--- a/wcfsetup/install/files/lib/data/user/online/UserOnline.class.php
+++ b/wcfsetup/install/files/lib/data/user/online/UserOnline.class.php
@@ -185,7 +185,7 @@ class UserOnline extends UserProfile {
 		}
 		
 		// firefox mobile
-		if (preg_match('~mobile.*firefox/([\d\.]+)|fennec/([\d\.]+)~i', $this->userAgent, $match)) {
+		if (preg_match('~(mobile.*firefox|fxios)/([\d\.]+)|fennec/([\d\.]+)~i', $this->userAgent, $match)) {
 			return 'Firefox Mobile '.(isset($match[2]) ? $match[2] : $match[1]);
 		}
 		
@@ -195,7 +195,7 @@ class UserOnline extends UserProfile {
 		}
 		
 		// firefox
-		if (preg_match('~(?:firefox|fxios)/([\d\.]+)~i', $this->userAgent, $match)) {
+		if (preg_match('~firefox/([\d\.]+)~i', $this->userAgent, $match)) {
 			return 'Firefox '.$match[1];
 		}
 		


### PR DESCRIPTION
Example UA: `Mozilla/5.0 (iPhone; CPU iPhone OS 12_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/18.2b15817 Mobile/15E148 Safari/605.1.15`