### PR TITLE
Added possiblity to disable the preview-button

### DIFF
--- a/wcfsetup/install/files/lib/system/form/builder/container/wysiwyg/WysiwygFormContainer.class.php
+++ b/wcfsetup/install/files/lib/system/form/builder/container/wysiwyg/WysiwygFormContainer.class.php
@@ -485,7 +485,7 @@ class WysiwygFormContainer extends FormContainer {
 					->objectType($this->messageObjectType)
 					->wysiwygId($this->getWysiwygId())
 					->objectId($this->getObjectId())
-				);
+			);
 		}
 		
 		EventHandler::getInstance()->fireAction($this, 'populate');

--- a/wcfsetup/install/files/lib/system/form/builder/container/wysiwyg/WysiwygFormContainer.class.php
+++ b/wcfsetup/install/files/lib/system/form/builder/container/wysiwyg/WysiwygFormContainer.class.php
@@ -47,7 +47,7 @@ class WysiwygFormContainer extends FormContainer {
 	protected $attachmentData;
 	
 	/**
-	 * `true` if the preview-button should be generated automatically and `false` otherwise
+	 * `true` if the preview button should be shown and `false` otherwise
 	 * @var         bool
 	 * @since       5.3
 	 */
@@ -214,9 +214,9 @@ class WysiwygFormContainer extends FormContainer {
 	}
 	
 	/**
-	 * Sets whether the preview-button should be generated or not and returns this form container.
+	 * Sets whether the preview button should be shown or not and returns this form container.
 	 * 
-	 * By default, the preview-button is enabled will be generated.
+	 * By default, the preview button is shown.
 	 * 
 	 * @param       bool                    $enablePreviewButton
 	 * @return      WysiwygFormContainer    this form container
@@ -339,8 +339,9 @@ class WysiwygFormContainer extends FormContainer {
 	}
 	
 	/**
-	 * Returns `true` if the preview-button should be generated automatically and returns `false` otherwise.
-	 * By default, the preview-button is generated automatically.
+	 * Returns `true` if the preview button will be shown and returns `false` otherwise.
+	 * 
+	 * By default, the preview button is shown.
 	 * 
 	 * @return      bool
 	 * @since       5.3

--- a/wcfsetup/install/files/lib/system/form/builder/container/wysiwyg/WysiwygFormContainer.class.php
+++ b/wcfsetup/install/files/lib/system/form/builder/container/wysiwyg/WysiwygFormContainer.class.php
@@ -47,6 +47,12 @@ class WysiwygFormContainer extends FormContainer {
 	protected $attachmentData;
 	
 	/**
+	 * `true` if the preview-button should be generated automatically and `false` otherwise
+	 * @var bool
+	 */
+	protected $enablePreviewButton = true;
+	
+	/**
 	 * name of the relevant message object type
 	 * @var	string
 	 */
@@ -207,6 +213,20 @@ class WysiwygFormContainer extends FormContainer {
 	}
 	
 	/**
+	 * Sets whether the preview-button should be generated or not and returns this form container.
+	 * 
+	 * By default, the preview-button is enabled will be generated.
+	 * 
+	 * @param	boolean		$enablePreviewButton
+	 * @return	WysiwygFormContainer		this form container
+	 */
+	public function enablePreviewButton($enablePreviewButton = true) {
+		$this->enablePreviewButton = $enablePreviewButton;
+		
+		return $this;
+	}
+	
+	/**
 	 * Returns the form field handling attachments.
 	 * 
 	 * @return	WysiwygAttachmentFormField
@@ -314,6 +334,16 @@ class WysiwygFormContainer extends FormContainer {
 	 */
 	public function isRequired() {
 		return $this->required;
+	}
+	
+	/**
+	 * Returns `true` if the preview-button should be generated automatically and returns `false` otherwise.
+	 * By default, the preview-button is generated automatically.
+	 *
+	 * @return	bool
+	 */
+	public function isPreviewButtonEnabled() {
+		return $this->enablePreviewButton;
 	}
 	
 	/**
@@ -448,12 +478,14 @@ class WysiwygFormContainer extends FormContainer {
 			$this->setAttachmentHandler();
 		}
 		
-		$this->getDocument()->addButton(
-			WysiwygPreviewFormButton::create($this->getWysiwygId() . 'PreviewButton')
-				->objectType($this->messageObjectType)
-				->wysiwygId($this->getWysiwygId())
-				->objectId($this->getObjectId())
-		);
+		if ($this->enablePreviewButton === true) {
+			$this->getDocument()->addButton(
+				WysiwygPreviewFormButton::create($this->getWysiwygId() . 'PreviewButton')
+					->objectType($this->messageObjectType)
+					->wysiwygId($this->getWysiwygId())
+					->objectId($this->getObjectId())
+				);
+		}
 		
 		EventHandler::getInstance()->fireAction($this, 'populate');
 	}

--- a/wcfsetup/install/files/lib/system/form/builder/container/wysiwyg/WysiwygFormContainer.class.php
+++ b/wcfsetup/install/files/lib/system/form/builder/container/wysiwyg/WysiwygFormContainer.class.php
@@ -482,7 +482,7 @@ class WysiwygFormContainer extends FormContainer {
 			$this->setAttachmentHandler();
 		}
 		
-		if ($this->enablePreviewButton === true) {
+		if ($this->enablePreviewButton) {
 			$this->getDocument()->addButton(
 				WysiwygPreviewFormButton::create($this->getWysiwygId() . 'PreviewButton')
 					->objectType($this->messageObjectType)

--- a/wcfsetup/install/files/lib/system/form/builder/container/wysiwyg/WysiwygFormContainer.class.php
+++ b/wcfsetup/install/files/lib/system/form/builder/container/wysiwyg/WysiwygFormContainer.class.php
@@ -48,7 +48,8 @@ class WysiwygFormContainer extends FormContainer {
 	
 	/**
 	 * `true` if the preview-button should be generated automatically and `false` otherwise
-	 * @var bool
+	 * @var         bool
+	 * @since       5.3
 	 */
 	protected $enablePreviewButton = true;
 	

--- a/wcfsetup/install/files/lib/system/form/builder/container/wysiwyg/WysiwygFormContainer.class.php
+++ b/wcfsetup/install/files/lib/system/form/builder/container/wysiwyg/WysiwygFormContainer.class.php
@@ -218,8 +218,9 @@ class WysiwygFormContainer extends FormContainer {
 	 * 
 	 * By default, the preview-button is enabled will be generated.
 	 * 
-	 * @param	boolean		$enablePreviewButton
-	 * @return	WysiwygFormContainer		this form container
+	 * @param       bool                    $enablePreviewButton
+	 * @return      WysiwygFormContainer    this form container
+	 * @since       5.3
 	 */
 	public function enablePreviewButton($enablePreviewButton = true) {
 		$this->enablePreviewButton = $enablePreviewButton;

--- a/wcfsetup/install/files/lib/system/form/builder/container/wysiwyg/WysiwygFormContainer.class.php
+++ b/wcfsetup/install/files/lib/system/form/builder/container/wysiwyg/WysiwygFormContainer.class.php
@@ -339,8 +339,9 @@ class WysiwygFormContainer extends FormContainer {
 	/**
 	 * Returns `true` if the preview-button should be generated automatically and returns `false` otherwise.
 	 * By default, the preview-button is generated automatically.
-	 *
-	 * @return	bool
+	 * 
+	 * @return      bool
+	 * @since       5.3
 	 */
 	public function isPreviewButtonEnabled() {
 		return $this->enablePreviewButton;


### PR DESCRIPTION
Added possibility to disable the preview-button of the wysiwyg form container, that - in default - will be generated automatically. In some cases you don't need the preview, because you implement another preview yourself (e.g. sending mails with wysiwyg input rendered directly in mail-template)