### PR TITLE
Fix markup for linked, blocked images in UGC

### DIFF
--- a/wcfsetup/install/files/lib/system/html/output/node/HtmlOutputNodeImg.class.php
+++ b/wcfsetup/install/files/lib/system/html/output/node/HtmlOutputNodeImg.class.php
@@ -152,10 +152,15 @@ class HtmlOutputNodeImg extends AbstractHtmlOutputNode {
 	protected function replaceExternalSource(\DOMElement $element, $src) {
 		$element->parentNode->insertBefore($element->ownerDocument->createTextNode('['.WCF::getLanguage()->get('wcf.bbcode.image.blocked').': '), $element);
 		
-		$link = $element->ownerDocument->createElement('a');
-		$link->setAttribute('href', $src);
-		$link->textContent = $src;
-		HtmlOutputNodeA::markLinkAsExternal($link);
+		if (!DOMUtil::hasParent($element, 'a')) {
+			$link = $element->ownerDocument->createElement('a');
+			$link->setAttribute('href', $src);
+			$link->textContent = $src;
+			HtmlOutputNodeA::markLinkAsExternal($link);
+		}
+		else {
+			$link = $element->ownerDocument->createTextNode($src);
+		}
 		
 		$element->parentNode->insertBefore($link, $element);
 		


### PR DESCRIPTION
The generated output now is:

```
<p><a href="https://www.woltlab.com/" class="externalURL" rel="nofollow">[Blocked Image: https://www.woltlab.com/images/default-logo.png]</a></p>
```

--------

Fixes #3384