### PR TITLE
Update breadcrumbs.tpl

### DIFF
--- a/com.woltlab.wcf/templates/breadcrumbs.tpl
+++ b/com.woltlab.wcf/templates/breadcrumbs.tpl
@@ -1,12 +1,20 @@
 {if !$__microdata|isset}{assign var=__microdata value=true}{/if}
+{if $__microdata}{assign var='__breadcrumbPos' value=1}{/if}
 {hascontent}
 	<nav class="breadcrumbs">
 		<ol{if $__microdata} itemprop="breadcrumb" itemscope itemtype="http://schema.org/BreadcrumbList"{/if}>
 			{content}
 				{foreach from=$__wcf->getBreadcrumbs() item=$breadcrumb}
-					<li title="{$breadcrumb->getLabel()}"{if $__microdata} itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem"{/if}>
-						<a href="{$breadcrumb->getURL()}"{if $__microdata} itemprop="item"{/if}><span{if $__microdata} itemprop="name"{/if}>{$breadcrumb->getLabel()}</span></a>
-					</li>
+					{* skip breadcrumbs that do not expose a visible label *}
+					{if $breadcrumb->getLabel()}
+						<li title="{$breadcrumb->getLabel()}"{if $__microdata} itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem"{/if}>
+							<a href="{$breadcrumb->getURL()}"{if $__microdata} itemprop="item"{/if}><span{if $__microdata} itemprop="name"{/if}>{$breadcrumb->getLabel()}</span></a>
+							{if $__microdata}
+								<meta itemprop="position" content="{@$__breadcrumbPos}">
+								{assign var='__breadcrumbPos' value=$__breadcrumbPos+1}
+							{/if}
+						</li>
+					{/if}
 				{/foreach}
 				
 				{event name='breadcrumbs'}


### PR DESCRIPTION
In WSC 5.2, this has already been fixed. However, there's no reason not to perform these changes in WSC prior to 5.2. And since Google is massively complaining about invalid structured data in the current version of the software (just received ~ 45k errors today), these changes should be applied to 3.0 and 3.1 as well:

- Hide breadcrumbs that do not expose a visible label (https://github.com/WoltLab/WCF/commit/a13969b803de11309e402868be5d5e88d0a1c6b8)
- Add position property in breadcrumbs microdata (https://github.com/WoltLab/WCF/commit/2dd4800f9c34f0c7bee0506b34d2ea69c3e24593)

The only difference in this PR is the missing aria-label. The proposed changes have been heavily tested in the last weeks.