### PR TITLE
Remove Turkish Lira from PayPal payment method

### DIFF
--- a/wcfsetup/install/files/lib/system/payment/method/PaypalPaymentMethod.class.php
+++ b/wcfsetup/install/files/lib/system/payment/method/PaypalPaymentMethod.class.php
@@ -48,7 +48,6 @@ class PaypalPaymentMethod extends AbstractPaymentMethod {
 			'CHF', // Swiss Franc
 			'TWD', // Taiwan New Dollar
 			'THB', // Thai Baht
-			'TRY', // Turkish Lira
 			'USD'  // U.S. Dollar
 		];
 	}


### PR DESCRIPTION
Turkish Lira is no longer supported by PayPal.

Evidence:
- [Policy Updates](https://www.paypalobjects.com/digitalassets/c/website/ua/pdf/PL/en/policy_updates.pdf?locale.x=en_PL) (3. `Sections of the PayPal User Agreement have been amended to clarify existing wording and correct minor typographical errors. For instance, we don’t support payments in Indian Rupee and Turkish Lira, so all remaining references to Indian Rupee and Turkish Lira have been removed to clarify this point.`)
- You can no longer add Turkish Lira as currency to your own PayPal account.
- In the [PayPal User Agreement](https://www.paypal.com/de/webapps/mpp/ua/useragreement-full?locale.x=en_DE) (A4.1.1. Currency Conversion Fee) there's no currency conversion fee for Turkish Lira.
- And finally, the [PayPal REST Payments API documentation](https://developer.paypal.com/docs/api/reference/currency-codes/#paypal-account-payments) doesn't list `TRY` as accepted currency.