### PR TITLE
Save changes to the sitemap objects in the registry

### DIFF
--- a/wcfsetup/install/files/acp/update_com.woltlab.wcf_5.3_sitemaps.php
+++ b/wcfsetup/install/files/acp/update_com.woltlab.wcf_5.3_sitemaps.php
@@ -1,0 +1,24 @@
+<?php
+use wcf\data\object\type\ObjectTypeCache;
+use wcf\system\registry\RegistryHandler;
+use wcf\system\worker\SitemapRebuildWorker;
+
+/**
+ * @author	Joshua Ruesweg
+ * @copyright	2001-2020 WoltLab GmbH
+ * @license	GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @package	WoltLabSuite\Core
+ */
+
+// HEADS UP: This script must be executed, BEFORE the objectType-PIP is executed.  
+
+$sitemapObjects = ObjectTypeCache::getInstance()->getObjectTypes('com.woltlab.wcf.sitemap.object');
+
+foreach ($sitemapObjects as $sitemapObject) {
+	RegistryHandler::getInstance()->set('com.woltlab.wcf', SitemapRebuildWorker::REGISTRY_PREFIX . $sitemapObject->objectType, serialize([
+		'priority' => $sitemapObject->priority,
+		'changeFreq' => $sitemapObject->changeFreq,
+		'rebuildTime' => $sitemapObject->rebuildTime,
+		'isDisabled' => $sitemapObject->isDisabled,
+	]));
+}

--- a/wcfsetup/install/files/lib/acp/page/SitemapListPage.class.php
+++ b/wcfsetup/install/files/lib/acp/page/SitemapListPage.class.php
@@ -4,6 +4,7 @@ use wcf\data\object\type\ObjectType;
 use wcf\data\object\type\ObjectTypeCache;
 use wcf\page\AbstractPage;
 use wcf\system\WCF;
+use wcf\system\worker\SitemapRebuildWorker;
 
 /**
  * Shows a list of sitemap object types. 
@@ -37,6 +38,10 @@ class SitemapListPage extends AbstractPage {
 		parent::readData();
 		
 		$this->sitemapObjectTypes = ObjectTypeCache::getInstance()->getObjectTypes('com.woltlab.wcf.sitemap.object');
+		
+		foreach ($this->sitemapObjectTypes as $sitemapObjectType) {
+			SitemapRebuildWorker::prepareSitemapObject($sitemapObjectType);
+		}
 	}
 	
 	/**

--- a/wcfsetup/install/files/lib/system/worker/SitemapRebuildWorker.class.php
+++ b/wcfsetup/install/files/lib/system/worker/SitemapRebuildWorker.class.php
@@ -31,6 +31,10 @@ class SitemapRebuildWorker extends AbstractRebuildDataWorker {
 	 */
 	const SITEMAP_OBJECT_LIMIT = 50000;
 	
+	/**
+	 * Prefix for stored data in the registry.
+	 * @since 5.3
+	 */
 	const REGISTRY_PREFIX = 'sitemapData_';
 	
 	/**
@@ -430,6 +434,7 @@ class SitemapRebuildWorker extends AbstractRebuildDataWorker {
 	 * Reads the columns changed by the user for this sitemap object from the registry and modifies the object accordingly.
 	 * 
 	 * @param       ObjectType      $object
+	 * @since       5.3
 	 */
 	public static function prepareSitemapObject(ObjectType &$object) {
 		$sitemapData = RegistryHandler::getInstance()->get('com.woltlab.wcf', self::REGISTRY_PREFIX . $object->objectType);

--- a/wcfsetup/install/files/lib/system/worker/SitemapRebuildWorker.class.php
+++ b/wcfsetup/install/files/lib/system/worker/SitemapRebuildWorker.class.php
@@ -436,7 +436,7 @@ class SitemapRebuildWorker extends AbstractRebuildDataWorker {
 	 * @param       ObjectType      $object
 	 * @since       5.3
 	 */
-	public static function prepareSitemapObject(ObjectType &$object) {
+	public static function prepareSitemapObject(ObjectType $object) {
 		$sitemapData = RegistryHandler::getInstance()->get('com.woltlab.wcf', self::REGISTRY_PREFIX . $object->objectType);
 		
 		if ($sitemapData !== null) {

--- a/wcfsetup/install/files/lib/system/worker/SitemapRebuildWorker.class.php
+++ b/wcfsetup/install/files/lib/system/worker/SitemapRebuildWorker.class.php
@@ -9,6 +9,7 @@ use wcf\system\exception\ImplementationException;
 use wcf\system\exception\ParentClassException;
 use wcf\system\io\AtomicWriter;
 use wcf\system\io\File;
+use wcf\system\registry\RegistryHandler;
 use wcf\system\request\LinkHandler;
 use wcf\system\Regex;
 use wcf\system\WCF;
@@ -29,6 +30,8 @@ class SitemapRebuildWorker extends AbstractRebuildDataWorker {
 	 * The limit of objects in one sitemap file.
 	 */
 	const SITEMAP_OBJECT_LIMIT = 50000;
+	
+	const REGISTRY_PREFIX = 'sitemapData_';
 	
 	/**
 	 * @inheritDoc
@@ -83,6 +86,7 @@ class SitemapRebuildWorker extends AbstractRebuildDataWorker {
 				// read sitemaps
 				$sitemapObjects = ObjectTypeCache::getInstance()->getObjectTypes('com.woltlab.wcf.sitemap.object');
 				foreach ($sitemapObjects as $sitemapObject) {
+					self::prepareSitemapObject($sitemapObject);
 					$processor = $sitemapObject->getProcessor();
 					
 					if ($processor->isAvailableType() && ($sitemapObject->isDisabled === null || !$sitemapObject->isDisabled)) {
@@ -420,5 +424,25 @@ class SitemapRebuildWorker extends AbstractRebuildDataWorker {
 	 */
 	private function changeToActualUser() {
 		WCF::getSession()->changeUser($this->actualUser, true);
+	}
+	
+	/**
+	 * Reads the columns changed by the user for this sitemap object from the registry and modifies the object accordingly.
+	 * 
+	 * @param       ObjectType      $object
+	 */
+	public static function prepareSitemapObject(ObjectType &$object) {
+		$sitemapData = RegistryHandler::getInstance()->get('com.woltlab.wcf', self::REGISTRY_PREFIX . $object->objectType);
+		
+		if ($sitemapData !== null) {
+			$sitemapData = @unserialize($sitemapData);
+			
+			if (is_array($sitemapData)) {
+				$object->priority = $sitemapData['priority'];
+				$object->changeFreq = $sitemapData['changeFreq'];
+				$object->rebuildTime = $sitemapData['rebuildTime'];
+				$object->isDisabled = $sitemapData['isDisabled'];
+			}
+		}
 	}
 }


### PR DESCRIPTION
Since changes to the sitemap are saved directly in the object type, there is the problem that when you update the WCF, these changes are potentially overwritten again. This commit fixes this problem by saving changes in the registry.
Fixes #3376