### PR TITLE
Add permissions for attachments in signatures

### DIFF
--- a/com.woltlab.wcf/userGroupOption.xml
+++ b/com.woltlab.wcf/userGroupOption.xml
@@ -694,6 +694,7 @@ bmp</defaultvalue>
 				<defaultvalue>10</defaultvalue>
 				<minvalue>1</minvalue>
 				<maxvalue>100</maxvalue>
+				<options>module_user_signature</options>
 			</option>
 			<!-- /user.signature -->
 			<!-- user.profile -->

--- a/com.woltlab.wcf/userGroupOption.xml
+++ b/com.woltlab.wcf/userGroupOption.xml
@@ -668,6 +668,7 @@ pdf</defaultvalue>
 				<optiontype>boolean</optiontype>
 				<defaultvalue>1</defaultvalue>
 				<usersonly>1</usersonly>
+				<enableoptions>user.signature.attachment.maxSize,user.signature.attachment.allowedExtensions,user.signature.attachment.maxCount</enableoptions>
 				<options>module_user_signature</options>
 			</option>
 			<option name="user.signature.attachment.maxSize">

--- a/com.woltlab.wcf/userGroupOption.xml
+++ b/com.woltlab.wcf/userGroupOption.xml
@@ -663,6 +663,38 @@ pdf</defaultvalue>
 				<options>module_user_signature</options>
 				<usersonly>1</usersonly>
 			</option>
+			<option name="user.signature.attachment.canUpload">
+				<categoryname>user.signature</categoryname>
+				<optiontype>boolean</optiontype>
+				<defaultvalue>1</defaultvalue>
+				<usersonly>1</usersonly>
+				<options>module_user_signature</options>
+			</option>
+			<option name="user.signature.attachment.maxSize">
+				<categoryname>user.signature</categoryname>
+				<optiontype>fileSize</optiontype>
+				<defaultvalue>2000000</defaultvalue>
+				<minvalue>10000</minvalue>
+				<options>module_user_signature</options>
+			</option>
+			<option name="user.signature.attachment.allowedExtensions">
+				<categoryname>user.signature</categoryname>
+				<optiontype>textarea</optiontype>
+				<defaultvalue>gif
+jpg
+jpeg
+png
+bmp</defaultvalue>
+				<wildcard>*</wildcard>
+				<options>module_user_signature</options>
+			</option>
+			<option name="user.signature.attachment.maxCount">
+				<categoryname>user.signature</categoryname>
+				<optiontype>integer</optiontype>
+				<defaultvalue>10</defaultvalue>
+				<minvalue>1</minvalue>
+				<maxvalue>100</maxvalue>
+			</option>
 			<!-- /user.signature -->
 			<!-- user.profile -->
 			<option name="user.profile.canChangeEmail">

--- a/wcfsetup/install/files/lib/system/attachment/SignatureAttachmentObjectType.class.php
+++ b/wcfsetup/install/files/lib/system/attachment/SignatureAttachmentObjectType.class.php
@@ -3,6 +3,7 @@ namespace wcf\system\attachment;
 use wcf\data\user\UserProfile;
 use wcf\system\cache\runtime\UserProfileRuntimeCache;
 use wcf\system\WCF;
