### PR TITLE
Remove calls to SessionHandler::resetSessions()

### DIFF
--- a/wcfsetup/install/files/acp/install.php
+++ b/wcfsetup/install/files/acp/install.php
@@ -1,5 +1,5 @@
 <?php
-use wcf\system\session\SessionHandler;
+use wcf\system\user\storage\UserStorageHandler;
 use wcf\system\WCF;
 use wcf\util\DateUtil;
 
@@ -15,8 +15,8 @@ $sql = "UPDATE	wcf".WCF_N."_package_installation_plugin
 $statement = WCF::getDB()->prepareStatement($sql);
 $statement->execute([1]);
 
-// reset sessions
-SessionHandler::resetSessions();
+// Clear any outdated cached data from WCFSetup.
+UserStorageHandler::getInstance()->clear();
 
 // update acp templates
 $sql = "UPDATE	wcf".WCF_N."_acp_template

--- a/wcfsetup/install/files/lib/acp/form/UserAssignToGroupForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/UserAssignToGroupForm.class.php
@@ -144,7 +144,6 @@ class UserAssignToGroupForm extends AbstractForm {
 		}
 		
 		ClipboardHandler::getInstance()->removeItems($this->objectTypeID);
-		SessionHandler::resetSessions($this->userIDs);
 		
 		$this->saved();
 		

--- a/wcfsetup/install/files/lib/acp/form/UserMergeForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/UserMergeForm.class.php
@@ -3,12 +3,12 @@ namespace wcf\acp\form;
 use wcf\data\object\type\ObjectTypeCache;
 use wcf\data\user\User;
 use wcf\data\user\UserAction;
+use wcf\data\user\UserEditor;
 use wcf\form\AbstractForm;
 use wcf\system\clipboard\ClipboardHandler;
 use wcf\system\database\util\PreparedStatementConditionBuilder;
 use wcf\system\exception\IllegalLinkException;
 use wcf\system\exception\UserInputException;
-use wcf\system\session\SessionHandler;
 use wcf\system\WCF;
 
 /**
@@ -259,7 +259,7 @@ class UserMergeForm extends AbstractForm {
 		
 		// reset clipboard
 		ClipboardHandler::getInstance()->removeItems($this->objectTypeID);
-		SessionHandler::resetSessions($this->userIDs);
+		UserEditor::resetCache();
 		$this->saved();
 		
 		// show success message

--- a/wcfsetup/install/files/lib/data/user/UserEditor.class.php
+++ b/wcfsetup/install/files/lib/data/user/UserEditor.class.php
@@ -6,9 +6,9 @@ use wcf\data\DatabaseObjectEditor;
 use wcf\data\IEditableCachedObject;
 use wcf\system\clipboard\ClipboardHandler;
 use wcf\system\language\LanguageFactory;
-use wcf\system\session\SessionHandler;
 use wcf\system\user\authentication\password\algorithm\Invalid as InvalidPasswordAlgorithm;
 use wcf\system\user\authentication\password\PasswordAlgorithmManager;
+use wcf\system\user\storage\UserStorageHandler;
 use wcf\system\WCF;
 
 /**
@@ -290,6 +290,7 @@ class UserEditor extends DatabaseObjectEditor implements IEditableCachedObject {
 	 * @inheritDoc
 	 */
 	public static function resetCache() {
-		SessionHandler::resetSessions();
+		UserStorageHandler::getInstance()->resetAll('groupIDs');
+		UserStorageHandler::getInstance()->resetAll('languageIDs');
 	}
 }

--- a/wcfsetup/install/files/lib/data/user/group/UserGroupEditor.class.php
+++ b/wcfsetup/install/files/lib/data/user/group/UserGroupEditor.class.php
@@ -5,7 +5,7 @@ use wcf\data\IEditableCachedObject;
 use wcf\system\cache\builder\UserGroupCacheBuilder;
 use wcf\system\cache\builder\UserGroupPermissionCacheBuilder;
 use wcf\system\exception\SystemException;
-use wcf\system\session\SessionHandler;
+use wcf\system\user\storage\UserStorageHandler;
 use wcf\system\WCF;
 
 /**
@@ -181,11 +181,11 @@ class UserGroupEditor extends DatabaseObjectEditor implements IEditableCachedObj
 	 * @inheritDoc
 	 */
 	public static function resetCache() {
-		// clear cache
+		// Clear group cache.
 		UserGroupCacheBuilder::getInstance()->reset();
 		UserGroupPermissionCacheBuilder::getInstance()->reset();
 		
-		// clear sessions
-		SessionHandler::resetSessions();
+		// Clear cached group assignments.
+		UserStorageHandler::getInstance()->resetAll('groupIDs');
 	}
 }


### PR DESCRIPTION
I did not yet adjust the usage in SessionHandler, because I am not entirely
sure whether the reset of the user storage is even required when deleting a
session. My hunch is that it's a very old relict of times that are long over,
but I want to make sure.

For the files that I adjusted it's a very clear case, though. The explicit
reset of the appropriate data is much cleaner and easier to understand.

This is related to #3647.

-------

- Remove call to SessionHandler::resetSessions() from UserAssignToGroupForm
- Remove call to SessionHandler::resetSessions() from UserGroupEditor
- Remove call to SessionHandler::resetSessions() from acp/install.php
- Remove call to SessionHandler::resetSessions() from UserEditor
- Remove call to SessionHandler::resetSessions() from UserMergeForm
