### PR TITLE
Improve `Ui/Object/Action` implementation

### DIFF
--- a/ts/WoltLabSuite/Core/Ui/Object/Action.ts
+++ b/ts/WoltLabSuite/Core/Ui/Object/Action.ts
@@ -88,6 +88,7 @@ function processAction(actionElement: HTMLElement, data: ResponseData | Database
     window.location.reload();
   } else {
     EventHandler.fire("WoltLabSuite/Core/Ui/Object/Action", actionElement.dataset.objectAction!, {
+      containerElement: actionElement.closest(containerSelector),
       data,
       objectElement: actionElement.closest(objectSelector),
     } as ObjectActionData);

--- a/ts/WoltLabSuite/Core/Ui/Object/Action/Delete.ts
+++ b/ts/WoltLabSuite/Core/Ui/Object/Action/Delete.ts
@@ -8,17 +8,22 @@
  */
 
 import UiObjectActionHandler from "./Handler";
-import { DatabaseObjectActionResponse } from "../../../Ajax/Data";
+import { ObjectActionData } from "../Data";
 
-function deleteObject(data: DatabaseObjectActionResponse, objectElement: HTMLElement): void {
-  const childContainer = objectElement.querySelector(".jsObjectActionObjectChildren");
+function deleteObject(data: ObjectActionData): void {
+  const actionElement = data.objectElement.querySelector('.jsObjectAction[data-object-action="delete"]') as HTMLElement;
+  if (!actionElement || actionElement.dataset.objectActionHandler) {
+    return;
+  }
+
+  const childContainer = data.objectElement.querySelector(".jsObjectActionObjectChildren");
   if (childContainer) {
     Array.from(childContainer.children).forEach((child: HTMLElement) => {
-      objectElement.parentNode!.insertBefore(child, objectElement);
+      data.objectElement.parentNode!.insertBefore(child, data.objectElement);
     });
   }
 
-  objectElement.remove();
+  data.objectElement.remove();
 }
 
 export function setup(): void {

--- a/ts/WoltLabSuite/Core/Ui/Object/Action/Delete.ts
+++ b/ts/WoltLabSuite/Core/Ui/Object/Action/Delete.ts
@@ -19,7 +19,7 @@ function deleteObject(data: ObjectActionData): void {
   const childContainer = data.objectElement.querySelector(".jsObjectActionObjectChildren");
   if (childContainer) {
     Array.from(childContainer.children).forEach((child: HTMLElement) => {
-      data.objectElement.parentNode!.insertBefore(child, data.objectElement);
+      data.objectElement.insertAdjacentElement("beforebegin", child);
     });
   }
 

--- a/ts/WoltLabSuite/Core/Ui/Object/Action/Handler.ts
+++ b/ts/WoltLabSuite/Core/Ui/Object/Action/Handler.ts
@@ -10,9 +10,8 @@
 import * as EventHandler from "../../../Event/Handler";
 import { ClipboardData, ObjectActionData } from "../Data";
 import * as ControllerClipboard from "../../../Controller/Clipboard";
-import { DatabaseObjectActionResponse } from "../../../Ajax/Data";
 
-export type ObjectAction = (data: DatabaseObjectActionResponse, objectElement: HTMLElement) => void;
+export type ObjectAction = (data: ObjectActionData) => void;
 
 export default class UiObjectActionHandler {
   protected readonly objectAction: ObjectAction;
@@ -48,14 +47,18 @@ export default class UiObjectActionHandler {
 
         data.responseData.objectIDs.forEach((deletedObjectId) => {
           if (~~deletedObjectId === ~~objectId) {
-            this.objectAction(data.responseData, clipboardObject);
+            this.objectAction({
+              containerElement: clipboardObject.closest(".jsObjectActionContainer") as HTMLElement,
+              data: data.responseData,
+              objectElement: clipboardObject,
+            });
           }
         });
       });
   }
 
   protected handleObjectAction(data: ObjectActionData): void {
-    this.objectAction(data.data, data.objectElement);
+    this.objectAction(data);
 
     ControllerClipboard.reload();
   }

--- a/ts/WoltLabSuite/Core/Ui/Object/Action/Toogle.ts
+++ b/ts/WoltLabSuite/Core/Ui/Object/Action/Toogle.ts
@@ -9,21 +9,24 @@
 
 import * as Language from "../../../Language";
 import UiObjectActionHandler from "./Handler";
-import { DatabaseObjectActionResponse } from "../../../Ajax/Data";
+import { ObjectActionData } from "../Data";
 
-function toggleObject(data: DatabaseObjectActionResponse, objectElement: HTMLElement): void {
-  const toggleButton = objectElement.querySelector('.jsObjectAction[data-object-action="toggle"]') as HTMLElement;
+function toggleObject(data: ObjectActionData): void {
+  const actionElement = data.objectElement.querySelector('.jsObjectAction[data-object-action="toggle"]') as HTMLElement;
+  if (!actionElement || actionElement.dataset.objectActionHandler) {
+    return;
+  }
 
-  if (toggleButton.classList.contains("fa-square-o")) {
-    toggleButton.classList.replace("fa-square-o", "fa-check-square-o");
+  if (actionElement.classList.contains("fa-square-o")) {
+    actionElement.classList.replace("fa-square-o", "fa-check-square-o");
 
-    const newTitle = toggleButton.dataset.disableTitle || Language.get("wcf.global.button.disable");
-    toggleButton.title = newTitle;
+    const newTitle = actionElement.dataset.disableTitle || Language.get("wcf.global.button.disable");
+    actionElement.title = newTitle;
   } else {
-    toggleButton.classList.replace("fa-check-square-o", "fa-square-o");
+    actionElement.classList.replace("fa-check-square-o", "fa-square-o");
 
-    const newTitle = toggleButton.dataset.enableTitle || Language.get("wcf.global.button.enable");
-    toggleButton.title = newTitle;
+    const newTitle = actionElement.dataset.enableTitle || Language.get("wcf.global.button.enable");
+    actionElement.title = newTitle;
   }
 }
 

--- a/ts/WoltLabSuite/Core/Ui/Object/Data.ts
+++ b/ts/WoltLabSuite/Core/Ui/Object/Data.ts
@@ -2,6 +2,7 @@ import { DatabaseObjectActionResponse } from "../../Ajax/Data";
 import { ClipboardActionData } from "../../Controller/Clipboard/Data";
 
 export interface ObjectActionData {
+  containerElement: HTMLElement;
   data: DatabaseObjectActionResponse;
   objectElement: HTMLElement;
 }

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Object/Action.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Object/Action.js
@@ -81,6 +81,7 @@ define(["require", "exports", "tslib", "../../Ajax", "../../Event/Handler", "../
         }
         else {
             EventHandler.fire("WoltLabSuite/Core/Ui/Object/Action", actionElement.dataset.objectAction, {
+                containerElement: actionElement.closest(containerSelector),
                 data,
                 objectElement: actionElement.closest(objectSelector),
             });

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Object/Action/Delete.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Object/Action/Delete.js
@@ -19,7 +19,7 @@ define(["require", "exports", "tslib", "./Handler"], function (require, exports,
         const childContainer = data.objectElement.querySelector(".jsObjectActionObjectChildren");
         if (childContainer) {
             Array.from(childContainer.children).forEach((child) => {
-                data.objectElement.parentNode.insertBefore(child, data.objectElement);
+                data.objectElement.insertAdjacentElement("beforebegin", child);
             });
         }
         data.objectElement.remove();

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Object/Action/Delete.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Object/Action/Delete.js
@@ -11,14 +11,18 @@ define(["require", "exports", "tslib", "./Handler"], function (require, exports,
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.setup = void 0;
     Handler_1 = tslib_1.__importDefault(Handler_1);
-    function deleteObject(data, objectElement) {
-        const childContainer = objectElement.querySelector(".jsObjectActionObjectChildren");
+    function deleteObject(data) {
+        const actionElement = data.objectElement.querySelector('.jsObjectAction[data-object-action="delete"]');
+        if (!actionElement || actionElement.dataset.objectActionHandler) {
+            return;
+        }
+        const childContainer = data.objectElement.querySelector(".jsObjectActionObjectChildren");
         if (childContainer) {
             Array.from(childContainer.children).forEach((child) => {
-                objectElement.parentNode.insertBefore(child, objectElement);
+                data.objectElement.parentNode.insertBefore(child, data.objectElement);
             });
         }
-        objectElement.remove();
+        data.objectElement.remove();
     }
     function setup() {
         new Handler_1.default("delete", ["delete"], deleteObject);

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Object/Action/Handler.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Object/Action/Handler.js
@@ -35,13 +35,17 @@ define(["require", "exports", "tslib", "../../../Event/Handler", "../../../Contr
                 const objectId = clipboardObject.dataset.objectId;
                 data.responseData.objectIDs.forEach((deletedObjectId) => {
                     if (~~deletedObjectId === ~~objectId) {
-                        this.objectAction(data.responseData, clipboardObject);
+                        this.objectAction({
+                            containerElement: clipboardObject.closest(".jsObjectActionContainer"),
+                            data: data.responseData,
+                            objectElement: clipboardObject,
+                        });
                     }
                 });
             });
         }
         handleObjectAction(data) {
-            this.objectAction(data.data, data.objectElement);
+            this.objectAction(data);
             ControllerClipboard.reload();
         }
     }

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Object/Action/Toogle.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Object/Action/Toogle.js
@@ -12,17 +12,20 @@ define(["require", "exports", "tslib", "../../../Language", "./Handler"], functi
     exports.setup = void 0;
     Language = tslib_1.__importStar(Language);
     Handler_1 = tslib_1.__importDefault(Handler_1);
-    function toggleObject(data, objectElement) {
-        const toggleButton = objectElement.querySelector('.jsObjectAction[data-object-action="toggle"]');
-        if (toggleButton.classList.contains("fa-square-o")) {
-            toggleButton.classList.replace("fa-square-o", "fa-check-square-o");
-            const newTitle = toggleButton.dataset.disableTitle || Language.get("wcf.global.button.disable");
-            toggleButton.title = newTitle;
+    function toggleObject(data) {
+        const actionElement = data.objectElement.querySelector('.jsObjectAction[data-object-action="toggle"]');
+        if (!actionElement || actionElement.dataset.objectActionHandler) {
+            return;
+        }
+        if (actionElement.classList.contains("fa-square-o")) {
+            actionElement.classList.replace("fa-square-o", "fa-check-square-o");
+            const newTitle = actionElement.dataset.disableTitle || Language.get("wcf.global.button.disable");
+            actionElement.title = newTitle;
         }
         else {
-            toggleButton.classList.replace("fa-check-square-o", "fa-square-o");
-            const newTitle = toggleButton.dataset.enableTitle || Language.get("wcf.global.button.enable");
-            toggleButton.title = newTitle;
+            actionElement.classList.replace("fa-check-square-o", "fa-square-o");
+            const newTitle = actionElement.dataset.enableTitle || Language.get("wcf.global.button.enable");
+            actionElement.title = newTitle;
         }
     }
     function setup() {

--- a/wcfsetup/install/files/lib/system/template/plugin/ObjectActionFunctionTemplatePlugin.class.php
+++ b/wcfsetup/install/files/lib/system/template/plugin/ObjectActionFunctionTemplatePlugin.class.php
@@ -66,9 +66,11 @@ class ObjectActionFunctionTemplatePlugin implements IFunctionTemplatePlugin
         if (isset($tagArgs['objectId'])) {
             $additionalAttributes .= " data-object-id=\"{$tagArgs['objectId']}\"";
         }
-        $className = null;
         if (isset($tagArgs['className'])) {
             $additionalAttributes .= " data-object-action-class-name=\"{$tagArgs['className']}\"";
+        }
+        if (isset($tagArgs['objectActionHandler'])) {
+            $additionalAttributes .= " data-object-action-handler=\"{$tagArgs['objectActionHandler']}\"";
         }
         foreach ($tagArgs as $key => $value) {
             if (\preg_match('~^parameter.+$~', $key)) {


### PR DESCRIPTION
1. The `objectAction` callback of `Ui/Object/Action/Handler` no gets the whole `data: ObjectActionData` data structure instead of each element separately.
2. `ObjectActionData` now also contains the container element.
3. Add support for `data-object-action-handler` for action buttons. The default actions ignore actions triggered by buttons with such attributes. Instead, custom handlers can react to specific actions by checking for the value of this attribute.