### PR TITLE
Add AnchorFunctionTemplatePlugin

### DIFF
--- a/wcfsetup/install/files/lib/system/template/plugin/AnchorFunctionTemplatePlugin.class.php
+++ b/wcfsetup/install/files/lib/system/template/plugin/AnchorFunctionTemplatePlugin.class.php
@@ -1,0 +1,110 @@
+<?php
+namespace wcf\system\template\plugin;
+use wcf\data\ILinkableObject;
+use wcf\data\ITitledLinkObject;
+use wcf\data\ITitledObject;
+use wcf\system\template\TemplateEngine;
+use wcf\util\ClassUtil;
+use wcf\util\StringUtil;
+
+/**
+ * Template function plugin which generate `a` HTML elements.
+ * 
+ * Required parameters are either:
+ * 	`object` (`ITitledLinkObject`)
+ * or both:
+ * 	`link` (`ILinkableObject`)
+ * 	`title` (`ITitledObject` or string)
+ * 
+ * When `link` and `title` are used, `title` cannot also be used as a `title` attribute.
+ * 
+ * The only additional parameter that is treated in a special way is `append` whose value is appended
+ * to the link.
+ * All other additional parameter values are added as attributes to the `a` element. Parameter names
+ * in camel case are changed to kebab case (`fooBar` becomes `foo-bar`).
+ * 
+ * The only additional parameter name that is disallowed is `href`.
+ *
+ * Usage:
+ * 	{anchor object=$object data-foo='bar'}
+ * 	{anchor object=$object}
+ * 	{anchor object=$object append='#anchor'}
+ * 	{anchor link=$linkObject title=$titleObject}
+ * 	{anchor link=$linkObject title='Title'}
+ * 
+ * @author	Matthias Schmidt
+ * @copyright	2001-2020 WoltLab GmbH
+ * @license	GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @package	WoltLabSuite\Core\System\Template\Plugin
+ * @since	5.3
+ */
+class AnchorFunctionTemplatePlugin implements IFunctionTemplatePlugin {
+	/**
+	 * @inheritDoc
+	 */
+	public function execute($tagArgs, TemplateEngine $tplObj) {
+		$link = $title = null;
+		if (isset($tagArgs['object'])) {
+			$object = $tagArgs['object'];
+			unset($tagArgs['object']);
+			
+			if (!($object instanceof ITitledLinkObject) && !ClassUtil::isDecoratedInstanceOf($object, ITitledLinkObject::class)) {
+				throw new \InvalidArgumentException("'object' attribute does not implement interface '" . ITitledLinkObject::class . "'.");
+			}
+			
+			$link = $object->getLink();
+			$title = $object->getTitle();
+		}
+		else if (isset($tagArgs['link']) && isset($tagArgs['title'])) {
+			if (!($tagArgs['link'] instanceof ILinkableObject) && !ClassUtil::isDecoratedInstanceOf($tagArgs['link'], ITitledLinkObject::class)) {
+				throw new \InvalidArgumentException("'link' attribute does not implement interface '" . ILinkableObject::class . "'.");
+			}
+			
+			$link = $tagArgs['link']->getLink();
+			unset($tagArgs['link']);
+			
+			if (is_object($tagArgs['title'])) {
+				if (method_exists($tagArgs['title'], '__toString')) {
+					$title = (string)$tagArgs['title'];
+				}
+				else if ($tagArgs['title'] instanceof ITitledObject || ClassUtil::isDecoratedInstanceOf($tagArgs['title'], ITitledObject::class)) {
+					$title = $tagArgs['title']->getTitle();
+				}
+				else {
+					throw new \InvalidArgumentException("'title' object does not implement " . ITitledObject::class . ".");
+				}
+			}
+			else if (is_string($tagArgs['title']) || is_numeric($tagArgs['title'])) {
+				$title = $tagArgs['title'];
+			}
+			else {
+				throw new \InvalidArgumentException("'title' attribute is of invalid type " . gettype($tagArgs['title']) . ".");
+			}
+			unset($tagArgs['title']);
+		}
+		else {
+			throw new \InvalidArgumentException("Missing 'object' attribute or 'link' and 'title' attributes.");
+		}
+		
+		if (isset($tagArgs['href'])) {
+			throw new \InvalidArgumentException("'href' attribute is not allowed.");
+		}
+		
+		$append = '';
+		if (isset($tagArgs['append'])) {
+			$append = $tagArgs['append'];
+			unset($tagArgs['append']);
+		}
+		
+		$additionalParameters = '';
+		foreach ($tagArgs as $name => $value) {
+			if (!preg_match('~[a-z]+([A-z]+)+~', $name)) {
+				throw new \InvalidArgumentException("Invalid additional argument name '{$name}'.");
+			}
+			
+			$additionalParameters .= ' ' . strtolower(preg_replace('~([A-Z])~', '-$1', $name)) . '="' . StringUtil::encodeHTML($value) . '"';
+		}
+		
+		return '<a href="' . StringUtil::encodeHTML($link . $append) . '"' . $additionalParameters . '>' . StringUtil::encodeHTML($title) . '</a>';
+	}
+}