+use wcf\util\ArrayUtil;
 
 /**
  * Attachment object type implementation for posts.
@@ -49,13 +50,15 @@ class SignatureAttachmentObjectType extends AbstractAttachmentObjectType {
 			return false;
 		}
 		
-		$userProfile = UserProfileRuntimeCache::getInstance()->getObject($objectID);
-		
 		if (!MODULE_USER_SIGNATURE) {
 			return false;
 		}
 		
+		$userProfile = UserProfileRuntimeCache::getInstance()->getObject($objectID);
 		if ($userProfile->disableSignature) {
+			return false;
+		}
+		if (!$userProfile->getPermission('user.signature.attachment.canUpload')) {
 			return false;
 		}
 		
@@ -74,6 +77,27 @@ class SignatureAttachmentObjectType extends AbstractAttachmentObjectType {
 	 */
 	public function cacheObjects(array $objectIDs) {
 		$this->setCachedObjects(UserProfileRuntimeCache::getInstance()->getObjects($objectIDs));
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function getMaxSize() {
+		return WCF::getSession()->getPermission('user.signature.attachment.maxSize');
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function getAllowedExtensions() {
+		return ArrayUtil::trim(explode("\n", WCF::getSession()->getPermission('user.signature.attachment.allowedExtensions')));
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function getMaxCount() {
+		return WCF::getSession()->getPermission('user.signature.attachment.maxCount');
 	}
 	
 	/** @noinspection PhpMissingParentCallCommonInspection */

--- a/wcfsetup/install/lang/de.xml
+++ b/wcfsetup/install/lang/de.xml
@@ -904,6 +904,11 @@ ACHTUNG: Die oben genannten Meldungen sind stark gekürzt. Sie können Details z
 		<item name="wcf.acp.group.promoteOwner"><![CDATA[Besitzer-Gruppe festlegen]]></item>
 		<item name="wcf.acp.group.promoteOwner.group"><![CDATA[Besitzer-Gruppe auswählen]]></item>
 		<item name="wcf.acp.group.promoteOwner.warning"><![CDATA[Die Besitzer-Gruppe kann, einmal festgelegt, nicht mehr geändert werden. Diese Gruppe verfügt über besondere Berechtigungen und wird vor Änderungen durch andere Gruppen geschützt, Mitglieder dieser Gruppe können nicht mehr gesperrt werden.]]></item>
+		<item name="wcf.acp.group.option.user.signature.attachment.canUpload"><![CDATA[Kann Dateianhänge hochladen]]></item>
+		<item name="wcf.acp.group.option.user.signature.attachment.maxSize"><![CDATA[Maximale Dateianhangsgröße]]></item>
+		<item name="wcf.acp.group.option.user.signature.attachment.allowedExtensions"><![CDATA[Erlaubte Dateiendungen]]></item>
+		<item name="wcf.acp.group.option.user.signature.attachment.allowedExtensions.description"><![CDATA[Eine Dateiendung pro Zeile]]></item>
+		<item name="wcf.acp.group.option.user.signature.attachment.maxCount"><![CDATA[Maximale Dateianhänge]]></item>
 	</category>
 	<category name="wcf.acp.index">
 		<item name="wcf.acp.index.credits"><![CDATA[Über WoltLab Suite&trade;]]></item>

--- a/wcfsetup/install/lang/en.xml
+++ b/wcfsetup/install/lang/en.xml
@@ -881,6 +881,11 @@ ATTENTION: The messages listed above are greatly shortened. You can view details
 		<item name="wcf.acp.group.promoteOwner"><![CDATA[Set Up the Owner Group]]></item>
 		<item name="wcf.acp.group.promoteOwner.group"><![CDATA[Select the owner group]]></item>
 		<item name="wcf.acp.group.promoteOwner.warning"><![CDATA[The owner group cannot be modified once it has been set up. This group has special privileges and is protected from modifications by any other group, its members cannot be banned.]]></item>
+		<item name="wcf.acp.group.option.user.signature.attachment.canUpload"><![CDATA[Can Upload Attachments]]></item>
+		<item name="wcf.acp.group.option.user.signature.attachment.maxSize"><![CDATA[Maximum Attachment File Size]]></item>
+		<item name="wcf.acp.group.option.user.signature.attachment.allowedExtensions"><![CDATA[Allowed Attachment File Extensions]]></item>
+		<item name="wcf.acp.group.option.user.signature.attachment.allowedExtensions.description"><![CDATA[Enter one extension per line.]]></item>
+		<item name="wcf.acp.group.option.user.signature.attachment.maxCount"><![CDATA[Maximum Attachments]]></item>
 	</category>
 	<category name="wcf.acp.index">
 		<item name="wcf.acp.index.credits"><![CDATA[About WoltLab Suite&trade;]]></item>


### PR DESCRIPTION
Close #3675

Compared to the default message permission, I removed `zip`, `txt`, and `pdf` as default allowed file extensions.