### PR TITLE
Reaction single item fix

### DIFF
--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Reaction/CountButtons.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Reaction/CountButtons.js
@@ -74,6 +74,7 @@ define(
 						reactButton: null,
 						summary: null,
 						
+						isSingleItem: this._options.isSingleItem,
 						objectId: objectId, 
 						element: element
 					};
@@ -107,7 +108,7 @@ define(
 			updateCountButtons: function(objectId, data) {
 				var triggerChange = false;
 				this._objects.get(objectId).forEach(function(elementData) {
-					var summaryList = elBySel(this._options.summaryListSelector, elementData.element);
+					var summaryList = elBySel(this._options.summaryListSelector, elementData.isSingleItem ? undefined : elementData.element);
 					
 					// summary list for the object not found; abort
 					if (summaryList === null) return; 


### PR DESCRIPTION
When the summary not in the 'containerSelector' but markt as single item, the reaction will not append after save.