### PR TITLE
Show note in pollVote.tpl if poll is public

### DIFF
--- a/com.woltlab.wcf/templates/pollVote.tpl
+++ b/com.woltlab.wcf/templates/pollVote.tpl
@@ -12,6 +12,7 @@
 {if $poll->canVote()}
 	{if $poll->maxVotes > 1}<p><small>{lang}wcf.poll.multipleVotes{/lang}</small></p>{/if}
 	{if $poll->endTime}<p><small>{lang}wcf.poll.endTimeInfo{/lang}</small></p>{/if}
+	{if $poll->isPublic}<p><small>{lang}wcf.poll.isPublic{/lang}</small></p>{/if}
 {else}
 	<p><small>{lang}wcf.poll.restrictedResult{/lang}</small></p>
 {/if}


### PR DESCRIPTION
Resolves #3258

------

Not terribly happy that possibly three info texts are shown below the voting buttons. However it would at least be consistent with the existing notes, while a label at the top would not.

![Bildschirmfoto vom 2020-05-29 15-55-02](https://user-images.githubusercontent.com/209270/83267827-10c1ff80-a1c5-11ea-817a-f5c549c2ab41.png)

Making the notes a list (not part of this PR) would improve readability, but is not exactly looking great, either:

![image](https://user-images.githubusercontent.com/209270/83268318-bf664000-a1c5-11ea-9c89-250d41888817.png)


Opinions?