### PR TITLE
Revert "Specify HTML.Doctype as HTML 4 Strict for HTML Purifier"

### DIFF
--- a/wcfsetup/install/files/lib/system/html/input/filter/MessageHtmlInputFilter.class.php
+++ b/wcfsetup/install/files/lib/system/html/input/filter/MessageHtmlInputFilter.class.php
@@ -52,7 +52,6 @@ class MessageHtmlInputFilter implements IHtmlInputFilter {
 			
 			$config->set('CSS.AllowedProperties', ['color', 'font-family', 'font-size']);
 			$config->set('HTML.ForbiddenAttributes', ['*@lang', '*@xml:lang']);
-			$config->set('HTML.Doctype', 'HTML 4.01 Strict');
 			
 			$allowedSchemes = $config->get('URI.AllowedSchemes');
 			$allowedSchemes['ts3server'] = true;


### PR DESCRIPTION
This change causes issues with legacy BBCode processing, because the `woltlab-metacode-marker` tag will no longer be self closing. XHTML 1.0 Strict fixes this, but might cause other side effects.

Reverts WoltLab/WCF#3203