### PR TITLE
Make subclasses of ItemListFormField compatible with IMultipleFormField

### DIFF
--- a/wcfsetup/install/files/lib/system/form/builder/field/option/OptionFormField.class.php
+++ b/wcfsetup/install/files/lib/system/form/builder/field/option/OptionFormField.class.php
@@ -28,6 +28,8 @@ class OptionFormField extends ItemListFormField implements IPackagesFormField {
 	 * Creates a new instance of `OptionsFormField`.
 	 */
 	public function __construct() {
+		parent::__construct();
+		
 		$this->label('wcf.form.field.option');
 	}
 	

--- a/wcfsetup/install/files/lib/system/form/builder/field/user/group/option/UserGroupOptionFormField.class.php
+++ b/wcfsetup/install/files/lib/system/form/builder/field/user/group/option/UserGroupOptionFormField.class.php
@@ -28,6 +28,8 @@ class UserGroupOptionFormField extends ItemListFormField implements IPackagesFor
 	 * Creates a new instance of `OptionsFormField`.
 	 */
 	public function __construct() {
+		parent::__construct();
+		
 		$this->label('wcf.form.field.userGroupOption');
 	}
 	

--- a/wcfsetup/install/files/lib/system/package/plugin/ObjectTypePackageInstallationPlugin.class.php
+++ b/wcfsetup/install/files/lib/system/package/plugin/ObjectTypePackageInstallationPlugin.class.php
@@ -485,7 +485,7 @@ class ObjectTypePackageInstallationPlugin extends AbstractXMLPackageInstallation
 					->objectProperty('disallowedBBCodesPermission')
 					->label('wcf.acp.pip.objectType.com.woltlab.wcf.message.disallowedBBCodesPermission')
 					->description('wcf.acp.pip.objectType.com.woltlab.wcf.message.disallowedBBCodesPermission.description')
-					->maximum(1)
+					->multiple(false)
 					->addValidator(new FormFieldValidator('optionType', function(UserGroupOptionFormField $formField) {
 						$value = $formField->getValue();
 						if (empty($value)) return;


### PR DESCRIPTION
All usages of `UserGroupOptionFormField` and `OptionFormField` are expecting no maximum multiples by default.