### PR TITLE
Hide stacktraces in "Exception in Exception"

### DIFF
--- a/wcfsetup/install/files/lib/system/WCF.class.php
+++ b/wcfsetup/install/files/lib/system/WCF.class.php
@@ -307,25 +307,43 @@ class WCF {
 				}
 			}
 		}
-		
+
+		// Debug variable only used in exception of exception handler.
+		// Kept minimal to prevent any exceptions from determining this.
+		$fatalDebug = defined('ENABLE_DEBUG_MODE') && ENABLE_DEBUG_MODE;
+
 		@header('HTTP/1.1 503 Service Unavailable');
 		try {
 			\wcf\functions\exception\printThrowable($e);
 		}
 		catch (\Throwable $e2) {
-			echo "<pre>An Exception was thrown while handling an Exception:\n\n";
-			echo preg_replace('/Database->__construct\(.*\)/', 'Database->__construct(...)', $e2);
-			echo "\n\nwas thrown while:\n\n";
-			echo preg_replace('/Database->__construct\(.*\)/', 'Database->__construct(...)', $e);
-			echo "\n\nwas handled.</pre>";
+			if ($fatalDebug) {
+				// only show stacktraces when in debug mode.
+				// the Database->__construct regex may not match if the line is too long because
+				// then parts of it will be omitted, resulting in the password being shown to the user.
+				echo "<pre>An Exception was thrown while handling an Exception:\n\n";
+				echo preg_replace('/Database->__construct\(.*\)/', 'Database->__construct(...)', $e2);
+				echo "\n\nwas thrown while:\n\n";
+				echo preg_replace('/Database->__construct\(.*\)/', 'Database->__construct(...)', $e);
+				echo "\n\nwas handled.</pre>";
+			} else {
+				echo "<p>An Exception was thrown while handling an Exception. Enable debug mode for more information.</p>";
+			}
 			exit;
 		}
 		catch (\Exception $e2) {
-			echo "<pre>An Exception was thrown while handling an Exception:\n\n";
-			echo preg_replace('/Database->__construct\(.*\)/', 'Database->__construct(...)', $e2);
-			echo "\n\nwas thrown while:\n\n";
-			echo preg_replace('/Database->__construct\(.*\)/', 'Database->__construct(...)', $e);
-			echo "\n\nwas handled.</pre>";
+			if ($fatalDebug) {
+				// only show stacktraces when in debug mode.
+				// the Database->__construct regex may not match if the line is too long because
+				// then parts of it will be omitted, resulting in the password being shown to the user.
+				echo "<pre>An Exception was thrown while handling an Exception:\n\n";
+				echo preg_replace('/Database->__construct\(.*\)/', 'Database->__construct(...)', $e2);
+				echo "\n\nwas thrown while:\n\n";
+				echo preg_replace('/Database->__construct\(.*\)/', 'Database->__construct(...)', $e);
+				echo "\n\nwas handled.</pre>";
+			} else {
+				echo "<p>An Exception was thrown while handling an Exception. Enable debug mode for more information.</p>";
+			}
 			exit;
 		}
 	}


### PR DESCRIPTION
Previously the Database->__construct filter might not match if the message is truncated such as in
```
#1 /var/www/html/intranet/lib/core.functions.php(154): file_put_contents('/var/www/html/i...', '<<<<<<<__construct('mysql:host=loca...', 'root', 'password', Array)
```
which caused our DB password to be leaked to users because the drive filled up and it couldn't log the SQL connection exception to the log file anymore.

If such a corrupt state occurs, I think it's better to rather check if debug mode is enabled and only then print the stack traces instead of always printing stack traces to prevent this leak.

Credentials and such could be in more functions than just `Database->__construct` so I think only having a case for this on something which will be facing the user is not a good solution and therefore I instead moved the whole stacktrace into the ENABLE_DEBUG_MODE flag.

Instead of using the class member function which can check if debug mode is enabled, just a simple `defined && constant` check is being done to prevent crashing in that class member method if it has some bug or gets changed.

I think this change should be included in the latest version, which is why I am merging this into the `master` branch according to the contributing guidelines, but then also be cherry-picked into the `3.0` branch to avoid this issue on the 3.0.x version.