### PR TITLE
Improve UrlFormField validation

### DIFF
--- a/wcfsetup/install/files/lib/system/form/builder/field/UrlFormField.class.php
+++ b/wcfsetup/install/files/lib/system/form/builder/field/UrlFormField.class.php
@@ -18,7 +18,7 @@ class UrlFormField extends TextFormField {
 	 * @inheritDoc
 	 */
 	protected function validateText($text, Language $language = null) {
-		if ($this->isRequired() && ($this->getValue() === null || $this->getValue() === '')) {
+		if ($this->isRequired() || !empty($this->getValue())) {
 			if (!Url::is($text)) {
 				$this->addValidationError(new FormFieldValidationError(
 					'invalid',


### PR DESCRIPTION
Currently the input is only validated if the field is required and the input is equal to NULL or ''. It would make more sense to always validate the input if one exists, and not only if the field is required.