### PR TITLE
Add TemplateScriptingCompiler#beforeCompile event

### DIFF
--- a/wcfsetup/install/files/lib/system/template/TemplateScriptingCompiler.class.php
+++ b/wcfsetup/install/files/lib/system/template/TemplateScriptingCompiler.class.php
@@ -324,7 +324,10 @@ class TemplateScriptingCompiler
     public function compileString($identifier, $sourceContent, array $metaData = [], $isolated = false)
     {
         $this->sourceContent = $sourceContent;
-        $data = [ 'metaData' => $metaData ]
+        $data = [
+            'identifier' => $identifier,
+            'metaData' => $metaData
+        ];
         EventHandler::getInstance()->fireAction($this, 'beforeCompile', $data);
         $sourceContent = $this->sourceContent;
 

--- a/wcfsetup/install/files/lib/system/template/TemplateScriptingCompiler.class.php
+++ b/wcfsetup/install/files/lib/system/template/TemplateScriptingCompiler.class.php
@@ -7,6 +7,7 @@ use wcf\system\template\plugin\ICompilerTemplatePlugin;
 use wcf\system\template\plugin\IPrefilterTemplatePlugin;
 use wcf\util\StringStack;
 use wcf\util\StringUtil;
+use wcf\system\event\EventHandler;
 
 /**
  * Compiles template sources into valid PHP code.
@@ -288,6 +289,12 @@ class TemplateScriptingCompiler
     protected $foreachLoops = [];
 
     /**
+     * source content of template for event modifications
+     * @var string
+     */
+    public $sourceContent;
+
+    /**
      * Creates a new TemplateScriptingCompiler object.
      *
      * @param TemplateEngine $template
@@ -316,6 +323,11 @@ class TemplateScriptingCompiler
      */
     public function compileString($identifier, $sourceContent, array $metaData = [], $isolated = false)
     {
+        $this->sourceContent = $sourceContent;
+        $data = [ 'metaData' => $metaData ]
+        EventHandler::getInstance()->fireAction($this, 'beforeCompile', $data);
+        $sourceContent = $this->sourceContent;
+
         $previousData = [];
         if ($isolated) {
             $previousData = [


### PR DESCRIPTION
It would be great to have this event to allow the patching of templates. This would add tons of more customization possibilities. 
For example would it allow adding additional buttons in the footer next to the style changer:
```php
if ($parameters['identifier'] === 'pageFooter') {
	$search = '/\s\{if \$__showStyleChanger\}/';
	$replace = '<span class="widthToggle jsOnly">test</span>$0';
	$eventObj->sourceContent = preg_replace($search, $replace, $eventObj->sourceContent);
}
```

The `beforeCompile` event in TemplateEngine doesn't fire for include templates and doesn't allow the modification of the source, which makes it not useable for this case.