### PR TITLE
Clean up wcf1_tag_to_object

### DIFF
--- a/com.woltlab.wcf/package.xml
+++ b/com.woltlab.wcf/package.xml
@@ -88,6 +88,12 @@ tar cvf com.woltlab.wcf/files_pre.tar -C wcfsetup/install/files/ \
 		<!-- Non-critical database adjustments. -->
 		<instruction type="script" run="standalone">acp/update_com.woltlab.wcf_5.4_db.php</instruction>
 		
+		<!-- Index updates for `wcf1_tag_to_object`. -->
+		<instruction type="script" run="standalone">acp/update_com.woltlab.wcf_5.4_wcf1_tag_to_object_step1.php</instruction>
+		<instruction type="script" run="standalone">acp/update_com.woltlab.wcf_5.4_wcf1_tag_to_object_step2.php</instruction>
+		<instruction type="script" run="standalone">acp/update_com.woltlab.wcf_5.4_wcf1_tag_to_object_step3.php</instruction>
+		<instruction type="script" run="standalone">acp/update_com.woltlab.wcf_5.4_wcf1_tag_to_object_step4.php</instruction>
+		
 		<!-- Cleanup of the filesystem. -->
 		<instruction type="script" run="standalone">acp/update_com.woltlab.wcf_5.4_removeFiles.php</instruction>
 		

--- a/wcfsetup/install/files/acp/update_com.woltlab.wcf_5.4_wcf1_tag_to_object_step1.php
+++ b/wcfsetup/install/files/acp/update_com.woltlab.wcf_5.4_wcf1_tag_to_object_step1.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * First step of the updates to the `wcf1_tag_to_object` table.
+ *
+ * The foreign keys needs to be dropped first because they required the dropped indices.
+ *
+ * @author  Matthias Schmidt
+ * @copyright   2001-2021 WoltLab GmbH
+ * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @package WoltLabSuite\Core
+ */
+
+use wcf\system\database\table\DatabaseTableChangeProcessor;
+use wcf\system\database\table\index\DatabaseTableForeignKey;
+use wcf\system\database\table\index\DatabaseTableIndex;
+use wcf\system\database\table\PartialDatabaseTable;
+use wcf\system\package\plugin\ScriptPackageInstallationPlugin;
+use wcf\system\WCF;
+
+$tables = [
+    PartialDatabaseTable::create('wcf1_tag_to_object')
+        ->foreignKeys([
+            DatabaseTableForeignKey::create()
+                ->columns(['tagID'])
+                ->referencedTable('wcf1_tag')
+                ->referencedColumns(['tagID'])
+                ->onDelete('CASCADE')
+                ->drop(),
+            DatabaseTableForeignKey::create()
+                ->columns(['languageID'])
+                ->referencedTable('wcf1_language')
+                ->referencedColumns(['languageID'])
+                ->onDelete('CASCADE')
+                ->drop(),
+            DatabaseTableForeignKey::create()
+                ->columns(['objectTypeID'])
+                ->referencedTable('wcf1_object_type')
+                ->referencedColumns(['objectTypeID'])
+                ->onDelete('CASCADE')
+                ->drop(),
+        ])
+        ->indices([
+            DatabaseTableIndex::create()
+                ->columns(['objectTypeID', 'languageID', 'objectID', 'tagID'])
+                ->type(DatabaseTableIndex::UNIQUE_TYPE)
+                ->drop(),
+            DatabaseTableIndex::create()
+                ->columns(['tagID', 'objectTypeID'])
+                ->drop(),
+        ]),
+];
+
+(new DatabaseTableChangeProcessor(
+    /** @var ScriptPackageInstallationPlugin $this */
+    $this->installation->getPackage(),
+    $tables,
+    WCF::getDB()->getEditor()
+))->process();

--- a/wcfsetup/install/files/acp/update_com.woltlab.wcf_5.4_wcf1_tag_to_object_step2.php
+++ b/wcfsetup/install/files/acp/update_com.woltlab.wcf_5.4_wcf1_tag_to_object_step2.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * Second step of the updates to the `wcf1_tag_to_object` table.
+ *
+ * @author  Matthias Schmidt
+ * @copyright   2001-2021 WoltLab GmbH
+ * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @package WoltLabSuite\Core
+ */
+
+use wcf\system\database\table\DatabaseTableChangeProcessor;
+use wcf\system\database\table\index\DatabaseTableIndex;
+use wcf\system\database\table\PartialDatabaseTable;
+use wcf\system\package\plugin\ScriptPackageInstallationPlugin;
+use wcf\system\WCF;
+
+$tables = [
+    PartialDatabaseTable::create('wcf1_tag_to_object')
+        ->indices([
+            DatabaseTableIndex::create()
+                ->columns(['objectTypeID', 'languageID', 'tagID'])
+                ->drop(),
+        ]),
+];
+
+(new DatabaseTableChangeProcessor(
+    /** @var ScriptPackageInstallationPlugin $this */
+    $this->installation->getPackage(),
+    $tables,
+    WCF::getDB()->getEditor()
+))->process();

