### PR TITLE
Use generic value for default cookie prefix

### DIFF
--- a/com.woltlab.wcf/option.xml
+++ b/com.woltlab.wcf/option.xml
@@ -599,7 +599,7 @@ private:wcf.acp.option.exception_privacy.private</selectoptions>
 			<option name="cookie_prefix">
 				<categoryname>general.system.cookie</categoryname>
 				<optiontype>text</optiontype>
-				<defaultvalue>wsc52_</defaultvalue>
+				<defaultvalue>wsc_</defaultvalue>
 				<validationpattern>^[a-zA-Z0-9_]+$</validationpattern>
 			</option>
 			<!-- /general.system.cookie-->

--- a/wcfsetup/install/files/lib/system/WCFSetup.class.php
+++ b/wcfsetup/install/files/lib/system/WCFSetup.class.php
@@ -1281,7 +1281,7 @@ class WCFSetup extends WCF {
 			$useRandomCookiePrefix = false;
 		}
 		
-		$prefix = 'wsc52_';
+		$prefix = 'wsc_';
 		if ($useRandomCookiePrefix) {
 			$cookieNames = array_keys($_COOKIE);
 			while (true) {

--- a/wcfsetup/install/files/options.inc.php
+++ b/wcfsetup/install/files/options.inc.php
@@ -8,7 +8,7 @@
  */
 define('LAST_UPDATE_TIME', TIME_NOW);
 
-$prefix = 'wsc52_';
+$prefix = 'wsc_';
 if (file_exists(WCF_DIR . 'cookiePrefix.txt')) {
 	// randomized cookie prefix during setup
 	$prefix = file_get_contents(WCF_DIR . 'cookiePrefix.txt');


### PR DESCRIPTION
... so that it doesn't have to be adjusted for new versions. See https://github.com/WoltLab/WCF/pull/3485#issuecomment-669991914.