### PR TITLE
Avoid duplicate injection of __formFieldDataHandler

### DIFF
--- a/com.woltlab.wcf/templates/__captchaFormField.tpl
+++ b/com.woltlab.wcf/templates/__captchaFormField.tpl
@@ -1,3 +1,1 @@
 {@$field->getObjectType()->getProcessor()->getFormElement()}
-
-{include file='__formFieldDataHandler'}

--- a/wcfsetup/install/files/acp/templates/__captchaFormField.tpl
+++ b/wcfsetup/install/files/acp/templates/__captchaFormField.tpl
@@ -1,3 +1,1 @@
 {@$field->getObjectType()->getProcessor()->getFormElement()}
-
-{include file='__formFieldDataHandler'}


### PR DESCRIPTION
Fixes duplicate injection of form field registration in AJAX mode.

Uncaught (in promise) Error: Form field with id 'captcha' has already been registered for form with id 'form1'.
    registerField http://localhost-php7/2019/js/WoltLabSuite/Core/Form/Builder/Manager.js?t=1593604959:138
    <anonymous> http://localhost-php7/2019/forum/index.php?thread/7-formulare/&postID=45#post45 line 171 > scriptElement:9
    promise http://localhost-php7/2019/js/require.linearExecution.js?v=1593604959:32