### PR TITLE
Add missing alt attribute to reaction type image

### DIFF
--- a/com.woltlab.wcf/templates/reactionTypeImage.tpl
+++ b/com.woltlab.wcf/templates/reactionTypeImage.tpl
@@ -1,5 +1,6 @@
 <img
 	src="{@$__wcf->getPath()}images/reaction/{$reactionType->iconFile}"
+	alt="{$reactionType->getTitle()}"
 	class="reactionType"
 	data-reaction-type-id="{$reactionType->reactionTypeID}"
 >


### PR DESCRIPTION
See: https://community.woltlab.com/thread/281417-reaktions-icons-alt-attribut-fehlt/