### PR TITLE
Deprecate Master Password

### DIFF
--- a/wcfsetup/install/files/acp/templates/masterPassword.tpl
+++ b/wcfsetup/install/files/acp/templates/masterPassword.tpl
@@ -10,6 +10,10 @@
 	<h1 class="contentTitle">{lang}wcf.acp.masterPassword.enter{/lang}</h1>
 </header>
 
+<p class="warning">
+	{lang}wcf.acp.masterPassword.enter.deprecated{/lang}
+</p>
+
 {include file='formError'}
 
 <form method="post" action="{link controller='MasterPassword'}{/link}">

--- a/wcfsetup/install/lang/de.xml
+++ b/wcfsetup/install/lang/de.xml
@@ -1049,6 +1049,7 @@ ACHTUNG: Die oben genannten Meldungen sind stark gekürzt. Sie können Details z
 		<item name="wcf.acp.masterPassword.example.set"><![CDATA[Vorschlag übernehmen]]></item>
 		<item name="wcf.acp.masterPassword.init"><![CDATA[Hauptkennwort festlegen]]></item>
 		<item name="wcf.acp.masterPassword.init.description"><![CDATA[Das Hauptkennwort ist ein zusätzlicher Schutz für sicherheitskritische Funktionen. {if LANGUAGE_USE_INFORMAL_VARIANT}Du solltest{else}Sie sollten{/if} ein möglichst sicheres Kennwort verwenden, dass sich von {if LANGUAGE_USE_INFORMAL_VARIANT}deinem{else}Ihrem{/if} regulären Administrator-Kennwort unterscheidet, Dritten nicht bekannt ist und auch nicht auf anderen Internetseiten verwendet wird.]]></item>
+		<item name="wcf.acp.masterPassword.enter.deprecated"><![CDATA[Die Unterstützung für das Hauptkennwort ist obsolet und wird in einer zukünftigen Version entfernt. Die <a href="{link controller='AccountSecurity' forceFrontend=true application='wcf'}{/link}">Mehrfaktor-Authentifizierung</a> schützt Benutzerkonten zuverlässiger und in allen Bereichen. Falls gewünscht, können einzelne Benutzergruppen verpflichtet werden, die Mehrfaktor-Authentifizierung einzurichten, bevor diese sensible Bereiche, wie beispielsweise die Administrationsoberfläche betreten können.]]></item>
 	</category>
 	<category name="wcf.acp.menu">
 		<item name="wcf.acp.menu.link.management"><![CDATA[Verwaltung]]></item>

--- a/wcfsetup/install/lang/de.xml
+++ b/wcfsetup/install/lang/de.xml
@@ -1364,8 +1364,8 @@ ACHTUNG: Die oben genannten Meldungen sind stark gekürzt. Sie können Details z
 		<item name="wcf.acp.option.meta_description"><![CDATA[Meta Description]]></item>
 		<item name="wcf.acp.option.og_image"><![CDATA[Standardwert „Open Graph“-Bild]]></item>
 		<item name="wcf.acp.option.og_image.description"><![CDATA[Pfad zur Bilddatei, die beim Verlinken von Inhalten auf Facebook, Twitter und anderen „Social Media“-Seiten standardmäßig eingebunden wird.]]></item>
-		<item name="wcf.acp.option.module_master_password"><![CDATA[Hauptkennwort aktivieren]]></item>
-		<item name="wcf.acp.option.module_master_password.description"><![CDATA[Aktiviert die zusätzliche Eingabe eines Kennworts beim Aufruf von sicherheitskritischen Bereichen.]]></item>
+		<item name="wcf.acp.option.module_master_password"><![CDATA[Hauptkennwort aktivieren (obsolet)]]></item>
+		<item name="wcf.acp.option.module_master_password.description"><![CDATA[Von der Verwendung des Hauptkennworts wird abgeraten. Stattdessen sollte die Mehrfaktor-Authentifizierung genutzt werden. Diese schützt Benutzerkonten zuverlässiger und in allen Bereichen. Die Unterstützung für das Hauptkennwort wird in einer zukünftigen Version entfernt.]]></item>
 		<item name="wcf.acp.option.page_description"><![CDATA[Seitenbeschreibung]]></item>
 		<item name="wcf.acp.option.page_title"><![CDATA[Titel der Seite]]></item>
 		<item name="wcf.acp.option.proxy_server_http"><![CDATA[Proxy-Server (HTTP)]]></item>

--- a/wcfsetup/install/lang/de.xml
+++ b/wcfsetup/install/lang/de.xml
@@ -1049,7 +1049,7 @@ ACHTUNG: Die oben genannten Meldungen sind stark gekürzt. Sie können Details z
 		<item name="wcf.acp.masterPassword.example.set"><![CDATA[Vorschlag übernehmen]]></item>
 		<item name="wcf.acp.masterPassword.init"><![CDATA[Hauptkennwort festlegen]]></item>
 		<item name="wcf.acp.masterPassword.init.description"><![CDATA[Das Hauptkennwort ist ein zusätzlicher Schutz für sicherheitskritische Funktionen. {if LANGUAGE_USE_INFORMAL_VARIANT}Du solltest{else}Sie sollten{/if} ein möglichst sicheres Kennwort verwenden, dass sich von {if LANGUAGE_USE_INFORMAL_VARIANT}deinem{else}Ihrem{/if} regulären Administrator-Kennwort unterscheidet, Dritten nicht bekannt ist und auch nicht auf anderen Internetseiten verwendet wird.]]></item>
