### PR TITLE
Fix typo in iOS platform detection

### DIFF
--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Environment.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Environment.js
@@ -70,7 +70,7 @@ define([], function() {
 			_touch = (!!('ontouchstart' in window) || (!!('msMaxTouchPoints' in window.navigator) && window.navigator.msMaxTouchPoints > 0) || window.DocumentTouch && document instanceof DocumentTouch);
 			
 			// The iPad Pro 12.9" masquerades as a desktop browser.
-			if (window.navigator.platform === 'macIntel' && window.navigator.maxTouchPoints > 1) {
+			if (window.navigator.platform === 'MacIntel' && window.navigator.maxTouchPoints > 1) {
 				_browser = 'safari';
 				_platform = 'ios';
 			}


### PR DESCRIPTION
`window.navigator.platform` outputs `MacIntel` on iOS / iPadOS when requesting the desktop version of a site.