### PR TITLE
Allow retrieving the driver specific error code from DatabaseQueryExe…

### DIFF
--- a/wcfsetup/install/files/lib/system/database/exception/DatabaseQueryExecutionException.class.php
+++ b/wcfsetup/install/files/lib/system/database/exception/DatabaseQueryExecutionException.class.php
@@ -19,6 +19,18 @@ class DatabaseQueryExecutionException extends DatabaseQueryException implements 
 	 */
 	protected $parameters = [];
 	
+	/**
+	 * @var	string|null
+	 * @since 5.3
+	 */
+	protected $sqlState;
+	
+	/**
+	 * @var	string|null
+	 * @since 5.3
+	 */
+	protected $driverCode;
+	
 	/** @noinspection PhpMissingParentConstructorInspection */
 	/**
 	 * @inheritDoc
@@ -27,6 +39,31 @@ class DatabaseQueryExecutionException extends DatabaseQueryException implements 
 		parent::__construct($message, $previous);
 		
 		$this->parameters = $parameters;
+		if ($previous) {
+			$errorInfo = $previous->errorInfo;
+			$this->sqlState = $errorInfo[0] ?? null;
+			$this->driverCode = $errorInfo[1] ?? null;
+		}
+	}
+	
+	/**
+	 * Returns the ANSI SQLSTATE or null.
+	 * 
+	 * @return string|null
+	 * @since 5.3
+	 */
+	public function getSqlState() {
+		return $this->sqlState;
+	}
+
+	/**
+	 * Returns the driver specific error code or null.
+	 * 
+	 * @return string|null
+	 * @since 5.3
+	 */
+	public function getDriverCode() {
+		return $this->driverCode;
 	}
 	
 	/**


### PR DESCRIPTION
…cutionException

A single ANSI SQLSTATE can indicate several distinct error conditions. The
driver code appears to be unique for MySQL.