### PR TITLE
Force lowercase during SFS check

### DIFF
--- a/wcfsetup/install/files/lib/data/blacklist/entry/BlacklistEntry.class.php
+++ b/wcfsetup/install/files/lib/data/blacklist/entry/BlacklistEntry.class.php
@@ -73,7 +73,7 @@ class BlacklistEntry extends DatabaseObject {
 	}
 	
 	protected static function getHash($string) {
-		return hash('sha256', $string, true);
+		return hash('sha256', mb_strtolower($string), true);
 	}
 	
 	protected static function isMatch($type, $occurrences) {


### PR DESCRIPTION
See https://community.woltlab.com/thread/288664-stopforumspam-spammer-werden-nicht-an-der-freischaltung-gehindert/

The spammer didn't register as ![image](https://user-images.githubusercontent.com/81188/108422740-369da180-7237-11eb-9af9-8cba23c32b44.png) but as ![image](https://user-images.githubusercontent.com/81188/108422786-47e6ae00-7237-11eb-9e86-1bfe66e199bb.png) and since the username and the email address are being checked "as is", the user was able to register without being flagged as potential spammer.