### PR TITLE
Improved the UI for the re-authentication prompt

### DIFF
--- a/com.woltlab.wcf/templates/__reauthenticationLoginAs.tpl
+++ b/com.woltlab.wcf/templates/__reauthenticationLoginAs.tpl
@@ -1,4 +1,9 @@
 <dl>
 	<dt>{lang}wcf.user.reauthentication.loginAs{/lang}</dt>
-	<dd>{$__wcf->user->username}</dd>
+	<dd>
+		{$__wcf->user->username}
+
+		{* This field is required to assist password managers. *}
+		<input type="text" autocomplete="username" value="{$__wcf->user->username}" style="display: none">
+	</dd>
 </dl>

--- a/wcfsetup/install/files/acp/templates/__devtoolsLanguageChooser.tpl
+++ b/wcfsetup/install/files/acp/templates/__devtoolsLanguageChooser.tpl
@@ -1,4 +1,4 @@
-{if ENABLE_DEBUG_MODE && ENABLE_DEVELOPER_TOOLS && $__wcf->user->userID}
+{if ENABLE_DEBUG_MODE && ENABLE_DEVELOPER_TOOLS && $__wcf->user->userID && $__isLogin|empty}
 	<script data-relocate="true">
 		require(['Ajax', 'WoltLabSuite/Core/Language/Chooser'], function(Ajax, LanguageChooser) {
 			var item = elCreate('li');

--- a/wcfsetup/install/files/acp/templates/__reauthenticationLoginAs.tpl
+++ b/wcfsetup/install/files/acp/templates/__reauthenticationLoginAs.tpl
@@ -3,5 +3,8 @@
 	<dd>
 		{$__wcf->user->username}
 		<small>{lang}wcf.user.reauthentication.logoutAndChangeUser{/lang}</small>
+
+		{* This field is required to assist password managers. *}
+		<input type="text" autocomplete="username" value="{$__wcf->user->username}" style="display: none">
 	</dd>
 </dl>

--- a/wcfsetup/install/files/acp/templates/header.tpl
+++ b/wcfsetup/install/files/acp/templates/header.tpl
@@ -183,7 +183,7 @@
 		$(function() {
 			if (jQuery.browser.touch) $('html').addClass('touch');
 			
-			{if $__wcf->user->userID}
+			{if $__wcf->user->userID && $__isLogin|empty}
 				new WCF.ACP.Search();
 			{/if}
 			
@@ -227,7 +227,7 @@
 			{if $_sectionMenuItem->menuItem|in_array:$_activeMenuItems}{assign var=_acpPageSubMenuActive value=true}{/if}
 		{/foreach}
 	{/if}
-	<div id="pageContainer" class="pageContainer{if !PACKAGE_ID || !$__wcf->user->userID} acpPageHiddenMenu{elseif $_acpPageSubMenuActive} acpPageSubMenuActive{/if}">
+	<div id="pageContainer" class="pageContainer{if !PACKAGE_ID || !$__wcf->user->userID || !$__isLogin|empty} acpPageHiddenMenu{elseif $_acpPageSubMenuActive} acpPageSubMenuActive{/if}">
 		{event name='beforePageHeader'}
 		
 		{include file='pageHeader'}

--- a/wcfsetup/install/files/acp/templates/pageMenu.tpl
+++ b/wcfsetup/install/files/acp/templates/pageMenu.tpl
@@ -1,4 +1,4 @@
-{if PACKAGE_ID && $__wcf->user->userID}
+{if PACKAGE_ID && $__wcf->user->userID && $__isLogin|empty}
 	{assign var=_activeMenuItems value=$__wcf->getACPMenu()->getActiveMenuItems()}
 	
 	<nav id="acpPageMenu" class="acpPageMenu">

--- a/wcfsetup/install/files/acp/templates/reauthentication.tpl
+++ b/wcfsetup/install/files/acp/templates/reauthentication.tpl
@@ -1,5 +1,6 @@
-{include file='header' pageTitle='wcf.user.reauthentication'}
+{include file='header' pageTitle='wcf.user.reauthentication' __isLogin=true}
 
+{*
 <header class="contentHeader">
 	<div class="contentHeaderTitle">
 		<h1 class="contentTitle">{lang}wcf.user.reauthentication{/lang}</h1>
@@ -7,7 +8,24 @@
 </header>
 
 <p class="info" role="status">{lang}wcf.user.reauthentication.explanation{/lang}</p>
+*}
 
-{@$form->getHtml()}
+<div id="reauthentication" style="display: none">
+	{@$form->getHtml()}
+</div>
+
+<script data-relocate="true">
+	require(["WoltLabSuite/Core/Ui/Dialog"], (UiDialog) => {
+		UiDialog.openStatic("reauthentication", null, {
+			closable: false,
+			title: '{lang}wcf.user.reauthentication{/lang}',
+			onShow() {
+				setTimeout(() => {
+					document.getElementById("password").focus();
+				}, 2);
+			}
+		});
+	});
+</script>
 
 {include file='footer'}

--- a/wcfsetup/install/files/lib/form/ReauthenticationForm.class.php
+++ b/wcfsetup/install/files/lib/form/ReauthenticationForm.class.php
@@ -69,6 +69,7 @@ class ReauthenticationForm extends AbstractFormBuilderForm
                 ->templateName('__reauthenticationLoginAs'),
             UserPasswordField::create()
                 ->required()
+                ->autocomplete('current-password')
                 ->autoFocus(),
         ]);
     }

--- a/wcfsetup/install/lang/de.xml
+++ b/wcfsetup/install/lang/de.xml
@@ -4795,7 +4795,7 @@ sich{/if} nicht bei uns registriert {if LANGUAGE_USE_INFORMAL_VARIANT}hast{else}
 		<item name="wcf.user.status.blacklistMatches"><![CDATA[Der Benutzer wurde aufgrund eines Treffers in der Datenbank von „Stop Forum Spam“ automatisch deaktiviert (Übereinstimmungen: {implode glue=', ' from=$user->getBlacklistMatchesTitle() item=matchLabel}{$matchLabel}{/implode}).]]></item>
 		<item name="wcf.user.reauthentication"><![CDATA[Erneute Authentifizierung]]></item>
 		<item name="wcf.user.reauthentication.explanation"><![CDATA[{if LANGUAGE_USE_INFORMAL_VARIANT}Du betrittst einen besonders geschützten Bereich. Aus Sicherheitsgründen ist es notwendig, dass du dich durch Eingabe deines Kennworts erneut authentifizierst.{else}Sie betreten einen besonders geschützten Bereich. Aus Sicherheitsgründen ist es notwendig, dass Sie sich durch Eingabe Ihres Kennworts erneut authentifizieren.{/if}]]></item>
-		<item name="wcf.user.reauthentication.loginAs"><![CDATA[Eingeloggt als]]></item>
+		<item name="wcf.user.reauthentication.loginAs"><![CDATA[Angemeldet als]]></item>
 		<item name="wcf.user.reauthentication.logoutAndChangeUser"><![CDATA[Nicht {$__wcf->user->username}? <a href="{link controller='FullLogout' application='wcf'}t={csrfToken type='url'}{/link}">Abmelden und Benutzer wechseln</a>.]]></item>
 	</category>
 	<category name="wcf.user.menu">


### PR DESCRIPTION
Overhauled the UI to mirror the appearance of the login dialog. The dysfunctional UI elements were quite distracting and everything behaved in a strange way, since the system does not expect a logged-in user to be _de facto_ unable to do anything.

Keeping the visuals as close as possible to the login dialog also improves safety by providing a UI that the user is familiar with.

![image](https://user-images.githubusercontent.com/208610/109338950-39b41580-7867-11eb-901b-040a4a9cd0b0.png)
