### PR TITLE
Create user group option values during group import

### DIFF
--- a/wcfsetup/install/files/lib/system/importer/UserGroupImporter.class.php
+++ b/wcfsetup/install/files/lib/system/importer/UserGroupImporter.class.php
@@ -3,6 +3,7 @@ namespace wcf\system\importer;
 use wcf\data\user\group\UserGroup;
 use wcf\data\user\group\UserGroupAction;
 use wcf\data\user\group\UserGroupEditor;
+use wcf\system\option\user\group\UserGroupOptionHandler;
 
 /**
  * Imports user groups.
@@ -32,7 +33,8 @@ class UserGroupImporter extends AbstractImporter {
 			}
 			
 			$action = new UserGroupAction([], 'create', [
-				'data' => $data
+				'data' => $data,
+				'options' => $this->getOptionHandler()->save(),
 			]);
 			$returnValues = $action->executeAction();
 			$group = $returnValues['returnValues'];
@@ -74,5 +76,13 @@ class UserGroupImporter extends AbstractImporter {
 		ImportHandler::getInstance()->saveNewID('com.woltlab.wcf.user.group', $oldID, $newGroupID);
 		
 		return $newGroupID;
+	}
+	
+	protected function getOptionHandler() {
+		$optionHandler = new UserGroupOptionHandler(false, '', '');
+		$optionHandler->init();
+		$optionHandler->readData();
+		
+		return $optionHandler;
 	}
 }


### PR DESCRIPTION
Tested locally by doing the following:

- Import the installation into itself: No user group option values for the new
  group.
- Update UserGroupImporter.
- Import the installation into itself again: Now user group option values are
  created.

I can confirm that some groups show an empty string in UserGroupOptionForm and
other groups show the default value.

-------------

Resolves #3534
