### PR TITLE
Simplify the validation of user group permissions

### DIFF
--- a/wcfsetup/install/files/lib/system/option/user/group/UserGroupOptionHandler.class.php
+++ b/wcfsetup/install/files/lib/system/option/user/group/UserGroupOptionHandler.class.php
@@ -118,6 +118,7 @@ class UserGroupOptionHandler extends OptionHandler {
 	 * Returns true if current user has the permissions to edit every user group.
 	 * 
 	 * @return	boolean
+	 * @deprecated  5.2
 	 */
 	protected function isAdmin() {
 		if ($this->isAdmin === null) {
@@ -147,31 +148,12 @@ class UserGroupOptionHandler extends OptionHandler {
 	protected function validateOption(Option $option) {
 		parent::validateOption($option);
 		
-		if (!$this->isAdmin()) {
+		if (!$this->isOwner()) {
 			// get type object
 			$typeObj = $this->getTypeObject($option->optionType);
 			
 			if ($typeObj->compare($this->optionValues[$option->optionName], WCF::getSession()->getPermission($option->optionName)) == 1) {
 				throw new UserInputException($option->optionName, 'exceedsOwnPermission');
-			}
-		}
-		else if (!$this->isOwner() && $option->optionName == 'admin.user.accessibleGroups' && $this->group !== null && $this->group->isAdminGroup()) {
-			$hasOtherAdminGroup = false;
-			foreach (UserGroup::getGroupsByType() as $userGroup) {
-				if ($userGroup->groupID != $this->group->groupID && $userGroup->isAdminGroup()) {
-					$hasOtherAdminGroup = true;
-					break;
-				}
-			}
-			
-			// prevent users from dropping their own admin state
-			if (!$hasOtherAdminGroup) {
-				// get type object
-				$typeObj = $this->getTypeObject($option->optionType);
-				
-				if ($typeObj->compare($this->optionValues[$option->optionName], WCF::getSession()->getPermission($option->optionName)) == -1) {
-					throw new UserInputException($option->optionName, 'cannotDropPrivileges');
-				}
 			}
 		}
 	}

--- a/wcfsetup/install/lang/de.xml
+++ b/wcfsetup/install/lang/de.xml
@@ -709,7 +709,6 @@ ACHTUNG: Die oben genannten Meldungen sind stark gekürzt. Sie können Details z
 		<item name="wcf.acp.group.option.category.user"><![CDATA[Allgemeine Rechte]]></item>
 		<item name="wcf.acp.group.option.category.user.message"><![CDATA[Nachrichten]]></item>
 		<item name="wcf.acp.group.option.category.user.message.comment"><![CDATA[Kommentare]]></item>
-		<item name="wcf.acp.group.option.error.cannotDropPrivileges"><![CDATA[Es muss immer mindestens eine Benutzergruppe mit vollen Rechten geben, es ist daher nicht möglich diese Berechtigung einzuschränken.]]></item>
 		<item name="wcf.acp.group.option.error.exceedsOwnPermission"><![CDATA[{if LANGUAGE_USE_INFORMAL_VARIANT}Du kannst{else}Sie können{/if} Benutzergruppen keine Berechtigungen gewähren, die {if LANGUAGE_USE_INFORMAL_VARIANT}deine{else}Ihre{/if} eigenen Berechtigungen übersteigen.]]></item>
 		<item name="wcf.acp.group.option.error.tooHigh"><![CDATA[Der angegebene Wert ist zu hoch.{if $option->maxvalue !== null} Der maximale Wert ist {#$option->maxvalue}.{/if}]]></item>
 		<item name="wcf.acp.group.option.error.tooLow"><![CDATA[Der angegebene Wert ist zu gering.{if $option->minvalue !== null} Der minimale Wert ist {#$option->minvalue}.{/if}]]></item>

--- a/wcfsetup/install/lang/en.xml
+++ b/wcfsetup/install/lang/en.xml
@@ -685,7 +685,6 @@ ATTENTION: The messages listed above are greatly shortened. You can view details
 		<item name="wcf.acp.group.option.category.user"><![CDATA[General Permissions]]></item>
 		<item name="wcf.acp.group.option.category.user.message"><![CDATA[Messages]]></item>
 		<item name="wcf.acp.group.option.category.user.message.comment"><![CDATA[Comments]]></item>
-		<item name="wcf.acp.group.option.error.cannotDropPrivileges"><![CDATA[There must be at least one user group with full access, therefore it is not possible to drop these privileges.]]></item>
 		<item name="wcf.acp.group.option.error.exceedsOwnPermission"><![CDATA[You cannot grant user group permissions exceeding your own permissions.]]></item>
 		<item name="wcf.acp.group.option.error.tooHigh"><![CDATA[The set value is too high.{if $option->maxvalue !== null} The maximum value is {#$option->maxvalue}.{/if}]]></item>
 		<item name="wcf.acp.group.option.error.tooLow"><![CDATA[The set value is too low.{if $option->minvalue !== null} The minimum value is {#$option->minvalue}.{/if}]]></item>


### PR DESCRIPTION
The owner group is unable to drop their privileges, because they are enforced through the permission calculation. Therefore, we only need to validate non owner groups and thus simplify the entire logic, because only non-owner groups are restricted.