### PR TITLE
Fix return values in the UserStorageHandler for modified fields unloa…

### DIFF
--- a/wcfsetup/install/files/lib/system/user/storage/UserStorageHandler.class.php
+++ b/wcfsetup/install/files/lib/system/user/storage/UserStorageHandler.class.php
@@ -79,12 +79,12 @@ class UserStorageHandler extends SingletonFactory {
 				$this->cache[$row['userID']] = [];
 			}
 			
-			// Skip the field, if the value is reset before the storage is loaded.
+			// Skip the field, if the value was reset before the storage had been loaded.
 			if (isset($this->resetFields[$row['userID']]) && in_array($row['field'], $this->resetFields[$row['userID']])) {
 				continue;
 			}
 			
-			// Use new value, if the field is updated before the storage is loaded.
+			// Use the new value, if the field was updated before the storage had been loaded.
 			if (isset($this->updateFields[$row['userID']][$row['field']])) {
 				$this->cache[$row['userID']][$row['field']] = $this->updateFields[$row['userID']][$row['field']];
 			}


### PR DESCRIPTION
…ded users

Currently the UserStorageHandler returns obsolete values if the value is deleted/updated before the user object is cached.