### PR TITLE
Add an unique id to share content dialogs

### DIFF
--- a/wcfsetup/install/files/js/WCF.Message.js
+++ b/wcfsetup/install/files/js/WCF.Message.js
@@ -2253,7 +2253,7 @@ WCF.Message.Share.Content = Class.extend({
 			// remove dialog contents
 			var $dialogInitialized = false;
 			if (this._dialog === null) {
-				this._dialog = $('<div />').hide().appendTo(document.body);
+				this._dialog = $('<div id="shareContent" />').hide().appendTo(document.body);
 				$dialogInitialized = true;
 			}
 			else {


### PR DESCRIPTION
The share content dialog uses in its current state only a dynamic id ( `wcfN` ) as the dialog id, which makes it impossible to apply CSS to this dialog only.