### PR TITLE
fix htaccess generation

### DIFF
--- a/wcfsetup/install/files/lib/data/option/OptionAction.class.php
+++ b/wcfsetup/install/files/lib/data/option/OptionAction.class.php
@@ -171,11 +171,12 @@ class OptionAction extends AbstractDatabaseObjectAction {
 			
 			foreach ($domainPaths as $domainPath => $value) {
 				$htaccess = "{$dir}.htaccess";
-				$path = FileUtil::removeTrailingSlash(substr($value, strlen($dir)));
+				$path = FileUtil::addTrailingSlash(substr($value, strlen($dir)));
+				if ($path == '/') $path = '';
 				$content = <<<SNIPPET
 RewriteCond %{SCRIPT_FILENAME} !-d
 RewriteCond %{SCRIPT_FILENAME} !-f
-RewriteRule ^/{$path}(.*)$ {$path}/index.php?$1 [L,QSA]
+RewriteRule ^{$path}(.*)$ {$path}index.php?$1 [L,QSA]
 
 
 SNIPPET;


### PR DESCRIPTION
The `/` was misplaced before.

Before:
```
RewriteCond %{SCRIPT_FILENAME} !-d
RewriteCond %{SCRIPT_FILENAME} !-f
RewriteRule ^/core(.*)$ core/index.php?$1 [L,QSA]

RewriteCond %{SCRIPT_FILENAME} !-d
RewriteCond %{SCRIPT_FILENAME} !-f
RewriteRule ^/calendar(.*)$ calendar/index.php?$1 [L,QSA]

RewriteCond %{SCRIPT_FILENAME} !-d
RewriteCond %{SCRIPT_FILENAME} !-f
RewriteRule ^/(.*)$ /index.php?$1 [L,QSA]
```

After:
```
RewriteCond %{SCRIPT_FILENAME} !-d
RewriteCond %{SCRIPT_FILENAME} !-f
RewriteRule ^core/(.*)$ core/index.php?$1 [L,QSA]

RewriteCond %{SCRIPT_FILENAME} !-d
RewriteCond %{SCRIPT_FILENAME} !-f
RewriteRule ^calendar/(.*)$ calendar/index.php?$1 [L,QSA]

RewriteCond %{SCRIPT_FILENAME} !-d
RewriteCond %{SCRIPT_FILENAME} !-f
RewriteRule ^(.*)$ index.php?$1 [L,QSA]
```