### PR TITLE
Fix PHP 8 compatibility for WCF::handleError()

### DIFF
--- a/wcfsetup/install/files/lib/system/WCF.class.php
+++ b/wcfsetup/install/files/lib/system/WCF.class.php
@@ -336,7 +336,7 @@ class WCF {
 	 */
 	public static final function handleError($severity, $message, $file, $line) {
 		// this is necessary for the shut-up operator
-		if (error_reporting() == 0) return;
+		if (!(error_reporting() & $severity)) return;
 		
 		throw new ErrorException($message, 0, $severity, $file, $line);
 	}


### PR DESCRIPTION
Quoting from the UPGRADING manual (https://github.com/php/php-src/blob/php-8.0.0alpha1/UPGRADING):

> The @ operator will no longer silence fatal errors (E_ERROR, E_CORE_ERROR,
> E_COMPILE_ERROR, E_USER_ERROR, E_RECOVERABLE_ERROR, E_PARSE). Error handlers
> that expect error_reporting to be 0 when @ is used, should be adjusted to
> use a mask check instead:

-----------------------

Full note below:

https://github.com/php/php-src/blob/3f95989a32c45ba2a25001de69673242e9efb52d/UPGRADING#L57-L80