### PR TITLE
Fixed regex in item lists

### DIFF
--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/ItemList.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/ItemList.js
@@ -110,7 +110,7 @@ define(['Core', 'Dictionary', 'Language', 'Dom/Traverse', 'EventKey', 'WoltLabSu
 							for (var i = 0, length = values.length; i < length; i++) {
 								input = elCreate('input');
 								input.type = 'hidden';
-								input.name = options.submitFieldName.replace(/\{\$objectId\}/, values[i].objectId);
+								input.name = options.submitFieldName.replace('{$objectId}', values[i].objectId);
 								input.value = values[i].value;
 								
 								form.appendChild(input);

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/ItemList.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/ItemList.js
@@ -110,7 +110,7 @@ define(['Core', 'Dictionary', 'Language', 'Dom/Traverse', 'EventKey', 'WoltLabSu
 							for (var i = 0, length = values.length; i < length; i++) {
 								input = elCreate('input');
 								input.type = 'hidden';
-								input.name = options.submitFieldName.replace(/{$objectId}/, values[i].objectId);
+								input.name = options.submitFieldName.replace(/{\$objectId}/, values[i].objectId);
 								input.value = values[i].value;
 								
 								form.appendChild(input);

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/ItemList.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/ItemList.js
@@ -110,7 +110,7 @@ define(['Core', 'Dictionary', 'Language', 'Dom/Traverse', 'EventKey', 'WoltLabSu
 							for (var i = 0, length = values.length; i < length; i++) {
 								input = elCreate('input');
 								input.type = 'hidden';
-								input.name = options.submitFieldName.replace(/{\$objectId}/, values[i].objectId);
+								input.name = options.submitFieldName.replace(/\{\$objectId\}/, values[i].objectId);
 								input.value = values[i].value;
 								
 								form.appendChild(input);

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/ItemList/Static.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/ItemList/Static.js
@@ -88,7 +88,7 @@ define(['Core', 'Dictionary', 'Language', 'Dom/Traverse', 'EventKey', 'Ui/Simple
 							for (var i = 0, length = values.length; i < length; i++) {
 								input = elCreate('input');
 								input.type = 'hidden';
-								input.name = options.submitFieldName.replace(/{\$objectId}/, values[i].objectId);
+								input.name = options.submitFieldName.replace(/\{\$objectId\}/, values[i].objectId);
 								input.value = values[i].value;
 								
 								form.appendChild(input);

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/ItemList/Static.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/ItemList/Static.js
@@ -88,7 +88,7 @@ define(['Core', 'Dictionary', 'Language', 'Dom/Traverse', 'EventKey', 'Ui/Simple
 							for (var i = 0, length = values.length; i < length; i++) {
 								input = elCreate('input');
 								input.type = 'hidden';
-								input.name = options.submitFieldName.replace(/{$objectId}/, values[i].objectId);
+								input.name = options.submitFieldName.replace(/{\$objectId}/, values[i].objectId);
 								input.value = values[i].value;
 								
 								form.appendChild(input);

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/ItemList/Static.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/ItemList/Static.js
@@ -88,7 +88,7 @@ define(['Core', 'Dictionary', 'Language', 'Dom/Traverse', 'EventKey', 'Ui/Simple
 							for (var i = 0, length = values.length; i < length; i++) {
 								input = elCreate('input');
 								input.type = 'hidden';
-								input.name = options.submitFieldName.replace(/\{\$objectId\}/, values[i].objectId);
+								input.name = options.submitFieldName.replace('{$objectId}', values[i].objectId);
 								input.value = values[i].value;
 								
 								form.appendChild(input);


### PR DESCRIPTION
Added escape character before `$` to match the expected purpose of the variable `{$objectId}` in `submitFieldName` in ItemList and StaticItemList