--- a/wcfsetup/install/files/acp/update_com.woltlab.wcf_5.4_wcf1_tag_to_object_step3.php
+++ b/wcfsetup/install/files/acp/update_com.woltlab.wcf_5.4_wcf1_tag_to_object_step3.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * Third step of the updates to the `wcf1_tag_to_object` table.
+ *
+ * @author  Matthias Schmidt
+ * @copyright   2001-2021 WoltLab GmbH
+ * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @package WoltLabSuite\Core
+ */
+
+use wcf\system\database\table\DatabaseTableChangeProcessor;
+use wcf\system\database\table\index\DatabaseTableForeignKey;
+use wcf\system\database\table\index\DatabaseTablePrimaryIndex;
+use wcf\system\database\table\PartialDatabaseTable;
+use wcf\system\package\plugin\ScriptPackageInstallationPlugin;
+use wcf\system\WCF;
+
+$tables = [
+    PartialDatabaseTable::create('wcf1_tag_to_object')
+        ->foreignKeys([
+            DatabaseTableForeignKey::create()
+                ->columns(['tagID'])
+                ->referencedTable('wcf1_tag')
+                ->referencedColumns(['tagID'])
+                ->onDelete('CASCADE'),
+            DatabaseTableForeignKey::create()
+                ->columns(['languageID'])
+                ->referencedTable('wcf1_language')
+                ->referencedColumns(['languageID'])
+                ->onDelete('CASCADE'),
+            DatabaseTableForeignKey::create()
+                ->columns(['objectTypeID'])
+                ->referencedTable('wcf1_object_type')
+                ->referencedColumns(['objectTypeID'])
+                ->onDelete('CASCADE'),
+        ])
+        ->indices([
+            DatabaseTablePrimaryIndex::create()
+                ->columns(['objectTypeID', 'objectID', 'tagID']),
+        ]),
+];
+
+(new DatabaseTableChangeProcessor(
+    /** @var ScriptPackageInstallationPlugin $this */
+    $this->installation->getPackage(),
+    $tables,
+    WCF::getDB()->getEditor()
+))->process();

--- a/wcfsetup/install/files/acp/update_com.woltlab.wcf_5.4_wcf1_tag_to_object_step4.php
+++ b/wcfsetup/install/files/acp/update_com.woltlab.wcf_5.4_wcf1_tag_to_object_step4.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * Fourth step of the updates to the `wcf1_tag_to_object` table.
+ *
+ * @author  Matthias Schmidt
+ * @copyright   2001-2021 WoltLab GmbH
+ * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @package WoltLabSuite\Core
+ */
+
+use wcf\system\database\table\DatabaseTableChangeProcessor;
+use wcf\system\database\table\index\DatabaseTableIndex;
+use wcf\system\database\table\PartialDatabaseTable;
+use wcf\system\package\plugin\ScriptPackageInstallationPlugin;
+use wcf\system\WCF;
+
+$tables = [
+    PartialDatabaseTable::create('wcf1_tag_to_object')
+        ->indices([
+            DatabaseTableIndex::create()
+                ->columns(['objectTypeID', 'tagID']),
+            DatabaseTableIndex::create()
+                ->columns(['tagID']),
+        ]),
+];
+
+(new DatabaseTableChangeProcessor(
+    /** @var ScriptPackageInstallationPlugin $this */
+    $this->installation->getPackage(),
+    $tables,
+    WCF::getDB()->getEditor()
+))->process();

--- a/wcfsetup/install/files/lib/system/cache/builder/TagCloudCacheBuilder.class.php
+++ b/wcfsetup/install/files/lib/system/cache/builder/TagCloudCacheBuilder.class.php
@@ -88,11 +88,13 @@ class TagCloudCacheBuilder extends AbstractCacheBuilder
             // get tag ids
             $conditionBuilder = new PreparedStatementConditionBuilder();
             $conditionBuilder->add('object.objectTypeID IN (?)', [$this->objectTypeIDs]);
-            $conditionBuilder->add('object.languageID IN (?)', [$this->languageIDs]);
-            $sql = "SELECT      COUNT(*) AS counter, object.tagID
+            $conditionBuilder->add('tag.languageID IN (?)', [$this->languageIDs]);
+            $sql = "SELECT      tag.tagID, COUNT(*) AS counter
                     FROM        wcf" . WCF_N . "_tag_to_object object
+                    INNER JOIN  wcf" . WCF_N . "_tag tag
+                            ON  tag.tagID = object.tagID
                     " . $conditionBuilder . "
-                    GROUP BY    object.tagID
+                    GROUP BY    tag.tagID
                     ORDER BY    counter DESC";
             $statement = WCF::getDB()->prepareStatement($sql, 500);
             $statement->execute($conditionBuilder->getParameters());

