### PR TITLE
Add beforePageContainer event to header

### DIFF
--- a/com.woltlab.wcf/templates/header.tpl
+++ b/com.woltlab.wcf/templates/header.tpl
@@ -28,6 +28,8 @@
 
 <a id="top"></a>
 
+{event name='beforePageContainer'}
+
 <div id="pageContainer" class="pageContainer">
 	{event name='beforePageHeader'}
 	


### PR DESCRIPTION
Adds an event to the header template to allow template listeners before any open html elements inside the body.