### PR TITLE
Specify HTML.Doctype as HTML 4 Strict for HTML Purifier

### DIFF
--- a/wcfsetup/install/files/lib/system/html/input/filter/MessageHtmlInputFilter.class.php
+++ b/wcfsetup/install/files/lib/system/html/input/filter/MessageHtmlInputFilter.class.php
@@ -52,6 +52,7 @@ class MessageHtmlInputFilter implements IHtmlInputFilter {
 			
 			$config->set('CSS.AllowedProperties', ['color', 'font-family', 'font-size']);
 			$config->set('HTML.ForbiddenAttributes', ['*@lang', '*@xml:lang']);
+			$config->set('HTML.Doctype', 'HTML 4.01 Strict');
 			
 			$allowedSchemes = $config->get('URI.AllowedSchemes');
 			$allowedSchemes['ts3server'] = true;


### PR DESCRIPTION
Not setting a Doctype defaults to HTML 4 Transitional, allowing legacy
tags. HTML 4 Strict will attempt to convert them into a standards compliant
format.

HTML Purifier does not support the HTML 5 Doctype as a readily available
configuration.

Before:

    string '<p><font size="6">This is some text!</font></p>' (length=47)

After:

    string '<p><span style="font-size:xx-large;">This is some text!</span></p>' (length=66)