### PR TITLE
Set X-Auto-Response-Suppress: OOF header on all mail

### DIFF
--- a/wcfsetup/install/files/lib/system/email/Email.class.php
+++ b/wcfsetup/install/files/lib/system/email/Email.class.php
@@ -551,6 +551,8 @@ class Email
         }
         $headers[] = ['mime-version', '1.0'];
 
+        $headers[] = ['x-auto-response-suppress', 'OOF'];
+
         if (!$this->body) {
             throw new \LogicException("Cannot generate message headers, you must set a body.");
         }


### PR DESCRIPTION
I was not able to think of a case where out-of-office notifications would be
desired in response to an email sent by WoltLab Suite, so onto all emails it
goes.

Resolves #4104
