### PR TITLE
Fix spider handling in sessions

### DIFF
--- a/wcfsetup/install/files/lib/system/session/SessionHandler.class.php
+++ b/wcfsetup/install/files/lib/system/session/SessionHandler.class.php
@@ -716,11 +716,8 @@ final class SessionHandler extends SingletonFactory
             'lastActivityTime' => TIME_NOW,
             'requestURI' => UserUtil::getRequestURI(),
             'requestMethod' => !empty($_SERVER['REQUEST_METHOD']) ? \substr($_SERVER['REQUEST_METHOD'], 0, 7) : '',
+            'spiderID' => $spiderID,
         ];
-
-        if ($spiderID !== null) {
-            $sessionData['spiderID'] = $spiderID;
-        }
 
         $this->legacySession = SessionEditor::create($sessionData);
     }

--- a/wcfsetup/install/files/lib/system/session/SessionHandler.class.php
+++ b/wcfsetup/install/files/lib/system/session/SessionHandler.class.php
@@ -1021,11 +1021,13 @@ final class SessionHandler extends SingletonFactory
 
             // ... perform the login ...
             $sql = "UPDATE  wcf" . WCF_N . "_user_session
-                    SET     userID = ?
+                    SET     userID = ?,
+                            spiderID = ?
                     WHERE   sessionID = ?";
             $statement = WCF::getDB()->prepareStatement($sql);
             $statement->execute([
                 $user->userID,
+                null,
                 $this->sessionID,
             ]);
 

--- a/wcfsetup/install/files/lib/system/session/SessionHandler.class.php
+++ b/wcfsetup/install/files/lib/system/session/SessionHandler.class.php
@@ -659,7 +659,7 @@ final class SessionHandler extends SingletonFactory
         $this->legacySession = $statement->fetchSingleObject(LegacySession::class);
 
         if (!$this->legacySession) {
-            $this->createLegacySession();
+            $this->legacySession = $this->createLegacySession();
         }
 
         return true;
@@ -717,11 +717,11 @@ final class SessionHandler extends SingletonFactory
         }
 
         if (!$this->legacySession) {
-            $this->createLegacySession();
+            $this->legacySession = $this->createLegacySession();
         }
     }
 
-    private function createLegacySession()
+    private function createLegacySession(): LegacySession
     {
         $spiderID = $this->getSpiderID(UserUtil::getUserAgent());
 
@@ -737,7 +737,7 @@ final class SessionHandler extends SingletonFactory
             'spiderID' => $spiderID,
         ];
 
-        $this->legacySession = SessionEditor::create($sessionData);
+        return SessionEditor::create($sessionData);
     }
 
     /**

--- a/wcfsetup/install/files/lib/system/session/SessionHandler.class.php
+++ b/wcfsetup/install/files/lib/system/session/SessionHandler.class.php
@@ -1323,20 +1323,19 @@ final class SessionHandler extends SingletonFactory
 
     /**
      * Returns the spider id for given user agent.
-     *
-     * @param string $userAgent
-     * @return  mixed
      */
-    protected function getSpiderID($userAgent)
+    protected function getSpiderID(string $userAgent): ?int
     {
         $spiderList = SpiderCacheBuilder::getInstance()->getData();
         $userAgent = \strtolower($userAgent);
 
         foreach ($spiderList as $spider) {
             if (\strpos($userAgent, $spider->spiderIdentifier) !== false) {
-                return $spider->spiderID;
+                return \intval($spider->spiderID);
             }
         }
+
+        return null;
     }
 
     /**


### PR DESCRIPTION
- Remove useless condition in SessionHandler::createLegacySession()
- Explicitly return `null` on no match in SessionHandler::getSpiderID()
- Correctly re-use spider sessions when creating new sessions
- Make SessionHandler::createLegacySession() return the session
- Clear the spiderID when logging in

Fixes #4066
/cc @mutec
