### PR TITLE
Add `title` attribute to device name in session list

### DIFF
--- a/com.woltlab.wcf/templates/accountSecurity.tpl
+++ b/com.woltlab.wcf/templates/accountSecurity.tpl
@@ -74,7 +74,7 @@
 				
 				<div class="accountSecurityContainer">
 					<div class="containerHeadline accountSecurityInformation">
-						<h3>{lang}wcf.user.security.sessionName{/lang}</h3>
+						<h3 title="{$session->getUserAgent()}">{lang}wcf.user.security.sessionName{/lang}</h3>
 						
 						<dl class="plain inlineDataList small">
 							<dt>{lang}wcf.user.security.lastActivity{/lang}</dt>


### PR DESCRIPTION
Not sure if having a `title` attribute on a `<h3>` element violates some style
guidelines, but I considered this the most fitting location.
