### PR TITLE
Fix incorrect check in UserGroupOptionForm whether the option exists

### DIFF
--- a/wcfsetup/install/files/lib/acp/form/UserGroupOptionForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/UserGroupOptionForm.class.php
@@ -84,7 +84,7 @@ class UserGroupOptionForm extends AbstractForm {
 		
 		if (isset($_REQUEST['id'])) $this->userGroupOptionID = intval($_REQUEST['id']);
 		$this->userGroupOption = new UserGroupOption($this->userGroupOptionID);
-		if (!$this->userGroupOption) {
+		if (!$this->userGroupOption->optionID) {
 			throw new IllegalLinkException();
 		}
 		


### PR DESCRIPTION
An exception is thrown if no `id` parameter is submitted or no user group option is found for the submitted `id` parameter value:
```Sun, 29 Mar 2020 21:58:56 +0000
Message: Undefined index: 
PHP version: 7.4.3
WoltLab Suite version: 5.2.4
Request URI: /acp/index.php?user-group-option/296/
Referrer: 
User Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:74.0) Gecko/20100101 Firefox/74.0
Peak Memory Usage: 2329024/268435456
======
Error Class: wcf\system\exception\ErrorException
Error Message: Undefined index: 
Error Code: 0
File: /var/www/[redacted]/lib/system/WCF.class.php (341)
Extra Information: -
Stack Trace: [{"file":"\/var\/www\/[redacted]\/lib\/acp\/form\/UserGroupOptionForm.class.php","line":105,"function":"handleError","class":"wcf\\system\\WCF","type":"::","args":[]},{"file":"\/var\/www\/[redacted]\/lib\/page\/AbstractPage.class.php","line":113,"function":"readParameters","class":"wcf\\acp\\form\\UserGroupOptionForm","type":"->","args":[]},{"file":"\/var\/www\/[redacted]\/lib\/system\/request\/Request.class.php","line":83,"function":"__run","class":"wcf\\page\\AbstractPage","type":"->","args":[]},{"file":"\/var\/www\/[redacted]\/lib\/system\/request\/RequestHandler.class.php","line":107,"function":"execute","class":"wcf\\system\\request\\Request","type":"->","args":[]},{"file":"\/var\/www\/[redacted]\/acp\/index.php","line":9,"function":"handle","class":"wcf\\system\\request\\RequestHandler","type":"->","args":[]}]```