-		<item name="wcf.acp.masterPassword.enter.deprecated"><![CDATA[Die Unterstützung für das Hauptkennwort ist obsolet und wird in einer zukünftigen Version entfernt. Die <a href="{link controller='AccountSecurity' forceFrontend=true application='wcf'}{/link}">Mehrfaktor-Authentifizierung</a> schützt Benutzerkonten zuverlässiger und in allen Bereichen. Falls gewünscht, können einzelne Benutzergruppen verpflichtet werden, die Mehrfaktor-Authentifizierung einzurichten, bevor diese sensible Bereiche, wie beispielsweise die Administrationsoberfläche betreten können.]]></item>
+		<item name="wcf.acp.masterPassword.enter.deprecated"><![CDATA[Die Unterstützung für das Hauptkennwort ist obsolet und wird in einer zukünftigen Version ohne weiteren Hinweis entfernt. Die <a href="{link controller='AccountSecurity' forceFrontend=true application='wcf'}{/link}">Mehrfaktor-Authentifizierung</a> schützt Benutzerkonten zuverlässiger und in allen Bereichen. Falls gewünscht, können einzelne Benutzergruppen verpflichtet werden, die Mehrfaktor-Authentifizierung einzurichten, bevor diese sensible Bereiche, wie beispielsweise die Administrationsoberfläche betreten können.]]></item>
 	</category>
 	<category name="wcf.acp.menu">
 		<item name="wcf.acp.menu.link.management"><![CDATA[Verwaltung]]></item>
@@ -1366,7 +1366,7 @@ ACHTUNG: Die oben genannten Meldungen sind stark gekürzt. Sie können Details z
 		<item name="wcf.acp.option.og_image"><![CDATA[Standardwert „Open Graph“-Bild]]></item>
 		<item name="wcf.acp.option.og_image.description"><![CDATA[Pfad zur Bilddatei, die beim Verlinken von Inhalten auf Facebook, Twitter und anderen „Social Media“-Seiten standardmäßig eingebunden wird.]]></item>
 		<item name="wcf.acp.option.module_master_password"><![CDATA[Hauptkennwort aktivieren (obsolet)]]></item>
-		<item name="wcf.acp.option.module_master_password.description"><![CDATA[Von der Verwendung des Hauptkennworts wird abgeraten. Stattdessen sollte die Mehrfaktor-Authentifizierung genutzt werden. Diese schützt Benutzerkonten zuverlässiger und in allen Bereichen. Die Unterstützung für das Hauptkennwort wird in einer zukünftigen Version entfernt.]]></item>
+		<item name="wcf.acp.option.module_master_password.description"><![CDATA[Von der Verwendung des Hauptkennworts wird abgeraten. Stattdessen sollte die Mehrfaktor-Authentifizierung genutzt werden. Diese schützt Benutzerkonten zuverlässiger und in allen Bereichen. Die Unterstützung für das Hauptkennwort wird in einer zukünftigen Version ohne weiteren Hinweis entfernt.]]></item>
 		<item name="wcf.acp.option.page_description"><![CDATA[Seitenbeschreibung]]></item>
 		<item name="wcf.acp.option.page_title"><![CDATA[Titel der Seite]]></item>
 		<item name="wcf.acp.option.proxy_server_http"><![CDATA[Proxy-Server (HTTP)]]></item>

--- a/wcfsetup/install/lang/en.xml
+++ b/wcfsetup/install/lang/en.xml
@@ -1026,6 +1026,7 @@ ATTENTION: The messages listed above are greatly shortened. You can view details
 		<item name="wcf.acp.masterPassword.example.set"><![CDATA[Use Suggestion]]></item>
 		<item name="wcf.acp.masterPassword.init"><![CDATA[Set Master Password]]></item>
 		<item name="wcf.acp.masterPassword.init.description"><![CDATA[The master password is the last line of defense, protecting both critical settings and sensitive data. One should choose a rather strong password which is neither known to any 3rd party person nor re-used on other web pages.]]></item>
+		<item name="wcf.acp.masterPassword.enter.deprecated"><![CDATA[Support for the master password is discouraged and will be removed in a future version. The <a href="{link controller='AccountSecurity' forceFrontend=true application='wcf'}{/link}">Multi-factor Authentication</a> protects accounts more reliably and in all areas. If desired, specific user groups can be required to set up multi-factor authentication, before they are able to enter sensitive areas, such as the Administration Control Panel.]]></item>
 	</category>
 	<category name="wcf.acp.menu">
 		<item name="wcf.acp.menu.link.management"><![CDATA[Management]]></item>

