### PR TITLE
Clean up StyleCompiler

### DIFF
--- a/wcfsetup/install/files/lib/system/style/StyleCompiler.class.php
+++ b/wcfsetup/install/files/lib/system/style/StyleCompiler.class.php
@@ -552,15 +552,7 @@ EOT;
 
         $content = $callback($content);
 
-        // write stylesheet
-        \file_put_contents($filename . '.css', $content);
-        FileUtil::makeWritable($filename . '.css');
-
-        $content = $this->convertToRtl($content);
-
-        // write stylesheet for RTL
-        \file_put_contents($filename . '-rtl.css', $content);
-        FileUtil::makeWritable($filename . '-rtl.css');
+        $this->writeCss($filename, $content);
     }
 
     /**
@@ -583,6 +575,18 @@ EOT;
         $css .= ".codeBox .codeBoxCode > code .codeBoxLine > a { margin-left: -7ch; margin-right: 0; text-align: right; } \n";
 
         return $css;
+    }
+
+    /**
+     * Writes the given css into the file with the given prefix.
+     */
+    private function writeCss(string $filePrefix, string $css): void
+    {
+        \file_put_contents($filePrefix . '.css', $css);
+        FileUtil::makeWritable($filePrefix . '.css');
+
+        \file_put_contents($filePrefix . '-rtl.css', $this->convertToRtl($css));
+        FileUtil::makeWritable($filePrefix . '-rtl.css');
     }
 
     /**

--- a/wcfsetup/install/files/lib/system/style/StyleCompiler.class.php
+++ b/wcfsetup/install/files/lib/system/style/StyleCompiler.class.php
@@ -556,19 +556,33 @@ EOT;
         \file_put_contents($filename . '.css', $content);
         FileUtil::makeWritable($filename . '.css');
 
-        // convert stylesheet to RTL
-        $content = StyleUtil::convertCSSToRTL($content);
-
-        // force code boxes to be always LTR
-        $content .= "\n/* RTL fix for code boxes */\n";
-        $content .= ".redactor-layer pre { direction: ltr; text-align: left; }\n";
-        $content .= ".codeBoxCode { direction: ltr; } \n";
-        $content .= ".codeBox .codeBoxCode { padding-left: 7ch; padding-right: 0; } \n";
-        $content .= ".codeBox .codeBoxCode > code .codeBoxLine > a { margin-left: -7ch; margin-right: 0; text-align: right; } \n";
+        $content = $this->convertToRtl($content);
 
         // write stylesheet for RTL
         \file_put_contents($filename . '-rtl.css', $content);
         FileUtil::makeWritable($filename . '-rtl.css');
+    }
+
+    /**
+     * Converts the given CSS into the RTL variant.
+     *
+     * This method differs from StyleUtil::convertCSSToRTL() in that it includes some fixes
+     * for elements that need to remain LTR.
+     *
+     * @see StyleUtil::convertCSSToRTL()
+     */
+    private function convertToRtl(string $css): string
+    {
+        $css = StyleUtil::convertCSSToRTL($css);
+
+        // force code boxes to be always LTR
+        $css .= "\n/* RTL fix for code boxes */\n";
+        $css .= ".redactor-layer pre { direction: ltr; text-align: left; }\n";
+        $css .= ".codeBoxCode { direction: ltr; } \n";
+        $css .= ".codeBox .codeBoxCode { padding-left: 7ch; padding-right: 0; } \n";
+        $css .= ".codeBox .codeBoxCode > code .codeBoxLine > a { margin-left: -7ch; margin-right: 0; text-align: right; } \n";
+
+        return $css;
     }
 
     /**

--- a/wcfsetup/install/files/lib/system/style/StyleCompiler.class.php
+++ b/wcfsetup/install/files/lib/system/style/StyleCompiler.class.php
@@ -162,7 +162,8 @@ final class StyleCompiler extends SingletonFactory
             $files[] = $customCustomSCSSFile;
         }
 
-        $scss = $this->bootstrap();
+        $scss = "/*!\n\nstylesheet for '" . $styleName . "', generated on " . \gmdate('r') . " -- DO NOT EDIT\n\n*/\n";
+        $scss .= $this->bootstrap();
         foreach ($files as $file) {
             $scss .= $this->prepareFile($file);
         }
@@ -176,10 +177,6 @@ final class StyleCompiler extends SingletonFactory
                 $scss,
                 $variables
             );
