### PR TITLE
Validate file extension before validating size

### DIFF
--- a/wcfsetup/install/files/lib/system/upload/DefaultUploadFileValidationStrategy.class.php
+++ b/wcfsetup/install/files/lib/system/upload/DefaultUploadFileValidationStrategy.class.php
@@ -52,13 +52,13 @@ class DefaultUploadFileValidationStrategy implements IUploadFileValidationStrate
 			return false;
 		}
 		
-		if ($uploadFile->getFilesize() > $this->maxFilesize) {
-			$uploadFile->setValidationErrorType('tooLarge');
+		if (!preg_match($this->fileExtensionRegex, mb_strtolower($uploadFile->getFilename()))) {
+			$uploadFile->setValidationErrorType('invalidExtension');
 			return false;
 		}
 		
-		if (!preg_match($this->fileExtensionRegex, mb_strtolower($uploadFile->getFilename()))) {
-			$uploadFile->setValidationErrorType('invalidExtension');
+		if ($uploadFile->getFilesize() > $this->maxFilesize) {
+			$uploadFile->setValidationErrorType('tooLarge');
 			return false;
 		}
 		


### PR DESCRIPTION
I just wasted some time compressing a file I wanted to upload because I was told it was too large. After compressing the file, I was told that the extension was invalid/not allowed. If a file can never be uploaded due to its extension, the user should be informed directly.