### PR TITLE
Prevent newline after the userBBCodeTag

### DIFF
--- a/com.woltlab.wcf/templates/userBBCodeTag.tpl
+++ b/com.woltlab.wcf/templates/userBBCodeTag.tpl
@@ -1,6 +1,6 @@
 {if $userProfile === null}
 	{* user no longer exists, use plain output rather than using a broken link *}
-	<span class="userMention">{$username}</span>
-{else}
-	<a href="{link controller='User' object=$userProfile->getDecoratedObject()}{/link}" class="userMention userLink" data-user-id="{@$userProfile->userID}">{$userProfile->username}</a>
-{/if}
+	<span class="userMention">{$username}</span>{* no newline after the tag
+*}{else}
+	<a href="{link controller='User' object=$userProfile->getDecoratedObject()}{/link}" class="userMention userLink" data-user-id="{@$userProfile->userID}">{$userProfile->username}</a>{* no newline after the tag
+*}{/if}


### PR DESCRIPTION
The newline renders as a single space, which looks bad when punctuation
is being used directly after a mention.

Previously a sentence such as:

> Good to see you @Foo!

would have resulted in:

> Good to see you <a>@Foo</a>
> !

which is being rendered as:

> Good to see you @Foo !