### PR TITLE
Fix param type for handleException

### DIFF
--- a/wcfsetup/install/files/lib/system/WCF.class.php
+++ b/wcfsetup/install/files/lib/system/WCF.class.php
@@ -268,7 +268,7 @@ class WCF {
 	/**
 	 * Calls the show method on the given exception.
 	 * 
-	 * @param	\Exception	$e
+	 * @param	\Throwable	$e
 	 */
 	public static final function handleException($e) {
 		// backwards compatibility


### PR DESCRIPTION
WCF::handleException incorrectly stated it would receive only \Exception, while it is registered to receive any \Throwable.

Reason for this change: Complaint by static type checker in a broader project.

I chose target WSC 5.2 here, because this was the first release targeting only PHP 7+. If you’d like to backport this further, then the `\Exception|\Throwable` union type would be correct in WSC 3.0 & 3.1, as on PHP 5 exceptions are not implementing \Throwable.