### PR TITLE
Check strings against '' instead of using empty when validating in DBO actions

### DIFF
--- a/wcfsetup/install/files/lib/data/AbstractDatabaseObjectAction.class.php
+++ b/wcfsetup/install/files/lib/data/AbstractDatabaseObjectAction.class.php
@@ -563,7 +563,7 @@ abstract class AbstractDatabaseObjectAction implements IDatabaseObjectAction, ID
 				else {
 					if ($structure === self::STRUCT_FLAT) {
 						$target[$variableName] = StringUtil::trim($target[$variableName]);
-						if (!$allowEmpty && empty($target[$variableName])) {
+						if (!$allowEmpty && $target[$variableName] === '') {
 							throw new UserInputException($variableName);
 						}
 					}
@@ -574,7 +574,7 @@ abstract class AbstractDatabaseObjectAction implements IDatabaseObjectAction, ID
 						}
 						
 						for ($i = 0, $length = count($target[$variableName]); $i < $length; $i++) {
-							if (empty($target[$variableName][$i])) {
+							if ($target[$variableName][$i] === '') {
 								throw new UserInputException($variableName);
 							}
 						}


### PR DESCRIPTION
Basing this PR against “master”, despite being a bugfix because this commit introduces a behavioral change and the user visible effect of this bug is quite small.

-------------------------

`empty('0')` will return true, despite the string not actually being empty
which is undesired.

Fixes WoltLab/com.woltlab.wbb#387