### PR TITLE
Synchronize attachments across instances

### DIFF
--- a/com.woltlab.wcf/option.xml
+++ b/com.woltlab.wcf/option.xml
@@ -1017,12 +1017,6 @@ redis:wcf.acp.option.cache_source_type.redis</selectoptions>
 				<optiontype>text</optiontype>
 			</option>
 			<!-- /general.payment -->
-			<option name="attachment_enable_thumbnails">
-				<categoryname>message.attachment</categoryname>
-				<optiontype>boolean</optiontype>
-				<defaultvalue>1</defaultvalue>
-				<enableoptions>attachment_retain_dimensions,attachment_thumbnail_height,attachment_thumbnail_width</enableoptions>
-			</option>
 			<option name="attachment_retain_dimensions">
 				<categoryname>message.attachment</categoryname>
 				<optiontype>boolean</optiontype>
@@ -1768,10 +1762,7 @@ DESC:wcf.global.sortOrder.descending</selectoptions>
 		</options>
 	</import>
 	<delete>
-		<option name="attachment_storage" />
-		<option name="like_allow_for_own_content" />
-		<option name="like_enable_dislike" />
-		<option name="module_attachment"/>
-		<option name="message_sidebar_enable_user_online_marking"/>
+		<option name="attachment_enable_thumbnails" />
+		<option name="message_sidebar_enable_user_online_marking" />
 	</delete>
 </data>

