### PR TITLE
Add contentAuthor badge to comments

### DIFF
--- a/com.woltlab.wcf/templates/commentList.tpl
+++ b/com.woltlab.wcf/templates/commentList.tpl
@@ -38,6 +38,10 @@
 								{if $comment->isDisabled}
 									<span class="badge label green jsIconDisabled">{lang}wcf.message.status.disabled{/lang}</span>
 								{/if}
+								
+								{if $commentManager->isContentAuthor($comment)}
+									<span class="badge label">{lang}wcf.comment.objectAuthor{/lang}</span>
+								{/if}
 							</h3>
 						</div>
 						

--- a/com.woltlab.wcf/templates/commentResponseList.tpl
+++ b/com.woltlab.wcf/templates/commentResponseList.tpl
@@ -30,6 +30,10 @@
 							{if $response->isDisabled}
 								<span class="badge label green jsIconDisabled">{lang}wcf.message.status.disabled{/lang}</span>
 							{/if}
+							
+							{if $commentManager->isContentAuthor($response)}
+								<span class="badge label">{lang}wcf.comment.objectAuthor{/lang}</span>
+							{/if}
 						</h3>
 					</div>
 					

--- a/wcfsetup/install/files/lib/page/AbstractArticlePage.class.php
+++ b/wcfsetup/install/files/lib/page/AbstractArticlePage.class.php
@@ -7,6 +7,7 @@ use wcf\data\article\ArticleAction;
 use wcf\data\article\ArticleEditor;
 use wcf\data\article\ViewableArticle;
 use wcf\data\tag\Tag;
+use wcf\system\cache\runtime\ViewableArticleRuntimeCache;
 use wcf\system\database\util\PreparedStatementConditionBuilder;
 use wcf\system\exception\IllegalLinkException;
 use wcf\system\exception\PermissionDeniedException;
@@ -83,7 +84,7 @@ abstract class AbstractArticlePage extends AbstractPage {
 			throw new IllegalLinkException();
 		}
 		
-		$this->article = ViewableArticle::getArticle($this->articleContent->articleID, false);
+		$this->article = ViewableArticleRuntimeCache::getInstance()->getObject($this->articleContent->articleID);
 		$this->article->getDiscussionProvider()->setArticleContent($this->articleContent->getDecoratedObject());
 		$this->category = $this->article->getCategory();
 		

--- a/wcfsetup/install/files/lib/system/comment/manager/AbstractCommentManager.class.php
+++ b/wcfsetup/install/files/lib/system/comment/manager/AbstractCommentManager.class.php
@@ -231,4 +231,11 @@ abstract class AbstractCommentManager extends SingletonFactory implements IComme
 		return $this->getLink($response->getComment()->objectTypeID, $response->getComment()->objectID)
 			. '#comment' . $response->commentID . '/response' . $response->responseID;
 	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function isContentAuthor($commentOrResponse) {
+		return false;
+	}
 }

--- a/wcfsetup/install/files/lib/system/comment/manager/ArticleCommentManager.class.php
+++ b/wcfsetup/install/files/lib/system/comment/manager/ArticleCommentManager.class.php
@@ -5,8 +5,11 @@ use wcf\data\article\content\ArticleContentList;
 use wcf\data\article\ArticleEditor;
 use wcf\data\comment\response\CommentResponseList;
 use wcf\data\comment\CommentList;
+use wcf\data\comment\response\CommentResponse;
+use wcf\data\DatabaseObjectDecorator;
 use wcf\data\object\type\ObjectTypeCache;
 use wcf\system\cache\runtime\UserProfileRuntimeCache;
+use wcf\system\cache\runtime\ViewableArticleRuntimeCache;
 use wcf\system\like\IViewableLikeProvider;
 use wcf\system\WCF;
 
