### PR TITLE
Refactor OAuth 2 login

### DIFF
--- a/com.woltlab.wcf/templates/accountManagement.tpl
+++ b/com.woltlab.wcf/templates/accountManagement.tpl
@@ -209,7 +209,7 @@
 						<dl>
 							<dt>{lang}wcf.user.3rdparty.github{/lang}</dt>
 							<dd>
-								{if $__wcf->getSession()->getVar('__githubToken')}
+								{if $__wcf->session->getVar('__3rdPartyProvider') === 'github' && $__wcf->session->getVar('__oauthUser')}
 									<label><input type="checkbox" name="githubConnect" value="1"{if $githubConnect} checked{/if}> {lang}wcf.user.3rdparty.github.connect{/lang}</label>
 								{else}
 									<a href="{link controller='GithubAuth'}{/link}" class="thirdPartyLoginButton githubLoginButton button"><span class="icon icon24 fa-github"></span> <span>{lang}wcf.user.3rdparty.github.connect{/lang}</span></a>
@@ -235,7 +235,7 @@
 						<dl>
 							<dt>{lang}wcf.user.3rdparty.facebook{/lang}</dt>
 							<dd>
-								{if $__wcf->getSession()->getVar('__facebookData')}
+								{if $__wcf->session->getVar('__3rdPartyProvider') === 'facebook' && $__wcf->session->getVar('__oauthUser')}
 									<label><input type="checkbox" name="facebookConnect" value="1"{if $facebookConnect} checked{/if}> {lang}wcf.user.3rdparty.facebook.connect{/lang}</label>
 								{else}
 									<a href="{link controller='FacebookAuth'}{/link}" class="thirdPartyLoginButton facebookLoginButton button"><span class="icon icon24 fa-facebook"></span> <span>{lang}wcf.user.3rdparty.facebook.connect{/lang}</span></a>
@@ -248,7 +248,7 @@
 						<dl>
 							<dt>{lang}wcf.user.3rdparty.google{/lang}</dt>
 							<dd>
-								{if $__wcf->getSession()->getVar('__googleData')}
+								{if $__wcf->session->getVar('__3rdPartyProvider') === 'google' && $__wcf->session->getVar('__oauthUser')}
 									<label><input type="checkbox" name="googleConnect" value="1"{if $googleConnect} checked{/if}> {lang}wcf.user.3rdparty.google.connect{/lang}</label>
 								{else}
 									<a href="{link controller='GoogleAuth'}{/link}" class="thirdPartyLoginButton googleLoginButton button"><span class="icon icon24 fa-google"></span> <span>{lang}wcf.user.3rdparty.google.connect{/lang}</span></a>

