### PR TITLE
Clean up ACP session log processing

### DIFF
--- a/wcfsetup/install/files/lib/data/acp/session/log/ACPSessionLog.class.php
+++ b/wcfsetup/install/files/lib/data/acp/session/log/ACPSessionLog.class.php
@@ -34,10 +34,8 @@ class ACPSessionLog extends DatabaseObject {
 	 */
 	public function __construct($id, array $row = null, DatabaseObject $object = null) {
 		if ($id !== null) {
-			$sql = "SELECT		acp_session_log.*, user_table.username, acp_session.sessionID AS active
+			$sql = "SELECT		acp_session_log.*, user_table.username, 0 AS active
 				FROM		wcf".WCF_N."_acp_session_log acp_session_log
-				LEFT JOIN	wcf".WCF_N."_acp_session acp_session
-				ON		(acp_session.sessionID = acp_session_log.sessionID)
 				LEFT JOIN	wcf".WCF_N."_user user_table
 				ON		(user_table.userID = acp_session_log.userID)
 				WHERE		acp_session_log.sessionLogID = ?";
@@ -53,25 +51,17 @@ class ACPSessionLog extends DatabaseObject {
 	}
 	
 	/**
-	 * Returns true if this session is active.
-	 * 
-	 * @return	bool
+	 * @deprecated 5.4 - This method always returns false.
 	 */
 	public function isActive() {
-		return $this->active ? true : false;
+		return false;
 	}
 	
 	/**
-	 * Returns true if this session is the active user session.
-	 * 
-	 * @return	bool
+	 * @deprecated 5.4 - This method always returns false.
 	 */
 	public function isActiveUserSession() {
-		if ($this->isActive() && $this->sessionID == WCF::getSession()->sessionID) {
-			return 1;
-		}
-		
-		return 0;
+		return false;
 	}
 	
 	/**

--- a/wcfsetup/install/files/lib/data/acp/session/log/ACPSessionLogList.class.php
+++ b/wcfsetup/install/files/lib/data/acp/session/log/ACPSessionLogList.class.php
@@ -26,11 +26,11 @@ class ACPSessionLogList extends DatabaseObjectList {
 	 */
 	public function readObjects() {
 		if (!empty($this->sqlSelects)) $this->sqlSelects .= ',';
-		$this->sqlSelects .= "	user_table.username, acp_session.sessionID AS active,
+		$this->sqlSelects .= "	user_table.username,
+					0 AS active,
 					(SELECT COUNT(*) FROM wcf".WCF_N."_acp_session_access_log WHERE sessionLogID = ".$this->getDatabaseTableAlias().".sessionLogID) AS accesses";
 		
-		$this->sqlJoins .= "	LEFT JOIN wcf".WCF_N."_user user_table ON (user_table.userID = ".$this->getDatabaseTableAlias().".userID)
-					LEFT JOIN wcf".WCF_N."_acp_session acp_session ON (acp_session.sessionID = ".$this->getDatabaseTableAlias().".sessionID)";
+		$this->sqlJoins .= "	LEFT JOIN wcf".WCF_N."_user user_table ON (user_table.userID = ".$this->getDatabaseTableAlias().".userID)";
 		
 		parent::readObjects();
 	}

--- a/wcfsetup/install/files/lib/system/event/listener/SessionAccessLogListener.class.php
+++ b/wcfsetup/install/files/lib/system/event/listener/SessionAccessLogListener.class.php
@@ -24,10 +24,12 @@ class SessionAccessLogListener implements IParameterizedEventListener {
 			// try to find existing session log
 			$sql = "SELECT	sessionLogID
 				FROM	wcf".WCF_N."_acp_session_log
-				WHERE	sessionID = ?";
+				WHERE	sessionID = ?
+				AND	lastActivityTime > ?";
 			$statement = WCF::getDB()->prepareStatement($sql);
 			$statement->execute([
 				WCF::getSession()->sessionID,
+				(TIME_NOW - 15 * 60)
 			]);
 			$row = $statement->fetchArray();
 			if (!empty($row['sessionLogID'])) {


### PR DESCRIPTION
These commits are cherry-picked from #3858.

--------------

- Stop accessing wcf1_acp_session in ACP session log
- Consider an ACP session to be expired after 15 minutes in SessionAccessLogListener
