### PR TITLE
Fix Url::is()

### DIFF
--- a/wcfsetup/install/files/lib/util/Url.class.php
+++ b/wcfsetup/install/files/lib/util/Url.class.php
@@ -38,13 +38,15 @@ final class Url implements \ArrayAccess {
 	];
 	
 	/**
-	 * Tests if provided url appears to be an url and can be processed by `parse_url()`.
+	 * Tests if provided $url appears to be an URL.
+	 * 
+	 * This method is a wrapper around filter_var with FILTER_VALIDATE_URL.
 	 * 
 	 * @param       string          $url
 	 * @return      boolean
 	 */
 	public static function is($url) {
-		return parse_url($url) !== false;
+		return filter_var($url, FILTER_VALIDATE_URL) !== false;
 	}
 	
 	/**


### PR DESCRIPTION
`parse_url()` cannot be used to validate an URL, because it will accept
roughly everything. In fact this is documented in the parse_url() docs:

> This function is not meant to validate the given URL, it only breaks
> it up into the above listed parts. Partial URLs are also accepted,
> parse_url() tries its best to parse them correctly.

Fixes #3391

/cc @SoftCreatR @TitusKirch 