--- a/wcfsetup/install/files/lib/action/AbstractOauth2Action.class.php
+++ b/wcfsetup/install/files/lib/action/AbstractOauth2Action.class.php
@@ -44,7 +44,9 @@ abstract class AbstractOauth2Action extends AbstractAction {
 	 */
 	protected final function getHttpClient(): ClientInterface {
 		if (!$this->httpClient) {
-			$this->httpClient = HttpFactory::makeClient();
+			$this->httpClient = HttpFactory::makeClient([
+				'timeout' => 5,
+			]);
 		}
 		
 		return $this->httpClient;

--- a/wcfsetup/install/files/lib/action/AbstractOauth2Action.class.php
+++ b/wcfsetup/install/files/lib/action/AbstractOauth2Action.class.php
@@ -1,0 +1,204 @@
+<?php
+namespace wcf\action;
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Psr7\Request;
+use ParagonIE\ConstantTime\Hex;
+use wcf\system\exception\IllegalLinkException;
+use wcf\system\exception\NamedUserException;
+use wcf\system\io\HttpFactory;
+use wcf\system\user\authentication\oauth\User as OauthUser;
+use wcf\system\WCF;
+use wcf\util\HeaderUtil;
+use wcf\util\JSON;
+
+/**
+ * Generic implementation to handle the OAuth 2 flow.
+ * 
+ * @author	Tim Duesterhus
+ * @copyright	2001-2021 WoltLab GmbH
+ * @license	GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @package	WoltLabSuite\Core\Action
+ */
+abstract class AbstractOauth2Action extends AbstractAction {
+	private const STATE = self::class . "\0state_parameter";
+	
+	/**
+	 * @var ClientInterface
+	 */
+	private $httpClient;
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function readParameters() {
+		parent::readParameters();
+		
+		if (WCF::getSession()->spiderID) {
+			throw new IllegalLinkException();
+		}
+	}
+	
+	/**
+	 * Returns a "static" instance of the HTTP client to use to allow
+	 * for TCP connection reuse.
+	 */
+	protected final function getHttpClient(): ClientInterface {
+		if (!$this->httpClient) {
+			$this->httpClient = HttpFactory::makeClient();
+		}
+		
+		return $this->httpClient;
+	}
+	
+	/**
+	 * Returns the URL of the '/token' endpoint that turns the code into an access token.
+	 */
+	abstract protected function getTokenEndpoint(): string;
+	
+	/**
+	 * Returns the 'client_id'.
+	 */
+	abstract protected function getClientId(): string;
+	
+	/**
+	 * Returns the 'client_secret'.
+	 */
+	abstract protected function getClientSecret(): string;
+	
+	/**
+	 * Returns the 'scope' to request.
+	 */
+	abstract protected function getScope(): string;
+	
+	/**
+	 * Returns the URL of the '/authorize' endpoint where the user is redirected to.
+	 */
+	abstract protected function getAuthorizeUrl(): string;
+	
+	/**
+	 * Returns the callback URL. This should most likely be:
+	 * 
+	 * LinkHandler::getInstance()->getControllerLink(self::class)
+	 */
+	abstract protected function getCallbackUrl(): string;
+	
+	/**
+	 * Whether to validate the state or not. Should be 'true' to protect
+	 * against CSRF attacks.
+	 */
+	abstract protected function supportsState(): bool;
+	
+	/**
+	 * Turns the access token response into an oauth user.
+	 */
+	abstract protected function getUser(array $accessToken): OauthUser;
+	
+	/**
+	 * Processes the user (e.g. by registering session variables and redirecting somewhere).
+	 */
+	abstract protected function processUser(OauthUser $oauthUser);
+
+	/**
+	 * Validates the state parameter.
+	 */
+	protected function validateState() {
+		if (!isset($_GET['state'])) {
+			throw new \Exception('Missing state parameter');
+		}
+		if (!($sessionState = WCF::getSession()->getVar(self::STATE))) {
+			throw new \Exception('Missing state in session');
+		}
+		if (!\hash_equals($sessionState, (string) $_GET['state'])) {
+			throw new \Exception('Mismatching state');
+		}
+		
+		WCF::getSession()->unregister(self::STATE);
+	}
+	
+	/**
+	 * Turns the 'code' into an access token.
+	 */
+	protected function codeToAccessToken(string $code): array {
+		$request = new Request('POST', $this->getTokenEndpoint(), [
+			'Accept' => 'application/json',
+			'Content-Type' => 'application/x-www-form-urlencoded',
+		], http_build_query([
+			'grant_type' => 'authorization_code',
+			'client_id' => $this->getClientId(),
+			'client_secret' => $this->getClientSecret(),
+			'redirect_uri' => $this->getCallbackUrl(),
+			'code' => $_GET['code'],
+		], '', '&', PHP_QUERY_RFC1738));
+		
+		$response = $this->getHttpClient()->send($request);
+		
+		// Validate state. Validation of state is executed after fetching the
+		// access_token to invalidate 'code'.
+		if ($this->supportsState()) {
+			$this->validateState();
+		}
+		
+		$parsed = JSON::decode((string) $response->getBody());
+		
+		if (!empty($parsed['error'])) {
+			throw new \Exception(\sprintf(
+				"Access token response indicates an error: '%s'",
+				$parsed['error']
+			));
+		}
+		
+		if (empty($parsed['access_token'])) {
+			throw new \Exception("Access token response does not have the 'access_token' key.");
+		}
+		
+		return $parsed;
+	}
+	
+	protected function handleError(string $error) {
+		throw new NamedUserException(WCF::getLanguage()->getDynamicVariable('wcf.user.3rdparty.login.error.'.$error));
+	}
+	
+	/**
+	 * Initiates the OAuth flow by redirecting to the '/authorize' URL.
+	 */
+	protected function initiate() {
+		$parameters = [
+			'response_type' => 'code',
+			'client_id' => $this->getClientId(),
+			'scope' => $this->getScope(),
+			'redirect_uri' => $this->getCallbackUrl(),
+		];
+		
+		if ($this->supportsState()) {
+			$token = Hex::encode(\random_bytes(16));
+			WCF::getSession()->register(self::STATE, $token);
+			
+			$parameters['state'] = $token;
+		}
+		
+		$url = $this->getAuthorizeUrl().'?'.http_build_query($parameters, '', '&');
+		
+		HeaderUtil::redirect($url);
+		exit;
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function execute() {
+		parent::execute();
+		
+		if (isset($_GET['code'])) {
+			$accessToken = $this->codeToAccessToken($_GET['code']);
+			$oauthUser = $this->getUser($accessToken);
+			
+			$this->processUser($oauthUser);
+		}
+		else if (isset($_GET['error'])) {
+			$this->handleError($_GET['error']);
+		}
+		else {
+			$this->initiate();
+		}
+	}
+}

--- a/wcfsetup/install/files/lib/action/AbstractOauth2Action.class.php
+++ b/wcfsetup/install/files/lib/action/AbstractOauth2Action.class.php
@@ -3,8 +3,8 @@ namespace wcf\action;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Psr7\Request;
 use ParagonIE\ConstantTime\Hex;
-use wcf\system\exception\IllegalLinkException;
 use wcf\system\exception\NamedUserException;
+use wcf\system\exception\PermissionDeniedException;
 use wcf\system\io\HttpFactory;
 use wcf\system\user\authentication\oauth\User as OauthUser;
 use wcf\system\WCF;
@@ -34,7 +34,7 @@ abstract class AbstractOauth2Action extends AbstractAction {
 		parent::readParameters();
 		
 		if (WCF::getSession()->spiderID) {
-			throw new IllegalLinkException();
+			throw new PermissionDeniedException();
 		}
 	}
 	

--- a/wcfsetup/install/files/lib/action/FacebookAuthAction.class.php
+++ b/wcfsetup/install/files/lib/action/FacebookAuthAction.class.php
@@ -1,28 +1,25 @@
 <?php
 namespace wcf\action;
-use ParagonIE\ConstantTime\Hex;
+use GuzzleHttp\Psr7\Request;
 use wcf\data\user\User;
-use wcf\data\user\UserEditor;
-use wcf\system\exception\IllegalLinkException;
+use wcf\form\RegisterForm;
 use wcf\system\exception\NamedUserException;
-use wcf\system\exception\SystemException;
 use wcf\system\request\LinkHandler;
-use wcf\system\user\authentication\UserAuthenticationFactory;
+use wcf\system\user\authentication\oauth\User as OauthUser;
 use wcf\system\WCF;
 use wcf\util\HeaderUtil;
-use wcf\util\HTTPRequest;
 use wcf\util\JSON;
 use wcf\util\StringUtil;
 
 /**
- * Handles facebook auth.
+ * Performs authentication against Facebook
  * 
  * @author	Tim Duesterhus
- * @copyright	2001-2019 WoltLab GmbH
+ * @copyright	2001-2021 WoltLab GmbH
  * @license	GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
  * @package	WoltLabSuite\Core\Action
  */
-class FacebookAuthAction extends AbstractAction {
+final class FacebookAuthAction extends AbstractOauth2Action {
 	/**
 	 * @inheritDoc
 	 */
@@ -31,125 +28,132 @@ class FacebookAuthAction extends AbstractAction {
 	/**
 	 * @inheritDoc
 	 */
-	public function readParameters() {
-		parent::readParameters();
-		
-		if (WCF::getSession()->spiderID) {
-			throw new IllegalLinkException();
-		}
+	protected function getTokenEndpoint(): string {
+		return 'https://graph.facebook.com/oauth/access_token';
 	}
 	
 	/**
 	 * @inheritDoc
 	 */
-	public function execute() {
-		parent::execute();
+	protected function getClientId(): string {
+		return StringUtil::trim(FACEBOOK_PUBLIC_KEY);
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	protected function getClientSecret(): string {
+		return StringUtil::trim(FACEBOOK_PRIVATE_KEY);
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	protected function getScope(): string {
+		return 'email';
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	protected function getAuthorizeUrl(): string {
+		return 'https://www.facebook.com/dialog/oauth';
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	protected function getCallbackUrl(): string {
+		$callbackURL = LinkHandler::getInstance()->getControllerLink(self::class);
 		
-		$callbackURL = LinkHandler::getInstance()->getLink('FacebookAuth');
-
 		// Work around Facebook performing an illegal substitution of the Slash
 		// by '%2F' when entering redirect URI (RFC 3986 sect. 2.2, sect. 3.4)
-		$callbackURL = preg_replace_callback('/(?<=\?).*/', function ($matches) {
-			return rawurlencode($matches[0]);
+		$callbackURL = \preg_replace_callback('/(?<=\?).*/', function ($matches) {
+			return \rawurlencode($matches[0]);
 		}, $callbackURL);
-
-		// user accepted the connection
-		if (isset($_GET['code'])) {
-			try {
-				// fetch access_token
-				$request = new HTTPRequest('https://graph.facebook.com/oauth/access_token?client_id='.StringUtil::trim(FACEBOOK_PUBLIC_KEY).'&redirect_uri='.rawurlencode($callbackURL).'&client_secret='.StringUtil::trim(FACEBOOK_PRIVATE_KEY).'&code='.rawurlencode($_GET['code']));
-				$request->execute();
-				$reply = $request->getReply();
+		
+		return $callbackURL;
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	protected function supportsState(): bool { 
+		return true;
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	protected function getUser(array $accessToken): OauthUser { 
+		$request = new Request('GET', 'https://graph.facebook.com/me?fields=email,id,name', [
+			'accept' => 'application/json',
+			'authorization' => \sprintf('Bearer %s', $accessToken['access_token']),
+		]);
+		$response = $this->getHttpClient()->send($request);
+		$parsed = JSON::decode((string) $response->getBody());
+		
+		$parsed['__id'] = $parsed['id'];
+		$parsed['__username'] = $parsed['name'];
+		$parsed['__email'] = $parsed['email'];
+		$parsed['accessToken'] = $accessToken;
+		
+		return new OauthUser($parsed);
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	protected function processUser(OauthUser $oauthUser) {
+		$user = User::getUserByAuthData('facebook:'.$oauthUser->getId());
+		
+		if ($user->userID) {
+			if (WCF::getUser()->userID) {
+				// This account belongs to an existing user, but we are already logged in.
+				// This can't be handled.
 				
-				$content = $reply['body'];
-			}
-			catch (SystemException $e) {
-				\wcf\functions\exception\logThrowable($e);
-				throw new IllegalLinkException();
-			}
-			
-			// validate state, validation of state is executed after fetching the access_token to invalidate 'code'
-			if (!isset($_GET['state']) || !WCF::getSession()->getVar('__facebookInit') || !\hash_equals(WCF::getSession()->getVar('__facebookInit'), $_GET['state'])) throw new IllegalLinkException();
-			WCF::getSession()->unregister('__facebookInit');
-			
-			try {
-				$data = JSON::decode($content);
-			}
-			catch (SystemException $e) {
-				parse_str($content, $data);
-			}
-			
-			if (!isset($data['access_token'])) throw new IllegalLinkException();
-			
-			try {
-				// fetch userdata
-				$request = new HTTPRequest('https://graph.facebook.com/me?access_token='.rawurlencode($data['access_token']).'&fields=email,id,name');
-				$request->execute();
-				$reply = $request->getReply();
-				
-				$content = $reply['body'];
-			}
-			catch (SystemException $e) {
-				\wcf\functions\exception\logThrowable($e);
-				throw new IllegalLinkException();
-			}
-			
-			$userData = JSON::decode($content);
-			
-			// check whether a user is connected to this facebook account
-			$user = User::getUserByAuthData('facebook:'.$userData['id']);
-			
-			if ($user->userID) {
-				// a user is already connected, but we are logged in, break
-				if (WCF::getUser()->userID) {
-					throw new NamedUserException(WCF::getLanguage()->getDynamicVariable('wcf.user.3rdparty.facebook.connect.error.inuse'));
-				}
-				// perform login
-				else {
-					WCF::getSession()->changeUser($user);
-					WCF::getSession()->update();
-					HeaderUtil::redirect(LinkHandler::getInstance()->getLink());
-				}
+				throw new NamedUserException(
+					WCF::getLanguage()->getDynamicVariable('wcf.user.3rdparty.facebook.connect.error.inuse')
+				);
 			}
 			else {
-				WCF::getSession()->register('__3rdPartyProvider', 'facebook');
-				// save data for connection
-				if (WCF::getUser()->userID) {
-					WCF::getSession()->register('__facebookUsername', $userData['name']);
-					WCF::getSession()->register('__facebookData', $userData);
-					
-					HeaderUtil::redirect(LinkHandler::getInstance()->getLink('AccountManagement').'#3rdParty');
-				}
-				// save data and redirect to registration
-				else {
-					WCF::getSession()->register('__username', $userData['name']);
-					if (isset($userData['email'])) WCF::getSession()->register('__email', $userData['email']);
-					WCF::getSession()->register('__facebookData', $userData);
-					
-					// we assume that bots won't register on facebook first
-					// thus no need for a captcha
-					if (REGISTER_USE_CAPTCHA) {
-						WCF::getSession()->register('noRegistrationCaptcha', true);
-					}
-					
-					WCF::getSession()->update();
-					HeaderUtil::redirect(LinkHandler::getInstance()->getLink('Register'));
-				}
+				// This account belongs to an existing user, we are not logged in.
+				// Perform the login.
+				
+				WCF::getSession()->changeUser($user);
+				WCF::getSession()->update();
+				HeaderUtil::redirect(LinkHandler::getInstance()->getLink());
+				exit;
 			}
+		}
+		else {
+			WCF::getSession()->register('__3rdPartyProvider', 'facebook');
 			
-			$this->executed();
-			exit;
+			if (WCF::getUser()->userID) {
+				// This account does not belong to anyone and we are already logged in.
+				// Thus we want to connect this account.
+				
+				WCF::getSession()->register('__oauthUser', $oauthUser);
+
+				HeaderUtil::redirect(LinkHandler::getInstance()->getLink('AccountManagement').'#3rdParty');
+				exit;
+			}
+			else {
+				// This account does not belong to anyone and we are not logged in.
+				// Thus we want to connect this account to a newly registered user.
+				
+				WCF::getSession()->register('__oauthUser', $oauthUser);
+				WCF::getSession()->register('__username', $oauthUser->getUsername());
+				WCF::getSession()->register('__email', $oauthUser->getEmail());
+				
+				// We assume that bots won't register an external account first, so
+				// we skip the captcha.
+				WCF::getSession()->register('noRegistrationCaptcha', true);
+				
+				WCF::getSession()->update();
+				HeaderUtil::redirect(LinkHandler::getInstance()->getControllerLink(RegisterForm::class));
+				exit;
+			}
 		}
-		// user declined or any other error that may occur
-		if (isset($_GET['error'])) {
-			throw new NamedUserException(WCF::getLanguage()->getDynamicVariable('wcf.user.3rdparty.facebook.login.error.'.$_GET['error']));
-		}
-		
-		// start auth by redirecting to facebook
-		$token = Hex::encode(\random_bytes(20));
-		WCF::getSession()->register('__facebookInit', $token);
-		HeaderUtil::redirect("https://www.facebook.com/dialog/oauth?client_id=".StringUtil::trim(FACEBOOK_PUBLIC_KEY). "&redirect_uri=".rawurlencode($callbackURL)."&state=".$token."&scope=email");
-		$this->executed();
-		exit;
 	}
 }

--- a/wcfsetup/install/files/lib/action/GoogleAuthAction.class.php
+++ b/wcfsetup/install/files/lib/action/GoogleAuthAction.class.php
@@ -1,158 +1,172 @@
 <?php
 namespace wcf\action;
-use ParagonIE\ConstantTime\Hex;
+use GuzzleHttp\Psr7\Request;
 use wcf\data\user\User;
-use wcf\data\user\UserEditor;
-use wcf\system\exception\IllegalLinkException;
+use wcf\form\RegisterForm;
 use wcf\system\exception\NamedUserException;
-use wcf\system\exception\SystemException;
 use wcf\system\request\LinkHandler;
-use wcf\system\user\authentication\UserAuthenticationFactory;
+use wcf\system\user\authentication\oauth\User as OauthUser;
 use wcf\system\WCF;
 use wcf\util\HeaderUtil;
-use wcf\util\HTTPRequest;
 use wcf\util\JSON;
 use wcf\util\StringUtil;
 
 /**
- * Handles google auth.
+ * Performs authentication against Google (GAIA).
  * 
  * @author	Tim Duesterhus
- * @copyright	2001-2019 WoltLab GmbH
+ * @copyright	2001-2021 WoltLab GmbH
  * @license	GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
  * @package	WoltLabSuite\Core\Action
  */
-class GoogleAuthAction extends AbstractAction {
+final class GoogleAuthAction extends AbstractOauth2Action {
 	/**
 	 * @inheritDoc
 	 */
 	public $neededModules = ['GOOGLE_PUBLIC_KEY', 'GOOGLE_PRIVATE_KEY'];
 	
 	/**
-	 * @inheritDoc
+	 * @var array
 	 */
-	public function readParameters() {
-		parent::readParameters();
-		
-		if (WCF::getSession()->spiderID) {
-			throw new IllegalLinkException();
+	private $configuration;
+	
+	/**
+	 * Returns Google's OpenID Connect configuration.
+	 */
+	private function getConfiguration() {
+		if (!$this->configuration) {
+			$request = new Request('GET', 'https://accounts.google.com/.well-known/openid-configuration');
+			$response = $this->getHttpClient()->send($request);
+			
+			$this->configuration = JSON::decode((string) $response->getBody());
 		}
+		
+		return $this->configuration;
 	}
 	
 	/**
 	 * @inheritDoc
 	 */
-	public function execute() {
-		parent::execute();
+	protected function getTokenEndpoint(): string {
+		return $this->getConfiguration()['token_endpoint'];
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	protected function getClientId(): string {
+		return StringUtil::trim(GOOGLE_PUBLIC_KEY);
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	protected function getClientSecret(): string {
+		return StringUtil::trim(GOOGLE_PRIVATE_KEY);
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	protected function getScope(): string {
+		return 'profile openid email';
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	protected function getAuthorizeUrl(): string {
+		return $this->getConfiguration()['authorization_endpoint'];
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	protected function getCallbackUrl(): string {
+		return LinkHandler::getInstance()->getControllerLink(self::class);
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	protected function supportsState(): bool { 
+		return true;
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	protected function getUser(array $accessToken): OauthUser { 
+		$request = new Request('GET', $this->getConfiguration()['userinfo_endpoint'], [
+			'accept' => 'application/json',
+			'authorization' => \sprintf('Bearer %s', $accessToken['access_token']),
+		]);
+		$response = $this->getHttpClient()->send($request);
+		$parsed = JSON::decode((string) $response->getBody());
 		
-		$callbackURL = LinkHandler::getInstance()->getLink('GoogleAuth');
-		// user accepted the connection
-		if (isset($_GET['code'])) {
-			try {
-				// fetch access_token
-				$request = new HTTPRequest('https://accounts.google.com/o/oauth2/token', [], [
-					'code' => $_GET['code'],
-					'client_id' => StringUtil::trim(GOOGLE_PUBLIC_KEY),
-					'client_secret' => StringUtil::trim(GOOGLE_PRIVATE_KEY),
-					'redirect_uri' => $callbackURL,
-					'grant_type' => 'authorization_code'
-				]);
-				$request->execute();
-				$reply = $request->getReply();
+		$parsed['__id'] = $parsed['sub'];
+		$parsed['__username'] = $parsed['name'];
+		if ($parsed['email']) {
+			$parsed['__email'] = $parsed['email'];
+		}
+		$parsed['accessToken'] = $accessToken;
+		
+		return new OauthUser($parsed);
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	protected function processUser(OauthUser $oauthUser) {
+		$user = User::getUserByAuthData('google:'.$oauthUser->getId());
+		
+		if ($user->userID) {
+			if (WCF::getUser()->userID) {
+				// This account belongs to an existing user, but we are already logged in.
+				// This can't be handled.
 				
-				$content = $reply['body'];
-			}
-			catch (SystemException $e) {
-				\wcf\functions\exception\logThrowable($e);
-				throw new IllegalLinkException();
-			}
-			
-			// validate state, validation of state is executed after fetching the access_token to invalidate 'code'
-			if (!isset($_GET['state']) || !WCF::getSession()->getVar('__googleInit') || !\hash_equals(WCF::getSession()->getVar('__googleInit'), $_GET['state'])) throw new IllegalLinkException();
-			WCF::getSession()->unregister('__googleInit');
-			
-			$data = JSON::decode($content);
-			
-			try {
-				// fetch openID connect configuration
-				$request = new HTTPRequest('https://accounts.google.com/.well-known/openid-configuration');
-				$request->execute();
-				$reply = $request->getReply();
-				$content = JSON::decode($reply['body']);
-				
-				// fetch userdata
-				$request = new HTTPRequest($content['userinfo_endpoint']);
-				$request->addHeader('Authorization', 'Bearer '.$data['access_token']);
-				$request->execute();
-				$reply = $request->getReply();
-				
-				$content = $reply['body'];
-			}
-			catch (SystemException $e) {
-				\wcf\functions\exception\logThrowable($e);
-				throw new IllegalLinkException();
-			}
-			
-			$userData = JSON::decode($content);
-			
-			// check whether a user is connected to this google account
-			$user = User::getUserByAuthData('google:'.$userData['sub']);
-			
-			if ($user->userID) {
-				// a user is already connected, but we are logged in, break
-				if (WCF::getUser()->userID) {
-					throw new NamedUserException(WCF::getLanguage()->getDynamicVariable('wcf.user.3rdparty.google.connect.error.inuse'));
-				}
-				// perform login
-				else {
-					WCF::getSession()->changeUser($user);
-					WCF::getSession()->update();
-					HeaderUtil::redirect(LinkHandler::getInstance()->getLink());
-				}
+				throw new NamedUserException(
+					WCF::getLanguage()->getDynamicVariable('wcf.user.3rdparty.google.connect.error.inuse')
+				);
 			}
 			else {
-				WCF::getSession()->register('__3rdPartyProvider', 'google');
+				// This account belongs to an existing user, we are not logged in.
+				// Perform the login.
 				
-				// save data for connection
-				if (WCF::getUser()->userID) {
-					WCF::getSession()->register('__googleUsername', $userData['name']);
-					WCF::getSession()->register('__googleData', $userData);
-					
-					HeaderUtil::redirect(LinkHandler::getInstance()->getLink('AccountManagement').'#3rdParty');
-				}
-				// save data and redirect to registration
-				else {
-					WCF::getSession()->register('__username', $userData['name']);
-					if (isset($userData['email'])) {
-						WCF::getSession()->register('__email', $userData['email']);
-					}
-					
-					WCF::getSession()->register('__googleData', $userData);
-					
-					// we assume that bots won't register on google first
-					// thus no need for a captcha
-					if (REGISTER_USE_CAPTCHA) {
-						WCF::getSession()->register('noRegistrationCaptcha', true);
-					}
-					
-					WCF::getSession()->update();
-					HeaderUtil::redirect(LinkHandler::getInstance()->getLink('Register'));
-				}
+				WCF::getSession()->changeUser($user);
+				WCF::getSession()->update();
+				HeaderUtil::redirect(LinkHandler::getInstance()->getLink());
+				exit;
 			}
+		}
+		else {
+			WCF::getSession()->register('__3rdPartyProvider', 'google');
 			
-			$this->executed();
-			exit;
+			if (WCF::getUser()->userID) {
+				// This account does not belong to anyone and we are already logged in.
+				// Thus we want to connect this account.
+				
+				WCF::getSession()->register('__oauthUser', $oauthUser);
+				
+				HeaderUtil::redirect(LinkHandler::getInstance()->getLink('AccountManagement').'#3rdParty');
+				exit;
+			}
+			else {
+				// This account does not belong to anyone and we are not logged in.
+				// Thus we want to connect this account to a newly registered user.
+				
+				WCF::getSession()->register('__oauthUser', $oauthUser);
+				WCF::getSession()->register('__username', $oauthUser->getUsername());
+				WCF::getSession()->register('__email', $oauthUser->getEmail());
+				
+				// We assume that bots won't register an external account first, so
+				// we skip the captcha.
+				WCF::getSession()->register('noRegistrationCaptcha', true);
+				
+				WCF::getSession()->update();
+				HeaderUtil::redirect(LinkHandler::getInstance()->getControllerLink(RegisterForm::class));
+				exit;
+			}
 		}
-		// user declined or any other error that may occur
-		if (isset($_GET['error'])) {
-			throw new NamedUserException(WCF::getLanguage()->getDynamicVariable('wcf.user.3rdparty.google.login.error.'.$_GET['error']));
-		}
-		
-		// start auth by redirecting to google
-		$token = Hex::encode(\random_bytes(20));
-		WCF::getSession()->register('__googleInit', $token);
-		HeaderUtil::redirect("https://accounts.google.com/o/oauth2/auth?client_id=".rawurlencode(StringUtil::trim(GOOGLE_PUBLIC_KEY)). "&redirect_uri=".rawurlencode($callbackURL)."&state=".$token."&scope=profile+openid+email&response_type=code");
-		$this->executed();
-		exit;
 	}
 }

--- a/wcfsetup/install/files/lib/action/TwitterAuthAction.class.php
+++ b/wcfsetup/install/files/lib/action/TwitterAuthAction.class.php
@@ -159,7 +159,7 @@ class TwitterAuthAction extends AbstractAction {
 		
 		// user declined
 		if (isset($_GET['denied'])) {
-			throw new NamedUserException(WCF::getLanguage()->getDynamicVariable('wcf.user.3rdparty.twitter.login.error.denied'));
+			throw new NamedUserException(WCF::getLanguage()->getDynamicVariable('wcf.user.3rdparty.login.error.denied'));
 		}
 		
 		// start auth by fetching request_token

--- a/wcfsetup/install/files/lib/action/TwitterAuthAction.class.php
+++ b/wcfsetup/install/files/lib/action/TwitterAuthAction.class.php
@@ -2,12 +2,11 @@
 namespace wcf\action;
 use ParagonIE\ConstantTime\Hex;
 use wcf\data\user\User;
-use wcf\data\user\UserEditor;
 use wcf\system\exception\IllegalLinkException;
 use wcf\system\exception\NamedUserException;
+use wcf\system\exception\PermissionDeniedException;
 use wcf\system\exception\SystemException;
 use wcf\system\request\LinkHandler;
-use wcf\system\user\authentication\UserAuthenticationFactory;
 use wcf\system\WCF;
 use wcf\util\HeaderUtil;
 use wcf\util\HTTPRequest;
@@ -34,7 +33,7 @@ class TwitterAuthAction extends AbstractAction {
 		parent::readParameters();
 		
 		if (WCF::getSession()->spiderID) {
-			throw new IllegalLinkException();
+			throw new PermissionDeniedException();
 		}
 	}
 	

--- a/wcfsetup/install/files/lib/form/AccountManagementForm.class.php
+++ b/wcfsetup/install/files/lib/form/AccountManagementForm.class.php
@@ -378,13 +378,16 @@ class AccountManagementForm extends AbstractForm {
 		
 		// 3rdParty
 		if (GITHUB_PUBLIC_KEY !== '' && GITHUB_PRIVATE_KEY !== '') {
-			if ($this->githubConnect && WCF::getSession()->getVar('__githubData')) {
-				$githubData = WCF::getSession()->getVar('__githubData');
-				$updateParameters['authData'] = 'github:'.$githubData['id'];
+			if (	$this->githubConnect &&
+				WCF::getSession()->getVar('__3rdPartyProvider') == 'github' &&
+				($oauthUser = WCF::getSession()->getVar('__oauthUser'))
+			) {
+				$updateParameters['authData'] = 'github:'.$oauthUser->getId();
+				$updateParameters['password'] = null;
 				$success[] = 'wcf.user.3rdparty.github.connect.success';
 				
-				WCF::getSession()->unregister('__githubToken');
-				WCF::getSession()->unregister('__githubUsername');
+				WCF::getSession()->unregister('__3rdPartyProvider');
+				WCF::getSession()->unregister('__oauthUser');
 			}
 		}
 		if ($this->githubDisconnect && StringUtil::startsWith(WCF::getUser()->authData, 'github:')) {
@@ -406,13 +409,17 @@ class AccountManagementForm extends AbstractForm {
 			$success[] = 'wcf.user.3rdparty.twitter.disconnect.success';
 		}
 		if (FACEBOOK_PUBLIC_KEY !== '' && FACEBOOK_PRIVATE_KEY !== '') {
-			if ($this->facebookConnect && WCF::getSession()->getVar('__facebookData')) {
-				$facebookData = WCF::getSession()->getVar('__facebookData');
-				$updateParameters['authData'] = 'facebook:'.$facebookData['id'];
+			if (
+				$this->facebookConnect &&
+				WCF::getSession()->getVar('__3rdPartyProvider') == 'facebook' &&
+				($oauthUser = WCF::getSession()->getVar('__oauthUser'))
+			) {
+				$updateParameters['authData'] = 'facebook:'.$oauthUser->getId();
+				$updateParameters['password'] = null;
 				$success[] = 'wcf.user.3rdparty.facebook.connect.success';
 				
-				WCF::getSession()->unregister('__facebookData');
-				WCF::getSession()->unregister('__facebookUsername');
+				WCF::getSession()->unregister('__3rdPartyProvider');
+				WCF::getSession()->unregister('__oauthUser');
 			}
 		}
 		if ($this->facebookDisconnect && StringUtil::startsWith(WCF::getUser()->authData, 'facebook:')) {
@@ -420,13 +427,17 @@ class AccountManagementForm extends AbstractForm {
 			$success[] = 'wcf.user.3rdparty.facebook.disconnect.success';
 		}
 		if (GOOGLE_PUBLIC_KEY !== '' && GOOGLE_PRIVATE_KEY !== '') {
-			if ($this->googleConnect && WCF::getSession()->getVar('__googleData')) {
-				$googleData = WCF::getSession()->getVar('__googleData');
-				$updateParameters['authData'] = 'google:'.$googleData['sub'];
+			if (
+				$this->googleConnect &&
+				WCF::getSession()->getVar('__3rdPartyProvider') == 'google' &&
+				($oauthUser = WCF::getSession()->getVar('__oauthUser'))
+			) {
+				$updateParameters['authData'] = 'google:'.$oauthUser->getId();
+				$updateParameters['password'] = null;
 				$success[] = 'wcf.user.3rdparty.google.connect.success';
 				
-				WCF::getSession()->unregister('__googleData');
-				WCF::getSession()->unregister('__googleUsername');
+				WCF::getSession()->unregister('__3rdPartyProvider');
+				WCF::getSession()->unregister('__oauthUser');
 			}
 		}
 		if ($this->googleDisconnect && StringUtil::startsWith(WCF::getUser()->authData, 'google:')) {

--- a/wcfsetup/install/files/lib/system/user/authentication/oauth/User.class.php
+++ b/wcfsetup/install/files/lib/system/user/authentication/oauth/User.class.php
@@ -1,0 +1,96 @@
+<?php
+namespace wcf\system\user\authentication\oauth;
+
+/**
+ * Represents user information retrieved from an OAuth provider.
+ * 
+ * @author	Tim Duesterhus
+ * @copyright	2001-2021 WoltLab GmbH
+ * @license	GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @package	WoltLabSuite\Core\System\User\Authentication\Oauth
+ * @since	5.4
+ */
+final class User implements \ArrayAccess {
+	private $data = [];
+	
+	public function __construct(array $data) {
+		if (empty($data['__id'])) {
+			throw new \InvalidArgumentException("Missing '__id' key");
+		}
+		if (empty($data['__username'])) {
+			throw new \InvalidArgumentException("Missing '__username' key");
+		}
+		
+		$this->data = $data;
+	}
+	
+	/**
+	 * Returns the unique identifier for this user at the OAuth provider.
+	 */
+	public function getId(): string {
+		return $this['__id'];
+	}
+	
+	/**
+	 * Returns what the user considers their "username" or "handle" at
+	 * the OAuth provider.
+	 * 
+	 * Depending on the provider this might be a real name, a handle or
+	 * something entirely different.
+	 */
+	public function getUsername(): string {
+		return $this['__username'];
+	}
+	
+	/**
+	 * Returns the user's email at the OAuth provider.
+	 * 
+	 * Some providers might not return an email, so this method may
+	 * return null.
+	 */
+	public function getEmail(): ?string {
+		return $this['__email'] ?? null;
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function offsetGet($offset) {
+		return $this->data[$offset] ?? null;
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function offsetSet($offset, $value) {
+		if ($offset === '__id') {
+			throw new \BadMethodCallException('You may not modify the id.');
+		}
+		if ($offset === '__username') {
+			throw new \BadMethodCallException('You may not modify the username.');
+		}
+		
+		$this->data[$offset] = $value;
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function offsetUnset($offset) {
+		if ($offset === '__id') {
+			throw new \BadMethodCallException('You may not modify the id.');
+		}
+		if ($offset === '__username') {
+			throw new \BadMethodCallException('You may not modify the username.');
+		}
+		
+		unset($this->data[$offset]);
+	}
+	
+	/**
+	 * @inheritDoc
+	 */
+	public function offsetExists($offset) {
+		return isset($this->data[$offset]);
+	}
+}

--- a/wcfsetup/install/files/lib/system/user/authentication/oauth/exception/StateValidationException.class.php
+++ b/wcfsetup/install/files/lib/system/user/authentication/oauth/exception/StateValidationException.class.php
@@ -1,0 +1,17 @@
+<?php
+namespace wcf\system\user\authentication\oauth\exception;
+
+/**
+ * Thrown when the CSRF 'state' parameter cannot be validated.
+ * 
+ * @author	Tim Duesterhus
+ * @copyright	2001-2021 WoltLab GmbH
+ * @license	GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @package	WoltLabSuite\Core\System\User\Authentication\Oauth\Exception
+ * @since	5.4
+ */
+final class StateValidationException extends \UnexpectedValueException {
+	public function __construct($message, ?\Throwable $previous = null) {
+		parent::__construct($message, 0, $previous);
+	}
+}

--- a/wcfsetup/install/lang/de.xml
+++ b/wcfsetup/install/lang/de.xml
@@ -5066,18 +5066,18 @@ Die E-Mail-Adresse des neuen Benutzers lautet: {@$user->email}
 	</category>
 	<category name="wcf.user.3rdparty">
 		<item name="wcf.user.3rdparty"><![CDATA[Drittanbieter]]></item>
+		<item name="wcf.user.3rdparty.login.error.access_denied"><![CDATA[Da {if LANGUAGE_USE_INFORMAL_VARIANT}du die Berechtigungen verweigert hast{else}Sie die Berechtigungen verweigert haben{/if}, ist die Anmeldung nicht möglich.]]></item>
+		<item name="wcf.user.3rdparty.login.error.denied"><![CDATA[Da {if LANGUAGE_USE_INFORMAL_VARIANT}du die Berechtigungen verweigert hast{else}Sie die Berechtigungen verweigert haben{/if}, ist die Anmeldung nicht möglich.]]></item>
 		<item name="wcf.user.3rdparty.github"><![CDATA[GitHub]]></item>
 		<item name="wcf.user.3rdparty.github.login"><![CDATA[Mit GitHub anmelden]]></item>
-		<item name="wcf.user.3rdparty.github.login.error.access_denied"><![CDATA[Da {if LANGUAGE_USE_INFORMAL_VARIANT}du die Berechtigungen verweigert hast{else}Sie die Berechtigungen verweigert haben{/if}, ist die Anmeldung mit GitHub nicht möglich.]]></item>
 		<item name="wcf.user.3rdparty.github.register"><![CDATA[{if LANGUAGE_USE_INFORMAL_VARIANT}Du erstellst{else}Sie erstellen{/if} ein Benutzerkonto über <span class="icon icon16 fa-github"></span>&nbsp;GitHub. Der Benutzername und {if LANGUAGE_USE_INFORMAL_VARIANT}deine{else}Ihre{/if} E-Mail-Adresse wurden daher bereits ausgefüllt.]]></item>
-		<item name="wcf.user.3rdparty.github.connect"><![CDATA[Mit GitHub-Konto {if $__wcf->session->getVar('__githubUsername')}(„<a href="https://github.com/{$__wcf->session->getVar('__githubUsername')}"{if EXTERNAL_LINK_TARGET_BLANK} target="_blank"{/if}>{$__wcf->session->getVar('__githubUsername')}</a>“){/if} verknüpfen]]></item>
+		<item name="wcf.user.3rdparty.github.connect"><![CDATA[Mit GitHub-Konto {if $__wcf->session->getVar('__3rdPartyProvider') === 'github'}(„<a href="https://github.com/{$__wcf->session->getVar('__oauthUser')->getUsername()}"{if EXTERNAL_LINK_TARGET_BLANK} target="_blank"{/if}>{$__wcf->session->getVar('__oauthUser')->getUsername()}</a>“){/if} verknüpfen]]></item>
 		<item name="wcf.user.3rdparty.github.connect.success"><![CDATA[{if LANGUAGE_USE_INFORMAL_VARIANT}Dein{else}Ihr{/if} Benutzerkonto wurde erfolgreich mit {if LANGUAGE_USE_INFORMAL_VARIANT}deinem{else}Ihrem{/if} GitHub-Konto verknüpft.]]></item>
 		<item name="wcf.user.3rdparty.github.connect.error.inuse"><![CDATA[{if LANGUAGE_USE_INFORMAL_VARIANT}Dein{else}Ihr{/if} GitHub-Konto ist bereits mit einem anderen Benutzerkonto verknüpft.]]></item>
 		<item name="wcf.user.3rdparty.github.disconnect"><![CDATA[Verknüpfung mit GitHub trennen]]></item>
 		<item name="wcf.user.3rdparty.github.disconnect.success"><![CDATA[Die Verknüpfung mit {if LANGUAGE_USE_INFORMAL_VARIANT}deinem{else}Ihrem{/if} GitHub-Konto wurde erfolgreich getrennt.]]></item>
 		<item name="wcf.user.3rdparty.twitter"><![CDATA[Twitter]]></item>
 		<item name="wcf.user.3rdparty.twitter.login"><![CDATA[Mit Twitter anmelden]]></item>
-		<item name="wcf.user.3rdparty.twitter.login.error.denied"><![CDATA[Da {if LANGUAGE_USE_INFORMAL_VARIANT}du die Berechtigungen verweigert hast{else}Sie die Berechtigungen verweigert haben{/if}, ist die Anmeldung mit Twitter nicht möglich.]]></item>
 		<item name="wcf.user.3rdparty.twitter.register"><![CDATA[{if LANGUAGE_USE_INFORMAL_VARIANT}Du erstellst{else}Sie erstellen{/if} ein Benutzerkonto über &nbsp;Twitter. Der Benutzername wurde daher bereits ausgefüllt. {if LANGUAGE_USE_INFORMAL_VARIANT}Gib nun noch deine{else}Geben Sie nun noch Ihre{/if} E-Mail-Adresse an und {if LANGUAGE_USE_INFORMAL_VARIANT}du kannst{else}Sie können{/if} sofort loslegen!]]></item>
 		<item name="wcf.user.3rdparty.twitter.connect"><![CDATA[Mit Twitter-Konto {if $__wcf->session->getVar('__twitterUsername')}(„<a href="https://twitter.com/{$__wcf->session->getVar('__twitterUsername')}"{if EXTERNAL_LINK_TARGET_BLANK} target="_blank"{/if}>{$__wcf->session->getVar('__twitterUsername')}</a>“){/if} verknüpfen]]></item>
 		<item name="wcf.user.3rdparty.twitter.connect.success"><![CDATA[{if LANGUAGE_USE_INFORMAL_VARIANT}Dein{else}Ihr{/if} Benutzerkonto wurde erfolgreich mit {if LANGUAGE_USE_INFORMAL_VARIANT}deinem{else}Ihrem{/if} Twitter-Konto verknüpft.]]></item>
@@ -5086,18 +5086,16 @@ Die E-Mail-Adresse des neuen Benutzers lautet: {@$user->email}
 		<item name="wcf.user.3rdparty.twitter.disconnect.success"><![CDATA[Die Verknüpfung mit {if LANGUAGE_USE_INFORMAL_VARIANT}deinem{else}Ihrem{/if} Twitter-Konto wurde erfolgreich getrennt.]]></item>
 		<item name="wcf.user.3rdparty.facebook"><![CDATA[Facebook]]></item>
 		<item name="wcf.user.3rdparty.facebook.login"><![CDATA[Mit Facebook anmelden]]></item>
-		<item name="wcf.user.3rdparty.facebook.login.error.access_denied"><![CDATA[Da {if LANGUAGE_USE_INFORMAL_VARIANT}du die Berechtigungen verweigert hast{else}Sie die Berechtigungen verweigert haben{/if}, ist die Anmeldung mit Facebook nicht möglich.]]></item>
 		<item name="wcf.user.3rdparty.facebook.register"><![CDATA[{if LANGUAGE_USE_INFORMAL_VARIANT}Du erstellst{else}Sie erstellen{/if} ein Benutzerkonto über <span class="icon icon16 fa-facebook"></span>&nbsp;Facebook. Der Benutzername und {if LANGUAGE_USE_INFORMAL_VARIANT}deine{else}Ihre{/if} E-Mail-Adresse wurden daher bereits ausgefüllt.]]></item>
-		<item name="wcf.user.3rdparty.facebook.connect"><![CDATA[Mit Facebook-Konto {if $__wcf->session->getVar('__facebookUsername')}(„{$__wcf->session->getVar('__facebookUsername')}“){/if} verknüpfen]]></item>
+		<item name="wcf.user.3rdparty.facebook.connect"><![CDATA[Mit Facebook-Konto {if $__wcf->session->getVar('__3rdPartyProvider') === 'facebook'}(„{$$__wcf->session->getVar('__oauthUser')->getUsername()}“){/if} verknüpfen]]></item>
 		<item name="wcf.user.3rdparty.facebook.connect.success"><![CDATA[{if LANGUAGE_USE_INFORMAL_VARIANT}Dein{else}Ihr{/if} Benutzerkonto wurde erfolgreich mit {if LANGUAGE_USE_INFORMAL_VARIANT}deinem{else}Ihrem{/if} Facebook-Konto verknüpft.]]></item>
 		<item name="wcf.user.3rdparty.facebook.connect.error.inuse"><![CDATA[{if LANGUAGE_USE_INFORMAL_VARIANT}Dein{else}Ihr{/if} Facebook-Konto ist bereits mit einem anderen Benutzerkonto verknüpft.]]></item>
 		<item name="wcf.user.3rdparty.facebook.disconnect"><![CDATA[Verknüpfung mit Facebook trennen]]></item>
 		<item name="wcf.user.3rdparty.facebook.disconnect.success"><![CDATA[Die Verknüpfung mit {if LANGUAGE_USE_INFORMAL_VARIANT}deinem{else}Ihrem{/if} Facebook-Konto wurde erfolgreich getrennt.]]></item>
 		<item name="wcf.user.3rdparty.google"><![CDATA[Google]]></item>
 		<item name="wcf.user.3rdparty.google.login"><![CDATA[Mit Google anmelden]]></item>
-		<item name="wcf.user.3rdparty.google.login.error.access_denied"><![CDATA[Da {if LANGUAGE_USE_INFORMAL_VARIANT}du die Berechtigungen verweigert hast{else}Sie die Berechtigungen verweigert haben{/if}, ist die Anmeldung mit Google nicht möglich.]]></item>
 		<item name="wcf.user.3rdparty.google.register"><![CDATA[{if LANGUAGE_USE_INFORMAL_VARIANT}Du erstellst{else}Sie erstellen{/if} ein Benutzerkonto über <span class="icon icon16 fa-google"></span>&nbsp;Google. Der Benutzername und {if LANGUAGE_USE_INFORMAL_VARIANT}deine{else}Ihre{/if} E-Mail-Adresse wurden daher bereits ausgefüllt.]]></item>
-		<item name="wcf.user.3rdparty.google.connect"><![CDATA[Mit Google-Konto {if $__wcf->session->getVar('__googleUsername')}(„{$__wcf->session->getVar('__googleUsername')}“){/if} verknüpfen]]></item>
+		<item name="wcf.user.3rdparty.google.connect"><![CDATA[Mit Google-Konto {if $__wcf->session->getVar('__3rdPartyProvider') === 'google'}(„{$__wcf->session->getVar('__oauthUser')->getUsername()}“){/if} verknüpfen]]></item>
 		<item name="wcf.user.3rdparty.google.connect.success"><![CDATA[{if LANGUAGE_USE_INFORMAL_VARIANT}Dein{else}Ihr{/if} Benutzerkonto wurde erfolgreich mit {if LANGUAGE_USE_INFORMAL_VARIANT}deinem{else}Ihrem{/if} Google-Konto verknüpft.]]></item>
 		<item name="wcf.user.3rdparty.google.connect.error.inuse"><![CDATA[{if LANGUAGE_USE_INFORMAL_VARIANT}Dein{else}Ihr{/if} Google-Konto ist bereits mit einem anderen Benutzerkonto verknüpft.]]></item>
 		<item name="wcf.user.3rdparty.google.disconnect"><![CDATA[Verknüpfung mit Google trennen]]></item>

--- a/wcfsetup/install/lang/de.xml
+++ b/wcfsetup/install/lang/de.xml
@@ -5068,6 +5068,9 @@ Die E-Mail-Adresse des neuen Benutzers lautet: {@$user->email}
 		<item name="wcf.user.3rdparty"><![CDATA[Drittanbieter]]></item>
 		<item name="wcf.user.3rdparty.login.error.access_denied"><![CDATA[Da {if LANGUAGE_USE_INFORMAL_VARIANT}du die Berechtigungen verweigert hast{else}Sie die Berechtigungen verweigert haben{/if}, ist die Anmeldung nicht möglich.]]></item>
 		<item name="wcf.user.3rdparty.login.error.denied"><![CDATA[Da {if LANGUAGE_USE_INFORMAL_VARIANT}du die Berechtigungen verweigert hast{else}Sie die Berechtigungen verweigert haben{/if}, ist die Anmeldung nicht möglich.]]></item>
+		<item name="wcf.user.3rdparty.login.error.httpError"><![CDATA[Die Kommunikation mit dem externen Dienst ist fehlgeschlagen. Interner Fehlercode: <code>{$exceptionID}</code>.]]></item>
+		<item name="wcf.user.3rdparty.login.error.genericException"><![CDATA[Bei der Verarbeitung der Anfrage ist ein Fehler aufgetreten. Bitte {if LANGUAGE_USE_INFORMAL_VARIANT}wende dich{else}wenden Sie sich{/if} an den Administrator. Interner Fehlercode: <code>{$exceptionID}</code>.]]></item>
+		<item name="wcf.user.3rdparty.login.error.stateValidation"><![CDATA[Die Anfrage konnte nicht zugeordnet werden. Möglicherweise ist {if LANGUAGE_USE_INFORMAL_VARIANT}deine{else}Ihre{/if} Sitzung abgelaufen.]]></item>
 		<item name="wcf.user.3rdparty.github"><![CDATA[GitHub]]></item>
 		<item name="wcf.user.3rdparty.github.login"><![CDATA[Mit GitHub anmelden]]></item>
 		<item name="wcf.user.3rdparty.github.register"><![CDATA[{if LANGUAGE_USE_INFORMAL_VARIANT}Du erstellst{else}Sie erstellen{/if} ein Benutzerkonto über <span class="icon icon16 fa-github"></span>&nbsp;GitHub. Der Benutzername und {if LANGUAGE_USE_INFORMAL_VARIANT}deine{else}Ihre{/if} E-Mail-Adresse wurden daher bereits ausgefüllt.]]></item>

--- a/wcfsetup/install/lang/en.xml
+++ b/wcfsetup/install/lang/en.xml
@@ -5065,6 +5065,9 @@ You also received a list of emergency codes to use when your second factor becom
 		<item name="wcf.user.3rdparty"><![CDATA[Third-Party Login]]></item>
 		<item name="wcf.user.3rdparty.login.error.access_denied"><![CDATA[Access to your external account has been rejected.]]></item>
 		<item name="wcf.user.3rdparty.login.error.denied"><![CDATA[Access to your external account has been rejected.]]></item>
+		<item name="wcf.user.3rdparty.login.error.httpError"><![CDATA[Unable to communicate with the external service. Internal error code: <code>{$exceptionID}</code>.]]></item>
+		<item name="wcf.user.3rdparty.login.error.genericException"><![CDATA[An error occurred while processing your authentication request. Please contact the administrator for help. Internal error code: <code>{$exceptionID}</code>.]]></item>
+		<item name="wcf.user.3rdparty.login.error.stateValidation"><![CDATA[Unable to find the authentication request. Maybe your session expired.]]></item>
 		<item name="wcf.user.3rdparty.github"><![CDATA[GitHub]]></item>
 		<item name="wcf.user.3rdparty.github.login"><![CDATA[Login with GitHub]]></item>
 		<item name="wcf.user.3rdparty.github.register"><![CDATA[You are creating an account through <span class="icon icon16 fa-github"></span>&nbsp;GitHub. The username and your email address have therefore already been entered.]]></item>

--- a/wcfsetup/install/lang/en.xml
+++ b/wcfsetup/install/lang/en.xml
@@ -5063,18 +5063,18 @@ You also received a list of emergency codes to use when your second factor becom
 	</category>
 	<category name="wcf.user.3rdparty">
 		<item name="wcf.user.3rdparty"><![CDATA[Third-Party Login]]></item>
+		<item name="wcf.user.3rdparty.login.error.access_denied"><![CDATA[Access to your external account has been rejected.]]></item>
+		<item name="wcf.user.3rdparty.login.error.denied"><![CDATA[Access to your external account has been rejected.]]></item>
 		<item name="wcf.user.3rdparty.github"><![CDATA[GitHub]]></item>
 		<item name="wcf.user.3rdparty.github.login"><![CDATA[Login with GitHub]]></item>
-		<item name="wcf.user.3rdparty.github.login.error.access_denied"><![CDATA[Access to your GitHub account has been rejected.]]></item>
 		<item name="wcf.user.3rdparty.github.register"><![CDATA[You are creating an account through <span class="icon icon16 fa-github"></span>&nbsp;GitHub. The username and your email address have therefore already been entered.]]></item>
-		<item name="wcf.user.3rdparty.github.connect"><![CDATA[Connect with your GitHub account{if $__wcf->session->getVar('__githubUsername')} “<a href="https://github.com/{$__wcf->session->getVar('__githubUsername')}"{if EXTERNAL_LINK_TARGET_BLANK} target="_blank"{/if}>{$__wcf->session->getVar('__githubUsername')}</a>”{/if}.]]></item>
+		<item name="wcf.user.3rdparty.github.connect"><![CDATA[Connect with your GitHub account{if $__wcf->session->getVar('__3rdPartyProvider') === 'github'} “<a href="https://github.com/{$__wcf->session->getVar('__oauthUser')->getUsername()}"{if EXTERNAL_LINK_TARGET_BLANK} target="_blank"{/if}>{$__wcf->session->getVar('__oauthUser')->getUsername()}</a>”{/if}.]]></item>
 		<item name="wcf.user.3rdparty.github.connect.success"><![CDATA[Your user account has been connected with GitHub.]]></item>
 		<item name="wcf.user.3rdparty.github.connect.error.inuse"><![CDATA[Your GitHub account is already connected to a different user.]]></item>
 		<item name="wcf.user.3rdparty.github.disconnect"><![CDATA[Cancel connection with GitHub]]></item>
 		<item name="wcf.user.3rdparty.github.disconnect.success"><![CDATA[Your account is no longer connected with GitHub.]]></item>
 		<item name="wcf.user.3rdparty.twitter"><![CDATA[Twitter]]></item>
 		<item name="wcf.user.3rdparty.twitter.login"><![CDATA[Login with Twitter]]></item>
-		<item name="wcf.user.3rdparty.twitter.login.error.denied"><![CDATA[Access to your Twitter account has been rejected.]]></item>
 		<item name="wcf.user.3rdparty.twitter.register"><![CDATA[You are creating an account through <span class="icon icon16 fa-twitter"></span>&nbsp;Twitter. The username has therefore already been entered. Now enter your email address and you can start right away!]]></item>
 		<item name="wcf.user.3rdparty.twitter.connect"><![CDATA[Connect with your Twitter account{if $__wcf->session->getVar('__twitterUsername')} “<a href="https://twitter.com/{$__wcf->session->getVar('__twitterUsername')}"{if EXTERNAL_LINK_TARGET_BLANK} target="_blank"{/if}>{$__wcf->session->getVar('__twitterUsername')}</a>”{/if}.]]></item>
 		<item name="wcf.user.3rdparty.twitter.connect.success"><![CDATA[Your user account has been connected with Twitter.]]></item>
@@ -5083,18 +5083,16 @@ You also received a list of emergency codes to use when your second factor becom
 		<item name="wcf.user.3rdparty.twitter.disconnect.success"><![CDATA[Your account is no longer connected with Twitter.]]></item>
 		<item name="wcf.user.3rdparty.facebook"><![CDATA[Facebook]]></item>
 		<item name="wcf.user.3rdparty.facebook.login"><![CDATA[Login with Facebook]]></item>
-		<item name="wcf.user.3rdparty.facebook.login.error.access_denied"><![CDATA[Access to your Facebook account has been rejected.]]></item>
 		<item name="wcf.user.3rdparty.facebook.register"><![CDATA[You are creating an account through <span class="icon icon16 fa-facebook"></span>&nbsp;Facebook. The username and your email address have therefore already been entered.]]></item>
-		<item name="wcf.user.3rdparty.facebook.connect"><![CDATA[Connect with your Facebook account{if $__wcf->session->getVar('__facebookUsername')} “{$__wcf->session->getVar('__facebookUsername')}”{/if}.]]></item>
+		<item name="wcf.user.3rdparty.facebook.connect"><![CDATA[Connect with your Facebook account{if $__wcf->session->getVar('__3rdPartyProvider') === 'facebook'} “{$__wcf->session->getVar('__oauthUser')->getUsername()}”{/if}.]]></item>
 		<item name="wcf.user.3rdparty.facebook.connect.success"><![CDATA[Your user account has been connected with Facebook.]]></item>
 		<item name="wcf.user.3rdparty.facebook.connect.error.inuse"><![CDATA[Your Facebook account is already connected to a different user.]]></item>
 		<item name="wcf.user.3rdparty.facebook.disconnect"><![CDATA[Cancel connection with Facebook]]></item>
 		<item name="wcf.user.3rdparty.facebook.disconnect.success"><![CDATA[Your account is no longer connected with Facebook.]]></item>
 		<item name="wcf.user.3rdparty.google"><![CDATA[Google]]></item>
 		<item name="wcf.user.3rdparty.google.login"><![CDATA[Login with Google]]></item>
-		<item name="wcf.user.3rdparty.google.login.error.access_denied"><![CDATA[Access to your Google account has been rejected.]]></item>
 		<item name="wcf.user.3rdparty.google.register"><![CDATA[You are creating an account through <span class="icon icon16 fa-google"></span>&nbsp;Google. The username and your email address have therefore already been entered.]]></item>
-		<item name="wcf.user.3rdparty.google.connect"><![CDATA[Connect with your Google account{if $__wcf->session->getVar('__googleUsername')} “{$__wcf->session->getVar('__googleUsername')}”{/if}.]]></item>
+		<item name="wcf.user.3rdparty.google.connect"><![CDATA[Connect with your Google account{if $__wcf->session->getVar('__3rdPartyProvider') === 'google'} “{$__wcf->session->getVar('__oauthUser')->getUsername()}”{/if}.]]></item>
 		<item name="wcf.user.3rdparty.google.connect.success"><![CDATA[Your user account has been connected with Google.]]></item>
 		<item name="wcf.user.3rdparty.google.connect.error.inuse"><![CDATA[Your Google account is already connected to a different user.]]></item>
 		<item name="wcf.user.3rdparty.google.disconnect"><![CDATA[Cancel connection with Google]]></item>


### PR DESCRIPTION
This pull request refactors the OAuth 2 login to be less copy and paste. It
does so by implementing the whole flow in a single abstract class with abstract
methods to grab all the parameters that change per provider (e.g. callback
URLs).

The PR is tested with all 4 providers (including the Twitter provider which
uses OAuth 1) for all of Registration, Login and Connecting to an existing
account. It however lacks proper error handling. I'll add the try-catch blocks
after a first early review.
