### PR TITLE
include WSC-domain within HTTPRequest useragent

### DIFF
--- a/wcfsetup/install/files/lib/system/io/HttpFactory.class.php
+++ b/wcfsetup/install/files/lib/system/io/HttpFactory.class.php
@@ -6,6 +6,7 @@ use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\RequestOptions;
 use InvalidArgumentException;
+use wcf\system\application\ApplicationHandler;
 use wcf\system\Regex;
 
 /**
@@ -33,15 +34,16 @@ final class HttpFactory
      */
     public static function getDefaultUserAgent(?string $comment = null): string
     {
+        $domain = ApplicationHandler::getInstance()->getApplicationByID(1)->domainName;
         if ($comment) {
             if (!Regex::compile("^[a-zA-Z0-9_:/\\. -]+$")->match($comment)) {
                 throw new InvalidArgumentException("Invalid comment for user agent given.");
             }
 
-            return \sprintf('WoltLabSuite/%s (%s)', \wcf\getMinorVersion(), $comment);
+            return \sprintf('WoltLabSuite/%s %s (%s)', \wcf\getMinorVersion(), $domain, $comment);
         }
 
-        return \sprintf('WoltLabSuite/%s', \wcf\getMinorVersion());
+        return \sprintf('WoltLabSuite/%s %s', $domain, \wcf\getMinorVersion());
     }
 
     /**

--- a/wcfsetup/install/files/lib/util/HTTPRequest.class.php
+++ b/wcfsetup/install/files/lib/util/HTTPRequest.class.php
@@ -11,6 +11,7 @@ use ParagonIE\ConstantTime\Hex;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\UriInterface;
+use wcf\system\application\ApplicationHandler;
 use wcf\system\exception\HTTPNotFoundException;
 use wcf\system\exception\HTTPServerErrorException;
 use wcf\system\exception\HTTPUnauthorizedException;
@@ -97,9 +98,10 @@ final class HTTPRequest
 
         // set default headers
         $language = WCF::getLanguage();
+        $domain = ApplicationHandler::getInstance()->getApplicationByID(1)->domainName;
         $this->addHeader(
             'user-agent',
-            "HTTP.PHP (HTTPRequest.class.php; WoltLab Suite/" . WCF_VERSION . "; " . ($language ? $language->languageCode : 'en') . ")"
+            "HTTP.PHP (HTTPRequest.class.php; WoltLab Suite/" . WCF_VERSION . "; " . ($language ? $language->languageCode : 'en') . "; " . $domain . ")"
         );
         $this->addHeader('accept', '*/*');
         if ($language) {


### PR DESCRIPTION
this is a big benefit for identifying unwanted sessions in the new security-section of the user account management
It helps the user to identify sessions created by their own instances reading e.g. package information, api-calls or RSS-feeds