--- a/wcfsetup/install/lang/en.xml
+++ b/wcfsetup/install/lang/en.xml
@@ -1341,8 +1341,8 @@ ATTENTION: The messages listed above are greatly shortened. You can view details
 		<item name="wcf.acp.option.meta_description"><![CDATA[Meta Description]]></item>
 		<item name="wcf.acp.option.og_image"><![CDATA[Open Graph Image]]></item>
 		<item name="wcf.acp.option.og_image.description"><![CDATA[Path to the default image that will be displayed when sharing your site on Facebook, Twitter and other social media sites.]]></item>
-		<item name="wcf.acp.option.module_master_password"><![CDATA[Enable master password]]></item>
-		<item name="wcf.acp.option.module_master_password.description"><![CDATA[Enables an additional password to protect both critical actions and sensitive data.]]></item>
+		<item name="wcf.acp.option.module_master_password"><![CDATA[Enable master password (Not Recommended)]]></item>
+		<item name="wcf.acp.option.module_master_password.description"><![CDATA[Use of the master password is discouraged. Instead multi-factor authentication should be set up. Multi-factor authentication protects accounts more reliably and in all areas. Support for the master password will be removed in a future version.]]></item>
 		<item name="wcf.acp.option.page_description"><![CDATA[Page Description]]></item>
 		<item name="wcf.acp.option.page_title"><![CDATA[Page Title]]></item>
 		<item name="wcf.acp.option.proxy_server_http"><![CDATA[Proxy-Server (HTTP)]]></item>

--- a/wcfsetup/install/lang/en.xml
+++ b/wcfsetup/install/lang/en.xml
@@ -1026,7 +1026,7 @@ ATTENTION: The messages listed above are greatly shortened. You can view details
 		<item name="wcf.acp.masterPassword.example.set"><![CDATA[Use Suggestion]]></item>
 		<item name="wcf.acp.masterPassword.init"><![CDATA[Set Master Password]]></item>
 		<item name="wcf.acp.masterPassword.init.description"><![CDATA[The master password is the last line of defense, protecting both critical settings and sensitive data. One should choose a rather strong password which is neither known to any 3rd party person nor re-used on other web pages.]]></item>
-		<item name="wcf.acp.masterPassword.enter.deprecated"><![CDATA[Support for the master password is discouraged and will be removed in a future version. The <a href="{link controller='AccountSecurity' forceFrontend=true application='wcf'}{/link}">Multi-factor Authentication</a> protects accounts more reliably and in all areas. If desired, specific user groups can be required to set up multi-factor authentication, before they are able to enter sensitive areas, such as the Administration Control Panel.]]></item>
+		<item name="wcf.acp.masterPassword.enter.deprecated"><![CDATA[Support for the master password is discouraged and will be removed in a future version without further notice. The <a href="{link controller='AccountSecurity' forceFrontend=true application='wcf'}{/link}">Multi-factor Authentication</a> protects accounts more reliably and in all areas. If desired, specific user groups can be required to set up multi-factor authentication, before they are able to enter sensitive areas, such as the Administration Control Panel.]]></item>
 	</category>
 	<category name="wcf.acp.menu">
 		<item name="wcf.acp.menu.link.management"><![CDATA[Management]]></item>
@@ -1343,7 +1343,7 @@ ATTENTION: The messages listed above are greatly shortened. You can view details
 		<item name="wcf.acp.option.og_image"><![CDATA[Open Graph Image]]></item>
 		<item name="wcf.acp.option.og_image.description"><![CDATA[Path to the default image that will be displayed when sharing your site on Facebook, Twitter and other social media sites.]]></item>
 		<item name="wcf.acp.option.module_master_password"><![CDATA[Enable master password (Not Recommended)]]></item>
-		<item name="wcf.acp.option.module_master_password.description"><![CDATA[Use of the master password is discouraged. Instead multi-factor authentication should be set up. Multi-factor authentication protects accounts more reliably and in all areas. Support for the master password will be removed in a future version.]]></item>
+		<item name="wcf.acp.option.module_master_password.description"><![CDATA[Use of the master password is discouraged. Instead multi-factor authentication should be set up. Multi-factor authentication protects accounts more reliably and in all areas. Support for the master password will be removed in a future version without further notice.]]></item>
 		<item name="wcf.acp.option.page_description"><![CDATA[Page Description]]></item>
 		<item name="wcf.acp.option.page_title"><![CDATA[Page Title]]></item>
 		<item name="wcf.acp.option.proxy_server_http"><![CDATA[Proxy-Server (HTTP)]]></item>


### PR DESCRIPTION
Still up for discussion:

- [x] Skipping the master password if it is not yet set up.
    - Preserve the functionality for "old users".
    - Disable the functionality for "new users".
- [x] Skipping the master password if the current user has MFA enabled.

Resolves #3698

-------------

- Mark the master password as deprecated in the option description
- Show deprecation message on master password authentication
