### PR TITLE
Work around bug in createImageBitmap in Chrome

### DIFF
--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Image/Resizer.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Image/Resizer.js
@@ -165,6 +165,10 @@ define([
 			
 			var canvas = document.createElement('canvas');
 			
+			var chromeBug = createImageBitmap(image).then(function (bitmap) {
+				if (bitmap.height != image.height) throw new Error('Chrome Bug #1069965');
+			});
+			
 			// Prevent upscaling
 			var newWidth = Math.min(maxWidth, image.width);
 			var newHeight = Math.min(maxHeight, image.height);
@@ -193,7 +197,9 @@ define([
 				alpha: true
 			};
 			
-			return pica.resize(image, canvas, options);
+			return chromeBug.then(function() {
+				return pica.resize(image, canvas, options)
+			});
 		}
 	};
 	


### PR DESCRIPTION
Google Chrome returns inconsistent sizing between `img.(width|height)` and
the (width|height) of the bitmap returned by `createImageBitmap()`.

See: https://bugs.chromium.org/p/chromium/issues/detail?id=1069965

This mismatch causes Pica to corrupt the resulting image.

This commit disables resizing when the bug is detected. The behavior might
need to be re-adjusted depending on what behavior Chrome's fix will result
in.