### PR TITLE
Add check for ctype extension

### DIFF
--- a/wcfsetup/test.php
+++ b/wcfsetup/test.php
@@ -212,7 +212,7 @@ if (isset($_GET['language']) && in_array($_GET['language'], ['de', 'en'])) {
 	<main>
 <?php
 const WSC_SRT_VERSION = '5.2.0';
-$requiredExtensions = ['dom', 'json', 'hash', 'libxml', 'mbstring', 'pcre', 'pdo', 'pdo_mysql', 'zlib'];
+$requiredExtensions = ['ctype', 'dom', 'json', 'hash', 'libxml', 'mbstring', 'pcre', 'pdo', 'pdo_mysql', 'zlib'];
 $requiredPHPVersion = '7.0.22';
 $phrases = [
 	'php_requirements' => [


### PR DESCRIPTION
The `ctype` extension is essential, but the test script doesn't check it, yet.