### PR TITLE
Prevent Android from collapsing the keyboard on [Enter]

### DIFF
--- a/wcfsetup/install/files/js/3rdParty/redactor2/redactor.js
+++ b/wcfsetup/install/files/js/3rdParty/redactor2/redactor.js
@@ -7913,7 +7913,7 @@
 			return {
 				isKey: function(key)
 				{
-					return key === this.keyCode.ENTER || key === this.keyCode.SPACE;
+					return false;
 				},
 				isLink: function(node)
 				{


### PR DESCRIPTION
Somehow the linkify redactor plugin causes Android to collapse the on-screen
keyboard if a new line is entered.

This plugin was already removed for 5.2 in commit 19af26fc22bc31d699db6021dee2eda1d23b8a14,
so let's effectively disable it for 3.1 as well.

see https://community.woltlab.com/thread/285573-wsc-3-1-17-smartphone-tastatur-schlie%C3%9Ft-sich-unbeabsichtigt/?postID=1816848#post1816848