### PR TITLE
Fix GitHub primary email not correctly being detected

### DIFF
--- a/wcfsetup/install/files/lib/action/GithubAuthAction.class.php
+++ b/wcfsetup/install/files/lib/action/GithubAuthAction.class.php
@@ -129,8 +129,10 @@ class GithubAuthAction extends AbstractAction {
 						// search primary email
 						$email = $emails[0]['email'];
 						foreach ($emails as $tmp) {
-							if ($tmp['primary']) $email = $tmp['email'];
-							break;
+							if ($tmp['primary']) {
+								$email = $tmp['email'];
+								break;
+							}
 						}
 						WCF::getSession()->register('__email', $email);
 					}


### PR DESCRIPTION
Response from the GitHub API:
```
Array
(
    [0] => Array
        (
            [email] => Krymonota@users.noreply.github.com
            [primary] => 
            [verified] => 1
            [visibility] => 
        )

    [1] => Array
        (
            [email] => MANUALLY_CENSORED_1
            [primary] => 1
            [verified] => 1
            [visibility] => private
        )

    [2] => Array
        (
            [email] => MANUALLY_CENSORED_2
            [primary] => 
            [verified] => 1
            [visibility] => 
        )
)
```

`Krymonota@users.noreply.github.com` has always been set as email during registration, although this isn't a primary email address. The problem was a misplaced `break` in a loop. I tested this change as well.