### PR TITLE
Properly support multiple instances of WoltLabSuite/Core/Ui/ItemList/User

### DIFF
--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/ItemList/User.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/ItemList/User.js
@@ -2,7 +2,7 @@
  * Provides an item list for users and groups.
  * 
  * @author	Alexander Ebert
- * @copyright	2001-2019 WoltLab GmbH
+ * @copyright	2001-2020 WoltLab GmbH
  * @license	GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
  * @module	WoltLabSuite/Core/Ui/ItemList/User
  */
@@ -22,8 +22,6 @@ define(['WoltLabSuite/Core/Ui/ItemList'], function(UiItemList) {
 	 * @exports	WoltLabSuite/Core/Ui/ItemList/User
 	 */
 	return {
-		_shadowGroups: null,
-		
 		/**
 		 * Initializes user suggestion support for an element.
 		 * 
@@ -31,8 +29,6 @@ define(['WoltLabSuite/Core/Ui/ItemList'], function(UiItemList) {
 		 * @param	{object}	options		option list
 		 */
 		init: function(elementId, options) {
-			this._shadowGroups = null;
-			
 			UiItemList.init(elementId, [], {
 				ajax: {
 					className: 'wcf\\data\\user\\UserAction',
@@ -70,13 +66,13 @@ define(['WoltLabSuite/Core/Ui/ItemList'], function(UiItemList) {
 			});
 			
 			data.shadow.value = users.join(',');
-			if (!this._shadowGroups) {
-				this._shadowGroups = elCreate('input');
-				this._shadowGroups.type = 'hidden';
-				this._shadowGroups.name = data.shadow.name + 'GroupIDs';
-				data.shadow.parentNode.insertBefore(this._shadowGroups, data.shadow);
+			if (!data._shadowGroups) {
+				data._shadowGroups = elCreate('input');
+				data._shadowGroups.type = 'hidden';
+				data._shadowGroups.name = data.shadow.name + 'GroupIDs';
+				data.shadow.parentNode.insertBefore(data._shadowGroups, data.shadow);
 			}
-			this._shadowGroups.value = groups.join(',');
+			data._shadowGroups.value = groups.join(',');
 			
 			return values;
 		}


### PR DESCRIPTION
WoltLabSuite/Core/Ui/ItemList/User is a singleton and thus only has a single
instance of each object member. This lead to the `_shadowGroups` value being
fixed to the first input used.

Move the `_shadowGroups` into the existing `data` object (where the regular
`shadow` resides) to fix this issue.

Introduced in 8faf6ea10ac894b87b3e357f5248f67b4fd7b716.
Fixes #3433.