### PR TITLE
Bind exportMailAddress bulk process to `canEditMailAddress` instead of `canMailUser`

### DIFF
--- a/com.woltlab.wcf/objectType.xml
+++ b/com.woltlab.wcf/objectType.xml
@@ -1246,7 +1246,7 @@
 			<definitionname>com.woltlab.wcf.bulkProcessing.user.action</definitionname>
 			<classname>wcf\system\bulk\processing\user\ExportMailAddressUserBulkProcessingAction</classname>
 			<action>exportMailAddress</action>
-			<permissions>admin.user.canMailUser</permissions>
+			<permissions>admin.user.canEditMailAddress</permissions>
 		</type>
 		<!-- /user bulk processing actions -->
 		<!-- user bulk processing conditions -->


### PR DESCRIPTION
Note the target branch of 5.3

-------

Unfortunately the `permissions` form a logical disjunction, not a conjunction,
thus we can't check both permissions. The `canEditMailAddress` is more fitting,
because even without `canMailUser` the admin could simply look up all users
manually if they are allowed to edit (and thus see) mail addresses. It's just a
larger effort.

Resolves #3963
