### PR TITLE
Fixed a bug where the packageurl was not loaded correctly when editing a project in the dev tools

### DIFF
--- a/wcfsetup/install/files/lib/acp/form/DevtoolsProjectEditForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/DevtoolsProjectEditForm.class.php
@@ -209,10 +209,10 @@ class DevtoolsProjectEditForm extends DevtoolsProjectAddForm {
 			$this->missingElements[] = 'date';
 		}
 		
-		if ($packageArchive->getPackageInfo('packageurl') !== null) {
+		if ($packageArchive->getPackageInfo('packageURL') !== null) {
 			/** @var TextFormField $packageUrl */
-			$packageUrl = $this->form->getNodeById('packageurl');
-			$packageUrl->value($packageArchive->getPackageInfo('packageurl'));
+			$packageUrl = $this->form->getNodeById('packageUrl');
+			$packageUrl->value($packageArchive->getPackageInfo('packageURL'));
 		}
 		
 		/** @var TextFormField $license */


### PR DESCRIPTION
In DevtoolsProjectEditForm.class.php the packageurl in $packageArchive should've been referenced as 'packageURL' not packageurl, that prevented loading it at all. Also the form field was referenced as 'packageurl' while the correct field name is 'packageUrl'. If you save a project again those 2 bugs will empty your packageurl field in the package.xml.

This pull request fixes that behavior.