### PR TITLE
Dynamic WebP avatars

### DIFF
--- a/wcfsetup/install/files/acp/update_com.woltlab.wcf_5.4_db.php
+++ b/wcfsetup/install/files/acp/update_com.woltlab.wcf_5.4_db.php
@@ -51,6 +51,11 @@ $tables = [
             DefaultFalseBooleanDatabaseTableColumn::create('multifactorActive'),
         ]),
 
+    PartialDatabaseTable::create('wcf1_user_avatar')
+        ->columns([
+            DefaultFalseBooleanDatabaseTableColumn::create("hasWebP"),
+        ]),
+
     DatabaseTable::create('wcf1_user_multifactor')
         ->columns([
             ObjectIdDatabaseTableColumn::create('setupID'),
@@ -149,9 +154,8 @@ $tables = [
 ];
 
 (new DatabaseTableChangeProcessor(
-/** @var ScriptPackageInstallationPlugin $this */
+    /** @var ScriptPackageInstallationPlugin $this */
     $this->installation->getPackage(),
     $tables,
     WCF::getDB()->getEditor()
-)
-)->process();
+))->process();

--- a/wcfsetup/install/files/lib/data/user/avatar/UserAvatar.class.php
+++ b/wcfsetup/install/files/lib/data/user/avatar/UserAvatar.class.php
@@ -84,6 +84,7 @@ class UserAvatar extends DatabaseObject implements IUserAvatar
         }
 
         $directory = \substr($this->fileHash, 0, 2);
