### PR TITLE
Deprecate `WCF.System.Dependency.Manager`

### DIFF
--- a/wcfsetup/install/files/js/WCF.js
+++ b/wcfsetup/install/files/js/WCF.js
@@ -4667,6 +4667,8 @@ WCF.System.Dependency = { };
 
 /**
  * JavaScript Dependency Manager.
+ * 
+ * @deprecated	5.4 - use `WoltLabSuite/Core/Event/Handler`
  */
 WCF.System.Dependency.Manager = {
 	/**


### PR DESCRIPTION
It has not been actively used for a very long time, see d1d6845c77fd7cde7558d0defd71ab7947643fe7.