### PR TITLE
add missing space during user search

### DIFF
--- a/wcfsetup/install/files/lib/form/UserSearchForm.class.php
+++ b/wcfsetup/install/files/lib/form/UserSearchForm.class.php
@@ -191,7 +191,7 @@ class UserSearchForm extends UserOptionListForm
         }
 
         // do search
-        $statement = WCF::getDB()->prepareStatement($sql . $this->conditions, $this->maxResults);
+        $statement = WCF::getDB()->prepareStatement($sql . " " . $this->conditions, $this->maxResults);
         $statement->execute($this->conditions->getParameters());
         $this->matches = $statement->fetchAll(\PDO::FETCH_COLUMN);
     }


### PR DESCRIPTION
Otherwise the query is going to look like: `SELECT user_table.userID FROM wcf1_user user_table LEFT JOIN wcf1_user_option_value option_value ON option_value.userID = user_table.userIDWHERE user_table.username LIKE ? LIMIT 1000`