### PR TITLE
Improved detection of empty option categories

### DIFF
--- a/wcfsetup/install/files/lib/system/menu/user/UserMenu.class.php
+++ b/wcfsetup/install/files/lib/system/menu/user/UserMenu.class.php
@@ -44,7 +44,7 @@ class UserMenu extends TreeMenu {
 		// Hide links to user option categories without accessible options.
 		if (strpos($item->menuItem, 'wcf.user.option.category.') === 0) {
 			$categoryName = str_replace('wcf.user.option.category.', '', $item->menuItem);
-			if (empty($this->optionHandler->getOptionTree($categoryName))) {
+			if (!$this->optionHandler->countCategoryOptions($categoryName)) {
 				return false;
 			}
 		}

--- a/wcfsetup/install/files/lib/system/option/OptionHandler.class.php
+++ b/wcfsetup/install/files/lib/system/option/OptionHandler.class.php
@@ -247,6 +247,35 @@ class OptionHandler implements IOptionHandler {
 	}
 	
 	/**
+	 * Counts the number of options in a specific option category.
+	 *
+	 * @param	string		$categoryName
+	 * @param	bool		$inherit
+	 * @return	int
+	 */
+	public function countCategoryOptions($categoryName = '', $inherit = true) {
+		$count = 0;
+		
+		if ($inherit && isset($this->cachedCategoryStructure[$categoryName])) {
+			foreach ($this->cachedCategoryStructure[$categoryName] as $subCategoryName) {
+				$count += $this->countCategoryOptions($subCategoryName);
+			}
+		}
+		
+		if ($categoryName !== '') {
+			if (isset($this->cachedOptionToCategories[$categoryName])) {
+				foreach ($this->cachedOptionToCategories[$categoryName] as $optionName) {
+					if (isset($this->options[$optionName]) && $this->checkOption($this->options[$optionName])) {
+						$count++;
+					}
+				}
+			}
+		}
+		
+		return $count;
+	}
+	
+	/**
 	 * @inheritDoc
 	 */
 	public function readData() {

--- a/wcfsetup/install/files/lib/system/option/OptionHandler.class.php
+++ b/wcfsetup/install/files/lib/system/option/OptionHandler.class.php
@@ -250,13 +250,12 @@ class OptionHandler implements IOptionHandler {
 	 * Counts the number of options in a specific option category.
 	 *
 	 * @param	string		$categoryName
-	 * @param	bool		$inherit
 	 * @return	int
 	 */
-	public function countCategoryOptions($categoryName = '', $inherit = true) {
+	public function countCategoryOptions($categoryName = '') {
 		$count = 0;
 		
-		if ($inherit && isset($this->cachedCategoryStructure[$categoryName])) {
+		if (isset($this->cachedCategoryStructure[$categoryName])) {
 			foreach ($this->cachedCategoryStructure[$categoryName] as $subCategoryName) {
 				$count += $this->countCategoryOptions($subCategoryName);
 			}


### PR DESCRIPTION
https://github.com/WoltLab/WCF/commit/f2d501fbb987b18576c80c1e38a36fa4225e8d51 took care of hiding empty options categories. Unfortunately, this was inefficient as it resulted in calling IOptionType::getFormElement() for all options on every page load.