### PR TITLE
Deprecate the API compatibility system / Adoption of SemVer

### DIFF
--- a/wcfsetup/install/files/acp/templates/index.tpl
+++ b/wcfsetup/install/files/acp/templates/index.tpl
@@ -87,16 +87,6 @@
 				<dt>{lang}wcf.acp.index.system.software.version{/lang}</dt>
 				<dd>{@WCF_VERSION}</dd>
 			</dl>
-			<dl>
-				<dt>{lang}wcf.acp.index.system.software.apiVersion{/lang}</dt>
-				<dd>{@WSC_API_VERSION}</dd>
-			</dl>
-			{if !$__wcf->getSupportedLegacyApiVersions()|empty}
-				<dl>
-					<dt>{lang}wcf.acp.index.system.software.legacyApiVersions{/lang}</dt>
-					<dd><small>{implode from=$__wcf->getSupportedLegacyApiVersions() item=version glue=', '}{$version}{/implode}</small></dd>
-				</dl>
-			{/if}
 			
 			{event name='softwareFields'}
 			

--- a/wcfsetup/install/files/lib/data/style/StyleEditor.class.php
+++ b/wcfsetup/install/files/lib/data/style/StyleEditor.class.php
@@ -40,15 +40,13 @@ use wcf\util\XMLWriter;
  * @mixin	Style
  */
 class StyleEditor extends DatabaseObjectEditor implements IEditableCachedObject {
-	/**
-	 * @deprecated 3.1 use the compatibility api versions instead
-	 */
-	const EXCLUDE_WCF_VERSION = '3.2.0 Alpha 1';
+	const EXCLUDE_WCF_VERSION = '6.0.0 Alpha 1';
 	const INFO_FILE = 'style.xml';
 	
 	/**
 	 * list of compatible API versions
 	 * @var integer[]
+	 * @deprecated 5.2
 	 */
 	public static $compatibilityApiVersions = [2018];
 	
@@ -931,6 +929,11 @@ class StyleEditor extends DatabaseObjectEditor implements IEditableCachedObject 
 			$xml->writeElement('requiredpackage', 'com.woltlab.wcf', ['minversion' => PackageCache::getInstance()->getPackageByIdentifier('com.woltlab.wcf')->packageVersion]);
 			$xml->endElement();
 			
+			$xml->startElement('excludedpackages');
+			$xml->writeElement('excludedpackage', 'com.woltlab.wcf', ['version' => self::EXCLUDE_WCF_VERSION]);
+			$xml->endElement();
+			
+			// @deprecated 5.2
 			$xml->startElement('compatibility');
 			foreach (self::$compatibilityApiVersions as $apiVersion) {
 				$xml->writeElement('api', '', ['version' => $apiVersion]);

--- a/wcfsetup/install/files/lib/system/WCF.class.php
+++ b/wcfsetup/install/files/lib/system/WCF.class.php
@@ -52,6 +52,7 @@ if (!@ini_get('date.timezone')) {
 define('WCF_VERSION', '5.2.0 Beta 3');
 
 // define current API version
+// @deprecated 5.2
 define('WSC_API_VERSION', 2019);
 
 // define current unix timestamp
@@ -76,6 +77,7 @@ class WCF {
 	/**
 	 * list of supported legacy API versions
 	 * @var integer[]
+	 * @deprecated 5.2
 	 */
 	private static $supportedLegacyApiVersions = [2017, 2018];
 	
@@ -1108,6 +1110,7 @@ class WCF {
 	 * 
 	 * @param       integer         $apiVersion
 	 * @return      boolean
+	 * @deprecated 5.2
 	 */
 	public static function isSupportedApiVersion($apiVersion) {
 		return ($apiVersion == WSC_API_VERSION) || in_array($apiVersion, self::$supportedLegacyApiVersions);
@@ -1117,6 +1120,7 @@ class WCF {
 	 * Returns the list of supported legacy API versions.
 	 * 
 	 * @return      integer[]
+	 * @deprecated 5.2
 	 */
 	public static function getSupportedLegacyApiVersions() {
 		return self::$supportedLegacyApiVersions;

--- a/wcfsetup/install/files/lib/system/package/PackageArchive.class.php
+++ b/wcfsetup/install/files/lib/system/package/PackageArchive.class.php
@@ -69,6 +69,7 @@ class PackageArchive {
 	/**
 	 * list of compatible API versions
 	 * @var integer[]
+	 * @deprecated 5.2
 	 */
 	protected $compatibility = [];
 	
@@ -299,6 +300,32 @@ class PackageArchive {
 			}
 			
 			$this->compatibility[] = $version;
+		}
+		
+		// API compatibility implies an exclude of `com.woltlab.wcf` in version `6.0.0 Alpha 1`, unless a lower version is explicitly excluded.
+		if (!empty($this->compatibility)) {
+			$excludeCore60 = '6.0.0 Alpha 1';
+			
+			$coreExclude = '';
+			foreach ($this->excludedPackages as $excludedPackage) {
+				if ($excludedPackage['name'] === 'com.woltlab.wcf') {
+					$coreExclude = $excludedPackage['version'];
+					break;
+				}
+			}
+			
+			if (!$coreExclude || Package::compareVersion($coreExclude, $excludeCore60, '>')) {
+				if ($coreExclude) {
+					$this->excludedPackages = array_filter($this->excludedPackages, function($exclude) {
+						return $exclude['name'] !== 'com.woltlab.wcf';
+					});
+				}
+				
+				$this->excludedPackages[] = [
+					'name' => 'com.woltlab.wcf',
+					'version' => $excludeCore60,
+				];
+			}
 		}
 		
 		// get instructions
@@ -554,6 +581,7 @@ class PackageArchive {
 	 * Returns the list of compatible API versions.
 	 * 
 	 * @return      integer[]
+	 * @deprecated 5.2
 	 */
 	public function getCompatibleVersions() {
 		return $this->compatibility;

--- a/wcfsetup/install/files/lib/system/package/validation/PackageValidationArchive.class.php
+++ b/wcfsetup/install/files/lib/system/package/validation/PackageValidationArchive.class.php
@@ -216,9 +216,7 @@ class PackageValidationArchive implements \RecursiveIterator {
 				throw new PackageValidationException(PackageValidationException::INCOMPATIBLE_API_VERSION, ['isOlderVersion' => $isOlderVersion]);
 			}
 		}
-		else if (ENABLE_DEBUG_MODE && ENABLE_DEVELOPER_TOOLS && ($package === null || $package->package !== 'com.woltlab.wcf')) {
-			throw new PackageValidationException(PackageValidationException::MISSING_API_VERSION);
-		}
+		// Missing details on API compatibility are no longer an error.
 		
 		// package is not installed yet
 		if ($package === null) {

--- a/wcfsetup/install/files/lib/system/package/validation/PackageValidationException.class.php
+++ b/wcfsetup/install/files/lib/system/package/validation/PackageValidationException.class.php
@@ -96,18 +96,21 @@ class PackageValidationException extends SystemException {
 	/**
 	 * the provided API version string is invalid and does not fall into the range from `2017` through `2099`
 	 * @var integer
+	 * @deprecated 5.2
 	 */
 	const INVALID_API_VERSION = 13;
 	
 	/**
 	 * the package is not compatible with the current API version or any other of the supported ones
 	 * @var integer
+	 * @deprecated 5.2
 	 */
 	const INCOMPATIBLE_API_VERSION = 14;
 	
 	/**
 	 * the package lacks any sort of API compatibility data
 	 * @var integer
+	 * @deprecated 5.2
 	 */
 	const MISSING_API_VERSION = 15;
 	


### PR DESCRIPTION
The API compatibility system was introduced as a way to improve the compatibility of packages by shifting the decision on includes more towards the API maintainers. Originally intended to transparently expose internal APIs that are part of the Core (such as the WYSIWYG editor), it was reduced to a simple "one version fits all" that covers the entire Core because of a myriad of hidden dependencies between those APIs.

The API compatibility system in its current state missed its goals and justs adds another moving part that needs to be handled atop the existing package dependency and exclusion system.

What will happen:
- Starting with version 5.2, we'll switch to [semantic versioning](https://semver.org/).
- **[9.](https://semver.org/#spec-item-9) and [10.](https://semver.org/#spec-item-10) of the SemVer spec are intentionally violated.**
  We cannot reliably change the version number format without breaking backwards compatibility, for example, we'll continue to use `5.2.0 Beta 1` instead of `5.2.0-beta.1`.
- Any existing API compatibility is treated as an exclusion of `com.woltlab.wcf` in version `6.0.0 Alpha 1`, unless the package excludes a lower version of the Core.