### PR TITLE
Use UserOption::getTitle() where possible

### DIFF
--- a/com.woltlab.wcf/templates/optionFieldList.tpl
+++ b/com.woltlab.wcf/templates/optionFieldList.tpl
@@ -7,7 +7,7 @@
 		{assign var=error value=''}
 	{/if}
 	<dl class="{$option->optionName}Input{if $error} formError{/if}">
-		<dt{if $optionData[cssClassName]} class="{$optionData[cssClassName]}"{/if}>{if $isSearchMode|empty || !$optionData[hideLabelInSearch]}<label for="{$option->optionName}">{if VISITOR_USE_TINY_BUILD && $isGuestGroup && $option->excludedInTinyBuild}<span class="icon icon16 fa-bolt red jsTooltip" title="{lang}wcf.acp.group.excludedInTinyBuild{/lang}"></span> {/if}{lang}{@$langPrefix}{$option->optionName}{/lang}</label>{/if}</dt>
+		<dt{if $optionData[cssClassName]} class="{$optionData[cssClassName]}"{/if}>{if $isSearchMode|empty || !$optionData[hideLabelInSearch]}<label for="{$option->optionName}">{if VISITOR_USE_TINY_BUILD && $isGuestGroup && $option->excludedInTinyBuild}<span class="icon icon16 fa-bolt red jsTooltip" title="{lang}wcf.acp.group.excludedInTinyBuild{/lang}"></span> {/if}{$langPrefix|concat:$option->optionName|language}</label>{/if}</dt>
 		<dd>{@$optionData[html]}
 			{if $error}
 				<small class="innerError">

--- a/com.woltlab.wcf/templates/userOptionFieldList.tpl
+++ b/com.woltlab.wcf/templates/userOptionFieldList.tpl
@@ -1,7 +1,7 @@
 {foreach from=$options item=optionData}
 	{assign var=option value=$optionData[object]}
 	<dl class="{$option->optionName}Input{if $errorType|is_array && $errorType[$option->optionName]|isset} formError{/if}">
-		<dt{if $optionData[cssClassName]} class="{$optionData[cssClassName]}"{/if}>{if $isSearchMode|empty || !$optionData[hideLabelInSearch]}<label for="{$option->optionName}">{lang}{@$langPrefix}{$option->optionName}{/lang}</label>{if $inSearchMode|empty && $option->required} <span class="customOptionRequired">*</span>{/if}{/if}</dt>
+		<dt{if $optionData[cssClassName]} class="{$optionData[cssClassName]}"{/if}>{if $isSearchMode|empty || !$optionData[hideLabelInSearch]}<label for="{$option->optionName}">{$langPrefix|concat:$option->optionName|language}</label>{if $inSearchMode|empty && $option->required} <span class="customOptionRequired">*</span>{/if}{/if}</dt>
 		<dd>{@$optionData[html]}
 			<small>{lang __optional=true}{@$langPrefix}{$option->optionName}.description{/lang}</small>
 			

--- a/com.woltlab.wcf/templates/userProfileAbout.tpl
+++ b/com.woltlab.wcf/templates/userProfileAbout.tpl
@@ -7,7 +7,7 @@
 					
 					{foreach from=$optionCategory[options] item=userOption}
 						<dl>
-							<dt>{lang}wcf.user.option.{@$userOption[object]->optionName}{/lang}</dt>
+							<dt>{$userOption[object]->getTitle()}</dt>
 							<dd>{@$userOption[object]->optionValue}</dd>
 						</dl>
 					{/foreach}

--- a/com.woltlab.wcf/templates/userProfileOptionFieldList.tpl
+++ b/com.woltlab.wcf/templates/userProfileOptionFieldList.tpl
@@ -6,7 +6,7 @@
 		{assign var=error value=''}
 	{/if}
 	<dl class="{$option->optionName}Input{if $error} formError{/if}">
-		<dt{if $optionData[cssClassName]} class="{$optionData[cssClassName]}"{/if}><label for="{$option->optionName}">{lang}{@$langPrefix}{$option->optionName}{/lang}</label></dt>
+		<dt{if $optionData[cssClassName]} class="{$optionData[cssClassName]}"{/if}><label for="{$option->optionName}">{$langPrefix|concat:$option->optionName|language}</label></dt>
 		<dd>{@$optionData[html]}
 			{if $error}
 				<small class="innerError">

--- a/wcfsetup/install/files/acp/templates/optionFieldList.tpl
+++ b/wcfsetup/install/files/acp/templates/optionFieldList.tpl
@@ -14,7 +14,7 @@
 					{if VISITOR_USE_TINY_BUILD && $isGuestGroup && $option->excludedInTinyBuild}<span class="icon icon16 fa-bolt red jsTooltip" title="{lang}wcf.acp.group.excludedInTinyBuild{/lang}"></span> {/if}
 					{if $groupIsOwner && $option->optionName|in_array:$ownerGroupPermissions}<span class="icon icon16 fa-shield jsTooltip" title="{lang}wcf.acp.group.ownerGroupPermission{/lang}"></span> {/if}
 					
-					{lang}{@$langPrefix}{$option->optionName}{/lang}
+					{$langPrefix|concat:$option->optionName|language}
 				</label>
 			{/if}
 		</dt>

--- a/wcfsetup/install/files/acp/templates/userOptionList.tpl
+++ b/wcfsetup/install/files/acp/templates/userOptionList.tpl
@@ -57,7 +57,7 @@
 							{event name='rowButtons'}
 						</td>
 						<td class="columnID">{@$option->optionID}</td>
-						<td class="columnTitle columnOptionName"><a href="{link controller='UserOptionEdit' id=$option->optionID}{/link}">{lang}wcf.user.option.{$option->optionName}{/lang}</a></td>
+						<td class="columnTitle columnOptionName"><a href="{link controller='UserOptionEdit' id=$option->optionID}{/link}">{$option->getTitle()}</a></td>
 						<td class="columnText columnCategoryName">{lang}wcf.user.option.category.{$option->categoryName}{/lang}</td>
 						<td class="columnText columnOptionType">{$option->optionType}</td>
 						<td class="columnDigits columnShowOrder">{#$option->showOrder}</td>

--- a/wcfsetup/install/files/acp/templates/userSearch.tpl
+++ b/wcfsetup/install/files/acp/templates/userSearch.tpl
@@ -95,7 +95,7 @@
 							
 							{* the 'about me' field does not qualify for display *}
 							{if $option->optionName !== 'aboutMe'}
-								<label><input type="checkbox" name="columns[]" value="{$option->optionName}"{if $option->optionName|in_array:$columns} checked{/if}> {lang}wcf.user.option.{$option->optionName}{/lang}</label>
+								<label><input type="checkbox" name="columns[]" value="{$option->optionName}"{if $option->optionName|in_array:$columns} checked{/if}> {$option->getTitle()}</label>
 							{/if}
 						{/foreach}
 					</dd>


### PR DESCRIPTION
Not all places could be adjusted for compatibility reasons, as the `Option`
super class does not have the `getTitle()` method and as the prefix is given
explicitly.

Helper methods for the description should also be added.

see #4107
