### PR TITLE
Add &display=swap to Google Font request

### DIFF
--- a/com.woltlab.wcf/templates/headInclude.tpl
+++ b/com.woltlab.wcf/templates/headInclude.tpl
@@ -7,7 +7,7 @@
 
 <!-- Stylesheets -->
 {if $__wcf->getStyleHandler()->getStyle()->getVariable('useGoogleFont')}
-	<link href='//fonts.googleapis.com/css?family={$__wcf->getStyleHandler()->getStyle()->getVariable('wcfFontFamilyGoogle')|urlencode}:400,300,600' rel='stylesheet' type='text/css'>
+	<link href='//fonts.googleapis.com/css?family={$__wcf->getStyleHandler()->getStyle()->getVariable('wcfFontFamilyGoogle')|urlencode}:400,300,600&amp;display=swap' rel='stylesheet' type='text/css'>
 {/if}
 {@$__wcf->getStyleHandler()->getStylesheet()}
 {event name='stylesheets'}


### PR DESCRIPTION
This requests Google Fonts to deliver fonts with the `font-display: swap;` CSS option, reducing time until meaningful display epecially on slow connections. Including this option is suggested by default now from Google Fonts.