### PR TITLE
added missing column wcf1_user_session.spiderID

### DIFF
--- a/wcfsetup/install/files/acp/update_com.woltlab.wcf_5.4_session_2_user_session.php
+++ b/wcfsetup/install/files/acp/update_com.woltlab.wcf_5.4_session_2_user_session.php
@@ -29,6 +29,8 @@ $tables = [
                 ->notNull(),
             IntDatabaseTableColumn::create('userID')
                 ->length(10),
+            IntDatabaseTableColumn::create('spiderID')
+                ->length(10),
             NotNullVarchar255DatabaseTableColumn::create('userAgent')
                 ->defaultValue(''),
             VarcharDatabaseTableColumn::create('ipAddress')
@@ -52,6 +54,11 @@ $tables = [
                 ->columns(['userID'])
                 ->referencedTable('wcf1_user')
                 ->referencedColumns(['userID'])
+                ->onDelete('CASCADE'),
+            DatabaseTableForeignKey::create()
+                ->columns(['spiderID'])
+                ->referencedTable('wcf1_spider')
+                ->referencedColumns(['spiderID'])
                 ->onDelete('CASCADE'),
         ]),
 ];

--- a/wcfsetup/setup/db/install.sql
+++ b/wcfsetup/setup/db/install.sql
@@ -1884,6 +1884,7 @@ DROP TABLE IF EXISTS wcf1_user_session;
 CREATE TABLE wcf1_user_session (
 	sessionID CHAR(40) NOT NULL PRIMARY KEY,
 	userID INT(10),
+	spiderID INT(10),
 	ipAddress VARCHAR(39) NOT NULL DEFAULT '',
 	userAgent VARCHAR(255) NOT NULL DEFAULT '',
 	lastActivityTime INT(10) NOT NULL DEFAULT 0,
@@ -2230,6 +2231,7 @@ ALTER TABLE wcf1_user_profile_visitor ADD FOREIGN KEY (ownerID) REFERENCES wcf1_
 ALTER TABLE wcf1_user_profile_visitor ADD FOREIGN KEY (userID) REFERENCES wcf1_user (userID) ON DELETE CASCADE;
 
 ALTER TABLE wcf1_user_session ADD FOREIGN KEY (userID) REFERENCES wcf1_user (userID) ON DELETE CASCADE;
+ALTER TABLE wcf1_user_session ADD FOREIGN KEY (spiderID) REFERENCES wcf1_spider (spiderID) ON DELETE CASCADE;
 
 ALTER TABLE wcf1_user_special_trophy ADD FOREIGN KEY (userID) REFERENCES wcf1_user (userID) ON DELETE CASCADE;
 ALTER TABLE wcf1_user_special_trophy ADD FOREIGN KEY (trophyID) REFERENCES wcf1_trophy (trophyID) ON DELETE CASCADE;


### PR DESCRIPTION
fixes #4067 which want's to use this column on line 1025 in `changeUserVirtual()`

/cc @TimWolla 