### PR TITLE
Allow specifying allowed file extensions for form builder's UploadFormField

### DIFF
--- a/com.woltlab.wcf/templates/uploadFieldComponent.tpl
+++ b/com.woltlab.wcf/templates/uploadFieldComponent.tpl
@@ -42,7 +42,12 @@
 		new Upload("{$uploadFieldId}UploadButtonDiv", "{$uploadFieldId}uploadFileList", {
 			internalId: '{$uploadField->getInternalId()}',
 			{if $uploadField->getMaxFiles()}maxFiles: {$uploadField->getMaxFiles()},{/if}
-			imagePreview: {if !$uploadField->supportMultipleFiles() && $uploadField->isImageOnly()}true{else}false{/if}
+			imagePreview: {if !$uploadField->supportMultipleFiles() && $uploadField->isImageOnly()}true{else}false{/if},
+			{if $uploadField->getAcceptableFiles()}
+				acceptableFiles: [
+					{implode from=$uploadField->getAcceptableFiles() item=accept}'{$accept|encodeJS}'{/implode}
+				],
+			{/if}
 		});
 	});
 </script>

--- a/wcfsetup/install/files/acp/templates/uploadFieldComponent.tpl
+++ b/wcfsetup/install/files/acp/templates/uploadFieldComponent.tpl
@@ -42,7 +42,12 @@
 		new Upload("{$uploadFieldId}UploadButtonDiv", "{$uploadFieldId}uploadFileList", {
 			internalId: '{$uploadField->getInternalId()}',
 			{if $uploadField->getMaxFiles()}maxFiles: {$uploadField->getMaxFiles()},{/if}
-			imagePreview: {if !$uploadField->supportMultipleFiles() && $uploadField->isImageOnly()}true{else}false{/if}
+			imagePreview: {if !$uploadField->supportMultipleFiles() && $uploadField->isImageOnly()}true{else}false{/if},
+			{if $uploadField->getAcceptableFiles()}
+				acceptableFiles: [
+					{implode from=$uploadField->getAcceptableFiles() item=accept}'{$accept|encodeJS}'{/implode}
+				],
+			{/if}
 		});
 	});
 </script>

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/File/Upload.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/File/Upload.js
@@ -31,7 +31,9 @@ define(['Core', 'Language', 'Dom/Util', 'WoltLabSuite/Core/Ui/File/Delete', 'Upl
 			// image preview
 			imagePreview: false,
 			// max files
-			maxFiles: null
+			maxFiles: null,
+			// array of acceptable file types, null if any file type is allowed
+			acceptableFiles: null,
 		}, options);
 		
 		this._options.multiple = this._options.maxFiles === null || this._options.maxFiles > 1; 

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/File/Upload.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/File/Upload.js
@@ -32,7 +32,7 @@ define(['Core', 'Language', 'Dom/Util', 'WoltLabSuite/Core/Ui/File/Delete', 'Upl
 			imagePreview: false,
 			// max files
 			maxFiles: null,
-			// array of acceptable file types, null if any file type is allowed
+			// array of acceptable file types, null if any file type is acceptable
 			acceptableFiles: null,
 		}, options);
 		

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Upload.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Upload.js
@@ -44,6 +44,8 @@ define(['AjaxRequest', 'Core', 'Dom/ChangeListener', 'Language', 'Dom/Util', 'Do
 			action: 'upload',
 			// is true if multiple files can be uploaded at once
 			multiple: false,
+			// array of accepted file types, null if any file type is allowed
+			acceptableFiles: null,
 			// name if the upload field
 			name: '__files[]',
 			// is true if every file from a multi-file selection is uploaded in its own request
@@ -88,6 +90,9 @@ define(['AjaxRequest', 'Core', 'Dom/ChangeListener', 'Language', 'Dom/Util', 'Do
 			elAttr(this._fileUpload, 'name', this._options.name);
 			if (this._options.multiple) {
 				elAttr(this._fileUpload, 'multiple', 'true');
+			}
+			if (this._options.acceptableFiles !== null) {
+				elAttr(this._fileUpload, 'accept', this._options.acceptableFiles.join(','));
 			}
 			this._fileUpload.addEventListener('change', this._upload.bind(this));
 			

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Upload.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Upload.js
@@ -44,7 +44,7 @@ define(['AjaxRequest', 'Core', 'Dom/ChangeListener', 'Language', 'Dom/Util', 'Do
 			action: 'upload',
 			// is true if multiple files can be uploaded at once
 			multiple: false,
-			// array of accepted file types, null if any file type is allowed
+			// array of acceptable file types, null if any file type is acceptable
 			acceptableFiles: null,
 			// name if the upload field
 			name: '__files[]',

--- a/wcfsetup/install/files/lib/system/file/upload/UploadField.class.php
+++ b/wcfsetup/install/files/lib/system/file/upload/UploadField.class.php
@@ -44,6 +44,13 @@ class UploadField {
 	public $allowSvgImage = false;
 	
 	/**
+	 * Acceptable file types.
+	 * @var string[]|null
+	 * @since 5.3
+	 */
+	public $acceptableFiles = null;
+	
+	/**
 	 * UploadField constructor.
 	 *
 	 * @param       string          $fieldId
@@ -119,10 +126,24 @@ class UploadField {
 	 * Sets the flag for `imageOnly`. This flag indicates whether only images
 	 * can uploaded via this field. Other file types will be rejected during upload.
 	 * 
+	 * If set to `true` will also set the acceptable types to `image/*`. If set to
+	 * false it will clear the acceptable types if they are `image/*`.
+	 * 
 	 * @param       boolean       $imageOnly
 	 */
 	public function setImageOnly($imageOnly) {
 		$this->imageOnly = $imageOnly;
+		
+		if ($imageOnly) {
+			$this->setAcceptableFiles(['image/*']);
+		}
+		else {
+			// Using == here is safe, because we match a single element array containing
+			// a scalar value.
+			if ($this->getAcceptableFiles() == ['image/*']) {
+				$this->setAcceptableFiles(null);
+			}
+		}
 	}
 	
 	/**
@@ -144,5 +165,37 @@ class UploadField {
 		}
 		
 		$this->allowSvgImage = $allowSvgImage;
+	}
+	
+	/**
+	 * Specifies acceptable file types. Use null to not specify any restrictions.
+	 * 
+	 * <strong>Heads up:</strong> This feature is used to improve user experience, by removing
+	 * unacceptable files from the file picker. It does not validate the type of the uploaded
+	 * file. You are responsible to perform (proper) validation on the server side.
+	 * 
+	 * Valid values are specified as "Unique file type specifiers":
+	 * - A case insensitive file extension starting with a dot.
+	 * - A mime type.
+	 * - `audio/*`
+	 * - `image/*`
+	 * - `video/*`
+	 * 
+	 * @see         https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#Unique_file_type_specifiers
+	 * @param       string[]|null     $acceptableFiles
+	 * @since       5.3
+	 */
+	public function setAcceptableFiles($acceptableFiles = null) {
+		$this->acceptableFiles = $acceptableFiles;
+	}
+	
+	/**
+	 * Returns the acceptable file types.
+	 * 
+	 * @return      string[]|null
+	 * @since       5.3
+	 */
+	public function getAcceptableFiles() {
+		return $this->acceptableFiles;
 	}
 }

--- a/wcfsetup/install/files/lib/system/form/builder/field/UploadFormField.class.php
+++ b/wcfsetup/install/files/lib/system/form/builder/field/UploadFormField.class.php
@@ -43,6 +43,13 @@ class UploadFormField extends AbstractFormField {
 	protected $allowSvgImage = false;
 	
 	/**
+	 * Acceptable file types.
+	 * @var null|string[]
+	 * @since 5.3
+	 */
+	protected $acceptableFiles = null;
+	
+	/**
 	 * maximum filesize for each uploaded file
 	 * @var	null|number
 	 */
@@ -110,6 +117,7 @@ class UploadFormField extends AbstractFormField {
 		if ($this->isImageOnly()) {
 			$uploadField->setAllowSvgImage($this->svgImageAllowed());
 		}
+		$uploadField->setAcceptableFiles($this->getAcceptableFiles());
 		
 		return $uploadField;
 	}
@@ -597,7 +605,10 @@ class UploadFormField extends AbstractFormField {
 	/**
 	 * Sets the flag for `imageOnly`. This flag indicates whether only images 
 	 * can uploaded via this field. Other file types will be rejected during upload.
-	 *
+	 * 
+	 * If set to `true` will also set the acceptable types to `image/*`. If set to
+	 * false it will clear the acceptable types if they are `image/*`.
+	 * 
 	 * @param	boolean	        $imageOnly
 	 * @return	static				this field
 	 * 
@@ -623,6 +634,16 @@ class UploadFormField extends AbstractFormField {
 		}
 		
 		$this->imageOnly = $imageOnly;
+		if ($imageOnly) {
+			$this->setAcceptableFiles(['image/*']);
+		}
+		else {
+			// Using == here is safe, because we match a single element array containing
+			// a scalar value.
+			if ($this->getAcceptableFiles() == ['image/*']) {
+				$this->setAcceptableFiles(null);
+			}
+		}
 		
 		return $this;
 	}
@@ -667,5 +688,39 @@ class UploadFormField extends AbstractFormField {
 	 */
 	public function svgImageAllowed() {
 		return $this->allowSvgImage;
+	}
+	
+	/**
+	 * Specifies acceptable file types. Use null to not specify any restrictions.
+	 * 
+	 * <strong>Heads up:</strong> This feature is used to improve user experience, by removing
+	 * unacceptable files from the file picker. It does not validate the type of the uploaded
+	 * file. You are responsible to perform (proper) validation on the server side.
+	 * 
+	 * Valid values are specified as "Unique file type specifiers":
+	 * - A case insensitive file extension starting with a dot.
+	 * - A mime type.
+	 * - `audio/*`
+	 * - `image/*`
+	 * - `video/*`
+	 * 
+	 * @see         https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#Unique_file_type_specifiers
+	 * @param       string[]|null     $acceptableFiles
+	 * @since       5.3
+	 */
+	public function setAcceptableFiles($acceptableFiles = null) {
+		$this->acceptableFiles = $acceptableFiles;
+		
+		return $this;
+	}
+	
+	/**
+	 * Returns the acceptable file types.
+	 * 
+	 * @return      string[]|null
+	 * @since       5.3
+	 */
+	public function getAcceptableFiles() {
+		return $this->acceptableFiles;
 	}
 }


### PR DESCRIPTION
I'm intentionally using a fairly elaborate wording “acceptable” instead of “valid” to make it clearer that no validation is happening automatically.

Resolves #3414 