### PR TITLE
Make use of TagEngine::getSubselectForObjectsByTags() in TaggedArticleList

### DIFF
--- a/wcfsetup/install/files/lib/data/article/TaggedArticleList.class.php
+++ b/wcfsetup/install/files/lib/data/article/TaggedArticleList.class.php
@@ -27,22 +27,14 @@ class TaggedArticleList extends AccessibleArticleList
 
         $this->sqlOrderBy = 'article.time ' . ARTICLE_SORT_ORDER;
 
-        $tagIDs = TagEngine::getInstance()->getTagIDs($tags);
+        $subselect = TagEngine::getInstance()->getSubselectForObjectsByTags(
+            'com.woltlab.wcf.article',
+            $tags
+        );
         $this->getConditionBuilder()->add("article.articleID IN (
             SELECT  articleID
             FROM    wcf" . WCF_N . "_article_content
-            WHERE   articleContentID IN (
-                SELECT      objectID
-                FROM        wcf" . WCF_N . "_tag_to_object
-                WHERE       objectTypeID = ?
-                        AND tagID IN (?)
-                GROUP BY    objectID
-                HAVING      COUNT(objectID) = ?
-            )
-        )", [
-            TagEngine::getInstance()->getObjectTypeID('com.woltlab.wcf.article'),
-            $tagIDs,
-            \count($tagIDs),
-        ]);
+            WHERE   articleContentID IN ({$subselect['sql']})
+        )", $subselect['parameters']);
     }
 }


### PR DESCRIPTION
Commit c9613f130106f74853fbe9a50f06c00208106b8c is fun.

It renamed the getSqlForObjectsByTags() method that was previously used in
TaggedArticleList to the current name getSubselectForObjectsByTags() and fixed
a bug in the method that prevented it from working correctly.

At the same time the commit edited TaggedArticleList to no longer use this
method and instead copied over the logic.

I'm not sure what exactly happened during the development of that commit, but
we simply should use this (fixed) method.
