### PR TITLE
Performance improvements of the search for packages

### DIFF
--- a/wcfsetup/install/files/acp/js/WCF.ACP.js
+++ b/wcfsetup/install/files/acp/js/WCF.ACP.js
@@ -1003,8 +1003,12 @@ WCF.ACP.Package.Update.Search = Class.extend({
 	
 	/**
 	 * Handles clicks on the search button.
+	 * 
+	 * @param {Event} event
 	 */
-	_click: function() {
+	_click: function(event) {
+		event.preventDefault();
+		
 		if (this._dialog === null) {
 			new WCF.Action.Proxy({
 				autoSend: true,


### PR DESCRIPTION
The previous implementation requested the database to insert a row and immediately retrieve its id. This causes the performance scaling to be linear due to the sequential write and read operations. The changes will write new rows in bulk and retrieve them in a secondary query, yielding a significant speedup - more than 2x with MariaDB on NVMe.