### PR TITLE
Overflow handling for reaction popovers on smartphones

### DIFF
--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Reaction/Handler.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Reaction/Handler.js
@@ -56,6 +56,7 @@ define(
 				this._popoverCurrentObjectId = 0;
 				
 				this._popover = null;
+				this._popoverContent = null;
 				
 				this._options = Core.extend({
 					// selectors
@@ -128,7 +129,7 @@ define(
 					elementData.reactButton = elBySel(this._options.buttonSelector, element);
 				}
 				
-				if (elementData.reactButton === null || elementData.reactButton.length === 0) {
+				if (elementData.reactButton === null || elementData.reactButton.length === 0) {
 					// The element may have no react button. 
 					return;
 				}
@@ -284,8 +285,8 @@ define(
 					this._popover = elCreate('div');
 					this._popover.className = 'reactionPopover forceHide';
 					
-					var _popoverContent = elCreate('div');
-					_popoverContent.className = 'reactionPopoverContent';
+					this._popoverContent = elCreate('div');
+					this._popoverContent.className = 'reactionPopoverContent';
 					
 					var popoverContentHTML = elCreate('ul');
 					popoverContentHTML.className = 'reactionTypeButtonList';
@@ -323,16 +324,10 @@ define(
 						popoverContentHTML.appendChild(reactionTypeItem);
 					}
 					
-					_popoverContent.appendChild(popoverContentHTML);
-					_popoverContent.addEventListener('scroll', function () {
-						var hasTopOverflow = _popoverContent.scrollTop > 0;
-						_popoverContent.classList[hasTopOverflow ? 'add' : 'remove']('overflowTop');
-						
-						var hasBottomOverflow = _popoverContent.scrollTop + _popoverContent.clientHeight < _popoverContent.scrollHeight;
-						_popoverContent.classList[hasBottomOverflow ? 'add' : 'remove']('overflowBottom');
-					}, {passive: true});
+					this._popoverContent.appendChild(popoverContentHTML);
+					this._popoverContent.addEventListener('scroll', this._rebuildOverflowIndicator.bind(this), {passive: true});
 					
-					this._popover.appendChild(_popoverContent);
+					this._popover.appendChild(this._popoverContent);
 					
 					var pointer = elCreate('span');
 					pointer.className = 'elementPointer';
@@ -341,10 +336,19 @@ define(
 					
 					document.body.appendChild(this._popover);
 					
+					this._rebuildOverflowIndicator();
 					DomChangeListener.trigger();
 				}
 				
 				return this._popover;
+			},
+			
+			_rebuildOverflowIndicator: function () {
+				var hasTopOverflow = this._popoverContent.scrollTop > 0;
+				this._popoverContent.classList[hasTopOverflow ? 'add' : 'remove']('overflowTop');
+				
+				var hasBottomOverflow = this._popoverContent.scrollTop + this._popoverContent.clientHeight < this._popoverContent.scrollHeight;
+				this._popoverContent.classList[hasBottomOverflow ? 'add' : 'remove']('overflowBottom');
 			},
 			
 			/**

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Reaction/Handler.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Reaction/Handler.js
@@ -193,8 +193,13 @@ define(
 					// The "first" reaction is positioned as close as possible to the toggle button,
 					// which means that we need to scroll the list to the bottom if the popover is
 					// displayed above the toggle button.
-					if (UiScreen.is('screen-xs') && !this._getPopover().classList.contains('inverseOrder')) {
-						scrollableContainer.scrollTop = scrollableContainer.scrollHeight - scrollableContainer.clientHeight;
+					if (UiScreen.is('screen-xs')) {
+						if (this._getPopover().classList.contains('inverseOrder')) {
+							scrollableContainer.scrollTop = 0;
+						}
+						else {
+							scrollableContainer.scrollTop = scrollableContainer.scrollHeight - scrollableContainer.clientHeight;
+						}
 					}
 				}
 			},

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Reaction/Handler.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Reaction/Handler.js
@@ -9,21 +9,28 @@
  */
 define(
 	[
-		'Ajax',      'Core',                            'Dictionary',           'Language',
-		'ObjectMap', 'StringUtil',                      'Dom/ChangeListener',   'Dom/Util',
-		'Ui/Dialog', 'WoltLabSuite/Core/Ui/User/List',  'User',                 'WoltLabSuite/Core/Ui/Reaction/CountButtons',
-		'Ui/Alignment', 'Ui/CloseOverlay'
+		'Ajax',
+		'Core',
+		'Dictionary',           
+		'Dom/ChangeListener',
+		'Dom/Util',
+		'Ui/Alignment',
+		'Ui/CloseOverlay',
+		'Ui/Screen',
+		'WoltLabSuite/Core/Ui/Reaction/CountButtons',
 	],
 	function(
-		Ajax,        Core,              Dictionary,             Language,
-		ObjectMap,   StringUtil,        DomChangeListener,      DomUtil,
-		UiDialog,    UiUserList,        User,                   CountButtons,
-		UiAlignment, UiCloseOverlay
-	)
-	{
+		Ajax,
+		Core,
+		Dictionary,             
+		DomChangeListener,
+		DomUtil,
+		UiAlignment,
+		UiCloseOverlay,
+		UiScreen,
+		CountButtons
+	) {
 		"use strict";
-		
-		var UiScreen = require('Ui/Screen');
 		
 		/**
 		 * @constructor

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Reaction/Handler.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Reaction/Handler.js
@@ -178,6 +178,7 @@ define(
 					element.classList.remove('active');
 				});
 				
+				var scrollableContainer = elBySel('.reactionPopoverContent', this._getPopover());
 				if (reactionTypeID) {
 					var reactionTypeButton = elBySel('.reactionTypeButton[data-reaction-type-id="' + reactionTypeID + '"]', this._getPopover());
 					reactionTypeButton.classList.add('active');
@@ -186,13 +187,19 @@ define(
 						elShow(reactionTypeButton);
 					}
 					
-					this._scrollReactionIntoView(reactionTypeButton);
+					this._scrollReactionIntoView(scrollableContainer, reactionTypeButton);
+				}
+				else {
+					// The "first" reaction is positioned as close as possible to the toggle button,
+					// which means that we need to scroll the list to the bottom if the popover is
+					// displayed above the toggle button.
+					if (UiScreen.is('screen-xs') && !this._getPopover().classList.contains('inverseOrder')) {
+						scrollableContainer.scrollTop = scrollableContainer.scrollHeight - scrollableContainer.clientHeight;
+					}
 				}
 			},
 			
-			_scrollReactionIntoView: function (reactionTypeButton) {
-				var scrollableContainer = elBySel('.reactionPopoverContent', this._getPopover());
-				
+			_scrollReactionIntoView: function (scrollableContainer, reactionTypeButton) {
 				// Do not scroll if the button is located in the upper 75%.
 				if (reactionTypeButton.offsetTop < scrollableContainer.clientHeight * 0.75) {
 					scrollableContainer.scrollTop = 0;
@@ -271,6 +278,8 @@ define(
 				
 				this._markReactionAsActive();
 				
+				this._rebuildOverflowIndicator();
+				
 				popover.classList.remove('forceHide');
 				popover.classList.add('active');
 			},
@@ -336,7 +345,6 @@ define(
 					
 					document.body.appendChild(this._popover);
 					
-					this._rebuildOverflowIndicator();
 					DomChangeListener.trigger();
 				}
 				

--- a/wcfsetup/install/files/style/ui/reactions.scss
+++ b/wcfsetup/install/files/style/ui/reactions.scss
@@ -27,7 +27,7 @@
 	
 	@include screen-xs {
 		&.inverseOrder .reactionTypeButtonList {
-			flex-direction: column-reverse;
+			flex-direction: column;
 		}
 	}
 }
@@ -201,7 +201,7 @@
 @include screen-xs {
 	.reactionTypeButtonList {
 		display: flex;
-		flex-direction: column;
+		flex-direction: column-reverse;
 	}
 }
 

--- a/wcfsetup/install/files/style/ui/reactions.scss
+++ b/wcfsetup/install/files/style/ui/reactions.scss
@@ -4,6 +4,7 @@
 	background-color: $wcfContentBackground;
 	border-radius: 2px;
 	box-shadow: 0 2px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23);
+	overflow: hidden;
 	position: absolute;
 	top: 0;
 	vertical-align: middle;
@@ -22,6 +23,12 @@
 	
 	> .elementPointer {
 		display: none;
+	}
+	
+	@include screen-xs {
+		&.inverseOrder .reactionTypeButtonList {
+			flex-direction: column-reverse;
+		}
 	}
 }
 
@@ -86,6 +93,39 @@
 		}
 	}
 	
+	@include screen-xs {
+		max-height: 200px;
+		overflow: auto;
+		
+		&::after,
+		&::before {
+			content: "";
+			height: 40px;
+			left: 0;
+			opacity: 0;
+			pointer-events: none;
+			position: absolute;
+			right: 0;
+			transition: opacity .12s linear;
+		}
+		
+		&::after {
+			background-image: linear-gradient(to bottom, transparent, $wcfContentBackground);
+			bottom: 0;
+		}
+		&.overflowBottom::after {
+			opacity: 1;
+		}
+		
+		&::before {
+			background-image: linear-gradient(to top, transparent, $wcfContentBackground);
+			top: 0;
+		}
+		&.overflowTop::before {
+			opacity: 1;
+		}
+	}
+	
 	@include screen-md-down {
 		padding: 5px 0;
 		
@@ -138,6 +178,11 @@
 			}
 		}
 	}
+}
+
+.reactionTypeButtonList {
+	display: flex;
+	flex-direction: column;
 }
 
 @include screen-lg {

--- a/wcfsetup/install/files/style/ui/reactions.scss
+++ b/wcfsetup/install/files/style/ui/reactions.scss
@@ -180,11 +180,6 @@
 	}
 }
 
-.reactionTypeButtonList {
-	display: flex;
-	flex-direction: column;
-}
-
 @include screen-lg {
 	html.touch .reactionPopoverContent .reactionTypeButton {
 		display: block;
@@ -200,6 +195,13 @@
 @include screen-sm-down {
 	.reactionStatusContainer {
 		display: none;
+	}
+}
+
+@include screen-xs {
+	.reactionTypeButtonList {
+		display: flex;
+		flex-direction: column;
 	}
 }
 


### PR DESCRIPTION
The popover for reactions does not play nicely with a larger amount of reactions, causing them to be stacked below/on top of each other, eventually overflowing the screen.

The updated implementation resolves this by a few changes:
* Align the popover to the bottom on smartphones, this is most likely the best possible space.
* Restrict the total height to 200px and allow scrolling, including an overflow indicator (fading out).
* If the popover is opened to the top, inverse the reaction order to place the "first" button as close to the toggle (their order matters!).

Closes #3518