### PR TITLE
deprecate some old session-related classes and implement new events directly

### DIFF
--- a/wcfsetup/install/files/lib/system/session/ACPSessionFactory.class.php
+++ b/wcfsetup/install/files/lib/system/session/ACPSessionFactory.class.php
@@ -12,6 +12,7 @@ use wcf\system\event\EventHandler;
  * @copyright   2001-2019 WoltLab GmbH
  * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
  * @package WoltLabSuite\Core\System\Session
+ * @deprecated 5.4 Use `SessionHandler` directly
  */
 class ACPSessionFactory
 {

--- a/wcfsetup/install/files/lib/system/session/AbstractSessionHandler.class.php
+++ b/wcfsetup/install/files/lib/system/session/AbstractSessionHandler.class.php
@@ -11,6 +11,7 @@ use wcf\system\SingletonFactory;
  * @copyright   2001-2019 WoltLab GmbH
  * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
  * @package WoltLabSuite\Core\System\Session
+ * @deprecated 5.4
  */
 abstract class AbstractSessionHandler extends SingletonFactory
 {

--- a/wcfsetup/install/files/lib/system/session/SessionFactory.class.php
+++ b/wcfsetup/install/files/lib/system/session/SessionFactory.class.php
@@ -11,6 +11,7 @@ use wcf\data\session\SessionEditor;
  * @copyright   2001-2019 WoltLab GmbH
  * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
  * @package WoltLabSuite\Core\System\Session
+ * @deprecated 5.4 Use `SessionHandler` directly
  */
 class SessionFactory extends ACPSessionFactory
 {

--- a/wcfsetup/install/files/lib/system/session/SessionHandler.class.php
+++ b/wcfsetup/install/files/lib/system/session/SessionHandler.class.php
@@ -369,6 +369,8 @@ final class SessionHandler extends SingletonFactory
         } else {
             $this->create();
         }
+	
+        if (!\defined('NO_IMPORTS')) EventHandler::getInstance()->fireAction($this, 'afterLoadFromCookie');
     }
 
     /**
@@ -412,6 +414,8 @@ final class SessionHandler extends SingletonFactory
             $this->firstVisit = true;
             $this->unregister('__wcfIsFirstVisit');
         }
+	
+        if (!\defined('NO_IMPORTS')) EventHandler::getInstance()->fireAction($this, 'afterInitSession');
     }
 
     /**

--- a/wcfsetup/install/files/lib/system/session/SessionHandler.class.php
+++ b/wcfsetup/install/files/lib/system/session/SessionHandler.class.php
@@ -369,8 +369,10 @@ final class SessionHandler extends SingletonFactory
         } else {
             $this->create();
         }
-	
-        if (!\defined('NO_IMPORTS')) EventHandler::getInstance()->fireAction($this, 'afterLoadFromCookie');
+
+        if (!\defined('NO_IMPORTS')) {
+            EventHandler::getInstance()->fireAction($this, 'afterLoadFromCookie');
+        }
     }
 
     /**
@@ -414,8 +416,10 @@ final class SessionHandler extends SingletonFactory
             $this->firstVisit = true;
             $this->unregister('__wcfIsFirstVisit');
         }
-	
-        if (!\defined('NO_IMPORTS')) EventHandler::getInstance()->fireAction($this, 'afterInitSession');
+
+        if (!\defined('NO_IMPORTS')) {
+            EventHandler::getInstance()->fireAction($this, 'afterInitSession');
+        }
     }
 
     /**


### PR DESCRIPTION
- deprecates some (nearly) unused classes
- implements new events in `\wcf\system\session\SessionHandler` in order to replace the 'old' API in the future completely