### PR TITLE
Improve WhatsApp Message Sharing

### DIFF
--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Message/Share.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Message/Share.js
@@ -57,7 +57,7 @@ define(['EventHandler'], function(EventHandler) {
 					whatsApp: {
 						link: elBySel('.jsShareWhatsApp', container),
 						share: (function() {
-							window.location.href = 'whatsapp://send?text=' + this._pageDescription + '%20' + this._pageUrl;
+							window.location.href = 'https://api.whatsapp.com/send?text=' + this._pageDescription + '%20' + this._pageUrl;
 						}).bind(this)
 					}
 				};


### PR DESCRIPTION
Currently, the WhatsApp sharing button requires `whatsapp` to be a registered protocol. For quite some time, they provide an intermediate web page, that is also compatible with desktops.