### PR TITLE
Use WoltLabSource.isActive() to check whether the source view is enabled

### DIFF
--- a/wcfsetup/install/files/js/3rdParty/redactor2/plugins/WoltLabSource.js
+++ b/wcfsetup/install/files/js/3rdParty/redactor2/plugins/WoltLabSource.js
@@ -109,7 +109,7 @@ $.Redactor.prototype.WoltLabSource = function() {
 			}).bind(this);
 			
 			WCF.System.Event.addListener('com.woltlab.wcf.redactor2', 'validate_' + id, (function (data) {
-				if (textarea.clientHeight) {
+				if (this.WoltLabSource.isActive()) {
 					data.api.throwError(this.$element[0], WCF.Language.get('wcf.editor.source.error.active'));
 					data.valid = false;
 				}


### PR DESCRIPTION
Apparently the previous version, checking the height of the textarea, is broken
in the Kiwi Browser for Android even though it pretends to be a standard Chrome
88 without indicating anywhere within the User-Agent that it is not.

Luckily the fix is easy enough and technically the more correct solution even
for non-broken browsers.

I verified the correct functionality using Kiwi on Android and Firefox on
Linux.
