### PR TITLE
Use timing safe comparison to validate `state` parameter for social login

### DIFF
--- a/wcfsetup/install/files/lib/action/FacebookAuthAction.class.php
+++ b/wcfsetup/install/files/lib/action/FacebookAuthAction.class.php
@@ -68,7 +68,7 @@ class FacebookAuthAction extends AbstractAction {
 			}
 			
 			// validate state, validation of state is executed after fetching the access_token to invalidate 'code'
-			if (!isset($_GET['state']) || $_GET['state'] != WCF::getSession()->getVar('__facebookInit')) throw new IllegalLinkException();
+			if (!isset($_GET['state']) || !\hash_equals(WCF::getSession()->getVar('__facebookInit'), $_GET['state'])) throw new IllegalLinkException();
 			WCF::getSession()->unregister('__facebookInit');
 			
 			try {

--- a/wcfsetup/install/files/lib/action/GithubAuthAction.class.php
+++ b/wcfsetup/install/files/lib/action/GithubAuthAction.class.php
@@ -64,7 +64,7 @@ class GithubAuthAction extends AbstractAction {
 			}
 			
 			// validate state, validation of state is executed after fetching the access_token to invalidate 'code'
-			if (!isset($_GET['state']) || $_GET['state'] != WCF::getSession()->getVar('__githubInit')) throw new IllegalLinkException();
+			if (!isset($_GET['state']) || !\hash_equals(WCF::getSession()->getVar('__githubInit'), $_GET['state'])) throw new IllegalLinkException();
 			WCF::getSession()->unregister('__githubInit');
 			
 			parse_str($content, $data);

--- a/wcfsetup/install/files/lib/action/GoogleAuthAction.class.php
+++ b/wcfsetup/install/files/lib/action/GoogleAuthAction.class.php
@@ -67,7 +67,7 @@ class GoogleAuthAction extends AbstractAction {
 			}
 			
 			// validate state, validation of state is executed after fetching the access_token to invalidate 'code'
-			if (!isset($_GET['state']) || $_GET['state'] != WCF::getSession()->getVar('__googleInit')) throw new IllegalLinkException();
+			if (!isset($_GET['state']) || !\hash_equals(WCF::getSession()->getVar('__googleInit'), $_GET['state'])) throw new IllegalLinkException();
 			WCF::getSession()->unregister('__googleInit');
 			
 			$data = JSON::decode($content);


### PR DESCRIPTION
The Twitter social login is left out because the implementation still uses OAuth 1.0, which does not support the `state` parameter.

Closes #3501