--- a/wcfsetup/install/files/lib/system/template/plugin/AnchorFunctionTemplatePlugin.class.php
+++ b/wcfsetup/install/files/lib/system/template/plugin/AnchorFunctionTemplatePlugin.class.php
@@ -64,11 +64,11 @@ class AnchorFunctionTemplatePlugin implements IFunctionTemplatePlugin {
 			unset($tagArgs['link']);
 			
 			if (is_object($tagArgs['title'])) {
-				if (method_exists($tagArgs['title'], '__toString')) {
-					$title = (string)$tagArgs['title'];
-				}
-				else if ($tagArgs['title'] instanceof ITitledObject || ClassUtil::isDecoratedInstanceOf($tagArgs['title'], ITitledObject::class)) {
+				if ($tagArgs['title'] instanceof ITitledObject || ClassUtil::isDecoratedInstanceOf($tagArgs['title'], ITitledObject::class)) {
 					$title = $tagArgs['title']->getTitle();
+				}
+				else if (method_exists($tagArgs['title'], '__toString')) {
+					$title = (string)$tagArgs['title'];
 				}
 				else {
 					throw new \InvalidArgumentException("'title' object does not implement " . ITitledObject::class . ".");


### PR DESCRIPTION
One frequent task in templates and language items is to generate a link to an object. For example, in WoltLab Suite Blog, a frequent piece of code in language items is

```smarty
<a href="{link application='blog' controller='Entry' object=$entry}{/link}">{$entry->subject}</a>
```

Using the link template plugin, this code could already be shortened to

```smarty
<a href="{$entry->getLink()}">{$entry->subject}</a>
```

But this piece of code still requires quite a bit of boilerplate code because the `Entry` class already implements `ITitledLinkObject`, thus it provides already all necessary information to generate the whole anchor automatically.

The new `AnchorFunctionTemplatePlugin` does exactly that:

```smarty
{anchor object=$entry}
```

Especially in language items, this makes the relevant code much shorter and improves readability.

The `object` attribute must implement `ITitledLinkObject` so that we can use the `getLink()` and `getTitle()` methods to generate the `href` of the anchor element and the contents of the anchor element.

Additionally, the `append` argument is supported whose contents are appended to the link, example:

```
{anchor object=$user append='#wall'}
```

All of the other arguments are added as attributes to the anchor element so that, for example, user links with additional information on hover can be created:

```
{anchor object=$user class='userLink' dataUserId=$user->userID}
```

Attribute names in camel case are transformed into kebab case. In the example above, `dataUserId` becomes `data-user-id`.

The only attribute name that is disallowed is `href` as it is already populated by the link.

As an alternative to the `object` argument, `link` and `title` can be passed separately. This is useful, for example, when linking comments when the link to the comment is used but the link title is the name of the object the comment belongs to:

```
{anchor link=$comment title=$object}
```

The `link` object has to implement `ILinkableObject` and the `title` argument either has to implement `ITitledObject`, be an object with an `__toString()` method, a string, or a number.

An open question with the `title` attribute in combination is what to do with the `title` attribute of the HTML element which could not be set when `title` is used in combination with `link`. An alternative might be to use `value` instead of `title` for the contents of the HTML element.