### PR TITLE
Remove redundant `implements IWorker`

### DIFF
--- a/wcfsetup/install/files/lib/system/worker/UserContentRemoveWorker.class.php
+++ b/wcfsetup/install/files/lib/system/worker/UserContentRemoveWorker.class.php
@@ -16,7 +16,7 @@ use wcf\system\WCF;
  * @package	WoltLabSuite\Core\System\Worker
  * @since	5.2
  */
-class UserContentRemoveWorker extends AbstractWorker implements IWorker {
+class UserContentRemoveWorker extends AbstractWorker {
 	/**
 	 * variable name for the session to store the data
 	 */


### PR DESCRIPTION
`AbstractWorker` already implements `IWorker`.