### PR TITLE
Fix updating decimal fields with default value

### DIFF
--- a/wcfsetup/install/files/lib/system/database/table/column/AbstractDecimalDatabaseTableColumn.class.php
+++ b/wcfsetup/install/files/lib/system/database/table/column/AbstractDecimalDatabaseTableColumn.class.php
@@ -12,4 +12,16 @@ namespace wcf\system\database\table\column;
  */
 abstract class AbstractDecimalDatabaseTableColumn extends AbstractDatabaseTableColumn implements IDecimalsDatabaseTableColumn {
 	use TDecimalsDatabaseTableColumn;
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function getDefaultValue() {
+		$defaultValue = parent::getDefaultValue();
+		if ($defaultValue === null) {
+			return $defaultValue;
+		}
+		
+		return number_format($defaultValue, $this->getDecimals() ?? 0, '.', '');
+	}
 }


### PR DESCRIPTION
MySQL stores the default value using the specified number of decimals so that when comparing the existing default value with the new default value, the same format should be used.