### PR TITLE
Stop RemoteFile from swallowing OpenSSL error details

### DIFF
--- a/wcfsetup/install/files/lib/system/io/RemoteFile.class.php
+++ b/wcfsetup/install/files/lib/system/io/RemoteFile.class.php
@@ -58,9 +58,14 @@ class RemoteFile extends File {
 		if (!preg_match('/^[a-z0-9]+:/', $this->host)) $this->host = 'tcp://'.$this->host;
 		
 		$context = stream_context_create($options);
-		$this->resource = @stream_socket_client($this->host.':'.$this->port, $this->errorNumber, $this->errorDesc, $timeout, STREAM_CLIENT_CONNECT, $context);
-		if ($this->resource === false) {
-			throw new SystemException('Can not connect to ' . $host, 0, $this->errorDesc);
+		try {
+			$this->resource = stream_socket_client($this->host.':'.$this->port, $this->errorNumber, $this->errorDesc, $timeout, STREAM_CLIENT_CONNECT, $context);
+			if ($this->resource === false) {
+				throw new \Exception('stream_socket_client returned false: ' . $this->errorDesc, $this->errorNumber);
+			}
+		}
+		catch (\Exception $e) {
+			throw new SystemException('Can not connect to ' . $host, 0, $this->errorDesc, $e);
 		}
 		
 		stream_set_timeout($this->resource, $timeout);


### PR DESCRIPTION
This PR is currently based on 5.2, instead of 5.3, because:

- It's something that aids debugging.
- It's fully compatible, because the outer exception is unchanged. It just has a `$previous` exception, while previously it had not. So any `catch` blocks will see the same stuff.

![image](https://user-images.githubusercontent.com/209270/84567519-77c0e600-ad79-11ea-80c7-0838cfc85a5c.png)

-------

Fixes #3107