### PR TITLE
Remove Typehint

### DIFF
--- a/wcfsetup/install/files/lib/system/CLIWCF.class.php
+++ b/wcfsetup/install/files/lib/system/CLIWCF.class.php
@@ -109,7 +109,7 @@ class CLIWCF extends WCF {
 	/**
 	 * @inheritDoc
 	 */
-	public static final function handleCLIException(\Exception $e) {
+	public static final function handleCLIException($e) {
 		die($e->getMessage()."\n".$e->getTraceAsString());
 	}
 	


### PR DESCRIPTION
`handleCLIException` fails, because it expects an Exception, but there are cases, where it receives an Error instead (e.g. phar extension missing).