### PR TITLE
Event added for changing variable $registerVia3rdParty in RegisterForm

### DIFF
--- a/wcfsetup/install/files/lib/form/RegisterForm.class.php
+++ b/wcfsetup/install/files/lib/form/RegisterForm.class.php
@@ -17,6 +17,7 @@ use wcf\system\email\Email;
 use wcf\system\email\Mailbox;
 use wcf\system\email\UserMailbox;
 use wcf\system\exception\NamedUserException;
+use wcf\system\event\EventHandler;
 use wcf\system\exception\PermissionDeniedException;
 use wcf\system\exception\SystemException;
 use wcf\system\exception\UserInputException;
@@ -403,6 +404,7 @@ class RegisterForm extends UserAddForm {
 			// create fake password
 			$this->password = StringUtil::getRandomID();
 		}
+		EventHandler::getInstance()->fireAction($registerVia3rdParty, 'registerVia3rdParty');
 		
 		$this->additionalFields['languageID'] = $this->languageID;
 		if (LOG_IP_ADDRESS) $this->additionalFields['registrationIpAddress'] = WCF::getSession()->ipAddress;

--- a/wcfsetup/install/files/lib/form/RegisterForm.class.php
+++ b/wcfsetup/install/files/lib/form/RegisterForm.class.php
@@ -404,7 +404,12 @@ class RegisterForm extends UserAddForm {
 			// create fake password
 			$this->password = StringUtil::getRandomID();
 		}
-		EventHandler::getInstance()->fireAction($registerVia3rdParty, 'registerVia3rdParty');
+		
+		$parameters = [
+			'saveOptions' => $saveOptions,
+			'registerVia3rdParty' => $registerVia3rdParty
+		];
+		EventHandler::getInstance()->fireAction($this, 'externalAuthentication', $parameters);
 		
 		$this->additionalFields['languageID'] = $this->languageID;
 		if (LOG_IP_ADDRESS) $this->additionalFields['registrationIpAddress'] = WCF::getSession()->ipAddress;

--- a/wcfsetup/install/files/lib/form/RegisterForm.class.php
+++ b/wcfsetup/install/files/lib/form/RegisterForm.class.php
@@ -404,12 +404,14 @@ class RegisterForm extends UserAddForm {
 			// create fake password
 			$this->password = StringUtil::getRandomID();
 		}
-		
-		$parameters = [
+
+		$data = [
 			'saveOptions' => $saveOptions,
 			'registerVia3rdParty' => $registerVia3rdParty
 		];
-		EventHandler::getInstance()->fireAction($this, 'externalAuthentication', $parameters);
+		EventHandler::getInstance()->fireAction($this, 'externalAuthentication', $data);
+		$saveOptions = $data['saveOptions'];
+		$registerVia3rdParty = $data['registerVia3rdParty'];
 		
 		$this->additionalFields['languageID'] = $this->languageID;
 		if (LOG_IP_ADDRESS) $this->additionalFields['registrationIpAddress'] = WCF::getSession()->ipAddress;


### PR DESCRIPTION
Most of SSO providers don't need a mail activation, because the mail is already confirmed. 3rd party developers currently can not manipulate the variable `$registerVia3rdParty` in method `wcf\form\RegisterForm::save()`. Because of that, I added an event handler for 3rd party developers.
Another solution would be to change the variable `$registerVia3rdParty` to a property of `RegisterForm`. 3rd party developers have the same problem with the variable `$saveOptions`.