### PR TITLE
Add preloading support to the StyleCompiler

### DIFF
--- a/wcfsetup/install/files/lib/system/style/StyleCompiler.class.php
+++ b/wcfsetup/install/files/lib/system/style/StyleCompiler.class.php
@@ -423,22 +423,22 @@ final class StyleCompiler extends SingletonFactory
 
         if (ApplicationHandler::getInstance()->isMultiDomainSetup()) {
             $content .= <<<'EOT'
-				@function getFont($filename, $family: "/", $version: "") {
-					@return "../font/getFont.php?family=" + $family + "&filename=" + $filename + "&v=" + $version;
-				}
+                @function getFont($filename, $family: "/", $version: "") {
+                    @return "../font/getFont.php?family=" + $family + "&filename=" + $filename + "&v=" + $version;
+                }
 EOT;
         } else {
             $content .= <<<'EOT'
-				@function getFont($filename, $family: "/", $version: "") {
-					@if ($family != "") {
-						$family: "families/" + $family + "/";
-					}
-					@if ($version != "") {
-						$version: "?v=" + $version;
-					}
-					
-					@return "../font/" + $family + $filename + $version;
-				}
+                @function getFont($filename, $family: "/", $version: "") {
+                    @if ($family != "") {
+                        $family: "families/" + $family + "/";
+                    }
+                    @if ($version != "") {
+                        $version: "?v=" + $version;
+                    }
+                    
+                    @return "../font/" + $family + $filename + $version;
+                }
 EOT;
         }
 

--- a/wcfsetup/install/files/lib/system/style/StyleCompiler.class.php
+++ b/wcfsetup/install/files/lib/system/style/StyleCompiler.class.php
@@ -69,7 +69,11 @@ final class StyleCompiler extends SingletonFactory
         $compiler->setEncoding('iso8859-1');
         $compiler->setImportPaths([WCF_DIR]);
 
-        $compiler->setOutputStyle(OutputStyle::COMPRESSED);
+        if (\ENABLE_DEBUG_MODE && \ENABLE_DEVELOPER_TOOLS) {
+            $compiler->setOutputStyle(OutputStyle::EXPANDED);
+        } else {
+            $compiler->setOutputStyle(OutputStyle::COMPRESSED);
+        }
 
         return $compiler;
     }

--- a/wcfsetup/install/files/lib/system/style/StyleHandler.class.php
+++ b/wcfsetup/install/files/lib/system/style/StyleHandler.class.php
@@ -139,6 +139,8 @@ class StyleHandler extends SingletonFactory
      */
     public function getStylesheet($isACP = false)
     {
+        $preload = '';
+
         if ($isACP) {
             // ACP
             $filename = 'acp/style/style' . (WCF::getLanguage()->get('wcf.global.pageDirection') == 'rtl' ? '-rtl' : '') . '.css';
@@ -151,9 +153,16 @@ class StyleHandler extends SingletonFactory
             if (!\file_exists(WCF_DIR . $filename)) {
                 StyleCompiler::getInstance()->compile($this->getStyle()->getDecoratedObject());
             }
+
+            if (\is_readable(WCF_DIR . 'style/style-' . $this->getStyle()->styleID . '-preload.json')) {
+                $decoded = JSON::decode(\file_get_contents(WCF_DIR . 'style/style-' . $this->getStyle()->styleID . '-preload.json'));
+                if (isset($decoded['html']) && \is_array($decoded['html'])) {
+                    $preload = \implode('', $decoded['html']);
+                }
+            }
         }
 
-        return '<link rel="stylesheet" type="text/css" href="' . WCF::getPath() . $filename . '?m=' . \filemtime(WCF_DIR . $filename) . '">';
+        return '<link rel="stylesheet" type="text/css" href="' . WCF::getPath() . $filename . '?m=' . \filemtime(WCF_DIR . $filename) . '">' . $preload;
     }
 
     /**

--- a/wcfsetup/install/files/style/icon/icon.scss
+++ b/wcfsetup/install/files/style/icon/icon.scss
@@ -1,6 +1,12 @@
 /* do NOT reference fonts directly, always make use of 'getFont.php' */
 @font-face {
 	font-family: "FontAwesome";
+	--woltlab-suite-preload: #{preload(
+			getFont("fontawesome-webfont.woff2", "", "4.7.0"),
+			$as: "font",
+			$crossorigin: true,
+			$type: "font/woff2"
+		)};
 	src: url(getFont("fontawesome-webfont.eot", "", "4.7.0"));
 	src: url(getFont("fontawesome-webfont.eot", "", "4.7.0") + "#iefix") format("embedded-opentype"),
 		url(getFont("fontawesome-webfont.woff2", "", "4.7.0")) format("woff2"),


### PR DESCRIPTION
The Google fonts will require some adjustments to the generated CSS at
fonts.woltlab.com and will be handled separately.

------

- Fix indentation for SCSS functions in StyleCompiler
- Generate uncompressed stylesheet in developer mode
- Add preload support to StyleCompiler
- Add preload tags to the generated HTML
- Preload the woff2 version of FontAwesome

Resolves #3916