--- a/com.woltlab.wcf/templates/__wysiwygAttachmentFormField.tpl
+++ b/com.woltlab.wcf/templates/__wysiwygAttachmentFormField.tpl
@@ -1,7 +1,6 @@
 <ul id="{@$field->getPrefixedID()}_attachmentList" {*
 	*}class="formAttachmentList"{*
 	*}{if !$field->getAttachmentHandler()->getAttachmentList()|count} style="display: none"{/if} {*
-	*}data-enable-thumbnails="{if ATTACHMENT_ENABLE_THUMBNAILS}true{else}false{/if}"{*
 *}>
 	{foreach from=$field->getAttachmentHandler()->getAttachmentList() item=$attachment}
 		<li class="box64" {*

--- a/com.woltlab.wcf/templates/__wysiwygAttachmentFormField.tpl
+++ b/com.woltlab.wcf/templates/__wysiwygAttachmentFormField.tpl
@@ -1,6 +1,6 @@
 <ul id="{@$field->getPrefixedID()}_attachmentList" {*
 	*}class="formAttachmentList"{*
-	*}{if !$field->getAttachmentHandler()->getAttachmentList()|count} style="display: none"{/if} {*
+	*}{if !$field->getAttachmentHandler()->getAttachmentList()|count} style="display: none"{/if}{*
 *}>
 	{foreach from=$field->getAttachmentHandler()->getAttachmentList() item=$attachment}
 		<li class="box64" {*

--- a/com.woltlab.wcf/templates/messageFormAttachments.tpl
+++ b/com.woltlab.wcf/templates/messageFormAttachments.tpl
@@ -1,5 +1,5 @@
 <div class="jsOnly formAttachmentContent messageTabMenuContent" id="attachments_{if $wysiwygSelector|isset}{$wysiwygSelector}{else}text{/if}">
-	<ul class="formAttachmentList clearfix"{if !$attachmentHandler->getAttachmentList()|count} style="display: none"{/if} data-enable-thumbnails="{if ATTACHMENT_ENABLE_THUMBNAILS}true{else}false{/if}">
+	<ul class="formAttachmentList clearfix"{if !$attachmentHandler->getAttachmentList()|count} style="display: none"{/if}>
 		{foreach from=$attachmentHandler->getAttachmentList() item=$attachment}
 			<li class="box64" data-object-id="{@$attachment->attachmentID}" data-height="{@$attachment->height}" data-width="{@$attachment->width}" data-is-image="{@$attachment->isImage}">
 				{if $attachment->tinyThumbnailType}

--- a/wcfsetup/install/files/acp/templates/__wysiwygAttachmentFormField.tpl
+++ b/wcfsetup/install/files/acp/templates/__wysiwygAttachmentFormField.tpl
@@ -1,7 +1,6 @@
 <ul id="{@$field->getPrefixedID()}_attachmentList" {*
 	*}class="formAttachmentList"{*
 	*}{if !$field->getAttachmentHandler()->getAttachmentList()|count} style="display: none"{/if} {*
-	*}data-enable-thumbnails="{if ATTACHMENT_ENABLE_THUMBNAILS}true{else}false{/if}"{*
 *}>
 	{foreach from=$field->getAttachmentHandler()->getAttachmentList() item=$attachment}
 		<li class="box64" {*

--- a/wcfsetup/install/files/acp/templates/__wysiwygAttachmentFormField.tpl
+++ b/wcfsetup/install/files/acp/templates/__wysiwygAttachmentFormField.tpl
@@ -1,6 +1,6 @@
 <ul id="{@$field->getPrefixedID()}_attachmentList" {*
 	*}class="formAttachmentList"{*
-	*}{if !$field->getAttachmentHandler()->getAttachmentList()|count} style="display: none"{/if} {*
+	*}{if !$field->getAttachmentHandler()->getAttachmentList()|count} style="display: none"{/if}{*
 *}>
 	{foreach from=$field->getAttachmentHandler()->getAttachmentList() item=$attachment}
 		<li class="box64" {*

--- a/wcfsetup/install/files/js/WCF.Attachment.js
+++ b/wcfsetup/install/files/js/WCF.Attachment.js
@@ -489,9 +489,10 @@ WCF.Attachment.Upload = WCF.Upload.extend({
 	 *
 	 * @return      {boolean}
 	 * @protected
+	 * @deprecated 5.3
 	 */
 	_useThumbnail: function() {
-		return elDataBool(this._fileListSelector[0], 'enable-thumbnails');
+		return true;
 	},
 	
 	/**
@@ -552,7 +553,7 @@ WCF.Attachment.Upload = WCF.Upload.extend({
 				$li.data('objectID', attachmentData.attachmentID);
 				
 				if (this._editorId) {
-					if (attachmentData.tinyURL || (!this._useThumbnail() && attachmentData.isImage)) {
+					if (attachmentData.tinyURL) {
 						if (attachmentData.thumbnailURL) {
 							$('<li><span class="button small jsButtonAttachmentInsertThumbnail" data-object-id="' + attachmentData.attachmentID + '" data-url="' + WCF.String.escapeHTML(attachmentData.thumbnailURL) + '">' + WCF.Language.get('wcf.attachment.insertThumbnail') + '</span></li>').appendTo($buttonList);
 						}
@@ -660,15 +661,12 @@ WCF.Attachment.Upload = WCF.Upload.extend({
 	 * Inserts all attachments at once.
 	 */
 	_insertAll: function () {
-		var attachment, button, preferThumbnail = this._useThumbnail();
+		var attachment, button;
 		for (var i = 0, length = this._fileListSelector[0].childNodes.length; i < length; i++) {
 			attachment = this._fileListSelector[0].childNodes[i];
 			if (attachment.nodeName === 'LI' && !attachment.classList.contains('uploadFailed')) {
-				button = null;
-				if (preferThumbnail) {
-					button = elBySel('.jsButtonAttachmentInsertThumbnail, .jsButtonAttachmentInsertPlain', attachment);
-				}
-
+				button = elBySel('.jsButtonAttachmentInsertThumbnail, .jsButtonAttachmentInsertPlain', attachment);
+				
 				if (button === null) {
 					button = elBySel('.jsButtonAttachmentInsertFull, .jsButtonAttachmentInsertPlain', attachment);
 				}

--- a/wcfsetup/install/files/js/WCF.Attachment.js
+++ b/wcfsetup/install/files/js/WCF.Attachment.js
@@ -87,8 +87,7 @@ WCF.Attachment.Upload = WCF.Upload.extend({
 		this._fileListSelector.find('.jsButtonAttachmentInsertThumbnail').click($.proxy(this._insert, this));
 		this._fileListSelector.find('.jsButtonAttachmentInsertFull').click($.proxy(this._insert, this));
 		
-		WCF.DOMNodeRemovedHandler.addCallback('WCF.Attachment.Upload', $.proxy(this._removeLimitError, this));
-		WCF.System.Event.addListener('com.woltlab.wcf.action.delete', 'attachment_' + this._editorId, $.proxy(this._removeLimitError, this));
+		WCF.System.Event.addListener('com.woltlab.wcf.action.delete', 'attachment', this._onDelete.bind(this));
 		
 		this._makeSortable();
 		
@@ -153,6 +152,8 @@ WCF.Attachment.Upload = WCF.Upload.extend({
 				}
 			}).bind(this));
 			
+			var syncUuid = WCF.System.Event.addListener('com.woltlab.wcf.redactor2', 'sync_' + this._tmpHash, this._sync.bind(this));
+			
 			WCF.System.Event.addListener('com.woltlab.wcf.redactor2', 'destroy_' + this._editorId, (function () {
 				WCF.System.Event.removeAllListeners('com.woltlab.wcf.redactor2', 'submit_' + this._editorId);
 				WCF.System.Event.removeAllListeners('com.woltlab.wcf.redactor2', 'reset_' + this._editorId);
@@ -162,6 +163,7 @@ WCF.Attachment.Upload = WCF.Upload.extend({
 				WCF.System.Event.removeAllListeners('com.woltlab.wcf.redactor2', 'autosaveMetaData_' + this._editorId);
 				
 				WCF.System.Event.removeListener('com.woltlab.wcf.redactor2', 'metacode_attach_' + this._editorId, metacodeAttachUuid);
+				WCF.System.Event.removeListener('com.woltlab.wcf.redactor2', 'sync_' + this._tmpHash, syncUuid);
 			}).bind(this));
 		}
 	},
@@ -172,7 +174,7 @@ WCF.Attachment.Upload = WCF.Upload.extend({
 	 * @param        object                data
 	 */
 	_editorUpload: function (data) {
-		var $uploadID, replace = null;
+		var replace = null;
 		
 		// show tab
 		this._fileListSelector.closest('.messageTabMenu').messageTabMenu('showTab', 'attachments', true);
@@ -189,10 +191,10 @@ WCF.Attachment.Upload = WCF.Upload.extend({
 		}).bind(this);
 		
 		if (data.file) {
-			$uploadID = this._upload(undefined, data.file, undefined, callbackUploadId);
+			this._upload(undefined, data.file, undefined, callbackUploadId);
 		}
 		else {
-			$uploadID = this._upload(undefined, undefined, data.blob, callbackUploadId);
+			this._upload(undefined, undefined, data.blob, callbackUploadId);
 			replace = data.replace || null;
 		}
 	},
@@ -461,7 +463,7 @@ WCF.Attachment.Upload = WCF.Upload.extend({
 	 * @see        WCF.Upload._initFile()
 	 */
 	_initFile: function (file) {
-		var $li = $('<li class="box64"><span class="icon icon64 fa-spinner" /><div><div><p>' + file.name + '</p><small><progress max="100"></progress></small></div><ul></ul></div></li>').data('filename', file.name);
+		var $li = $('<li class="box64 formAttachmentListItem"><span class="icon icon64 fa-spinner" /><div><div><p>' + file.name + '</p><small><progress max="100"></progress></small></div><ul></ul></div></li>').data('filename', file.name);
 		this._fileListSelector.append($li);
 		this._fileListSelector.show();
 		
@@ -514,6 +516,8 @@ WCF.Attachment.Upload = WCF.Upload.extend({
 			if (data.returnValues && data.returnValues.attachments[$internalFileID]) {
 				attachmentData = data.returnValues.attachments[$internalFileID];
 				
+				elData($li[0], 'object-id', attachmentData.attachmentID);
+				
 				// show thumbnail
 				if (attachmentData.tinyURL) {
 					$li.children('.fa-spinner').replaceWith($('<img src="' + attachmentData.tinyURL + '" alt="" class="attachmentTinyThumbnail" />'));
@@ -542,7 +546,7 @@ WCF.Attachment.Upload = WCF.Upload.extend({
 				
 				// init buttons
 				var $buttonList = $li.find('ul').addClass('buttonGroup');
-				var $deleteButton = $('<li><span class="button small jsDeleteButton" data-object-id="' + attachmentData.attachmentID + '" data-confirm-message="' + WCF.Language.get('wcf.attachment.delete.sure') + '" data-event-name="attachment_' + this._editorId + '">' + WCF.Language.get('wcf.global.button.delete') + '</span></li>');
+				var $deleteButton = $('<li><span class="button small jsDeleteButton" data-object-id="' + attachmentData.attachmentID + '" data-confirm-message="' + WCF.Language.get('wcf.attachment.delete.sure') + '" data-event-name="attachment">' + WCF.Language.get('wcf.global.button.delete') + '</span></li>');
 				$buttonList.append($deleteButton);
 				
 				$li.data('objectID', attachmentData.attachmentID);
@@ -550,18 +554,21 @@ WCF.Attachment.Upload = WCF.Upload.extend({
 				if (this._editorId) {
 					if (attachmentData.tinyURL || (!this._useThumbnail() && attachmentData.isImage)) {
 						if (attachmentData.thumbnailURL) {
-							var $insertThumbnail = $('<li><span class="button small jsButtonAttachmentInsertThumbnail" data-object-id="' + attachmentData.attachmentID + '" data-url="' + WCF.String.escapeHTML(attachmentData.thumbnailURL) + '">' + WCF.Language.get('wcf.attachment.insertThumbnail') + '</span></li>').appendTo($buttonList);
-							$insertThumbnail.children('span.button').click($.proxy(this._insert, this));
+							$('<li><span class="button small jsButtonAttachmentInsertThumbnail" data-object-id="' + attachmentData.attachmentID + '" data-url="' + WCF.String.escapeHTML(attachmentData.thumbnailURL) + '">' + WCF.Language.get('wcf.attachment.insertThumbnail') + '</span></li>').appendTo($buttonList);
 						}
 						
-						var $insertOriginal = $('<li><span class="button small jsButtonAttachmentInsertFull" data-object-id="' + attachmentData.attachmentID + '" data-url="' + WCF.String.escapeHTML(attachmentData.url) + '">' + WCF.Language.get('wcf.attachment.insertFull') + '</span></li>').appendTo($buttonList);
-						$insertOriginal.children('span.button').click($.proxy(this._insert, this));
+						$('<li><span class="button small jsButtonAttachmentInsertFull" data-object-id="' + attachmentData.attachmentID + '" data-url="' + WCF.String.escapeHTML(attachmentData.url) + '">' + WCF.Language.get('wcf.attachment.insertFull') + '</span></li>').appendTo($buttonList);
 					}
 					else {
-						var $insertPlain = $('<li><span class="button small jsButtonAttachmentInsertPlain" data-object-id="' + attachmentData.attachmentID + '">' + WCF.Language.get('wcf.attachment.insert') + '</span></li>');
-						$insertPlain.appendTo($buttonList).children('span.button').click($.proxy(this._insert, this));
+						$('<li><span class="button small jsButtonAttachmentInsertPlain" data-object-id="' + attachmentData.attachmentID + '">' + WCF.Language.get('wcf.attachment.insert') + '</span></li>').appendTo($buttonList);
 					}
 				}
+				
+				this._triggerSync('new', {
+					html: $li[0].outerHTML
+				});
+				
+				this._registerEditorButtons($li[0]);
 				
 				if (this._replaceOnLoad.hasOwnProperty(uploadID)) {
 					if (!$li.hasClass('uploadFailed')) {
@@ -623,6 +630,14 @@ WCF.Attachment.Upload = WCF.Upload.extend({
 		}
 		
 		WCF.DOMNodeInsertedHandler.execute();
+	},
+	
+	_registerEditorButtons: function (attachment) {
+		if (this._editorId) {
+			elBySelAll('.jsButtonAttachmentInsertThumbnail, .jsButtonAttachmentInsertFull, .jsButtonAttachmentInsertPlain', attachment, (function(button) {
+				button.addEventListener('click', this._insert.bind(this));
+			}).bind(this));
+		}
 	},
 	
 	/**
@@ -723,5 +738,66 @@ WCF.Attachment.Upload = WCF.Upload.extend({
 				}
 			}).bind(this));
 		}
+	},
+	
+	/**
+	 * @param {Object} data
+	 * @param {jQuery} data.button
+	 * @param {jQuery} data.container
+	 */
+	_onDelete: function (data) {
+		var objectId = elData(data.button[0], 'object-id');
+		var attachment = elBySel('.formAttachmentListItem[data-object-id="' + objectId + '"]', this._fileListSelector[0]);
+		if (attachment !== null) {
+			elRemove(attachment);
+		}
+		
+		this._removeLimitError(data);
+	},
+	
+	/**
+	 * @param {Object} payload
+	 * @param {Object} payload.data
+	 * @param {Object} payload.source
+	 * @param {string} payload.type
+	 */
+	_sync: function (payload) {
+		if (payload.source === this) {
+			return;
+		}
+		
+		switch (payload.type) {
+			case 'new':
+				this._syncNew(payload.data);
+				break;
+				
+			default:
+				throw new Error("Unexpected type '" + payload.type + "'");
+		}
+	},
+	
+	/**
+	 * @param {Object} data
+	 */
+	_syncNew: function (data) {
+		require(['Dom/Util'], (function (DomUtil) {
+			var fragment = DomUtil.createFragmentFromHtml(data.html);
+			var attachment = elBySel('li', fragment);
+			attachment.id = '';
+			
+			this._registerEditorButtons(attachment);
+			
+			this._fileListSelector[0].appendChild(attachment);
+			
+			elShow(this._fileListSelector[0]);
+		}).bind(this));
+	},
+	
+	_triggerSync: function (type, data) {
+		WCF.System.Event.fireEvent('com.woltlab.wcf.redactor2', 'sync_' + this._tmpHash, {
+			source: this,
+			type: type,
+			data: data
+		});
 	}
 });

--- a/wcfsetup/install/files/js/WCF.Attachment.js
+++ b/wcfsetup/install/files/js/WCF.Attachment.js
@@ -620,6 +620,10 @@ WCF.Attachment.Upload = WCF.Upload.extend({
 			}
 		}
 		
+		this._rebuildInterface();
+	},
+	
+	_rebuildInterface: function () {
 		this._makeSortable();
 		
 		if (this._fileListSelector.children('li:not(.uploadFailed)').length) {
@@ -790,9 +794,15 @@ WCF.Attachment.Upload = WCF.Upload.extend({
 			this._fileListSelector[0].appendChild(attachment);
 			
 			elShow(this._fileListSelector[0]);
+			
+			this._rebuildInterface();
 		}).bind(this));
 	},
 	
+	/**
+	 * @param {string} type
+	 * @param {Object} data
+	 */
 	_triggerSync: function (type, data) {
 		WCF.System.Event.fireEvent('com.woltlab.wcf.redactor2', 'sync_' + this._tmpHash, {
 			source: this,

--- a/wcfsetup/install/files/lib/data/attachment/Attachment.class.php
+++ b/wcfsetup/install/files/lib/data/attachment/Attachment.class.php
@@ -246,7 +246,7 @@ class Attachment extends DatabaseObject implements ILinkableObject, IRouteContro
 	 */
 	public function showAsImage() {
 		if ($this->isImage) {
-			if (ATTACHMENT_ENABLE_THUMBNAILS && !$this->hasThumbnail() && ($this->width > ATTACHMENT_THUMBNAIL_WIDTH || $this->height > ATTACHMENT_THUMBNAIL_HEIGHT)) return false;
+			if (!$this->hasThumbnail() && ($this->width > ATTACHMENT_THUMBNAIL_WIDTH || $this->height > ATTACHMENT_THUMBNAIL_HEIGHT)) return false;
 			
 			if ($this->canDownload()) return true;
 			

--- a/wcfsetup/install/files/lib/data/attachment/AttachmentAction.class.php
+++ b/wcfsetup/install/files/lib/data/attachment/AttachmentAction.class.php
@@ -135,7 +135,7 @@ class AttachmentAction extends AbstractDatabaseObjectAction implements ISortable
 		
 		// save files
 		$saveStrategy = new DefaultUploadFileSaveStrategy(self::class, [
-			'generateThumbnails' => ATTACHMENT_ENABLE_THUMBNAILS,
+			'generateThumbnails' => true,
 			'rotateImages' => true
 		], [
 			'objectID' => intval($this->parameters['objectID']),

--- a/wcfsetup/install/files/lib/system/WCF.class.php
+++ b/wcfsetup/install/files/lib/system/WCF.class.php
@@ -368,6 +368,9 @@ class WCF {
 		define('LIKE_ALLOW_FOR_OWN_CONTENT', 0);
 		define('LIKE_ENABLE_DISLIKE', 0);
 		
+		// Thumbnails for attachments are already enabled since 5.3.
+		define('ATTACHMENT_ENABLE_THUMBNAILS', 1);
+		
 		// User markings are always applied in sidebars since 5.3.
 		// https://github.com/WoltLab/WCF/issues/3330
 		define('MESSAGE_SIDEBAR_ENABLE_USER_ONLINE_MARKING', 1);

--- a/wcfsetup/install/files/lib/system/WCF.class.php
+++ b/wcfsetup/install/files/lib/system/WCF.class.php
@@ -369,6 +369,7 @@ class WCF {
 		define('LIKE_ENABLE_DISLIKE', 0);
 		
 		// Thumbnails for attachments are already enabled since 5.3.
+		// https://github.com/WoltLab/WCF/pull/3444
 		define('ATTACHMENT_ENABLE_THUMBNAILS', 1);
 		
 		// User markings are always applied in sidebars since 5.3.

--- a/wcfsetup/install/lang/de.xml
+++ b/wcfsetup/install/lang/de.xml
@@ -1405,7 +1405,6 @@ ACHTUNG: Die oben genannten Meldungen sind stark gekürzt. Sie können Details z
 		<item name="wcf.acp.option.recaptcha_publickey_invisible.description"><![CDATA[{if LANGUAGE_USE_INFORMAL_VARIANT}Trage{else}Tragen Sie{/if} hier, <b>zusätzlich</b> zu den obigen Schlüsseln, Schlüssel für das unsichtbare reCAPTCHA ein, wenn {if LANGUAGE_USE_INFORMAL_VARIANT}du{else}Sie{/if} diese Variante nutzen {if LANGUAGE_USE_INFORMAL_VARIANT}möchtest{else}möchten{/if}.]]></item>
 		<item name="wcf.acp.option.recaptcha_privatekey_invisible"><![CDATA[Geheimer Schlüssel (Unsichtbares reCAPTCHA)]]></item>
 		<item name="wcf.acp.option.category.message.attachment"><![CDATA[Dateianhänge]]></item>
-		<item name="wcf.acp.option.attachment_enable_thumbnails"><![CDATA[Vorschaugrafiken von hochgeladenen Bilder erzeugen]]></item>
 		<item name="wcf.acp.option.attachment_retain_dimensions"><![CDATA[Bildformat beim Erzeugen von Vorschaugrafiken beibehalten]]></item>
 		<item name="wcf.acp.option.attachment_thumbnail_height"><![CDATA[Höhe der Vorschaugrafiken]]></item>
 		<item name="wcf.acp.option.attachment_thumbnail_width"><![CDATA[Breite der Vorschaugrafiken]]></item>

--- a/wcfsetup/install/lang/en.xml
+++ b/wcfsetup/install/lang/en.xml
@@ -1382,7 +1382,6 @@ ATTENTION: The messages listed above are greatly shortened. You can view details
 		<item name="wcf.acp.option.recaptcha_publickey_invisible.description"><![CDATA[Enter the keys <b>in addition</b> to the keys above if you want to use the invisible variant of reCAPTCHA.]]></item>
 		<item name="wcf.acp.option.recaptcha_privatekey_invisible"><![CDATA[Private API Key (Invisible reCAPTCHA)]]></item>
 		<item name="wcf.acp.option.category.message.attachment"><![CDATA[Attachments]]></item>
-		<item name="wcf.acp.option.attachment_enable_thumbnails"><![CDATA[Create thumbnails for attachment images]]></item>
 		<item name="wcf.acp.option.attachment_retain_dimensions"><![CDATA[Retain thumbnail dimensions]]></item>
 		<item name="wcf.acp.option.attachment_thumbnail_height"><![CDATA[Thumbnail Height]]></item>
 		<item name="wcf.acp.option.attachment_thumbnail_width"><![CDATA[Thumbnail Width]]></item>


### PR DESCRIPTION
Attachment handlers using the same `tmpHash` are now synchronized to share the same uploaded attachments, including removal. In addition, the option to enable thumbnails for attachments is now force enabled and cannot be turned off.