### PR TITLE
Enable ability for applications to add their own custom fields in their own namespace

### DIFF
--- a/wcfsetup/install/files/lib/system/form/builder/field/AbstractFormField.class.php
+++ b/wcfsetup/install/files/lib/system/form/builder/field/AbstractFormField.class.php
@@ -49,7 +49,7 @@ abstract class AbstractFormField implements IFormField {
 	 * name of the template's application used to output this field
 	 * @var	string
 	 */
-	protected $application = 'wcf';
+	protected $templateApplication = 'wcf';
 	
 	/**
 	 * validation errors of this field
@@ -105,7 +105,7 @@ abstract class AbstractFormField implements IFormField {
 		
 		return WCF::getTPL()->fetch(
 			$this->templateName,
-			$this->application,
+			$this->templateApplication,
 			array_merge($this->getHtmlVariables(), [
 				'field' => $this
 			]),

--- a/wcfsetup/install/files/lib/system/form/builder/field/AbstractFormField.class.php
+++ b/wcfsetup/install/files/lib/system/form/builder/field/AbstractFormField.class.php
@@ -46,6 +46,12 @@ abstract class AbstractFormField implements IFormField {
 	protected $templateName;
 	
 	/**
+	 * name of the template's application used to output this field
+	 * @var	string
+	 */
+	protected $application = 'wcf';
+	
+	/**
 	 * validation errors of this field
 	 * @var	IFormFieldValidationError[]
 	 */
@@ -99,7 +105,7 @@ abstract class AbstractFormField implements IFormField {
 		
 		return WCF::getTPL()->fetch(
 			$this->templateName,
-			'wcf',
+			$this->application,
 			array_merge($this->getHtmlVariables(), [
 				'field' => $this
 			]),


### PR DESCRIPTION
Currently all field templates have to be placed in the wcf folder. If an application wants to create their own custom field, the template has to placed in the wcf folder as well. This change enables custom components to use their own template folder.