### PR TITLE
Prevent rich metacode being dysfunctional in new messages

### DIFF
--- a/com.woltlab.wcf/templates/codeMetaCode.tpl
+++ b/com.woltlab.wcf/templates/codeMetaCode.tpl
@@ -15,8 +15,7 @@
 		<span class="toggleButton" data-title-collapse="{lang}wcf.bbcode.button.collapse{/lang}" data-title-expand="{lang}wcf.bbcode.button.showAll{/lang}">{lang}wcf.bbcode.button.showAll{/lang}</span>
 	{/if}
 </div>
-{if !$isAmp && !$__wcfCodeBBCodeJavaScript|isset}
-	{assign var='__wcfCodeBBCodeJavaScript' value=true}
+{if !$isAmp}
 	<script data-relocate="true">
 		require(['Language', 'WoltLabSuite/Core/Bbcode/Collapsible', 'WoltLabSuite/Core/Bbcode/Code'], function (Language, BbcodeCollapsible, BbcodeCode) {
 			Language.addObject({

--- a/com.woltlab.wcf/templates/quoteMetaCode.tpl
+++ b/com.woltlab.wcf/templates/quoteMetaCode.tpl
@@ -28,13 +28,10 @@
 	{if $collapseQuote}
 		<span class="toggleButton" data-title-collapse="{lang}wcf.bbcode.button.collapse{/lang}" data-title-expand="{lang}wcf.bbcode.button.showAll{/lang}">{lang}wcf.bbcode.button.showAll{/lang}</span>
 		
-		{if !$__overlongBBCodeBoxSeen|isset}
-			{assign var='__overlongBBCodeBoxSeen' value=true}
-			<script data-relocate="true">
-				require(['WoltLabSuite/Core/Bbcode/Collapsible'], function(BbcodeCollapsible) {
-					BbcodeCollapsible.observe();
-				});
-			</script>
-		{/if}
+		<script data-relocate="true">
+			require(['WoltLabSuite/Core/Bbcode/Collapsible'], function(BbcodeCollapsible) {
+				BbcodeCollapsible.observe();
+			});
+		</script>
 	{/if}
 </blockquote>

--- a/com.woltlab.wcf/templates/spoilerMetaCode.tpl
+++ b/com.woltlab.wcf/templates/spoilerMetaCode.tpl
@@ -6,30 +6,14 @@
 	<div class="spoilerBoxContent" style="display: none" id="spoiler-content-{@$spoilerID}" aria-hidden="true" aria-labelledby="spoiler-button-{@$spoilerID}">
 		<!-- META_CODE_INNER_CONTENT -->
 	</div>
-	
-	{if !$__wcfSpoilerBBCodeJavaScript|isset}
-		{assign var='__wcfSpoilerBBCodeJavaScript' value=true}
-		<script data-relocate="true">
-			elBySelAll('.jsSpoilerBox', null, function(spoilerBox) {
-				spoilerBox.classList.remove('jsSpoilerBox');
-				
-				var toggleButton = elBySel('.jsSpoilerToggle', spoilerBox);
-				var container = toggleButton.parentNode.nextElementSibling;
-				
-				toggleButton.addEventListener(WCF_CLICK_EVENT, function(event) {
-					event.preventDefault();
-					
-					toggleButton.classList.toggle('active');
-					var isActive = toggleButton.classList.contains('active');
-					window[(isActive ? 'elShow' : 'elHide')](container);
-					elAttr(toggleButton, 'aria-expanded', isActive);
-					elAttr(container, 'aria-hidden', !isActive);
-					
-					if (!elDataBool(toggleButton, 'has-custom-label')) {
-						toggleButton.textContent = (toggleButton.classList.contains('active')) ? '{lang}wcf.bbcode.spoiler.hide{/lang}' : '{lang}wcf.bbcode.spoiler.show{/lang}';
-					}
-				});
-			});
-		</script>
-	{/if}
 </div>
+<script data-relocate="true">
+	require(['Language', 'WoltLabSuite/Core/Bbcode/Spoiler'], function (Language, BbcodeSpoiler) {
+		Language.addObject({
+			'wcf.bbcode.spoiler.hide' : '{lang}wcf.bbcode.spoiler.hide{/lang}',
+			'wcf.bbcode.spoiler.show' : '{lang}wcf.bbcode.spoiler.show{/lang}'
+		});
+		
+		BbcodeSpoiler.observe();
+	});
+</script>

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Bbcode/Spoiler.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Bbcode/Spoiler.js
@@ -1,0 +1,49 @@
+/**
+ * Generic handler for spoiler boxes.
+ *
+ * @author      Alexander Ebert
+ * @copyright   2001-2020 WoltLab GmbH
+ * @license     GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @module      WoltLabSuite/Core/Bbcode/Spoiler
+ */
+define(['Language'], function (Language) {
+	'use strict';
+	
+	var _containers = elByClass('jsSpoilerBox');
+	
+	/**
+	 * @exports	WoltLabSuite/Core/Bbcode/Spoiler
+	 */
+	return {
+		observe: function () {
+			var container, toggleButton;
+			while (_containers.length) {
+				container = _containers[0];
+				container.classList.remove('jsSpoilerBox');
+				
+				toggleButton = elBySel('.jsSpoilerToggle', container);
+				container = toggleButton.parentNode.nextElementSibling;
+				
+				toggleButton.addEventListener(
+					WCF_CLICK_EVENT,
+					this._onClick.bind(this, container, toggleButton)
+				);
+			}
+		},
+		
+		_onClick: function (container, toggleButton, event) {
+			event.preventDefault();
+			
+			toggleButton.classList.toggle('active');
+			
+			var isActive = toggleButton.classList.contains('active');
+			window[(isActive ? 'elShow' : 'elHide')](container);
+			elAttr(toggleButton, 'aria-expanded', isActive);
+			elAttr(container, 'aria-hidden', !isActive);
+			
+			if (!elDataBool(toggleButton, 'has-custom-label')) {
+				toggleButton.textContent = Language.get(toggleButton.classList.contains('active') ? 'wcf.bbcode.spoiler.hide' : 'wcf.bbcode.spoiler.show');
+			}
+		}
+	};
+});


### PR DESCRIPTION
The `isset` strategy does not work properly, because in some cases the HTML is evaluated before being placed in the final template, causing the variable to be set already.

This changes modifies the behavior to always attempt to initialize the JavaScript, but made changes to ensure that each subsequent call is idempotent. One side effect of this change is the increase of generated HTML if an affected metacode appears more than once. We should revisit the entire system in future iterations by introducing a central class that performs the on-the-fly initialization of such components.