-
-            $header = "/* stylesheet for '" . $styleName . "', generated on " . \gmdate('r') . " -- DO NOT EDIT */";
-
-            $css = $this->injectHeader($header, $css);
 
             $this->writeCss(FileUtil::addTrailingSlash($testFileDir) . 'style', $css);
         } catch (\Exception $e) {
@@ -269,7 +266,8 @@ final class StyleCompiler extends SingletonFactory
         $parameters = ['scss' => ''];
         EventHandler::getInstance()->fireAction($this, 'compile', $parameters);
 
-        $scss = $this->bootstrap();
+        $scss = "/*!\n\nstylesheet for '" . $style->styleName . "', generated on " . \gmdate('r') . " -- DO NOT EDIT\n\n*/\n";
+        $scss .= $this->bootstrap();
         foreach ($this->getFiles() as $file) {
             $scss .= $this->prepareFile($file);
         }
@@ -282,10 +280,6 @@ final class StyleCompiler extends SingletonFactory
             $scss,
             $variables
         );
-
-        $header = "/* stylesheet for '" . $style->styleName . "', generated on " . \gmdate('r') . " -- DO NOT EDIT */";
-
-        $css = $this->injectHeader($header, $css);
 
         $this->writeCss($this->getFilenameForStyle($style), $css);
     }
@@ -330,7 +324,8 @@ final class StyleCompiler extends SingletonFactory
 
         $variables['style_image_path'] = "'../images/'";
 
-        $scss = $this->bootstrap();
+        $scss = "/*!\n\nstylesheet for the admin panel, generated on " . \gmdate('r') . " -- DO NOT EDIT\n\n*/\n";
+        $scss .= $this->bootstrap();
         foreach ($files as $file) {
             $scss .= $this->prepareFile($file);
         }
@@ -345,23 +340,7 @@ final class StyleCompiler extends SingletonFactory
         $css = \str_replace('../icon/', '../../icon/', $css);
         $css = \preg_replace('~\.\./images/~', '../../images/', $css);
 
-        $header = "/* stylesheet for the admin panel, generated on " . \gmdate('r') . " -- DO NOT EDIT */";
-
-        $css = $this->injectHeader($header, $css);
-
         $this->writeCss(WCF_DIR . 'acp/style/style', $css);
-    }
-
-    /**
-     * Injects the given header string into the given css while ensuring
-     * that the charset at-rule remains at the beginning.
-     */
-    private function injectHeader(string $header, string $css): string
-    {
-        // Strip charset at-rule.
-        $css = \preg_replace('~^@charset "UTF-8";\r?\n~', '', $css);
-
-        return '@charset "UTF-8";' . "\n\n{$header}\n\n{$css}";
     }
 
     /**

--- a/wcfsetup/install/files/lib/system/style/StyleCompiler.class.php
+++ b/wcfsetup/install/files/lib/system/style/StyleCompiler.class.php
@@ -317,11 +317,6 @@ final class StyleCompiler extends SingletonFactory
             $variables[$row['variableName']] = $value;
         }
 
-        $variables['wcfFontFamily'] = $variables['wcfFontFamilyFallback'];
-        if (!empty($variables['wcfFontFamilyGoogle'])) {
-            $variables['wcfFontFamily'] = '"' . $variables['wcfFontFamilyGoogle'] . '", ' . $variables['wcfFontFamily'];
-        }
-
         $variables['style_image_path'] = "'../images/'";
 
         $scss = "/*!\n\nstylesheet for the admin panel, generated on " . \gmdate('r') . " -- DO NOT EDIT\n\n*/\n";

--- a/wcfsetup/install/files/lib/system/style/StyleCompiler.class.php
+++ b/wcfsetup/install/files/lib/system/style/StyleCompiler.class.php
@@ -24,7 +24,7 @@ use wcf\util\StyleUtil;
  * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
  * @package WoltLabSuite\Core\System\Style
  */
-class StyleCompiler extends SingletonFactory
+final class StyleCompiler extends SingletonFactory
 {
     /**
      * SCSS compiler object


### PR DESCRIPTION
This PR performs a cleanup within the StyleCompiler in preparation of upcoming changes.

Specifically the compileStylesheet() monster method was simplified by moving
the SCSS preprocessing (~ SCSS file concatenation) and CSS postprocessing (~
header insertion) into the caller. For the latter the necessary code already
resided in the caller and was passed in as a callback method.

While this new style compilation logic might look a bit like copy and paste it
should be no less readable by moving common logic into helper methods and by
simplifying the control and data flow with the removal of the callback.

It also allows us much greater control over the whole process, e.g. allowing us
to insert specific CSS for the frontend styles only.

------------

- Make the StyleCompiler `final`
- Remove the StyleCompiler::$compiler property
- Add StyleCompiler::injectHeader()
- Add StyleCompiler::convertToRtl()
- Add StyleCompiler::writeCss()
- Make StyleCompiler::compileStylesheet() only compile
- Pass SCSS instead of files + invididualScss to StyleCompiler::compileStylesheet()
- Use a `/*!` comment for the CSS header