+
         return \sprintf(
             '%s/%d-%s.%s',
             $directory,

--- a/wcfsetup/install/files/lib/data/user/avatar/UserAvatar.class.php
+++ b/wcfsetup/install/files/lib/data/user/avatar/UserAvatar.class.php
@@ -4,6 +4,7 @@ namespace wcf\data\user\avatar;
 
 use wcf\data\DatabaseObject;
 use wcf\system\WCF;
+use wcf\util\ImageUtil;
 use wcf\util\StringUtil;
 
 /**
@@ -14,13 +15,14 @@ use wcf\util\StringUtil;
  * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
  * @package WoltLabSuite\Core\Data\User\Avatar
  *
- * @property-read   int $avatarID       unique id of the user avatar
- * @property-read   string $avatarName     name of the original avatar file
- * @property-read   string $avatarExtension    extension of the avatar file
- * @property-read   int $width          width of the user avatar image
- * @property-read   int $height         height of the user avatar image
- * @property-read   int|null $userID         id of the user to which the user avatar belongs or null
- * @property-read   string $fileHash       SHA1 hash of the original avatar file
+ * @property-read int $avatarID unique id of the user avatar
+ * @property-read string $avatarName name of the original avatar file
+ * @property-read string $avatarExtension extension of the avatar file
+ * @property-read int $width width of the user avatar image
+ * @property-read int $height height of the user avatar image
+ * @property-read int|null $userID id of the user to which the user avatar belongs or null
+ * @property-read string $fileHash SHA1 hash of the original avatar file
+ * @property-read int $hasWebP `1` if there is a WebP variant, else `0`
  */
 class UserAvatar extends DatabaseObject implements IUserAvatar
 {
@@ -55,26 +57,37 @@ class UserAvatar extends DatabaseObject implements IUserAvatar
      * Returns the physical location of this avatar.
      *
      * @param int $size
-     * @return  string
+     * @param bool|null $forceWebP
+     * @return string
      */
-    public function getLocation($size = null)
+    public function getLocation($size = null, ?bool $forceWebP = null)
     {
-        return WCF_DIR . 'images/avatars/' . $this->getFilename($size);
+        return WCF_DIR . 'images/avatars/' . $this->getFilename($size, $forceWebP);
     }
 
     /**
      * Returns the file name of this avatar.
      *
      * @param int $size
-     * @return  string
+     * @param bool|null $forceWebP
+     * @return string
      */
-    public function getFilename($size = null)
+    public function getFilename($size = null, ?bool $forceWebP = null)
     {
-        return \substr(
-            $this->fileHash,
-            0,
-            2
-        ) . '/' . $this->avatarID . '-' . $this->fileHash . ($size !== null ? ('-' . $size) : '') . '.' . $this->avatarExtension;
+        if ($forceWebP === true || ($forceWebP === null && $this->hasWebP && ImageUtil::browserSupportsWebP())) {
+            $fileExtension = "webp";
+        } else {
+            $fileExtension = $this->avatarExtension;
+        }
+
+        $directory = \substr($this->fileHash, 0, 2);
+        return \sprintf(
+            '%s/%d-%s.%s',
+            $directory,
+            $this->avatarID,
+            $this->fileHash . ($size !== null ? ('-' . $size) : ''),
+            $fileExtension
+        );
     }
 
     /**

--- a/wcfsetup/install/files/lib/data/user/avatar/UserAvatar.class.php
+++ b/wcfsetup/install/files/lib/data/user/avatar/UserAvatar.class.php
@@ -74,7 +74,10 @@ class UserAvatar extends DatabaseObject implements IUserAvatar
      */
     public function getFilename($size = null, ?bool $forceWebP = null)
     {
-        if ($forceWebP === true || ($forceWebP === null && $this->hasWebP && ImageUtil::browserSupportsWebP())) {
+        if (
+            $forceWebP === true
+            || ($forceWebP === null && $this->hasWebP && ImageUtil::browserSupportsWebP())
+        ) {
             $fileExtension = "webp";
         } else {
             $fileExtension = $this->avatarExtension;

--- a/wcfsetup/install/files/lib/data/user/avatar/UserAvatarEditor.class.php
+++ b/wcfsetup/install/files/lib/data/user/avatar/UserAvatarEditor.class.php
@@ -112,14 +112,14 @@ class UserAvatarEditor extends DatabaseObjectEditor
         // If the uploaded avatar is already a WebP image, then create a JPEG
         // as a fallback image and flip the image data to match the JPEG.
         if ($this->avatarExtension === "webp") {
-            $filenameJpeg = preg_replace('~\.webp$~', '.jpeg', $filenameWebP);
+            $filenameJpeg = \preg_replace('~\.webp$~', '.jpeg', $filenameWebP);
 
             $imageAdapter->saveImageAs($image, $filenameJpeg, "jpeg", 80);
 
             // The new file has a different SHA1 hash, which means that apart from
             // updating the `fileHash` we also need to move it to a different physical
             // location.
-            $newFileHash = sha1_file($filenameJpeg);
+            $newFileHash = \sha1_file($filenameJpeg);
 
             $tmpAvatar = clone $this;
             $tmpAvatar->data["avatarExtension"] = "jpeg";

--- a/wcfsetup/install/files/lib/data/user/avatar/UserAvatarEditor.class.php
+++ b/wcfsetup/install/files/lib/data/user/avatar/UserAvatarEditor.class.php
@@ -84,7 +84,7 @@ class UserAvatarEditor extends DatabaseObjectEditor
      * Creates a WebP variant of the avatar, unless it is a GIF image. If the
      * user uploads a WebP image, this method will create a JPEG variant as a
      * fallback for ancient clients.
-     * 
+     *
      * Will return `true` if a variant has been created.
      *
      * @since 5.4

--- a/wcfsetup/install/files/lib/data/user/avatar/UserAvatarEditor.class.php
+++ b/wcfsetup/install/files/lib/data/user/avatar/UserAvatarEditor.class.php
@@ -127,11 +127,11 @@ class UserAvatarEditor extends DatabaseObjectEditor
             $newLocation = $tmpAvatar->getLocation(null, false);
 
             $dir = \dirname($newLocation);
-            if (!@\file_exists($dir)) {
+            if (!\file_exists($dir)) {
                 FileUtil::makePath($dir);
             }
 
-            @\rename($filenameJpeg, $newLocation);
+            \rename($filenameJpeg, $newLocation);
 
             $data = [
                 "avatarExtension" => "jpeg",

--- a/wcfsetup/install/files/lib/system/upload/AvatarUploadFileSaveStrategy.class.php
+++ b/wcfsetup/install/files/lib/system/upload/AvatarUploadFileSaveStrategy.class.php
@@ -76,7 +76,8 @@ class AvatarUploadFileSaveStrategy implements IUploadFileSaveStrategy
                     UserAvatar::AVATAR_SIZE,
                     false
                 );
-            } /** @noinspection PhpRedundantCatchClauseInspection */
+            }
+            /** @noinspection PhpRedundantCatchClauseInspection */
             catch (SystemException $e) {
                 $uploadFile->setValidationErrorType('tooLarge');
 
@@ -105,14 +106,20 @@ class AvatarUploadFileSaveStrategy implements IUploadFileSaveStrategy
 
             // check avatar directory
             // and create subdirectory if necessary
-            $dir = \dirname($this->avatar->getLocation());
+            $dir = \dirname($this->avatar->getLocation(null, false));
             if (!@\file_exists($dir)) {
                 FileUtil::makePath($dir);
             }
 
             // move uploaded file
-            if (@\copy($fileLocation, $this->avatar->getLocation())) {
+            if (@\copy($fileLocation, $this->avatar->getLocation(null, false))) {
                 @\unlink($fileLocation);
+
+                // Create the WebP variant or the JPEG fallback of the avatar.
+                $avatarEditor = new UserAvatarEditor($this->avatar);
+                if ($avatarEditor->createAvatarVariant()) {
+                    $this->avatar = new UserAvatar($this->avatar->avatarID);
+                }
 
                 // delete old avatar
                 if ($this->user->avatarID) {

--- a/wcfsetup/install/files/lib/system/worker/UserRebuildDataWorker.class.php
+++ b/wcfsetup/install/files/lib/system/worker/UserRebuildDataWorker.class.php
@@ -212,9 +212,9 @@ class UserRebuildDataWorker extends AbstractRebuildDataWorker
             $avatarList->getConditionBuilder()->add('user_avatar.userID IN (?)', [$userIDs]);
             $avatarList->getConditionBuilder()->add(
                 '(
-					(user_avatar.width <> ? OR user_avatar.height <> ?)
-					OR (user_avatar.hasWebP = ? AND user_avatar.avatarExtension <> ?)
-				)',
+                    (user_avatar.width <> ? OR user_avatar.height <> ?)
+                    OR (user_avatar.hasWebP = ? AND user_avatar.avatarExtension <> ?)
+                )',
                 [
                     UserAvatar::AVATAR_SIZE,
                     UserAvatar::AVATAR_SIZE,

--- a/wcfsetup/install/files/lib/system/worker/UserRebuildDataWorker.class.php
+++ b/wcfsetup/install/files/lib/system/worker/UserRebuildDataWorker.class.php
@@ -211,8 +211,16 @@ class UserRebuildDataWorker extends AbstractRebuildDataWorker
             $avatarList = new UserAvatarList();
             $avatarList->getConditionBuilder()->add('user_avatar.userID IN (?)', [$userIDs]);
             $avatarList->getConditionBuilder()->add(
-                '(user_avatar.width <> ? OR user_avatar.height <> ?)',
-                [UserAvatar::AVATAR_SIZE, UserAvatar::AVATAR_SIZE]
+                '(
+					(user_avatar.width <> ? OR user_avatar.height <> ?)
+					OR (user_avatar.hasWebP = ? AND user_avatar.avatarExtension <> ?)
+				)',
+                [
+                    UserAvatar::AVATAR_SIZE,
+                    UserAvatar::AVATAR_SIZE,
+                    1,
+                    "gif",
+                ]
             );
             $avatarList->readObjects();
             foreach ($avatarList as $avatar) {
@@ -260,6 +268,8 @@ class UserRebuildDataWorker extends AbstractRebuildDataWorker
                     $adapter->writeImage($adapter->getImage(), $avatar->getLocation());
                     $width = $height = UserAvatar::AVATAR_SIZE;
                 }
+
+                $editor->createAvatarVariant();
 
                 $editor->update([
                     'width' => $width,

--- a/wcfsetup/install/files/lib/util/ImageUtil.class.php
+++ b/wcfsetup/install/files/lib/util/ImageUtil.class.php
@@ -199,6 +199,33 @@ final class ImageUtil
     }
 
     /**
+     * Examines the `accept` header to determine if the browser
+     * supports WebP images.
+     * 
+     * @since 5.4
+     */
+    public static function browserSupportsWebP(): bool
+    {
+        static $supportsWebP = null;
+
+        if ($supportsWebP === null) {
+            $supportsWebP = false;
+            if (!empty($_SERVER["HTTP_ACCEPT"])) {
+                $acceptableMimeTypes = array_map(function ($acceptableMimeType) {
+                    [$mimeType] = ArrayUtil::trim(explode(";", $acceptableMimeType));
+                    return $mimeType;
+                }, explode(",", $_SERVER["HTTP_ACCEPT"]));
+
+                if (in_array("image/webp", $acceptableMimeTypes)) {
+                    $supportsWebP = true;
+                }
+            }
+        }
+
+        return $supportsWebP;
+    }
+
+    /**
      * Forbid creation of ImageUtil objects.
      */
     private function __construct()

--- a/wcfsetup/install/files/lib/util/ImageUtil.class.php
+++ b/wcfsetup/install/files/lib/util/ImageUtil.class.php
@@ -211,8 +211,9 @@ final class ImageUtil
         if ($supportsWebP === null) {
             $supportsWebP = false;
             if (!empty($_SERVER["HTTP_ACCEPT"])) {
-                $acceptableMimeTypes = \array_map(function ($acceptableMimeType) {
+                $acceptableMimeTypes = \array_map(static function ($acceptableMimeType) {
                     [$mimeType] = ArrayUtil::trim(\explode(";", $acceptableMimeType));
+
                     return $mimeType;
                 }, \explode(",", $_SERVER["HTTP_ACCEPT"]));
 

--- a/wcfsetup/install/files/lib/util/ImageUtil.class.php
+++ b/wcfsetup/install/files/lib/util/ImageUtil.class.php
@@ -201,7 +201,7 @@ final class ImageUtil
     /**
      * Examines the `accept` header to determine if the browser
      * supports WebP images.
-     * 
+     *
      * @since 5.4
      */
     public static function browserSupportsWebP(): bool

--- a/wcfsetup/install/files/lib/util/ImageUtil.class.php
+++ b/wcfsetup/install/files/lib/util/ImageUtil.class.php
@@ -211,12 +211,12 @@ final class ImageUtil
         if ($supportsWebP === null) {
             $supportsWebP = false;
             if (!empty($_SERVER["HTTP_ACCEPT"])) {
-                $acceptableMimeTypes = array_map(function ($acceptableMimeType) {
-                    [$mimeType] = ArrayUtil::trim(explode(";", $acceptableMimeType));
+                $acceptableMimeTypes = \array_map(function ($acceptableMimeType) {
+                    [$mimeType] = ArrayUtil::trim(\explode(";", $acceptableMimeType));
                     return $mimeType;
-                }, explode(",", $_SERVER["HTTP_ACCEPT"]));
+                }, \explode(",", $_SERVER["HTTP_ACCEPT"]));
 
-                if (in_array("image/webp", $acceptableMimeTypes)) {
+                if (\in_array("image/webp", $acceptableMimeTypes)) {
                     $supportsWebP = true;
                 }
             }

--- a/wcfsetup/setup/db/install.sql
+++ b/wcfsetup/setup/db/install.sql
@@ -1541,7 +1541,8 @@ CREATE TABLE wcf1_user_avatar (
 	width SMALLINT(5) NOT NULL DEFAULT 0,
 	height SMALLINT(5) NOT NULL DEFAULT 0,
 	userID INT(10),
-	fileHash VARCHAR(40) NOT NULL DEFAULT ''
+	fileHash VARCHAR(40) NOT NULL DEFAULT '',
+    hasWebP TINYINT(1) NOT NULL DEFAULT 0
 );
 
 DROP TABLE IF EXISTS wcf1_user_collapsible_content;

--- a/wcfsetup/setup/db/install.sql
+++ b/wcfsetup/setup/db/install.sql
@@ -1542,7 +1542,7 @@ CREATE TABLE wcf1_user_avatar (
 	height SMALLINT(5) NOT NULL DEFAULT 0,
 	userID INT(10),
 	fileHash VARCHAR(40) NOT NULL DEFAULT '',
-    hasWebP TINYINT(1) NOT NULL DEFAULT 0
+	hasWebP TINYINT(1) NOT NULL DEFAULT 0
 );
 
 DROP TABLE IF EXISTS wcf1_user_collapsible_content;


### PR DESCRIPTION
User avatars are served as WebP images if the browser indicated support for it via the accept http header. This approach is less flexible than <picture>, but is fully backwards compatible and thus does not introduce any breaking changes whatsoever.

Closes #3862

Replaces #3863 which was created prior to the PSR-12 adoption and recreating it was cleaner.