### PR TITLE
Do not expose wcf.media.imageDimensions.value to JavaScript

### DIFF
--- a/com.woltlab.wcf/templates/mediaJavaScript.tpl
+++ b/com.woltlab.wcf/templates/mediaJavaScript.tpl
@@ -5,7 +5,6 @@
 			'wcf.media.button.replaceFile': '{jslang}wcf.media.button.replaceFile{/jslang}',
 			'wcf.media.button.select': '{jslang}wcf.media.button.select{/jslang}',
 			'wcf.media.delete.confirmMessage': '{jslang __encode=true __literal=true}wcf.media.delete.confirmMessage{/jslang}',
-			'wcf.media.imageDimensions.value': '{jslang __literal=true}wcf.media.imageDimensions.value{/jslang}',
 			'wcf.media.insert': '{jslang}wcf.media.insert{/jslang}',
 			'wcf.media.insert.imageSize': '{jslang}wcf.media.insert.imageSize{/jslang}',
 			'wcf.media.insert.imageSize.small': '{jslang}wcf.media.insert.imageSize.small{/jslang}',

--- a/wcfsetup/install/files/acp/templates/mediaJavaScript.tpl
+++ b/wcfsetup/install/files/acp/templates/mediaJavaScript.tpl
@@ -5,7 +5,6 @@
 			'wcf.media.button.replaceFile': '{jslang}wcf.media.button.replaceFile{/jslang}',
 			'wcf.media.button.select': '{jslang}wcf.media.button.select{/jslang}',
 			'wcf.media.delete.confirmMessage': '{jslang __encode=true __literal=true}wcf.media.delete.confirmMessage{/jslang}',
-			'wcf.media.imageDimensions.value': '{jslang __literal=true}wcf.media.imageDimensions.value{/jslang}',
 			'wcf.media.insert': '{jslang}wcf.media.insert{/jslang}',
 			'wcf.media.insert.imageSize': '{jslang}wcf.media.insert.imageSize{/jslang}',
 			'wcf.media.insert.imageSize.small': '{jslang}wcf.media.insert.imageSize.small{/jslang}',


### PR DESCRIPTION
This language item uses PHP template syntax and thus is not compatible with JavaScript:

    Parse error on line 1:
    {#$media->width}×{#$media->h
    --------^
    Expecting '}', got 'T_ANY'

I also could not find any JavaScript users (which was expected, given that it
would not work).