@@ -207,5 +210,18 @@ class ArticleCommentManager extends AbstractCommentManager implements IViewableL
 				}
 			}
 		}
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function isContentAuthor($commentOrResponse) {
+		if ($commentOrResponse instanceof CommentResponse || ($commentOrResponse instanceof DatabaseObjectDecorator && $commentOrResponse->getDecoratedObject() instanceof CommentResponse)) {
+			$article = ViewableArticleRuntimeCache::getInstance()->getObject($commentOrResponse->getComment()->objectID);
+		}
+		else {
+			$article = ViewableArticleRuntimeCache::getInstance()->getObject($commentOrResponse->objectID);
+		}
+		return $article->userID == $commentOrResponse->userID;
 	}
 }

--- a/wcfsetup/install/files/lib/system/comment/manager/ICommentManager.class.php
+++ b/wcfsetup/install/files/lib/system/comment/manager/ICommentManager.class.php
@@ -147,4 +147,13 @@ interface ICommentManager {
 	 * Sets the list of disallowed bbcodes.
 	 */
 	public function setDisallowedBBCodes();
+	
+	/**
+	 * Returns whether the given Comment or CommentResponse was created by
+	 * the content's author.
+	 * 
+	 * @param	Comment|CommentResponse	$commentOrResponse
+	 * @return	boolean
+	 */
+	public function isContentAuthor($commentOrResponse);
 }

--- a/wcfsetup/install/files/lib/system/comment/manager/UserProfileCommentManager.class.php
+++ b/wcfsetup/install/files/lib/system/comment/manager/UserProfileCommentManager.class.php
@@ -4,6 +4,7 @@ use wcf\data\comment\response\CommentResponse;
 use wcf\data\comment\response\CommentResponseList;
 use wcf\data\comment\Comment;
 use wcf\data\comment\CommentList;
+use wcf\data\DatabaseObjectDecorator;
 use wcf\data\object\type\ObjectTypeCache;
 use wcf\system\cache\runtime\UserProfileRuntimeCache;
 use wcf\system\like\IViewableLikeProvider;
@@ -250,5 +251,15 @@ class UserProfileCommentManager extends AbstractCommentManager implements IViewa
 				}
 			}
 		}
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function isContentAuthor($commentOrResponse) {
+		if ($commentOrResponse instanceof CommentResponse || ($commentOrResponse instanceof DatabaseObjectDecorator && $commentOrResponse->getDecoratedObject() instanceof CommentResponse)) {
+			return $commentOrResponse->userID == $commentOrResponse->getComment()->objectID;
+		}
+		return $commentOrResponse->userID == $commentOrResponse->objectID;
 	}
 }

--- a/wcfsetup/install/lang/de.xml
+++ b/wcfsetup/install/lang/de.xml
@@ -3435,6 +3435,7 @@ Fehler sind beispielsweise:
 		<item name="wcf.comment.guestDialog.title"><![CDATA[Gastkommentar]]></item>
 		<item name="wcf.comment.sortField.cumulativeLikes"><![CDATA[Reaktionen]]></item>
 		<item name="wcf.comment.sortField.time"><![CDATA[Datum]]></item>
+		<item name="wcf.comment.objectAuthor"><![CDATA[Autor]]></item>
 	</category>
 	<category name="wcf.condition">
 		<item name="wcf.condition.greaterThan"><![CDATA[mehr als]]></item>

--- a/wcfsetup/install/lang/en.xml
+++ b/wcfsetup/install/lang/en.xml
@@ -3358,6 +3358,7 @@ Errors are:
 		<item name="wcf.comment.guestDialog.title"><![CDATA[Guest Comment]]></item>
 		<item name="wcf.comment.sortField.cumulativeLikes"><![CDATA[Reactions]]></item>
 		<item name="wcf.comment.sortField.time"><![CDATA[Date]]></item>
+		<item name="wcf.comment.objectAuthor"><![CDATA[Author]]></item>
 	</category>
 	<category name="wcf.condition">
 		<item name="wcf.condition.greaterThan"><![CDATA[greater than]]></item>


### PR DESCRIPTION
- No implementation for page comments, because pages don't have an explicit author.
- No implementation for moderation queue comments, because the author usually has no access anyway.
- Performance characteristics of the implementation of articles might need to be checked. From the benchmark it looks like the ArticlePage generally reads a bit of redundant data.

---------------

Resolves #3386 