### PR TITLE
Set display from browser to standalone

### DIFF
--- a/wcfsetup/install/files/images/favicon/default.manifest.json
+++ b/wcfsetup/install/files/images/favicon/default.manifest.json
@@ -14,5 +14,5 @@
     ],
     "theme_color": "#ffffff",
     "background_color": "#ffffff",
-    "display": "browser"
+    "display": "standalone"
 }


### PR DESCRIPTION
In my opinion this change increases the UX and UI on mobile devices (if you have saved a page on the desktop). It may not quite fulfil the wish of this potential customer (https://community.woltlab.com/thread/284454-pwa-als-button-speichern-app-simulieren/), but it is at least a step in the direction of his wish.

> Opens the web application to look and feel like a standalone native application. This can include the application having a different window, its own icon in the application launcher, etc. In this mode, the user agent will exclude standard browser UI elements such as an URL bar, but can include other system UI elements such as a status bar and/or system back button.
The fallback display mode for standalone is minimal-ui.

Source: https://www.w3.org/TR/appmanifest/#dom-displaymodetype-standalone