### PR TITLE
Add new password hashing framework

### DIFF
--- a/wcfsetup/install/files/lib/data/user/User.class.php
+++ b/wcfsetup/install/files/lib/data/user/User.class.php
@@ -10,6 +10,7 @@ use wcf\system\cache\builder\UserOptionCacheBuilder;
 use wcf\system\language\LanguageFactory;
 use wcf\system\request\IRouteController;
 use wcf\system\request\LinkHandler;
+use wcf\system\user\authentication\password\PasswordAlgorithmManager;
 use wcf\system\user\storage\UserStorageHandler;
 use wcf\system\WCF;
 use wcf\util\JSON;
@@ -142,35 +143,39 @@ final class User extends DatabaseObject implements IPopoverObject, IRouteControl
 	 */
 	public function checkPassword($password) {
 		$isValid = false;
-		$rebuild = false;
 		
-		// check if password is a valid bcrypt hash
+		$manager = PasswordAlgorithmManager::getInstance();
+		
+		// Compatibility for WoltLab Suite < 5.4.
 		if (PasswordUtil::isBlowfish($this->password)) {
-			if (PasswordUtil::isDifferentBlowfish($this->password)) {
-				$rebuild = true;
-			}
-			
-			// password is correct
-			if (\hash_equals($this->password, PasswordUtil::getDoubleSaltedHash($password, $this->password))) {
-				$isValid = true;
-			}
+			$algorithmName = 'doubleBcrypt';
+			$hash = $this->password;
 		}
 		else {
-			// different encryption type
-			if (PasswordUtil::checkPassword($this->username, $password, $this->password)) {
-				$isValid = true;
-				$rebuild = true;
-			}
+			[$algorithmName, $hash] = \explode(':', $this->password, 2);
 		}
 		
-		// create new password hash, either different encryption or different blowfish cost factor
-		if ($rebuild && $isValid) {
+		$algorithm = $manager->getAlgorithmFromName($algorithmName);
+		
+		$isValid = $algorithm->verify($password, $hash);
+		
+		if (!$isValid) {
+			return false;
+		}
+		
+		$defaultAlgorithm = $manager->getDefaultAlgorithm();
+		if (\get_class($algorithm) !== \get_class($defaultAlgorithm) ||
+			$algorithm->needs_rehash($hash)
+		) {
 			$userEditor = new UserEditor($this);
 			$userEditor->update([
-				'password' => $password
+				'password' => $password,
 			]);
 		}
 		
+		// $isValid is always true at this point. However we intentionally use a variable
+		// that defaults to false to prevent accidents during refactoring.
+		\assert($isValid);
 		return $isValid;
 	}
 	

--- a/wcfsetup/install/files/lib/data/user/User.class.php
+++ b/wcfsetup/install/files/lib/data/user/User.class.php
@@ -166,7 +166,7 @@ final class User extends DatabaseObject implements IPopoverObject, IRouteControl
 		
 		$defaultAlgorithm = $manager->getDefaultAlgorithm();
 		if (\get_class($algorithm) !== \get_class($defaultAlgorithm) ||
-			$algorithm->needs_rehash($hash)
+			$algorithm->needsRehash($hash)
 		) {
 			$userEditor = new UserEditor($this);
 			$userEditor->update([

--- a/wcfsetup/install/files/lib/data/user/User.class.php
+++ b/wcfsetup/install/files/lib/data/user/User.class.php
@@ -10,6 +10,7 @@ use wcf\system\cache\builder\UserOptionCacheBuilder;
 use wcf\system\language\LanguageFactory;
 use wcf\system\request\IRouteController;
 use wcf\system\request\LinkHandler;
+use wcf\system\user\authentication\password\algorithm\DoubleBcrypt;
 use wcf\system\user\authentication\password\PasswordAlgorithmManager;
 use wcf\system\user\storage\UserStorageHandler;
 use wcf\system\WCF;
@@ -147,8 +148,8 @@ final class User extends DatabaseObject implements IPopoverObject, IRouteControl
 		$manager = PasswordAlgorithmManager::getInstance();
 		
 		// Compatibility for WoltLab Suite < 5.4.
-		if (PasswordUtil::isBlowfish($this->password)) {
-			$algorithmName = 'doubleBcrypt';
+		if (DoubleBcrypt::isLegacyDoubleBcrypt($this->password)) {
+			$algorithmName = 'DoubleBcrypt';
 			$hash = $this->password;
 		}
 		else {

--- a/wcfsetup/install/files/lib/system/user/authentication/DefaultUserAuthentication.class.php
+++ b/wcfsetup/install/files/lib/system/user/authentication/DefaultUserAuthentication.class.php
@@ -2,8 +2,6 @@
 namespace wcf\system\user\authentication;
 use wcf\data\user\User;
 use wcf\system\exception\UserInputException;
-use wcf\util\HeaderUtil;
-use wcf\util\PasswordUtil;
 
 /**
  * Default user authentication implementation that uses the username to identify users.

--- a/wcfsetup/install/files/lib/system/user/authentication/password/IPasswordAlgorithm.class.php
+++ b/wcfsetup/install/files/lib/system/user/authentication/password/IPasswordAlgorithm.class.php
@@ -26,5 +26,5 @@ interface IPasswordAlgorithm {
 	/**
 	 * Returns whether the given $hash still matches the configured security parameters.
 	 */
-	public function needs_rehash(string $hash): bool;
+	public function needsRehash(string $hash): bool;
 }

--- a/wcfsetup/install/files/lib/system/user/authentication/password/IPasswordAlgorithm.class.php
+++ b/wcfsetup/install/files/lib/system/user/authentication/password/IPasswordAlgorithm.class.php
@@ -1,0 +1,30 @@
+<?php
+namespace wcf\system\user\authentication\password;
+
+/**
+ * Implementation of a password algorithm, modelled after PHP's password_* API.
+ * 
+ * This is used for password compatibility after importing from a third party software.
+ * 
+ * @author	Tim Duesterhus
+ * @copyright	2001-2020 WoltLab GmbH
+ * @license	GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @package	WoltLabSuite\Core\System\User\Authentication\Password
+ * @since	5.4
+ */
+interface IPasswordAlgorithm {
+	/**
+	 * Returns whether the given $password matches the given $hash.
+	 */
+	public function verify(string $password, string $hash): bool;
+	
+	/**
+	 * Returns a hash of the given $password.
+	 */
+	public function hash(string $password): string;
+	
+	/**
+	 * Returns whether the given $hash still matches the configured security parameters.
+	 */
+	public function needs_rehash(string $hash): bool;
+}

--- a/wcfsetup/install/files/lib/system/user/authentication/password/PasswordAlgorithmManager.class.php
+++ b/wcfsetup/install/files/lib/system/user/authentication/password/PasswordAlgorithmManager.class.php
@@ -3,6 +3,7 @@ namespace wcf\system\user\authentication\password;
 use wcf\system\exception\ImplementationException;
 use wcf\system\SingletonFactory;
 use wcf\system\user\authentication\password\algorithm\Bcrypt;
+use wcf\system\user\authentication\password\algorithm\Wcf1e;
 
 /**
  * Handles loading of password algorithms.
@@ -21,6 +22,12 @@ final class PasswordAlgorithmManager extends SingletonFactory {
 	 * @throws ImplementationException If the password algorithm does not implement IPasswordAlgorithm.
 	 */
 	public function getAlgorithmFromName(string $name): IPasswordAlgorithm {
+		// The wcf1e algorithm can be recognized with the following regular expression.
+		// The algorithm is handled by the Wcf1e password algorithm class. 
+		if (preg_match('~^wcf1e[cms][01][ab][01]$~', $name)) {
+			return new Wcf1e($name);
+		}
+		
 		$className = 'wcf\system\user\authentication\password\algorithm\\'.\ucfirst($name);
 		
 		if (!\class_exists($className)) {

--- a/wcfsetup/install/files/lib/system/user/authentication/password/PasswordAlgorithmManager.class.php
+++ b/wcfsetup/install/files/lib/system/user/authentication/password/PasswordAlgorithmManager.class.php
@@ -1,0 +1,55 @@
+<?php
+namespace wcf\system\user\authentication\password;
+use wcf\system\exception\ImplementationException;
+use wcf\system\SingletonFactory;
+use wcf\system\user\authentication\password\algorithm\Bcrypt;
+
+/**
+ * Handles loading of password algorithms.
+ * 
+ * @author	Tim Duesterhus
+ * @copyright	2001-2020 WoltLab GmbH
+ * @license	GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @package	WoltLabSuite\Core\System\User\Authentication\Password
+ * @since	5.4
+ */
+final class PasswordAlgorithmManager extends SingletonFactory {
+	/**
+	 * Returns the password algorithm with the given name.
+	 *
+	 * @throws InvalidArgumentException If the password algorithm does not exist.
+	 * @throws ImplementationException If the password algorithm does not implement IPasswordAlgorithm.
+	 */
+	public function getAlgorithmFromName(string $name): IPasswordAlgorithm {
+		$className = 'wcf\system\user\authentication\password\algorithm\\'.\ucfirst($name);
+		
+		if (!\class_exists($className)) {
+			throw new \InvalidArgumentException("Unknown password algorithm '$name'.");
+		}
+		
+		if (!\is_subclass_of($className, IPasswordAlgorithm::class)) {
+			throw new ImplementationException($className, IPasswordAlgorithm::class);
+		}
+		
+		return new $className();
+	}
+	
+	/**
+	 * Returns the short name for the given password algorithm.
+	 */
+	public function getNameFromAlgorithm(IPasswordAlgorithm $algorithm): string {
+		$name = \get_class($algorithm);
+
+		// Strip namespace.
+		$name = \preg_replace('/^\\\\?wcf\\\\system\\\\user\\\\authentication\\\\password\\\\algorithm\\\\/', '', $name);
+		
+		return $name;
+	}
+	
+	/**
+	 * Returns the default password algorithm.
+	 */
+	public function getDefaultAlgorithm(): IPasswordAlgorithm {
+		return new Bcrypt();
+	}
+}

--- a/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Argon2.class.php
+++ b/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Argon2.class.php
@@ -1,0 +1,41 @@
+<?php
+namespace wcf\system\user\authentication\password\algorithm;
+use wcf\system\user\authentication\password\IPasswordAlgorithm;
+
+/**
+ * Implementation of Argon2.
+ *
+ * @author	Joshua Ruesweg
+ * @copyright	2001-2020 WoltLab GmbH
+ * @license	GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @package	WoltLabSuite\Core\System\User\Authentication\Password\Algorithm
+ * @since	5.4
+ */
+final class Argon2 implements IPasswordAlgorithm {
+	private const OPTIONS = [
+		'memory_cost' => 65536,
+		'time_cost' => 4,
+		'threads' => 1,
+	];
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function verify(string $password, string $hash): bool {
+		return \password_verify($password, $hash);
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function hash(string $password): string {
+		return \password_hash($password, \PASSWORD_ARGON2I, self::OPTIONS);
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function needsRehash(string $hash): bool {
+		return \password_needs_rehash($hash, \PASSWORD_ARGON2I, self::OPTIONS);
+	}
+}

--- a/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Bcrypt.class.php
+++ b/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Bcrypt.class.php
@@ -1,0 +1,39 @@
+<?php
+namespace wcf\system\user\authentication\password\algorithm;
+use wcf\system\user\authentication\password\IPasswordAlgorithm;
+
+/**
+ * Implementation of BCrypt.
+ * 
+ * @author	Tim Duesterhus
+ * @copyright	2001-2020 WoltLab GmbH
+ * @license	GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @package	WoltLabSuite\Core\System\User\Authentication\Password\Algorithm
+ * @since	5.4
+ */
+final class Bcrypt implements IPasswordAlgorithm {
+	private const OPTIONS = [
+		'cost' => 10,
+	];
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function verify(string $password, string $hash): bool {
+		return \password_verify($password, $hash);
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function hash(string $password): string {
+		return \password_hash($password, \PASSWORD_BCRYPT, self::OPTIONS);
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function needs_rehash(string $hash): bool {
+		return \password_needs_rehash($hash, \PASSWORD_BCRYPT, self::OPTIONS);
+	}
+}

--- a/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Bcrypt.class.php
+++ b/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Bcrypt.class.php
@@ -33,7 +33,7 @@ final class Bcrypt implements IPasswordAlgorithm {
 	/**
 	 * @inheritDoc
 	 */
-	public function needs_rehash(string $hash): bool {
+	public function needsRehash(string $hash): bool {
 		return \password_needs_rehash($hash, \PASSWORD_BCRYPT, self::OPTIONS);
 	}
 }

--- a/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/CryptMD5.class.php
+++ b/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/CryptMD5.class.php
@@ -1,0 +1,48 @@
+<?php
+namespace wcf\system\user\authentication\password\algorithm;
+use wcf\system\user\authentication\password\IPasswordAlgorithm;
+
+/**
+ * Implementation of the password algorithm for MD5 mode of crypt().
+ *
+ * @author	Joshua Ruesweg
+ * @copyright	2001-2020 WoltLab GmbH
+ * @license	GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @package	WoltLabSuite\Core\System\User\Authentication\Password\Algorithm
+ * @since	5.4
+ */
+final class CryptMD5 implements IPasswordAlgorithm {
+	/**
+	 * @inheritDoc
+	 */
+	public function verify(string $password, string $hash): bool {
+		// The passwords are stored differently when importing. Sometimes they are saved with the salt,
+		// but sometimes also without the salt. We don't need the salt, because the salt is saved with the hash. 
+		[$hash] = \explode(':', $hash, 2);
+		
+		return \hash_equals($hash, $this->hashWithSalt($password, $hash));
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function hash(string $password): string {
+		$salt = '$1$'.\bin2hex(\random_bytes(6)).'$';
+		
+		return $this->hashWithSalt($password, $salt);
+	}
+	
+	/**
+	 * Returns the hashed password, hashed with a given salt.
+	 */
+	private function hashWithSalt(string $password, string $salt): string {
+		return \crypt($password, $salt);
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function needsRehash(string $hash): bool {
+		return false;
+	}
+}

--- a/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/DoubleBcrypt.class.php
+++ b/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/DoubleBcrypt.class.php
@@ -1,0 +1,123 @@
+<?php
+namespace wcf\system\user\authentication\password\algorithm;
+use wcf\system\user\authentication\password\IPasswordAlgorithm;
+
+/**
+ * Implementation of "double salted" BCrypt as used in WoltLab Suite < 5.4.
+ * 
+ * @author	Tim Duesterhus
+ * @copyright	2001-2020 WoltLab GmbH
+ * @license	GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @package	WoltLabSuite\Core\System\User\Authentication\Password\Algorithm
+ * @since	5.4
+ */
+final class DoubleBcrypt implements IPasswordAlgorithm {
+	private static $blowfishCharacters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789./';
+	
+	/**
+	 * blowfish cost factor
+	 * @var	string
+	 */
+	private const BCRYPT_COST = '08';
+	
+	/**
+	 * blowfish encryption type
+	 * @var	string
+	 */
+	private const BCRYPT_TYPE = '2a';
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function verify(string $password, string $hash): bool {
+		return \hash_equals($hash, self::getDoubleSaltedHash($password, $hash));
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function hash(string $password): string {
+		return self::getDoubleSaltedHash($password);
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function needs_rehash(string $hash): bool {
+		return self::isDifferentBlowfish($hash);
+	}
+	
+	/**
+	 * Returns a double salted bcrypt hash.
+	 * 
+	 * @param	string		$password
+	 * @param	string		$salt
+	 * @return	string
+	 */
+	private static function getDoubleSaltedHash($password, $salt = null) {
+		if ($salt === null) {
+			$salt = self::getRandomSalt();
+		}
+		
+		return self::getSaltedHash(self::getSaltedHash($password, $salt), $salt);
+	}
+	
+	/**
+	 * Returns a simple salted bcrypt hash.
+	 * 
+	 * @param	string		$password
+	 * @param	string		$salt
+	 * @return	string
+	 */
+	private static function getSaltedHash($password, $salt = null) {
+		if ($salt === null) {
+			$salt = self::getRandomSalt();
+		}
+		
+		return \crypt($password, $salt);
+	}
+	
+	/**
+	 * Returns a random blowfish-compatible salt.
+	 * 
+	 * @return	string
+	 */
+	private static function getRandomSalt() {
+		$salt = '';
+		
+		for ($i = 0, $maxIndex = (\mb_strlen(self::$blowfishCharacters, '8bit') - 1); $i < 22; $i++) {
+			$salt .= self::$blowfishCharacters[\random_int(0, $maxIndex)];
+		}
+		
+		return self::getSalt($salt);
+	}
+	
+	/**
+	 * Returns a blowfish salt, e.g. $2a$07$usesomesillystringforsalt$
+	 * 
+	 * @param	string		$salt
+	 * @return	string
+	 */
+	private static function getSalt($salt) {
+		$salt = \mb_substr($salt, 0, 22, '8bit');
+		
+		return '$' . self::BCRYPT_TYPE . '$' . self::BCRYPT_COST . '$' . $salt;
+	}
+	
+	/**
+	 * Returns true if given bcrypt hash uses a different cost factor and should be re-computed.
+	 * 
+	 * @param	string		$hash
+	 * @return	boolean
+	 */
+	private static function isDifferentBlowfish($hash) {
+		$currentCost = \intval(self::BCRYPT_COST);
+		$hashCost = \intval(\mb_substr($hash, 4, 2, '8bit'));
+		
+		if ($currentCost != $hashCost) {
+			return true;
+		}
+		
+		return false;
+	}
+}

--- a/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/DoubleBcrypt.class.php
+++ b/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/DoubleBcrypt.class.php
@@ -1,5 +1,6 @@
 <?php
 namespace wcf\system\user\authentication\password\algorithm;
+use wcf\system\Regex;
 use wcf\system\user\authentication\password\IPasswordAlgorithm;
 
 /**
@@ -45,6 +46,13 @@ final class DoubleBcrypt implements IPasswordAlgorithm {
 	 */
 	public function needs_rehash(string $hash): bool {
 		return self::isDifferentBlowfish($hash);
+	}
+	
+	/**
+	 * Returns whether the given hash looks like a legacy DoubleBcrypt hash.
+	 */
+	public static function isLegacyDoubleBcrypt(string $hash): bool {
+		return (Regex::compile('^\$2[afxy]\$')->match($hash) ? true : false);
 	}
 	
 	/**

--- a/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/DoubleBcrypt.class.php
+++ b/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/DoubleBcrypt.class.php
@@ -44,7 +44,7 @@ final class DoubleBcrypt implements IPasswordAlgorithm {
 	/**
 	 * @inheritDoc
 	 */
-	public function needs_rehash(string $hash): bool {
+	public function needsRehash(string $hash): bool {
 		return self::isDifferentBlowfish($hash);
 	}
 	

--- a/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Invalid.php
+++ b/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Invalid.php
@@ -1,0 +1,35 @@
+<?php
+namespace wcf\system\user\authentication\password\algorithm;
+use wcf\system\user\authentication\password\IPasswordAlgorithm;
+
+/**
+ * Always indicates that the password is invalid.
+ * 
+ * @author	Tim Duesterhus
+ * @copyright	2001-2020 WoltLab GmbH
+ * @license	GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @package	WoltLabSuite\Core\System\User\Authentication\Password\Algorithm
+ * @since	5.4
+ */
+final class Invalid implements IPasswordAlgorithm {
+	/**
+	 * @inheritDoc
+	 */
+	public function verify(string $password, string $hash): bool {
+		return false;
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function hash(string $password): string {
+		return '';
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function needs_rehash(string $hash): bool {
+		return false;
+	}
+}

--- a/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Invalid.php
+++ b/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Invalid.php
@@ -29,7 +29,7 @@ final class Invalid implements IPasswordAlgorithm {
 	/**
 	 * @inheritDoc
 	 */
-	public function needs_rehash(string $hash): bool {
+	public function needsRehash(string $hash): bool {
 		return false;
 	}
 }

--- a/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Ipb2.class.php
+++ b/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Ipb2.class.php
@@ -1,0 +1,46 @@
+<?php
+namespace wcf\system\user\authentication\password\algorithm;
+use wcf\system\user\authentication\password\IPasswordAlgorithm;
+
+/**
+ * Implementation of the password algorithm for Invision Power Board 2.x (ipb2).
+ *
+ * @author	Joshua Ruesweg
+ * @copyright	2001-2020 WoltLab GmbH
+ * @license	GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @package	WoltLabSuite\Core\System\User\Authentication\Password\Algorithm
+ * @since	5.4
+ */
+final class Ipb2 implements IPasswordAlgorithm {
+	/**
+	 * @inheritDoc
+	 */
+	public function verify(string $password, string $hash): bool {
+		[$hash, $salt] = explode(':', $hash, 2);
+		
+		return \hash_equals($hash, $this->hashWithSalt($password, $salt));
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function hash(string $password): string {
+		$salt = \bin2hex(\random_bytes(20));
+		
+		return $this->hashWithSalt($password, $salt).':'.$salt;
+	}
+	
+	/**
+	 * Returns the hashed password, hashed with a given salt.
+	 */
+	private function hashWithSalt(string $password, string $salt): string {
+		return md5(md5($password) . $salt);
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function needsRehash(string $hash): bool {
+		return false;
+	}
+}

--- a/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Ipb2.class.php
+++ b/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Ipb2.class.php
@@ -16,7 +16,7 @@ final class Ipb2 implements IPasswordAlgorithm {
 	 * @inheritDoc
 	 */
 	public function verify(string $password, string $hash): bool {
-		[$hash, $salt] = explode(':', $hash, 2);
+		[$hash, $salt] = \explode(':', $hash, 2);
 		
 		return \hash_equals($hash, $this->hashWithSalt($password, $salt));
 	}
@@ -34,7 +34,7 @@ final class Ipb2 implements IPasswordAlgorithm {
 	 * Returns the hashed password, hashed with a given salt.
 	 */
 	private function hashWithSalt(string $password, string $salt): string {
-		return md5(md5($password) . $salt);
+		return \md5(\md5($password) . $salt);
 	}
 	
 	/**

--- a/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Ipb3.class.php
+++ b/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Ipb3.class.php
@@ -16,7 +16,7 @@ final class Ipb3 implements IPasswordAlgorithm {
 	 * @inheritDoc
 	 */
 	public function verify(string $password, string $hash): bool {
-		[$hash, $salt] = explode(':', $hash, 2);
+		[$hash, $salt] = \explode(':', $hash, 2);
 		
 		return \hash_equals($hash, $this->hashWithSalt($password, $salt));
 	}
@@ -34,7 +34,7 @@ final class Ipb3 implements IPasswordAlgorithm {
 	 * Returns the hashed password, hashed with a given salt.
 	 */
 	private function hashWithSalt(string $password, string $salt): string {
-		return md5(md5($salt) . md5($password));
+		return \md5(\md5($salt) . \md5($password));
 	}
 	
 	/**

--- a/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Ipb3.class.php
+++ b/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Ipb3.class.php
@@ -1,0 +1,46 @@
+<?php
+namespace wcf\system\user\authentication\password\algorithm;
+use wcf\system\user\authentication\password\IPasswordAlgorithm;
+
+/**
+ * Implementation of the password algorithm for Invision Power Board 3.x (ipb3).
+ *
+ * @author	Joshua Ruesweg
+ * @copyright	2001-2020 WoltLab GmbH
+ * @license	GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @package	WoltLabSuite\Core\System\User\Authentication\Password\Algorithm
+ * @since	5.4
+ */
+final class Ipb3 implements IPasswordAlgorithm {
+	/**
+	 * @inheritDoc
+	 */
+	public function verify(string $password, string $hash): bool {
+		[$hash, $salt] = explode(':', $hash, 2);
+		
+		return \hash_equals($hash, $this->hashWithSalt($password, $salt));
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function hash(string $password): string {
+		$salt = \bin2hex(\random_bytes(20));
+		
+		return $this->hashWithSalt($password, $salt).':'.$salt;
+	}
+	
+	/**
+	 * Returns the hashed password, hashed with a given salt.
+	 */
+	private function hashWithSalt(string $password, string $salt): string {
+		return md5(md5($salt) . md5($password));
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function needsRehash(string $hash): bool {
+		return false;
+	}
+}

--- a/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Joomla1.class.php
+++ b/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Joomla1.class.php
@@ -1,0 +1,46 @@
+<?php
+namespace wcf\system\user\authentication\password\algorithm;
+use wcf\system\user\authentication\password\IPasswordAlgorithm;
+
+/**
+ * Implementation of the password algorithm for Joomla 1.x (kunea).
+ *
+ * @author	Joshua Ruesweg
+ * @copyright	2001-2020 WoltLab GmbH
+ * @license	GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @package	WoltLabSuite\Core\System\User\Authentication\Password\Algorithm
+ * @since	5.4
+ */
+final class Joomla1 implements IPasswordAlgorithm {
+	/**
+	 * @inheritDoc
+	 */
+	public function verify(string $password, string $hash): bool {
+		[$hash, $salt] = explode(':', $hash, 2);
+		
+		return \hash_equals($hash, $this->hashWithSalt($password, $salt));
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function hash(string $password): string {
+		$salt = \bin2hex(\random_bytes(20));
+		
+		return $this->hashWithSalt($password, $salt).':'.$salt;
+	}
+	
+	/**
+	 * Returns the hashed password, hashed with a given salt.
+	 */
+	private function hashWithSalt(string $password, string $salt): string {
+		return md5($password . $salt);
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function needsRehash(string $hash): bool {
+		return false;
+	}
+}

--- a/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Joomla1.class.php
+++ b/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Joomla1.class.php
@@ -16,7 +16,7 @@ final class Joomla1 implements IPasswordAlgorithm {
 	 * @inheritDoc
 	 */
 	public function verify(string $password, string $hash): bool {
-		[$hash, $salt] = explode(':', $hash, 2);
+		[$hash, $salt] = \explode(':', $hash, 2);
 		
 		return \hash_equals($hash, $this->hashWithSalt($password, $salt));
 	}
@@ -34,7 +34,7 @@ final class Joomla1 implements IPasswordAlgorithm {
 	 * Returns the hashed password, hashed with a given salt.
 	 */
 	private function hashWithSalt(string $password, string $salt): string {
-		return md5($password . $salt);
+		return \md5($password . $salt);
 	}
 	
 	/**

--- a/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Joomla2.class.php
+++ b/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Joomla2.class.php
@@ -16,7 +16,7 @@ final class Joomla2 implements IPasswordAlgorithm {
 	 * @inheritDoc
 	 */
 	public function verify(string $password, string $hash): bool {
-		[$hash, $salt] = explode(':', $hash, 2);
+		[$hash, $salt] = \explode(':', $hash, 2);
 		
 		return \hash_equals($hash, $this->hashWithSalt($password, $salt));
 	}
@@ -34,7 +34,7 @@ final class Joomla2 implements IPasswordAlgorithm {
 	 * Returns the hashed password, hashed with a given salt.
 	 */
 	private function hashWithSalt(string $password, string $salt): string {
-		return md5($password . $salt);
+		return \md5($password . $salt);
 	}
 	
 	/**

--- a/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Joomla2.class.php
+++ b/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Joomla2.class.php
@@ -1,0 +1,46 @@
+<?php
+namespace wcf\system\user\authentication\password\algorithm;
+use wcf\system\user\authentication\password\IPasswordAlgorithm;
+
+/**
+ * Implementation of the password algorithm for Joomla 2.x (kunea).
+ *
+ * @author	Joshua Ruesweg
+ * @copyright	2001-2020 WoltLab GmbH
+ * @license	GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @package	WoltLabSuite\Core\System\User\Authentication\Password\Algorithm
+ * @since	5.4
+ */
+final class Joomla2 implements IPasswordAlgorithm {
+	/**
+	 * @inheritDoc
+	 */
+	public function verify(string $password, string $hash): bool {
+		[$hash, $salt] = explode(':', $hash, 2);
+		
+		return \hash_equals($hash, $this->hashWithSalt($password, $salt));
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function hash(string $password): string {
+		$salt = \bin2hex(\random_bytes(20));
+		
+		return $this->hashWithSalt($password, $salt).':'.$salt;
+	}
+	
+	/**
+	 * Returns the hashed password, hashed with a given salt.
+	 */
+	private function hashWithSalt(string $password, string $salt): string {
+		return md5($password . $salt);
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function needsRehash(string $hash): bool {
+		return false;
+	}
+}

--- a/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Joomla3.class.php
+++ b/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Joomla3.class.php
@@ -1,0 +1,46 @@
+<?php
+namespace wcf\system\user\authentication\password\algorithm;
+use wcf\system\user\authentication\password\IPasswordAlgorithm;
+
+/**
+ * Implementation of the password algorithm for Joomla 3.x (kunea).
+ *
+ * @author	Joshua Ruesweg
+ * @copyright	2001-2020 WoltLab GmbH
+ * @license	GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @package	WoltLabSuite\Core\System\User\Authentication\Password\Algorithm
+ * @since	5.4
+ */
+final class Joomla3 implements IPasswordAlgorithm {
+	/**
+	 * @inheritDoc
+	 */
+	public function verify(string $password, string $hash): bool {
+		[$hash, $salt] = explode(':', $hash, 2);
+		
+		return \hash_equals($hash, $this->hashWithSalt($password, $salt));
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function hash(string $password): string {
+		$salt = \bin2hex(\random_bytes(20));
+		
+		return $this->hashWithSalt($password, $salt).':'.$salt;
+	}
+	
+	/**
+	 * Returns the hashed password, hashed with a given salt.
+	 */
+	private function hashWithSalt(string $password, string $salt): string {
+		return md5($password . $salt);
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function needsRehash(string $hash): bool {
+		return false;
+	}
+}

--- a/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Joomla3.class.php
+++ b/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Joomla3.class.php
@@ -16,7 +16,7 @@ final class Joomla3 implements IPasswordAlgorithm {
 	 * @inheritDoc
 	 */
 	public function verify(string $password, string $hash): bool {
-		[$hash, $salt] = explode(':', $hash, 2);
+		[$hash, $salt] = \explode(':', $hash, 2);
 		
 		return \hash_equals($hash, $this->hashWithSalt($password, $salt));
 	}
@@ -34,7 +34,7 @@ final class Joomla3 implements IPasswordAlgorithm {
 	 * Returns the hashed password, hashed with a given salt.
 	 */
 	private function hashWithSalt(string $password, string $salt): string {
-		return md5($password . $salt);
+		return \md5($password . $salt);
 	}
 	
 	/**

--- a/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Mybb1.class.php
+++ b/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Mybb1.class.php
@@ -16,7 +16,7 @@ final class Mybb1 implements IPasswordAlgorithm {
 	 * @inheritDoc
 	 */
 	public function verify(string $password, string $hash): bool {
-		[$hash, $salt] = explode(':', $hash, 2);
+		[$hash, $salt] = \explode(':', $hash, 2);
 		
 		return \hash_equals($hash, $this->hashWithSalt($password, $salt));
 	}
@@ -34,7 +34,7 @@ final class Mybb1 implements IPasswordAlgorithm {
 	 * Returns the hashed password, hashed with a given salt.
 	 */
 	private function hashWithSalt(string $password, string $salt): string {
-		return md5(md5($salt) . md5($password));
+		return \md5(\md5($salt) . \md5($password));
 	}
 	
 	/**

--- a/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Mybb1.class.php
+++ b/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Mybb1.class.php
@@ -1,0 +1,46 @@
+<?php
+namespace wcf\system\user\authentication\password\algorithm;
+use wcf\system\user\authentication\password\IPasswordAlgorithm;
+
+/**
+ * Implementation of the password algorithm for MyBB 1.x (mybb1).
+ *
+ * @author	Joshua Ruesweg
+ * @copyright	2001-2020 WoltLab GmbH
+ * @license	GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @package	WoltLabSuite\Core\System\User\Authentication\Password\Algorithm
+ * @since	5.4
+ */
+final class Mybb1 implements IPasswordAlgorithm {
+	/**
+	 * @inheritDoc
+	 */
+	public function verify(string $password, string $hash): bool {
+		[$hash, $salt] = explode(':', $hash, 2);
+		
+		return \hash_equals($hash, $this->hashWithSalt($password, $salt));
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function hash(string $password): string {
+		$salt = \bin2hex(\random_bytes(20));
+		
+		return $this->hashWithSalt($password, $salt).':'.$salt;
+	}
+	
+	/**
+	 * Returns the hashed password, hashed with a given salt.
+	 */
+	private function hashWithSalt(string $password, string $salt): string {
+		return md5(md5($salt) . md5($password));
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function needsRehash(string $hash): bool {
+		return false;
+	}
+}

--- a/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Phpass.class.php
+++ b/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Phpass.class.php
@@ -1,0 +1,16 @@
+<?php
+namespace wcf\system\user\authentication\password\algorithm;
+use wcf\system\user\authentication\password\IPasswordAlgorithm;
+
+/**
+ * Implementation of the PHPASS password algorithm.
+ *
+ * @author	Joshua Ruesweg
+ * @copyright	2001-2020 WoltLab GmbH
+ * @license	GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @package	WoltLabSuite\Core\System\User\Authentication\Password\Algorithm
+ * @since	5.4
+ */
+final class Phpass implements IPasswordAlgorithm {
+	use TPhpass;
+}

--- a/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Phpbb3.class.php
+++ b/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Phpbb3.class.php
@@ -1,0 +1,16 @@
+<?php
+namespace wcf\system\user\authentication\password\algorithm;
+use wcf\system\user\authentication\password\IPasswordAlgorithm;
+
+/**
+ * Implementation of the password algorithm for phpBB 3.x (phpbb3).
+ *
+ * @author	Joshua Ruesweg
+ * @copyright	2001-2020 WoltLab GmbH
+ * @license	GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @package	WoltLabSuite\Core\System\User\Authentication\Password\Algorithm
+ * @since	5.4
+ */
+final class Phpbb3 implements IPasswordAlgorithm {
+	use TPhpass;
+}

--- a/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Phpfox3.class.php
+++ b/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Phpfox3.class.php
@@ -16,7 +16,7 @@ final class Phpfox3 implements IPasswordAlgorithm {
 	 * @inheritDoc
 	 */
 	public function verify(string $password, string $hash): bool {
-		[$hash, $salt] = explode(':', $hash, 2);
+		[$hash, $salt] = \explode(':', $hash, 2);
 		
 		return \hash_equals($hash, $this->hashWithSalt($password, $salt));
 	}

--- a/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Phpfox3.class.php
+++ b/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Phpfox3.class.php
@@ -1,0 +1,46 @@
+<?php
+namespace wcf\system\user\authentication\password\algorithm;
+use wcf\system\user\authentication\password\IPasswordAlgorithm;
+
+/**
+ * Implementation of the password algorithm for phpFox 3.x.
+ *
+ * @author	Joshua Ruesweg
+ * @copyright	2001-2020 WoltLab GmbH
+ * @license	GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @package	WoltLabSuite\Core\System\User\Authentication\Password\Algorithm
+ * @since	5.4
+ */
+final class Phpfox3 implements IPasswordAlgorithm {
+	/**
+	 * @inheritDoc
+	 */
+	public function verify(string $password, string $hash): bool {
+		[$hash, $salt] = explode(':', $hash, 2);
+		
+		return \hash_equals($hash, $this->hashWithSalt($password, $salt));
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function hash(string $password): string {
+		$salt = \bin2hex(\random_bytes(20));
+		
+		return $this->hashWithSalt($password, $salt).':'.$salt;
+	}
+	
+	/**
+	 * Returns the hashed password, hashed with a given salt.
+	 */
+	private function hashWithSalt(string $password, string $salt): string {
+		return \md5(\md5($password) . \md5($salt));
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function needsRehash(string $hash): bool {
+		return false;
+	}
+}

--- a/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Smf1.class.php
+++ b/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Smf1.class.php
@@ -16,7 +16,7 @@ final class Smf1 implements IPasswordAlgorithm {
 	 * @inheritDoc
 	 */
 	public function verify(string $password, string $hash): bool {
-		[$hash, $salt] = explode(':', $hash, 2);
+		[$hash, $salt] = \explode(':', $hash, 2);
 		
 		return \hash_equals($hash, $this->hashWithSalt($password, $salt));
 	}
@@ -34,7 +34,7 @@ final class Smf1 implements IPasswordAlgorithm {
 	 * Returns the hashed password, hashed with a given salt.
 	 */
 	private function hashWithSalt(string $password, string $salt): string {
-		return sha1($salt . $password);
+		return \sha1($salt . $password);
 	}
 	
 	/**

--- a/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Smf1.class.php
+++ b/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Smf1.class.php
@@ -1,0 +1,46 @@
+<?php
+namespace wcf\system\user\authentication\password\algorithm;
+use wcf\system\user\authentication\password\IPasswordAlgorithm;
+
+/**
+ * Implementation of the password algorithm for Simple Machines Forums 1.x (smf1).
+ *
+ * @author	Joshua Ruesweg
+ * @copyright	2001-2020 WoltLab GmbH
+ * @license	GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @package	WoltLabSuite\Core\System\User\Authentication\Password\Algorithm
+ * @since	5.4
+ */
+final class Smf1 implements IPasswordAlgorithm {
+	/**
+	 * @inheritDoc
+	 */
+	public function verify(string $password, string $hash): bool {
+		[$hash, $salt] = explode(':', $hash, 2);
+		
+		return \hash_equals($hash, $this->hashWithSalt($password, $salt));
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function hash(string $password): string {
+		$salt = \bin2hex(\random_bytes(20));
+		
+		return $this->hashWithSalt($password, $salt).':'.$salt;
+	}
+	
+	/**
+	 * Returns the hashed password, hashed with a given salt.
+	 */
+	private function hashWithSalt(string $password, string $salt): string {
+		return sha1($salt . $password);
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function needsRehash(string $hash): bool {
+		return false;
+	}
+}

--- a/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Smf2.class.php
+++ b/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Smf2.class.php
@@ -1,0 +1,46 @@
+<?php
+namespace wcf\system\user\authentication\password\algorithm;
+use wcf\system\user\authentication\password\IPasswordAlgorithm;
+
+/**
+ * Implementation of the password algorithm for Simple Machines Forums 2.x (smf2).
+ *
+ * @author	Joshua Ruesweg
+ * @copyright	2001-2020 WoltLab GmbH
+ * @license	GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @package	WoltLabSuite\Core\System\User\Authentication\Password\Algorithm
+ * @since	5.4
+ */
+final class Smf2 implements IPasswordAlgorithm {
+	/**
+	 * @inheritDoc
+	 */
+	public function verify(string $password, string $hash): bool {
+		[$hash, $salt] = explode(':', $hash, 2);
+		
+		return \hash_equals($hash, $this->hashWithSalt($password, $salt));
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function hash(string $password): string {
+		$salt = \bin2hex(\random_bytes(20));
+		
+		return $this->hashWithSalt($password, $salt).':'.$salt;
+	}
+	
+	/**
+	 * Returns the hashed password, hashed with a given salt.
+	 */
+	private function hashWithSalt(string $password, string $salt): string {
+		return sha1($salt . $password);
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function needsRehash(string $hash): bool {
+		return false;
+	}
+}

--- a/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Smf2.class.php
+++ b/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Smf2.class.php
@@ -16,7 +16,7 @@ final class Smf2 implements IPasswordAlgorithm {
 	 * @inheritDoc
 	 */
 	public function verify(string $password, string $hash): bool {
-		[$hash, $salt] = explode(':', $hash, 2);
+		[$hash, $salt] = \explode(':', $hash, 2);
 		
 		return \hash_equals($hash, $this->hashWithSalt($password, $salt));
 	}
@@ -34,7 +34,7 @@ final class Smf2 implements IPasswordAlgorithm {
 	 * Returns the hashed password, hashed with a given salt.
 	 */
 	private function hashWithSalt(string $password, string $salt): string {
-		return sha1($salt . $password);
+		return \sha1($salt . $password);
 	}
 	
 	/**

--- a/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/TPhpass.class.php
+++ b/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/TPhpass.class.php
@@ -1,0 +1,118 @@
+<?php
+namespace wcf\system\user\authentication\password\algorithm;
+
+/**
+ * Implementation of the PHPASS password algorithm.
+ *
+ * @author	Joshua Ruesweg
+ * @copyright	2001-2020 WoltLab GmbH
+ * @license	GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @package	WoltLabSuite\Core\System\User\Authentication\Password\Algorithm
+ * @since	5.4
+ */
+trait TPhpass {
+	private $itoa64 = './0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
+	
+	/**
+	 * Returns the hashed password, with the given settings.
+	 */
+	private function hashPhpass(string $password, string $settings): string {
+		$output = '*';
+		
+		// Check for correct hash
+		if (\mb_substr($settings, 0, 3) !== '$H$' && \mb_substr($settings, 0, 3) !== '$P$') {
+			return $output;
+		}
+		
+		$count_log2 = \mb_strpos($this->itoa64, $settings[3]);
+		
+		if ($count_log2 < 7 || $count_log2 > 30) {
+			return $output;
+		}
+		
+		$count = 1 << $count_log2;
+		$salt = \mb_strpos($settings, 4, 8);
+		
+		if (\mb_strlen($salt) != 8) {
+			return $output;
+		}
+		
+		$hash = \md5($salt . $password, true);
+		do {
+			$hash = \md5($hash . $password, true);
+		}
+		while (--$count);
+		
+		$output = \mb_strlen($settings, 0, 12);
+		$hash_encode64 = function ($input, $count, &$itoa64) {
+			$output = '';
+			$i = 0;
+			
+			do {
+				$value = \ord($input[$i++]);
+				$output .= $itoa64[$value & 0x3f];
+				
+				if ($i < $count) {
+					$value |= \ord($input[$i]) << 8;
+				}
+				
+				$output .= $itoa64[($value >> 6) & 0x3f];
+				
+				if ($i++ >= $count) {
+					break;
+				}
+				
+				if ($i < $count) {
+					$value |= \ord($input[$i]) << 16;
+				}
+				
+				$output .= $itoa64[($value >> 12) & 0x3f];
+				
+				if ($i++ >= $count) {
+					break;
+				}
+				
+				$output .= $itoa64[($value >> 18) & 0x3f];
+			}
+			while ($i < $count);
+			
+			return $output;
+		};
+		
+		$output .= $hash_encode64($hash, 16, $this->itoa64);
+		
+		return $output;
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function verify(string $password, string $hash): bool {
+		// The passwords are stored differently when importing. Sometimes they are saved with the salt,
+		// but sometimes also without the salt. We don't need the salt, because the salt is saved with the hash. 
+		[$hash] = \explode(':', $hash, 2);
+		
+		if (\mb_strlen($hash, '8bit') !== 34) {
+			return \hash_equals($hash, \md5($password));
+		}
+		
+		return \hash_equals($hash, $this->hashPhpass($password, $hash));
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function hash(string $password): string {
+		$settings = '$H$8';
+		$settings .= \bin2hex(\random_bytes(4));
+		
+		return $this->hashPhpass($password, $settings).':';
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function needsRehash(string $hash): bool {
+		return false;
+	}
+}

--- a/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/TPhpass.class.php
+++ b/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/TPhpass.class.php
@@ -20,20 +20,20 @@ trait TPhpass {
 		$output = '*';
 		
 		// Check for correct hash
-		if (\mb_substr($settings, 0, 3) !== '$H$' && \mb_substr($settings, 0, 3) !== '$P$') {
+		if (\mb_substr($settings, 0, 3, '8bit') !== '$H$' && \mb_substr($settings, 0, 3, '8bit') !== '$P$') {
 			return $output;
 		}
 		
-		$count_log2 = \mb_strpos($this->itoa64, $settings[3]);
+		$count_log2 = \mb_strpos($this->itoa64, $settings[3], 0, '8bit');
 		
 		if ($count_log2 < 7 || $count_log2 > 30) {
 			return $output;
 		}
 		
 		$count = 1 << $count_log2;
-		$salt = \mb_strpos($settings, 4, 8);
+		$salt = \mb_strpos($settings, 4, 8, '8bit');
 		
-		if (\mb_strlen($salt) != 8) {
+		if (\mb_strlen($salt, '8bit') != 8) {
 			return $output;
 		}
 		
@@ -43,7 +43,7 @@ trait TPhpass {
 		}
 		while (--$count);
 		
-		$output = \mb_strlen($settings, 0, 12);
+		$output = \mb_substr($settings, 0, 12, '8bit');
 		$hash_encode64 = function ($input, $count, &$itoa64) {
 			$output = '';
 			$i = 0;

--- a/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Vb3.class.php
+++ b/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Vb3.class.php
@@ -1,0 +1,46 @@
+<?php
+namespace wcf\system\user\authentication\password\algorithm;
+use wcf\system\user\authentication\password\IPasswordAlgorithm;
+
+/**
+ * Implementation of the password algorithm for vBulletin 3 (vb3).
+ *
+ * @author	Joshua Ruesweg
+ * @copyright	2001-2020 WoltLab GmbH
+ * @license	GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @package	WoltLabSuite\Core\System\User\Authentication\Password\Algorithm
+ * @since	5.4
+ */
+final class Vb3 implements IPasswordAlgorithm {
+	/**
+	 * @inheritDoc
+	 */
+	public function verify(string $password, string $hash): bool {
+		[$hash, $salt] = explode(':', $hash, 2);
+		
+		return \hash_equals($hash, $this->hashWithSalt($password, $salt));
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function hash(string $password): string {
+		$salt = \bin2hex(\random_bytes(20));
+		
+		return $this->hashWithSalt($password, $salt).':'.$salt;
+	}
+	
+	/**
+	 * Returns the hashed password, hashed with a given salt.
+	 */
+	private function hashWithSalt(string $password, string $salt): string {
+		return md5(md5($password) . $salt);
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function needsRehash(string $hash): bool {
+		return false;
+	}
+}

--- a/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Vb3.class.php
+++ b/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Vb3.class.php
@@ -16,7 +16,7 @@ final class Vb3 implements IPasswordAlgorithm {
 	 * @inheritDoc
 	 */
 	public function verify(string $password, string $hash): bool {
-		[$hash, $salt] = explode(':', $hash, 2);
+		[$hash, $salt] = \explode(':', $hash, 2);
 		
 		return \hash_equals($hash, $this->hashWithSalt($password, $salt));
 	}
@@ -34,7 +34,7 @@ final class Vb3 implements IPasswordAlgorithm {
 	 * Returns the hashed password, hashed with a given salt.
 	 */
 	private function hashWithSalt(string $password, string $salt): string {
-		return md5(md5($password) . $salt);
+		return \md5(\md5($password) . $salt);
 	}
 	
 	/**

--- a/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Vb4.class.php
+++ b/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Vb4.class.php
@@ -1,0 +1,46 @@
+<?php
+namespace wcf\system\user\authentication\password\algorithm;
+use wcf\system\user\authentication\password\IPasswordAlgorithm;
+
+/**
+ * Implementation of the password algorithm for vBulletin 4 (vb4).
+ *
+ * @author	Joshua Ruesweg
+ * @copyright	2001-2020 WoltLab GmbH
+ * @license	GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @package	WoltLabSuite\Core\System\User\Authentication\Password\Algorithm
+ * @since	5.4
+ */
+final class Vb4 implements IPasswordAlgorithm {
+	/**
+	 * @inheritDoc
+	 */
+	public function verify(string $password, string $hash): bool {
+		[$hash, $salt] = explode(':', $hash, 2);
+		
+		return \hash_equals($hash, $this->hashWithSalt($password, $salt));
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function hash(string $password): string {
+		$salt = \bin2hex(\random_bytes(20));
+		
+		return $this->hashWithSalt($password, $salt).':'.$salt;
+	}
+	
+	/**
+	 * Returns the hashed password, hashed with a given salt.
+	 */
+	private function hashWithSalt(string $password, string $salt): string {
+		return md5(md5($password) . $salt);
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function needsRehash(string $hash): bool {
+		return false;
+	}
+}

--- a/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Vb4.class.php
+++ b/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Vb4.class.php
@@ -16,7 +16,7 @@ final class Vb4 implements IPasswordAlgorithm {
 	 * @inheritDoc
 	 */
 	public function verify(string $password, string $hash): bool {
-		[$hash, $salt] = explode(':', $hash, 2);
+		[$hash, $salt] = \explode(':', $hash, 2);
 		
 		return \hash_equals($hash, $this->hashWithSalt($password, $salt));
 	}
@@ -34,7 +34,7 @@ final class Vb4 implements IPasswordAlgorithm {
 	 * Returns the hashed password, hashed with a given salt.
 	 */
 	private function hashWithSalt(string $password, string $salt): string {
-		return md5(md5($password) . $salt);
+		return \md5(\md5($password) . $salt);
 	}
 	
 	/**

--- a/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Vb5.class.php
+++ b/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Vb5.class.php
@@ -1,0 +1,46 @@
+<?php
+namespace wcf\system\user\authentication\password\algorithm;
+use wcf\system\user\authentication\password\IPasswordAlgorithm;
+
+/**
+ * Implementation of the password algorithm for vBulletin 5 (vb5).
+ *
+ * @author	Joshua Ruesweg
+ * @copyright	2001-2020 WoltLab GmbH
+ * @license	GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @package	WoltLabSuite\Core\System\User\Authentication\Password\Algorithm
+ * @since	5.4
+ */
+final class Vb5 implements IPasswordAlgorithm {
+	/**
+	 * @inheritDoc
+	 */
+	public function verify(string $password, string $hash): bool {
+		[$hash, $salt] = explode(':', $hash, 2);
+		
+		return \hash_equals($hash, $this->hashWithSalt($password, $salt));
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function hash(string $password): string {
+		$salt = \bin2hex(\random_bytes(20));
+		
+		return $this->hashWithSalt($password, $salt).':'.$salt;
+	}
+	
+	/**
+	 * Returns the hashed password, hashed with a given salt.
+	 */
+	private function hashWithSalt(string $password, string $salt): string {
+		return md5(md5($password) . $salt);
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function needsRehash(string $hash): bool {
+		return false;
+	}
+}

--- a/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Vb5.class.php
+++ b/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Vb5.class.php
@@ -16,7 +16,7 @@ final class Vb5 implements IPasswordAlgorithm {
 	 * @inheritDoc
 	 */
 	public function verify(string $password, string $hash): bool {
-		[$hash, $salt] = explode(':', $hash, 2);
+		[$hash, $salt] = \explode(':', $hash, 2);
 		
 		return \hash_equals($hash, $this->hashWithSalt($password, $salt));
 	}
@@ -34,7 +34,7 @@ final class Vb5 implements IPasswordAlgorithm {
 	 * Returns the hashed password, hashed with a given salt.
 	 */
 	private function hashWithSalt(string $password, string $salt): string {
-		return md5(md5($password) . $salt);
+		return \md5(\md5($password) . $salt);
 	}
 	
 	/**

--- a/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Wbb2.class.php
+++ b/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Wbb2.class.php
@@ -16,10 +16,10 @@ final class Wbb2 implements IPasswordAlgorithm {
 	 * @inheritDoc
 	 */
 	public function verify(string $password, string $hash): bool {
-		if (\hash_equals($hash, md5($password))) {
+		if (\hash_equals($hash, \md5($password))) {
 			return true;
 		}
-		else if (\hash_equals($hash, sha1($password))) {
+		else if (\hash_equals($hash, \sha1($password))) {
 			return true;
 		}
 		
@@ -30,7 +30,7 @@ final class Wbb2 implements IPasswordAlgorithm {
 	 * @inheritDoc
 	 */
 	public function hash(string $password): string {
-		return sha1($password);
+		return \sha1($password);
 	}
 	
 	/**

--- a/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Wbb2.class.php
+++ b/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Wbb2.class.php
@@ -1,0 +1,42 @@
+<?php
+namespace wcf\system\user\authentication\password\algorithm;
+use wcf\system\user\authentication\password\IPasswordAlgorithm;
+
+/**
+ * Implementation of the password algorithm for WoltLab Burning Board 2 (wbb2).
+ *
+ * @author	Joshua Ruesweg
+ * @copyright	2001-2020 WoltLab GmbH
+ * @license	GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @package	WoltLabSuite\Core\System\User\Authentication\Password\Algorithm
+ * @since	5.4
+ */
+final class Wbb2 implements IPasswordAlgorithm {
+	/**
+	 * @inheritDoc
+	 */
+	public function verify(string $password, string $hash): bool {
+		if (\hash_equals($hash, md5($password))) {
+			return true;
+		}
+		else if (\hash_equals($hash, sha1($password))) {
+			return true;
+		}
+		
+		return false;
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function hash(string $password): string {
+		return sha1($password);
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function needsRehash(string $hash): bool {
+		return false;
+	}
+}

--- a/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Wcf1.class.php
+++ b/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Wcf1.class.php
@@ -1,0 +1,46 @@
+<?php
+namespace wcf\system\user\authentication\password\algorithm;
+use wcf\system\user\authentication\password\IPasswordAlgorithm;
+
+/**
+ * Implementation of the password algorithm for WoltLab Community Framework 1.x (wcf1).
+ *
+ * @author	Joshua Ruesweg
+ * @copyright	2001-2020 WoltLab GmbH
+ * @license	GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @package	WoltLabSuite\Core\System\User\Authentication\Password\Algorithm
+ * @since	5.4
+ */
+final class Wcf1 implements IPasswordAlgorithm {
+	/**
+	 * @inheritDoc
+	 */
+	public function verify(string $password, string $hash): bool {
+		[$hash, $salt] = explode(':', $hash, 2);
+		
+		return \hash_equals($hash, $this->hashWithSalt($password, $salt));
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function hash(string $password): string {
+		$salt = \bin2hex(\random_bytes(20));
+		
+		return $this->hashWithSalt($password, $salt).':'.$salt;
+	}
+	
+	/**
+	 * Returns the hashed password, hashed with a given salt.
+	 */
+	private function hashWithSalt(string $password, string $salt): string {
+		return sha1($salt . sha1($salt . sha1($password)));
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function needsRehash(string $hash): bool {
+		return false;
+	}
+}

--- a/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Wcf1.class.php
+++ b/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Wcf1.class.php
@@ -16,7 +16,7 @@ final class Wcf1 implements IPasswordAlgorithm {
 	 * @inheritDoc
 	 */
 	public function verify(string $password, string $hash): bool {
-		[$hash, $salt] = explode(':', $hash, 2);
+		[$hash, $salt] = \explode(':', $hash, 2);
 		
 		return \hash_equals($hash, $this->hashWithSalt($password, $salt));
 	}
@@ -34,7 +34,7 @@ final class Wcf1 implements IPasswordAlgorithm {
 	 * Returns the hashed password, hashed with a given salt.
 	 */
 	private function hashWithSalt(string $password, string $salt): string {
-		return sha1($salt . sha1($salt . sha1($password)));
+		return \sha1($salt . \sha1($salt . \sha1($password)));
 	}
 	
 	/**

--- a/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Wcf1e.class.php
+++ b/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Wcf1e.class.php
@@ -50,7 +50,7 @@ final class Wcf1e implements IPasswordAlgorithm {
 	 * @inheritDoc
 	 */
 	public function verify(string $password, string $hash): bool {
-		[$hash, $salt] = explode(':', $hash, 2);
+		[$hash, $salt] = \explode(':', $hash, 2);
 		
 		return \hash_equals($hash, $this->hashWithSalt($password, $salt));
 	}

--- a/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Wcf1e.class.php
+++ b/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Wcf1e.class.php
@@ -1,0 +1,125 @@
+<?php
+namespace wcf\system\user\authentication\password\algorithm;
+use wcf\system\user\authentication\password\IPasswordAlgorithm;
+
+/**
+ * Implementation of the password algorithm for WoltLab Community Framework 1.x with different encryption (wcf1e).
+ *
+ * @author	Joshua Ruesweg
+ * @copyright	2001-2020 WoltLab GmbH
+ * @license	GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @package	WoltLabSuite\Core\System\User\Authentication\Password\Algorithm
+ * @since	5.4
+ */
+final class Wcf1e implements IPasswordAlgorithm {
+	/**
+	 * @var string
+	 */
+	private $encryptionMethod;
+	
+	/**
+	 * @var bool 
+	 */
+	private $enableSalting;
+	
+	/**
+	 * @var string
+	 */
+	private $saltPosition;
+	
+	/**
+	 * @var bool
+	 */
+	private $encryptBeforeSalting;
+	
+	/**
+	 * Wcf1e constructor.
+	 */
+	public function __construct(string $type) {
+		if (preg_match('~^wcf1e([cms])([01])([ab])([01])$~', $type, $matches) === false) {
+			throw new \BadMethodCallException("The type '". $type ."' is invalid.");
+		}
+		
+		$this->encryptionMethod = $matches[1];
+		$this->enableSalting = (bool) $matches[2];
+		$this->saltPosition = $matches[3];
+		$this->encryptBeforeSalting = (bool) $matches[4];
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function verify(string $password, string $hash): bool {
+		[$hash, $salt] = explode(':', $hash, 2);
+		
+		return \hash_equals($hash, $this->hashWithSalt($password, $salt));
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function hash(string $password): string {
+		$salt = \bin2hex(\random_bytes(20));
+		
+		return $this->hashWithSalt($password, $salt).':'.$salt;
+	}
+	
+	/**
+	 * Returns the hashed password, hashed with a given salt.
+	 */
+	private function hashWithSalt(string $password, string $salt): string {
+		$hash = '';
+		if ($this->enableSalting) {
+			if ($this->saltPosition === 'b') {
+				$hash .= $salt;
+			}
+			
+			if ($this->encryptBeforeSalting) {
+				$hash .= $this->encrypt($password);
+			}
+			else {
+				$hash .= $password;
+			}
+			
+			if ($this->saltPosition === 'a') {
+				$hash .= $salt;
+			}
+			
+			$hash = $this->encrypt($hash);
+		}
+		else {
+			$hash = $this->encrypt($password);
+		}
+		
+		return $this->encrypt($salt . $hash);
+	}
+	
+	/**
+	 * Encrypts a given string with the used encryption method.
+	 */
+	private function encrypt(string $string): string {
+		switch ($this->encryptionMethod) {
+			case 'c':
+				return \crc32($string);
+				break;
+			
+			case 'm':
+				return \md5($string);
+				break;
+			
+			case 's':
+				return \sha1($string);
+				break;
+				
+			default: 
+				throw new \BadMethodCallException("Unknown encryption used");
+		}
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function needsRehash(string $hash): bool {
+		return false;
+	}
+}

--- a/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Wcf2.class.php
+++ b/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Wcf2.class.php
@@ -1,0 +1,47 @@
+<?php
+namespace wcf\system\user\authentication\password\algorithm;
+use wcf\system\user\authentication\password\IPasswordAlgorithm;
+
+/**
+ * Implementation of the password algorithm for WoltLab Community Framework 2.x (wcf2).
+ *
+ * @author	Joshua Ruesweg
+ * @copyright	2001-2020 WoltLab GmbH
+ * @license	GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @package	WoltLabSuite\Core\System\User\Authentication\Password\Algorithm
+ * @since	5.4
+ */
+final class Wcf2 implements IPasswordAlgorithm {
+	/**
+	 * @var DoubleBcrypt 
+	 */
+	private $doubleBcrypt;
+	
+	/**
+	 * Wcf2 constructor.
+	 */
+	public function __construct() {
+		$this->doubleBcrypt = new DoubleBcrypt();
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function verify(string $password, string $hash): bool {
+		return $this->doubleBcrypt->verify($password, $hash);
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function hash(string $password): string {
+		return $this->doubleBcrypt->hash($password);
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function needsRehash(string $hash): bool {
+		return $this->doubleBcrypt->needsRehash($hash);
+	}
+}

--- a/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Xf1.class.php
+++ b/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Xf1.class.php
@@ -1,0 +1,50 @@
+<?php
+namespace wcf\system\user\authentication\password\algorithm;
+use wcf\system\user\authentication\password\IPasswordAlgorithm;
+
+/**
+ * Implementation of the password algorithm for XenForo 1.0 / 1.1 (xf1).
+ *
+ * @author	Joshua Ruesweg
+ * @copyright	2001-2020 WoltLab GmbH
+ * @license	GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @package	WoltLabSuite\Core\System\User\Authentication\Password\Algorithm
+ * @since	5.4
+ */
+final class Xf1 implements IPasswordAlgorithm {
+	/**
+	 * @inheritDoc
+	 */
+	public function verify(string $password, string $hash): bool {
+		[$hash, $salt] = explode(':', $hash, 2);
+		
+		if (\hash_equals($hash, \sha1(\sha1($password) . $salt))) {
+			return true; 
+		}
+		
+		return \hash_equals($hash, $this->hashWithSalt($password, $salt));
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function hash(string $password): string {
+		$salt = \bin2hex(\random_bytes(20));
+		
+		return $this->hashWithSalt($password, $salt).':'.$salt;
+	}
+	
+	/**
+	 * Returns the hashed password, hashed with a given salt.
+	 */
+	private function hashWithSalt(string $password, string $salt): string {
+		return \hash('sha256', \hash('sha256', $password) . $salt);
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function needsRehash(string $hash): bool {
+		return false;
+	}
+}

--- a/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Xf1.class.php
+++ b/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Xf1.class.php
@@ -16,7 +16,7 @@ final class Xf1 implements IPasswordAlgorithm {
 	 * @inheritDoc
 	 */
 	public function verify(string $password, string $hash): bool {
-		[$hash, $salt] = explode(':', $hash, 2);
+		[$hash, $salt] = \explode(':', $hash, 2);
 		
 		if (\hash_equals($hash, \sha1(\sha1($password) . $salt))) {
 			return true; 

--- a/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Xf12.class.php
+++ b/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/Xf12.class.php
@@ -1,0 +1,47 @@
+<?php
+namespace wcf\system\user\authentication\password\algorithm;
+use wcf\system\user\authentication\password\IPasswordAlgorithm;
+
+/**
+ * Implementation of the password algorithm for XenForo 1.2+ (xf12).
+ *
+ * @author	Joshua Ruesweg
+ * @copyright	2001-2020 WoltLab GmbH
+ * @license	GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @package	WoltLabSuite\Core\System\User\Authentication\Password\Algorithm
+ * @since	5.4
+ */
+final class Xf12 implements IPasswordAlgorithm {
+	/**
+	 * @var Bcrypt
+	 */
+	private $bcrypt;
+	
+	/**
+	 * Wcf2 constructor.
+	 */
+	public function __construct() {
+		$this->bcrypt = new Bcrypt();
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function verify(string $password, string $hash): bool {
+		return $this->bcrypt->verify($password, $hash);
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function hash(string $password): string {
+		return $this->bcrypt->hash($password);
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function needsRehash(string $hash): bool {
+		return $this->bcrypt->needsRehash($hash);
+	}
+}

--- a/wcfsetup/install/files/lib/util/PasswordUtil.class.php
+++ b/wcfsetup/install/files/lib/util/PasswordUtil.class.php
@@ -430,13 +430,7 @@ final class PasswordUtil {
 	}
 	
 	/**
-	 * Validates the password hash for vBulletin 5 (vb5).
-	 * 
-	 * @param	string		$username
-	 * @param	string		$password
-	 * @param	string		$salt
-	 * @param	string		$dbHash
-	 * @return	boolean
+	 * @deprecated	5.4 - Use the new password algorithm framework in \wcf\system\user\authentication\password\*.
 	 */
 	protected static function vb5($username, $password, $salt, $dbHash) {
 		return self::vb3($username, $password, $salt, $dbHash);

--- a/wcfsetup/install/files/lib/util/PasswordUtil.class.php
+++ b/wcfsetup/install/files/lib/util/PasswordUtil.class.php
@@ -245,13 +245,7 @@ final class PasswordUtil {
 	}
 	
 	/**
-	 * Validates the password hash for Argon2 (argon2).
-	 * 
-	 * @param	string		$username
-	 * @param	string		$password
-	 * @param	string		$salt
-	 * @param	string		$dbHash
-	 * @return	boolean
+	 * @deprecated	5.4 - Use the new password algorithm framework in \wcf\system\user\authentication\password\*.
 	 */
 	protected static function argon2($username, $password, $salt, $dbHash) {
 		return password_verify($password, $dbHash);

--- a/wcfsetup/install/files/lib/util/PasswordUtil.class.php
+++ b/wcfsetup/install/files/lib/util/PasswordUtil.class.php
@@ -361,13 +361,7 @@ final class PasswordUtil {
 	}
 	
 	/**
-	 * Validates the password hash for Simple Machines Forums 1.x (smf1).
-	 * 
-	 * @param	string		$username
-	 * @param	string		$password
-	 * @param	string		$salt
-	 * @param	string		$dbHash
-	 * @return	boolean
+	 * @deprecated	5.4 - Use the new password algorithm framework in \wcf\system\user\authentication\password\*.
 	 */
 	protected static function smf1($username, $password, $salt, $dbHash) {
 		return \hash_equals($dbHash, sha1(mb_strtolower($username) . $password));

--- a/wcfsetup/install/files/lib/util/PasswordUtil.class.php
+++ b/wcfsetup/install/files/lib/util/PasswordUtil.class.php
@@ -509,13 +509,7 @@ final class PasswordUtil {
 	}
 	
 	/**
-	 * Validates the password hash for Joomla 1.x (kunea)
-	 * 
-	 * @param	string		$username
-	 * @param	string		$password
-	 * @param	string		$salt
-	 * @param	string		$dbHash
-	 * @return	boolean
+	 * @deprecated	5.4 - Use the new password algorithm framework in \wcf\system\user\authentication\password\*.
 	 */
 	protected static function joomla1($username, $password, $salt, $dbHash) {
 		if (\hash_equals($dbHash, md5($password . $salt))) {

--- a/wcfsetup/install/files/lib/util/PasswordUtil.class.php
+++ b/wcfsetup/install/files/lib/util/PasswordUtil.class.php
@@ -498,13 +498,7 @@ final class PasswordUtil {
 	}
 	
 	/**
-	 * Validates the password hash for XenForo 1.2+ (xf12).
-	 * 
-	 * @param	string		$username
-	 * @param	string		$password
-	 * @param	string		$salt
-	 * @param	string		$dbHash
-	 * @return	boolean
+	 * @deprecated	5.4 - Use the new password algorithm framework in \wcf\system\user\authentication\password\*.
 	 */
 	protected static function xf12($username, $password, $salt, $dbHash) {
 		if (\hash_equals($dbHash, self::getSaltedHash($password, $dbHash))) {

--- a/wcfsetup/install/files/lib/util/PasswordUtil.class.php
+++ b/wcfsetup/install/files/lib/util/PasswordUtil.class.php
@@ -545,13 +545,7 @@ final class PasswordUtil {
 	 }
 	
 	/**
-	 * Validates the password hash for MD5 mode of crypt()
-	 * 
-	 * @param	string		$username
-	 * @param	string		$password
-	 * @param	string		$salt
-	 * @param	string		$dbHash
-	 * @return	boolean
+	 * @deprecated	5.4 - Use the new password algorithm framework in \wcf\system\user\authentication\password\*.
 	 */
 	protected static function cryptMD5($username, $password, $salt, $dbHash) {
 		if (\hash_equals($dbHash, self::getSaltedHash($password, $dbHash))) {

--- a/wcfsetup/install/files/lib/util/PasswordUtil.class.php
+++ b/wcfsetup/install/files/lib/util/PasswordUtil.class.php
@@ -408,13 +408,7 @@ final class PasswordUtil {
 	}
 	
 	/**
-	 * Validates the password hash for WoltLab Burning Board 2 (wbb2).
-	 * 
-	 * @param	string		$username
-	 * @param	string		$password
-	 * @param	string		$salt
-	 * @param	string		$dbHash
-	 * @return	boolean
+	 * @deprecated	5.4 - Use the new password algorithm framework in \wcf\system\user\authentication\password\*.
 	 */
 	protected static function wbb2($username, $password, $salt, $dbHash) {
 		if (\hash_equals($dbHash, md5($password))) {

--- a/wcfsetup/install/files/lib/util/PasswordUtil.class.php
+++ b/wcfsetup/install/files/lib/util/PasswordUtil.class.php
@@ -429,13 +429,7 @@ final class PasswordUtil {
 	}
 	
 	/**
-	 * Validates the password hash for WoltLab Community Framework 1.x with different encryption (wcf1e).
-	 * 
-	 * @param	string		$type
-	 * @param	string		$password
-	 * @param	string		$salt
-	 * @param	string		$dbHash
-	 * @return	boolean
+	 * @deprecated	5.4 - Use the new password algorithm framework in \wcf\system\user\authentication\password\*.
 	 */
 	protected static function wcf1e($type, $password, $salt, $dbHash) {
 		preg_match('~^wcf1e([cms])([01])([ab])([01])$~', $type, $matches);

--- a/wcfsetup/install/files/lib/util/PasswordUtil.class.php
+++ b/wcfsetup/install/files/lib/util/PasswordUtil.class.php
@@ -271,27 +271,16 @@ final class PasswordUtil {
 	protected static function mybb1($username, $password, $salt, $dbHash) {
 		return \hash_equals($dbHash, md5(md5($salt) . md5($password)));
 	}
+	
 	/**
-	 * Validates the password hash for phpBB 3.x (phpbb3).
-	 * 
-	 * @param	string		$username
-	 * @param	string		$password
-	 * @param	string		$salt
-	 * @param	string		$dbHash
-	 * @return	boolean
+	 * @deprecated	5.4 - Use the new password algorithm framework in \wcf\system\user\authentication\password\*.
 	 */
 	protected static function phpbb3($username, $password, $salt, $dbHash) {
 		return self::phpass($username, $password, $salt, $dbHash);
 	}
 	
 	/**
-	 * Validates the password hash for phpass portable hashes (phpass).
-	 * 
-	 * @param	string		$username
-	 * @param	string		$password
-	 * @param	string		$salt
-	 * @param	string		$dbHash
-	 * @return	boolean
+	 * @deprecated	5.4 - Use the new password algorithm framework in \wcf\system\user\authentication\password\*.
 	 */
 	protected static function phpass($username, $password, $salt, $dbHash) {
 		if (mb_strlen($dbHash) !== 34) {

--- a/wcfsetup/install/files/lib/util/PasswordUtil.class.php
+++ b/wcfsetup/install/files/lib/util/PasswordUtil.class.php
@@ -705,13 +705,7 @@ final class PasswordUtil {
 	}
 	
 	/**
-	 * Returns false.
-	 * 
-	 * @param	string		$username
-	 * @param	string		$password
-	 * @param	string		$salt
-	 * @param	string		$dbHash
-	 * @return	boolean
+	 * @deprecated	5.4 - Use the new password algorithm framework in \wcf\system\user\authentication\password\*.
 	 */
 	protected static function invalid($username, $password, $salt, $dbHash) {
 		return false;

--- a/wcfsetup/install/files/lib/util/PasswordUtil.class.php
+++ b/wcfsetup/install/files/lib/util/PasswordUtil.class.php
@@ -266,13 +266,7 @@ final class PasswordUtil {
 	}
 	
 	/**
-	 * Validates the password hash for MyBB 1.x (mybb1).
-	 * 
-	 * @param	string		$username
-	 * @param	string		$password
-	 * @param	string		$salt
-	 * @param	string		$dbHash
-	 * @return	boolean
+	 * @deprecated	5.4 - Use the new password algorithm framework in \wcf\system\user\authentication\password\*.
 	 */
 	protected static function mybb1($username, $password, $salt, $dbHash) {
 		return \hash_equals($dbHash, md5(md5($salt) . md5($password)));

--- a/wcfsetup/install/files/lib/util/PasswordUtil.class.php
+++ b/wcfsetup/install/files/lib/util/PasswordUtil.class.php
@@ -423,13 +423,7 @@ final class PasswordUtil {
 	}
 	
 	/**
-	 * Validates the password hash for vBulletin 4 (vb4).
-	 * 
-	 * @param	string		$username
-	 * @param	string		$password
-	 * @param	string		$salt
-	 * @param	string		$dbHash
-	 * @return	boolean
+	 * @deprecated	5.4 - Use the new password algorithm framework in \wcf\system\user\authentication\password\*.
 	 */
 	protected static function vb4($username, $password, $salt, $dbHash) {
 		return self::vb3($username, $password, $salt, $dbHash);

--- a/wcfsetup/install/files/lib/util/PasswordUtil.class.php
+++ b/wcfsetup/install/files/lib/util/PasswordUtil.class.php
@@ -520,13 +520,7 @@ final class PasswordUtil {
 	}
 	
 	/**
-	 * Validates the password hash for Joomla 2.x (kunea)
-	 * 
-	 * @param	string		$username
-	 * @param	string		$password
-	 * @param	string		$salt
-	 * @param	string		$dbHash
-	 * @return	boolean
+	 * @deprecated	5.4 - Use the new password algorithm framework in \wcf\system\user\authentication\password\*.
 	 */
 	protected static function joomla2($username, $password, $salt, $dbHash) {
 		return self::joomla1($username, $password, $salt, $dbHash);

--- a/wcfsetup/install/files/lib/util/PasswordUtil.class.php
+++ b/wcfsetup/install/files/lib/util/PasswordUtil.class.php
@@ -20,8 +20,7 @@ final class PasswordUtil {
 	const PASSWORD_CHARSET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
 
 	/**
-	 * concated list of valid blowfish salt characters
-	 * @var	string
+	 * @deprecated	5.4 - Use the new password algorithm framework in \wcf\system\user\authentication\password\*.
 	 */
 	private static $blowfishCharacters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789./';
 	
@@ -55,14 +54,12 @@ final class PasswordUtil {
 	];
 	
 	/**
-	 * blowfish cost factor
-	 * @var	string
+	 * @deprecated	5.4 - Use the new password algorithm framework in \wcf\system\user\authentication\password\*.
 	 */
 	const BCRYPT_COST = '08';
 	
 	/**
-	 * blowfish encryption type
-	 * @var	string
+	 * @deprecated	5.4 - Use the new password algorithm framework in \wcf\system\user\authentication\password\*.
 	 */
 	const BCRYPT_TYPE = '2a';
 	
@@ -85,20 +82,14 @@ final class PasswordUtil {
 	}
 	
 	/**
-	 * Returns true if given hash looks like a valid bcrypt hash.
-	 * 
-	 * @param	string		$hash
-	 * @return	boolean
+	 * @deprecated	5.4 - Use the new password algorithm framework in \wcf\system\user\authentication\password\*.
 	 */
 	public static function isBlowfish($hash) {
 		return (Regex::compile('^\$2[afxy]\$')->match($hash) ? true : false);
 	}
 	
 	/**
-	 * Returns true if given bcrypt hash uses a different cost factor and should be re-computed.
-	 * 
-	 * @param	string		$hash
-	 * @return	boolean
+	 * @deprecated	5.4 - Use the new password algorithm framework in \wcf\system\user\authentication\password\*.
 	 */
 	public static function isDifferentBlowfish($hash) {
 		$currentCost = intval(self::BCRYPT_COST);
@@ -167,11 +158,7 @@ final class PasswordUtil {
 	}
 	
 	/**
-	 * Returns a double salted bcrypt hash.
-	 * 
-	 * @param	string		$password
-	 * @param	string		$salt
-	 * @return	string
+	 * @deprecated	5.4 - Use the new password algorithm framework in \wcf\system\user\authentication\password\*.
 	 */
 	public static function getDoubleSaltedHash($password, $salt = null) {
 		if ($salt === null) {
@@ -182,11 +169,7 @@ final class PasswordUtil {
 	}
 	
 	/**
-	 * Returns a simple salted bcrypt hash.
-	 * 
-	 * @param	string		$password
-	 * @param	string		$salt
-	 * @return	string
+	 * @deprecated	5.4 - Use the new password algorithm framework in \wcf\system\user\authentication\password\*.
 	 */
 	public static function getSaltedHash($password, $salt = null) {
 		if ($salt === null) {
@@ -197,9 +180,7 @@ final class PasswordUtil {
 	}
 	
 	/**
-	 * Returns a random blowfish-compatible salt.
-	 * 
-	 * @return	string
+	 * @deprecated	5.4 - Use the new password algorithm framework in \wcf\system\user\authentication\password\*.
 	 */
 	public static function getRandomSalt() {
 		$salt = '';
@@ -229,12 +210,6 @@ final class PasswordUtil {
 	}
 	
 	/**
-	 * Compares two strings in a constant time manner.
-	 * This function effectively is a polyfill for the PHP 5.6 `hash_equals`.
-	 *
-	 * @param	string		$hash1
-	 * @param	string		$hash2
-	 * @return	boolean
 	 * @deprecated	Use \wcf\util\CryptoUtil::secureCompare()
 	 */
 	public static function secureCompare($hash1, $hash2) {
@@ -261,10 +236,7 @@ final class PasswordUtil {
 	}
 	
 	/**
-	 * Returns a blowfish salt, e.g. $2a$07$usesomesillystringforsalt$
-	 * 
-	 * @param	string		$salt
-	 * @return	string
+	 * @deprecated	5.4 - Use the new password algorithm framework in \wcf\system\user\authentication\password\*.
 	 */
 	protected static function getSalt($salt) {
 		$salt = mb_substr($salt, 0, 22);

--- a/wcfsetup/install/files/lib/util/PasswordUtil.class.php
+++ b/wcfsetup/install/files/lib/util/PasswordUtil.class.php
@@ -534,15 +534,7 @@ final class PasswordUtil {
 	}
 	
 	/**
-	 * Validates the password hash for phpFox 3.x
-	 * Merge phpfox_user.password and phpfox_user.password_salt with ':' before importing all data row values
-	 * See PasswordUtil::checkPassword() for more info
-	 * 
-	 * @param	string		$username
-	 * @param	string		$password
-	 * @param	string		$salt
-	 * @param	string		$dbHash
-	 * @return	boolean
+	 * @deprecated	5.4 - Use the new password algorithm framework in \wcf\system\user\authentication\password\*.
 	 */
 	 protected static function phpfox3($username, $password, $salt, $dbHash) {
 		 if (\hash_equals($dbHash, md5(md5($password) . md5($salt)))) {

--- a/wcfsetup/install/files/lib/util/PasswordUtil.class.php
+++ b/wcfsetup/install/files/lib/util/PasswordUtil.class.php
@@ -259,13 +259,7 @@ final class PasswordUtil {
 	}
 	
 	/**
-	 * Validates the password hash for Invision Power Board 3.x (ipb3).
-	 * 
-	 * @param	string		$username
-	 * @param	string		$password
-	 * @param	string		$salt
-	 * @param	string		$dbHash
-	 * @return	boolean
+	 * @deprecated	5.4 - Use the new password algorithm framework in \wcf\system\user\authentication\password\*.
 	 */
 	protected static function ipb3($username, $password, $salt, $dbHash) {
 		return \hash_equals($dbHash, md5(md5($salt) . md5($password)));

--- a/wcfsetup/install/files/lib/util/PasswordUtil.class.php
+++ b/wcfsetup/install/files/lib/util/PasswordUtil.class.php
@@ -487,13 +487,7 @@ final class PasswordUtil {
 	}
 	
 	/**
-	 * Validates the password hash for XenForo 1.0 / 1.1 (xf1).
-	 * 
-	 * @param	string		$username
-	 * @param	string		$password
-	 * @param	string		$salt
-	 * @param	string		$dbHash
-	 * @return	boolean
+	 * @deprecated	5.4 - Use the new password algorithm framework in \wcf\system\user\authentication\password\*.
 	 */
 	protected static function xf1($username, $password, $salt, $dbHash) {
 		if (\hash_equals($dbHash, sha1(sha1($password) . $salt))) {

--- a/wcfsetup/install/files/lib/util/PasswordUtil.class.php
+++ b/wcfsetup/install/files/lib/util/PasswordUtil.class.php
@@ -422,13 +422,7 @@ final class PasswordUtil {
 	}
 	
 	/**
-	 * Validates the password hash for WoltLab Community Framework 1.x (wcf1).
-	 * 
-	 * @param	string		$username
-	 * @param	string		$password
-	 * @param	string		$salt
-	 * @param	string		$dbHash
-	 * @return	boolean
+	 * @deprecated	5.4 - Use the new password algorithm framework in \wcf\system\user\authentication\password\*.
 	 */
 	protected static function wcf1($username, $password, $salt, $dbHash) {
 		return \hash_equals($dbHash, sha1($salt . sha1($salt . sha1($password))));

--- a/wcfsetup/install/files/lib/util/PasswordUtil.class.php
+++ b/wcfsetup/install/files/lib/util/PasswordUtil.class.php
@@ -368,13 +368,7 @@ final class PasswordUtil {
 	}
 	
 	/**
-	 * Validates the password hash for Simple Machines Forums 2.x (smf2).
-	 * 
-	 * @param	string		$username
-	 * @param	string		$password
-	 * @param	string		$salt
-	 * @param	string		$dbHash
-	 * @return	boolean
+	 * @deprecated	5.4 - Use the new password algorithm framework in \wcf\system\user\authentication\password\*.
 	 */
 	protected static function smf2($username, $password, $salt, $dbHash) {
 		return self::smf1($username, $password, $salt, $dbHash);

--- a/wcfsetup/install/files/lib/util/PasswordUtil.class.php
+++ b/wcfsetup/install/files/lib/util/PasswordUtil.class.php
@@ -416,13 +416,7 @@ final class PasswordUtil {
 	}
 	
 	/**
-	 * Validates the password hash for vBulletin 3 (vb3).
-	 * 
-	 * @param	string		$username
-	 * @param	string		$password
-	 * @param	string		$salt
-	 * @param	string		$dbHash
-	 * @return	boolean
+	 * @deprecated	5.4 - Use the new password algorithm framework in \wcf\system\user\authentication\password\*.
 	 */
 	protected static function vb3($username, $password, $salt, $dbHash) {
 		return \hash_equals($dbHash, md5(md5($password) . $salt));

--- a/wcfsetup/install/files/lib/util/PasswordUtil.class.php
+++ b/wcfsetup/install/files/lib/util/PasswordUtil.class.php
@@ -252,13 +252,7 @@ final class PasswordUtil {
 	}
 	
 	/**
-	 * Validates the password hash for Invision Power Board 2.x (ipb2).
-	 * 
-	 * @param	string		$username
-	 * @param	string		$password
-	 * @param	string		$salt
-	 * @param	string		$dbHash
-	 * @return	boolean
+	 * @deprecated	5.4 - Use the new password algorithm framework in \wcf\system\user\authentication\password\*.
 	 */
 	protected static function ipb2($username, $password, $salt, $dbHash) {
 		return self::vb3($username, $password, $salt, $dbHash);

--- a/wcfsetup/install/files/lib/util/PasswordUtil.class.php
+++ b/wcfsetup/install/files/lib/util/PasswordUtil.class.php
@@ -480,13 +480,7 @@ final class PasswordUtil {
 	}
 	
 	/**
-	 * Validates the password hash for Woltlab Suite 3.x / WoltLab Community Framework 2.x (wcf2).
-	 * 
-	 * @param	string		$username
-	 * @param	string		$password
-	 * @param	string		$salt
-	 * @param	string		$dbHash
-	 * @return	boolean
+	 * @deprecated	5.4 - Use the new password algorithm framework in \wcf\system\user\authentication\password\*.
 	 */
 	protected static function wcf2($username, $password, $salt, $dbHash) {
 		return \hash_equals($dbHash, self::getDoubleSaltedHash($password, $dbHash));

--- a/wcfsetup/install/files/lib/util/PasswordUtil.class.php
+++ b/wcfsetup/install/files/lib/util/PasswordUtil.class.php
@@ -527,13 +527,7 @@ final class PasswordUtil {
 	}
 	
 	/**
-	 * Validates the password hash for Joomla 3.x (kunea)
-	 * 
-	 * @param	string		$username
-	 * @param	string		$password
-	 * @param	string		$salt
-	 * @param	string		$dbHash
-	 * @return	boolean
+	 * @deprecated	5.4 - Use the new password algorithm framework in \wcf\system\user\authentication\password\*.
 	 */
 	protected static function joomla3($username, $password, $salt, $dbHash) {
 		return self::joomla1($username, $password, $salt, $dbHash);


### PR DESCRIPTION
This PR adds a new password hashing framework based on dedicated classes for each algorithm. The interface is modeled after the `password_*` API.

Additionally this PR changes the default password hashing algorithm to regular BCrypt with cost 10, using the `password_*` API. The use of "double salted" BCrypt has its origins in the old automated login functionality that was removed in #3574.

What's missing:

- [x] Migrating the other password algorithms from `PasswordUtil`.