### PR TITLE
fix updating the styles to 5.3

### DIFF
--- a/wcfsetup/install/files/acp/update_com.woltlab.wcf_5.3_style.php
+++ b/wcfsetup/install/files/acp/update_com.woltlab.wcf_5.3_style.php
@@ -1,5 +1,4 @@
 <?php
-require('global.php');
 
 use wcf\data\style\StyleEditor;
 use wcf\data\style\StyleList;
@@ -32,8 +31,8 @@ foreach ($styleList as $style) {
 	
 	// 3) If the file had a custom image folder we need to copy all files into the asset folder.
 	// Moving the files is unsafe, because multiple styles can share a single image folder.
-	if ($style->imagePath != 'images/') {
-		$srcPath = FileUtil::addTrailingSlash(WCF_DIR.$style->imagePath);
+	$srcPath = FileUtil::addTrailingSlash(WCF_DIR.$style->imagePath);
+	if ($srcPath !== WCF_DIR && $srcPath !== WCF_DIR.'images/') {
 		if ($srcPath == $style->getAssetPath()) {
 			$srcPath = FileUtil::removeTrailingSlash($style->getAssetPath()) . '.old53/';
 		}


### PR DESCRIPTION
If `Style::$imagePath` is empty, it resulted in copying the shole WSC-folder into a style-asset-folder - and doing this until we reache the timeout limits.
Including `global.php` ended up in trying to define the option-constants (especially the fixed-value-options like `MODULE_ATTACHMENT`) again while they are already defined - which causes a Fatal Error-Message.