### PR TITLE
Limit media images' caption size to image width

### DIFF
--- a/com.woltlab.wcf/templates/mediaBBCodeTag.tpl
+++ b/com.woltlab.wcf/templates/mediaBBCodeTag.tpl
@@ -8,11 +8,13 @@
 	
 	{if $media->caption}
 		<span class="mediaBBCodeCaption">
-			{if $media->captionEnableHtml}
-				{@$media->caption}
-			{else}
-				{$media->caption}
-			{/if}
+			<span class="mediaBBCodeCaptionAlignment">
+				{if $media->captionEnableHtml}
+					{@$media->caption}
+				{else}
+					{$media->caption}
+				{/if}
+			</span>
 		</span>
 	{/if}
 </span>

--- a/wcfsetup/install/files/acp/templates/mediaBBCodeTag.tpl
+++ b/wcfsetup/install/files/acp/templates/mediaBBCodeTag.tpl
@@ -8,11 +8,13 @@
 	
 	{if $media->caption}
 		<span class="mediaBBCodeCaption">
-			{if $media->captionEnableHtml}
-				{@$media->caption}
-			{else}
-				{$media->caption}
-			{/if}
+			<span class="mediaBBCodeCaptionAlignment">
+				{if $media->captionEnableHtml}
+					{@$media->caption}
+				{else}
+					{$media->caption}
+				{/if}
+			</span>
 		</span>
 	{/if}
 </span>

--- a/wcfsetup/install/files/style/bbcode/media.scss
+++ b/wcfsetup/install/files/style/bbcode/media.scss
@@ -1,14 +1,22 @@
 .mediaBBCode {
-	display: inline-block;
+	display: table;
 	max-width: 100%;
 	
 	.mediaBBCodeCaption {
 		color: $wcfContentDimmedText;
-		display: block;
+		// https://stackoverflow.com/a/11652170/782822
+		display: table-caption;
+		caption-side: bottom;
 		margin-top: 5px;
 		text-align: center;
 		
 		@include wcfFontSmall;
+		
+		.mediaBBCodeCaptionAlignment {
+			// https://stackoverflow.com/a/43627669/782822
+			display: inline-block;
+			text-align: justify;
+		}
 	}
 	
 	video {


### PR DESCRIPTION
The main difference is that the `.mediaBBCode` will now be rendered like a block element (seen in the last post on the page). But according to `bbcode.xml` the `wsm` BBCode already is `<isBlockElement>1</isBlockElement>`. I am a bit confused why it didn't previously render as such and why it is a valid child of a `<p>` element. **This probably warrants filing a follow up issue.**

<details><summary>Before (click me)</summary>

![before](https://user-images.githubusercontent.com/209270/85853363-ac3d9480-b7b2-11ea-80e4-59bbd8ed7bbc.png)

</details>
<details><summary>After (click me)</summary>

![after](https://user-images.githubusercontent.com/209270/85853393-ba8bb080-b7b2-11ea-811b-e3f1204d190b.png)

</details>

-----

Resolves #3228