### PR TITLE
Preload box content even for system boxes

### DIFF
--- a/wcfsetup/install/files/lib/data/box/BoxList.class.php
+++ b/wcfsetup/install/files/lib/data/box/BoxList.class.php
@@ -42,14 +42,7 @@ class BoxList extends DatabaseObjectList
 
         // get box content
         if ($this->contentLoading) {
-            $boxIDs = [];
-            foreach ($this->getObjects() as $box) {
-                if ($box->boxType != 'system' && $box->boxType != 'menu') {
-                    $boxIDs[] = $box->boxID;
-                }
-            }
-
-            if (!empty($boxIDs)) {
+            if (!empty($this->objectIDs)) {
                 $contentList = new BoxContentList();
                 $contentList->enableImageLoading();
                 $contentList->enableEmbeddedObjectLoading();


### PR DESCRIPTION
Box::getBoxContentTitle() unconditionally loads the box contents for all box
types, because even system boxes might fall back to the box title that is
configured within the ACP.

This might result on O(n) queries when a page has several system boxes.

Fix this issue by preloading the box contents for all boxes.
