### PR TITLE
Fix reading ACL values in non-Ajax form builder forms

### DIFF
--- a/com.woltlab.wcf/templates/__aclFormField.tpl
+++ b/com.woltlab.wcf/templates/__aclFormField.tpl
@@ -2,4 +2,4 @@
 	{include file='aclPermissions'}
 {/if}
 
-{include file='aclPermissionJavaScript' containerID=$field->getPrefixedId()|concat:'Container' categoryName=$field->getCategoryName() objectID=$field->getObjectID() objectTypeID=$field->getObjectType()->objectTypeID aclFormBuilderMode=true}
+{include file='aclPermissionJavaScript' containerID=$field->getPrefixedId()|concat:'Container' categoryName=$field->getCategoryName() objectID=$field->getObjectID() objectTypeID=$field->getObjectType()->objectTypeID aclFormBuilderMode=true aclValuesFieldName=$field->getPrefixedId()}

--- a/com.woltlab.wcf/templates/aclPermissionJavaScript.tpl
+++ b/com.woltlab.wcf/templates/aclPermissionJavaScript.tpl
@@ -88,7 +88,15 @@
 			{/if}
 		{/if}
 		
-		var aclList = new {if $aclListClassName|isset}{@$aclListClassName}{else}WCF.ACL.List{/if}($('#{@$containerID}'), {@$objectTypeID}, {if $categoryName|isset}'{@$categoryName}'{else}null{/if}, {if $objectID|isset}{@$objectID}{else}0{/if}, {if !$includeUserGroups|isset || $includeUserGroups}true{else}false{/if}{if $aclValues[$objectTypeID]|isset}, initialPermissions{/if});
+		var aclList = new {if $aclListClassName|isset}{@$aclListClassName}{else}WCF.ACL.List{/if}(
+			$('#{@$containerID}'),
+			{@$objectTypeID},
+			{if $categoryName|isset}'{@$categoryName}'{else}null{/if},
+			{if $objectID|isset}{@$objectID}{else}0{/if},
+			{if !$includeUserGroups|isset || $includeUserGroups}true{else}false{/if},
+			{if $aclValues[$objectTypeID]|isset}initialPermissions{else}undefined{/if},
+			{if $aclValuesFieldName|isset}'{@$aclValuesFieldName}'{else}undefined{/if}
+		);
 		
 		{if !$aclFormBuilderMode|empty}
 			require(['WoltLabSuite/Core/Form/Builder/Manager'], function(FormBuilderManager) {

--- a/wcfsetup/install/files/acp/templates/__aclFormField.tpl
+++ b/wcfsetup/install/files/acp/templates/__aclFormField.tpl
@@ -2,4 +2,4 @@
 	{include file='aclPermissions'}
 {/if}
 
-{include file='aclPermissionJavaScript' containerID=$field->getPrefixedId()|concat:'Container' categoryName=$field->getCategoryName() objectID=$field->getObjectID() objectTypeID=$field->getObjectType()->objectTypeID aclFormBuilderMode=true}
+{include file='aclPermissionJavaScript' containerID=$field->getPrefixedId()|concat:'Container' categoryName=$field->getCategoryName() objectID=$field->getObjectID() objectTypeID=$field->getObjectType()->objectTypeID aclFormBuilderMode=true aclValuesFieldName=$field->getPrefixedId()}

--- a/wcfsetup/install/files/acp/templates/aclPermissionJavaScript.tpl
+++ b/wcfsetup/install/files/acp/templates/aclPermissionJavaScript.tpl
@@ -88,7 +88,15 @@
 			{/if}
 		{/if}
 		
-		var aclList = new {if $aclListClassName|isset}{@$aclListClassName}{else}WCF.ACL.List{/if}($('#{@$containerID}'), {@$objectTypeID}, {if $categoryName|isset}'{@$categoryName}'{else}null{/if}, {if $objectID|isset}{@$objectID}{else}0{/if}, {if !$includeUserGroups|isset || $includeUserGroups}true{else}false{/if}{if $aclValues[$objectTypeID]|isset}, initialPermissions{/if});
+		var aclList = new {if $aclListClassName|isset}{@$aclListClassName}{else}WCF.ACL.List{/if}(
+			$('#{@$containerID}'),
+			{@$objectTypeID},
+			{if $categoryName|isset}'{@$categoryName}'{else}null{/if},
+			{if $objectID|isset}{@$objectID}{else}0{/if},
+			{if !$includeUserGroups|isset || $includeUserGroups}true{else}false{/if},
+			{if $aclValues[$objectTypeID]|isset}initialPermissions{else}undefined{/if},
+			{if $aclValuesFieldName|isset}'{@$aclValuesFieldName}'{else}undefined{/if}
+		);
 		
 		{if !$aclFormBuilderMode|empty}
 			require(['WoltLabSuite/Core/Form/Builder/Manager'], function(FormBuilderManager) {

--- a/wcfsetup/install/files/js/WCF.ACL.js
+++ b/wcfsetup/install/files/js/WCF.ACL.js
@@ -79,8 +79,9 @@ if (COMPILER_TARGET_DEFAULT) {
 		 * @param        string                categoryName
 		 * @param        integer                objectID
 		 * @param        boolean                includeUserGroups
+		 * @param        string|undefined       aclValuesFieldName
 		 */
-		init: function (containerSelector, objectTypeID, categoryName, objectID, includeUserGroups, initialPermissions) {
+		init: function (containerSelector, objectTypeID, categoryName, objectID, includeUserGroups, initialPermissions, aclValuesFieldName) {
 			this._objectID = objectID || 0;
 			this._objectTypeID = objectTypeID;
 			this._categoryName = categoryName;
@@ -91,6 +92,7 @@ if (COMPILER_TARGET_DEFAULT) {
 				group: {},
 				user: {}
 			};
+			this._aclValuesFieldName = aclValuesFieldName || 'aclValues';
 			
 			this._proxy = new WCF.Action.Proxy({
 				showLoadingOverlay: false,
@@ -595,7 +597,7 @@ if (COMPILER_TARGET_DEFAULT) {
 					var $object = this._values[$type][$objectID];
 					
 					for (var $optionID in $object) {
-						$('<input type="hidden" name="aclValues[' + $type + '][' + $objectID + '][' + $optionID + ']" value="' + $object[$optionID] + '" />').appendTo($form);
+						$('<input type="hidden" name="' + this._aclValuesFieldName + '[' + $type + '][' + $objectID + '][' + $optionID + ']" value="' + $object[$optionID] + '" />').appendTo($form);
 					}
 				}
 			}

--- a/wcfsetup/install/files/lib/system/form/builder/field/acl/AclFormField.class.php
+++ b/wcfsetup/install/files/lib/system/form/builder/field/acl/AclFormField.class.php
@@ -150,7 +150,7 @@ class AclFormField extends AbstractFormField implements IObjectTypeFormNode {
 	 * @inheritDoc
 	 */
 	public function readValue() {
-		$valueSource = $_POST;
+		$valueSource = $_POST[$this->getPrefixedId()] ?? [];
 		if ($this->getDocument()->isAjax()) {
 			$valueSource = [];
 			if (


### PR DESCRIPTION
The wrong data source was used in `AclFormField` (the whole `$_POST` array instead of the dedicated entry) and the data was always stored in `aclValues` instead of a dedicated entry per form field.