### PR TITLE
Update GitHub authorization to use headers instead of query parameters

### DIFF
--- a/wcfsetup/install/files/lib/action/GithubAuthAction.class.php
+++ b/wcfsetup/install/files/lib/action/GithubAuthAction.class.php
@@ -63,7 +63,8 @@ class GithubAuthAction extends AbstractAction {
 			
 			try {
 				// fetch userdata
-				$request = new HTTPRequest('https://api.github.com/user?access_token='.$data['access_token']);
+				$request = new HTTPRequest('https://api.github.com/user');
+				$request->addHeader('Authorization', 'token '.$data['access_token']);
 				$request->execute();
 				$reply = $request->getReply();
 				$userData = JSON::decode(StringUtil::trim($reply['body']));
@@ -119,7 +120,8 @@ class GithubAuthAction extends AbstractAction {
 					WCF::getSession()->register('__username', $userData['login']);
 					
 					try {
-						$request = new HTTPRequest('https://api.github.com/user/emails?access_token='.$data['access_token']);
+						$request = new HTTPRequest('https://api.github.com/user/emails');
+						$request->addHeader('Authorization', 'token '.$data['access_token']);
 						$request->execute();
 						$reply = $request->getReply();
 						$emails = JSON::decode(StringUtil::trim($reply['body']));


### PR DESCRIPTION
Using query parameters for access_token has been deprecated.

For further information, check out:
- https://community.woltlab.com/thread/281366-github-api-deprecation-notice-for-authentication-via-url-query-parameters/
- https://developer.github.com/changes/2019-11-05-deprecated-passwords-and-authorizations-api/#authenticating-using-query-parameters