### PR TITLE
make CoreRewriteTestAction available during offline mode

### DIFF
--- a/wcfsetup/install/files/lib/action/CoreRewriteTestAction.class.php
+++ b/wcfsetup/install/files/lib/action/CoreRewriteTestAction.class.php
@@ -14,6 +14,8 @@ use wcf\util\JSON;
  * @since       3.1
  */
 class CoreRewriteTestAction extends AbstractAction {
+	const AVAILABLE_DURING_OFFLINE_MODE = true;
+	
 	/**
 	 * @inheritDoc
 	 * 


### PR DESCRIPTION
Configuring SEO urls during offline mode is currently not possible in case the user is not logged into the frontend. This might lead to confused administrators and us searching for the reason.