### PR TITLE
Overly restrictive access to permissions

### DIFF
--- a/wcfsetup/install/files/lib/acp/form/UserGroupOptionForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/UserGroupOptionForm.class.php
@@ -14,6 +14,7 @@ use wcf\system\exception\SystemException;
 use wcf\system\exception\UserInputException;
 use wcf\system\option\user\group\IUserGroupGroupOptionType;
 use wcf\system\option\user\group\IUserGroupOptionType;
+use wcf\system\option\user\group\UserGroupOptionHandler;
 use wcf\system\WCF;
 use wcf\system\WCFACP;
 
@@ -168,7 +169,15 @@ class UserGroupOptionForm extends AbstractForm {
 				$this->errorType[$groupID] = $e->getType();
 			}
 			
-			if (!WCF::getUser()->hasOwnerAccess() && $this->optionType->compare($optionValue, WCF::getSession()->getPermission($this->userGroupOption->optionName)) == 1) {
+			if (WCF::getUser()->hasOwnerAccess()) {
+				continue;
+			}
+			
+			if (WCF::getUser()->hasAdministrativeAccess() && (!ENABLE_ENTERPRISE_MODE || !in_array($this->userGroupOption->optionName, UserGroupOption::ENTERPRISE_BLACKLIST))) {
+				continue;
+			}
+			
+			if ($this->optionType->compare($optionValue, WCF::getSession()->getPermission($this->userGroupOption->optionName)) == 1) {
 				$this->errorType[$groupID] = 'exceedsOwnPermission';
 			}
 		}

--- a/wcfsetup/install/files/lib/data/user/group/option/UserGroupOption.class.php
+++ b/wcfsetup/install/files/lib/data/user/group/option/UserGroupOption.class.php
@@ -18,4 +18,23 @@ class UserGroupOption extends Option {
 	 * @inheritDoc
 	 */
 	protected static $databaseTableName = 'user_group_option';
+	
+	/**
+	 * List of permission names that may not be altered when the enterprise mode is active.
+	 * @var string[]
+	 */
+	const ENTERPRISE_BLACKLIST = [
+		// Configuration
+		'admin.configuration.canManageApplication',
+		'admin.configuration.package.canUpdatePackage',
+		'admin.configuration.package.canEditServer',
+		
+		// User
+		'admin.user.canMailUser',
+		
+		// Management
+		'admin.management.canImportData',
+		'admin.management.canManageCronjob',
+		'admin.management.canRebuildData',
+	];
 }

--- a/wcfsetup/install/files/lib/system/option/user/group/UserGroupOptionHandler.class.php
+++ b/wcfsetup/install/files/lib/system/option/user/group/UserGroupOptionHandler.class.php
@@ -1,6 +1,7 @@
 <?php
 namespace wcf\system\option\user\group;
 use wcf\data\option\Option;
+use wcf\data\user\group\option\UserGroupOption;
 use wcf\data\user\group\UserGroup;
 use wcf\system\cache\builder\UserGroupOptionCacheBuilder;
 use wcf\system\exception\ImplementationException;
@@ -40,25 +41,6 @@ class UserGroupOptionHandler extends OptionHandler {
 	 * @since 5.2
 	 */
 	protected $isOwner = null;
-	
-	/**
-	 * List of permission names that may not be altered when the enterprise mode is active.
-	 * @var string[]
-	 */
-	protected $enterpriseBlacklist = [
-		// Configuration
-		'admin.configuration.canManageApplication',
-		'admin.configuration.package.canUpdatePackage',
-		'admin.configuration.package.canEditServer',
-		
-		// User
-		'admin.user.canMailUser',
-		
-		// Management
-		'admin.management.canImportData',
-		'admin.management.canManageCronjob',
-		'admin.management.canRebuildData',
-	];
 	
 	/**
 	 * Sets current user group.
@@ -170,7 +152,7 @@ class UserGroupOptionHandler extends OptionHandler {
 			return;
 		}
 		
-		if ($this->isAdmin() && (!ENABLE_ENTERPRISE_MODE || !in_array($option->optionName, $this->enterpriseBlacklist))) {
+		if ($this->isAdmin() && (!ENABLE_ENTERPRISE_MODE || !in_array($option->optionName, UserGroupOption::ENTERPRISE_BLACKLIST))) {
 			return;
 		}
 		


### PR DESCRIPTION
The changes in #3206 were not applied to the UserGroupOptionForm, incorrectly enforcing limits on administrator when running in enterprise mode.