--- a/wcfsetup/install/files/lib/system/tagging/TagEngine.class.php
+++ b/wcfsetup/install/files/lib/system/tagging/TagEngine.class.php
@@ -41,10 +41,13 @@ class TagEngine extends SingletonFactory
 
         // remove tags prior to apply the new ones (prevents duplicate entries)
         if ($replace) {
-            $sql = "DELETE FROM wcf" . WCF_N . "_tag_to_object
-                    WHERE       objectTypeID = ?
-                            AND objectID = ?
-                            AND languageID = ?";
+            $sql = "DELETE      tag_to_object
+                    FROM        wcf" . WCF_N . "_tag_to_object tag_to_object
+                    INNER JOIN  wcf" . WCF_N . "_tag tag
+                            ON  tag.tagID = tag_to_object.tagID
+                    WHERE       tag_to_object.objectTypeID = ?
+                            AND tag_to_object.objectID = ?
+                            AND tag.languageID = ?";
             $statement = WCF::getDB()->prepareStatement($sql);
             $statement->execute([
                 $objectTypeID,
@@ -111,10 +114,13 @@ class TagEngine extends SingletonFactory
     {
         $objectTypeID = $this->getObjectTypeID($objectType);
 
-        $sql = "DELETE FROM wcf" . WCF_N . "_tag_to_object
-                WHERE       objectTypeID = ?
-                        AND objectID = ?
-                        " . ($languageID !== null ? "AND languageID = ?" : "");
+        $sql = "DELETE      tag_to_object
+                FROM        wcf" . WCF_N . "_tag_to_object tag_to_object
+                INNER JOIN  wcf" . WCF_N . "_tag tag
+                        ON  tag.tagID = tag_to_object.tagID
+                WHERE       tag_to_object.objectTypeID = ?
+                        AND tag_to_object.objectID = ?
+                        " . ($languageID !== null ? "AND tag.languageID = ?" : "");
         $statement = WCF::getDB()->prepareStatement($sql);
         $parameters = [
             $objectTypeID,

--- a/wcfsetup/install/files/lib/system/tagging/TagEngine.class.php
+++ b/wcfsetup/install/files/lib/system/tagging/TagEngine.class.php
@@ -199,7 +199,7 @@ class TagEngine extends SingletonFactory
                 }
             }
 
-            $conditions->add("tag_to_object.languageID IN (?)", [$languageIDs]);
+            $conditions->add("tag.languageID IN (?)", [$languageIDs]);
         }
 
         $sql = "SELECT      tag.*, tag_to_object.objectID

--- a/wcfsetup/setup/db/install.sql
+++ b/wcfsetup/setup/db/install.sql
@@ -1349,8 +1349,8 @@ CREATE TABLE wcf1_tag_to_object (
 	tagID INT(10) NOT NULL,
 	objectTypeID INT(10) NOT NULL,
 	languageID INT(10) NOT NULL,
-	UNIQUE KEY (objectTypeID, languageID, objectID, tagID),
-	KEY (objectTypeID, languageID, tagID),
+	UNIQUE KEY (objectTypeID, objectID, tagID),
+	KEY (objectTypeID, tagID),
 	KEY (tagID, objectTypeID)
 );
 

--- a/wcfsetup/setup/db/install.sql
+++ b/wcfsetup/setup/db/install.sql
@@ -1349,7 +1349,7 @@ CREATE TABLE wcf1_tag_to_object (
 	tagID INT(10) NOT NULL,
 	objectTypeID INT(10) NOT NULL,
 	languageID INT(10) NOT NULL,
-	UNIQUE KEY (objectTypeID, objectID, tagID),
+	PRIMARY KEY (objectTypeID, objectID, tagID),
 	KEY (objectTypeID, tagID),
 	KEY (tagID)
 );

--- a/wcfsetup/setup/db/install.sql
+++ b/wcfsetup/setup/db/install.sql
@@ -1351,7 +1351,7 @@ CREATE TABLE wcf1_tag_to_object (
 	languageID INT(10) NOT NULL,
 	UNIQUE KEY (objectTypeID, objectID, tagID),
 	KEY (objectTypeID, tagID),
-	KEY (tagID, objectTypeID)
+	KEY (tagID)
 );
 
 DROP TABLE IF EXISTS wcf1_template;


### PR DESCRIPTION
see #3803

- Stop accessing wcf1_tag_to_object.languageID in TagCloudCacheBuilder::getTags()
- Stop accessing wcf1_tag_to_object.languageID during DELETE in TagEngine
- Stop accessing wcf1_tag_to_object.languageID in TagEngine::getObjectsTags()
- Remove the languageID column from keys in wcf1_tag_to_object
- Remove redundant column from wcf1_tag_to_object.tagID key
- Make wcf1_tag_to_object's PRIMARY KEY a UNIQUE KEY
