### PR TITLE
Fixes exception when not using primary PayPal email

### DIFF
--- a/wcfsetup/install/files/lib/action/PaypalCallbackAction.class.php
+++ b/wcfsetup/install/files/lib/action/PaypalCallbackAction.class.php
@@ -56,7 +56,7 @@ class PaypalCallbackAction extends AbstractAction {
 			
 			// Check that receiver_email is your Primary PayPal email
 			if (strtolower($_POST['receiver_email']) != strtolower(PAYPAL_EMAIL_ADDRESS) && strtolower($_POST['business']) != strtolower(PAYPAL_EMAIL_ADDRESS)) {
-				throw new SystemException("Mismatching receiver_email and business '" . $_POST['receiver_email'] . "', expected '".PAYPAL_EMAIL_ADDRESS."'.");
+				throw new SystemException("Mismatching receiver_email ('" . $_POST['receiver_email'] . "') and business ('" . $_POST['business'] . "'), expected '".PAYPAL_EMAIL_ADDRESS."'.");
 			}
 			
 			// get token

--- a/wcfsetup/install/files/lib/action/PaypalCallbackAction.class.php
+++ b/wcfsetup/install/files/lib/action/PaypalCallbackAction.class.php
@@ -55,8 +55,14 @@ class PaypalCallbackAction extends AbstractAction {
 			}
 			
 			// Check that receiver_email is your Primary PayPal email
-			if (strtolower($_POST['receiver_email']) != strtolower(PAYPAL_EMAIL_ADDRESS) && strtolower($_POST['business']) != strtolower(PAYPAL_EMAIL_ADDRESS)) {
-				throw new SystemException("Mismatching receiver_email ('" . $_POST['receiver_email'] . "') and business ('" . $_POST['business'] . "'), expected '".PAYPAL_EMAIL_ADDRESS."'.");
+			$paypalEmail = strtolower(PAYPAL_EMAIL_ADDRESS);
+			if (strtolower($_POST['receiver_email']) != $paypalEmail && (!isset($_POST['business']) || strtolower($_POST['business']) != $paypalEmail)) {
+				$exceptionMessage = "Mismatching receiver_email ('" . $_POST['receiver_email'] . "')";
+				if (isset($_POST['business'])) {
+					$exceptionMessage .= " and business ('" . $_POST['business'] . "')";
+				}
+				$exceptionMessage .= ", expected '".PAYPAL_EMAIL_ADDRESS."'.";
+				throw new SystemException($exceptionMessage);
 			}
 			
 			// get token

--- a/wcfsetup/install/files/lib/action/PaypalCallbackAction.class.php
+++ b/wcfsetup/install/files/lib/action/PaypalCallbackAction.class.php
@@ -55,8 +55,8 @@ class PaypalCallbackAction extends AbstractAction {
 			}
 			
 			// Check that receiver_email is your Primary PayPal email
-			if (strtolower($_POST['receiver_email']) != strtolower(PAYPAL_EMAIL_ADDRESS)) {
-				throw new SystemException("Mismatching receiver_email '" . $_POST['receiver_email'] . "', expected '".PAYPAL_EMAIL_ADDRESS."'.");
+			if (strtolower($_POST['receiver_email']) != strtolower(PAYPAL_EMAIL_ADDRESS) && strtolower($_POST['business']) != strtolower(PAYPAL_EMAIL_ADDRESS)) {
+				throw new SystemException("Mismatching receiver_email and business '" . $_POST['receiver_email'] . "', expected '".PAYPAL_EMAIL_ADDRESS."'.");
 			}
 			
 			// get token


### PR DESCRIPTION
PayPal allows adding multiple emails, if you are using one of the alternative emails instead of the primary email then WoltLab will throw the exception. If the email is being validated then both should be checked to allow using none primary emails.

The `receiver_email` is always the primary email while `business` is the secondary in the IPN.