### PR TITLE
Disable visit tracking for search engines

### DIFF
--- a/wcfsetup/install/files/lib/system/visitTracker/VisitTracker.class.php
+++ b/wcfsetup/install/files/lib/system/visitTracker/VisitTracker.class.php
@@ -85,7 +85,7 @@ class VisitTracker extends SingletonFactory {
 					$this->userVisits = @unserialize($data);
 				}
 			}
-			else if (WCF::getSession()->spiderID === null) {
+			else {
 				$this->userVisits = WCF::getSession()->getVar('trackedUserVisits');
 			}
 			
@@ -128,7 +128,7 @@ class VisitTracker extends SingletonFactory {
 			$row = $statement->fetchArray();
 			if ($row) return $row['visitTime'];
 		}
-		else if (WCF::getSession()->spiderID === null) {
+		else {
 			if ($visitTime = WCF::getSession()->getVar('trackedUserVisit_'.$this->getObjectTypeID($objectType).'_'.$objectID)) {
 				return $visitTime;
 			}
@@ -192,7 +192,7 @@ class VisitTracker extends SingletonFactory {
 			$statement = WCF::getDB()->prepareStatement($sql);
 			$statement->execute([$this->getObjectTypeID($objectType), $objectID, WCF::getUser()->userID, $time]);
 		}
-		else {
+		else if (WCF::getSession()->spiderID === null) {
 			WCF::getSession()->register('trackedUserVisit_'.$this->getObjectTypeID($objectType).'_'.$objectID, $time);
 		}
 	}
@@ -223,7 +223,7 @@ class VisitTracker extends SingletonFactory {
 			// reset storage
 			UserStorageHandler::getInstance()->reset([WCF::getUser()->userID], 'trackedUserVisits');
 		}
-		else {
+		else if (WCF::getSession()->spiderID === null) {
 			$this->getVisitTime($objectType);
 			$this->userVisits[$this->getObjectTypeID($objectType)] = $time;
 			WCF::getSession()->register('trackedUserVisits', $this->userVisits);

--- a/wcfsetup/install/files/lib/system/visitTracker/VisitTracker.class.php
+++ b/wcfsetup/install/files/lib/system/visitTracker/VisitTracker.class.php
@@ -85,7 +85,7 @@ class VisitTracker extends SingletonFactory {
 					$this->userVisits = @unserialize($data);
 				}
 			}
-			else {
+			else if (WCF::getSession()->spiderID === null) {
 				$this->userVisits = WCF::getSession()->getVar('trackedUserVisits');
 			}
 			
@@ -128,7 +128,7 @@ class VisitTracker extends SingletonFactory {
 			$row = $statement->fetchArray();
 			if ($row) return $row['visitTime'];
 		}
-		else {
+		else if (WCF::getSession()->spiderID === null) {
 			if ($visitTime = WCF::getSession()->getVar('trackedUserVisit_'.$this->getObjectTypeID($objectType).'_'.$objectID)) {
 				return $visitTime;
 			}


### PR DESCRIPTION
Tracking object visits for search engines can yield rather large session variables for nicely behaving search engines that keep their session. Removing the tracking for those should reduce the load on MySQL's binlog, improving the throughput for very large sites.