### PR TITLE
Improve the performance of the HTMLOutputProcessor

### DIFF
--- a/wcfsetup/install/files/lib/system/html/node/AbstractHtmlNodeProcessor.class.php
+++ b/wcfsetup/install/files/lib/system/html/node/AbstractHtmlNodeProcessor.class.php
@@ -283,7 +283,7 @@ abstract class AbstractHtmlNodeProcessor implements IHtmlNodeProcessor {
 		}
 		
 		$elements = [];
-		foreach ($this->getDocument()->getElementsByTagName($tagName) as $element) {
+		foreach ($this->getXPath()->query("//{$tagName}") as $element) {
 			$elements[] = $element;
 		}
 		

--- a/wcfsetup/install/files/lib/system/html/node/AbstractHtmlNodeProcessor.class.php
+++ b/wcfsetup/install/files/lib/system/html/node/AbstractHtmlNodeProcessor.class.php
@@ -304,7 +304,7 @@ abstract class AbstractHtmlNodeProcessor implements IHtmlNodeProcessor {
 		
 		$tags = [];
 		/** @var \DOMElement $tag */
-		foreach ($this->getDocument()->getElementsByTagName('*') as $tag) {
+		foreach ($this->getXPath()->query("//*") as $tag) {
 			$tagName = $tag->nodeName;
 			if (!isset($tags[$tagName])) $tags[$tagName] = $tagName;
 		}

--- a/wcfsetup/install/files/lib/system/html/output/node/HtmlOutputNodeProcessor.class.php
+++ b/wcfsetup/install/files/lib/system/html/output/node/HtmlOutputNodeProcessor.class.php
@@ -91,22 +91,15 @@ class HtmlOutputNodeProcessor extends AbstractHtmlNodeProcessor {
 		$this->invokeNodeHandlers('wcf\system\html\output\node\HtmlOutputNode', ['woltlab-metacode']);
 		
 		if ($this->getHtmlProcessor()->removeLinks) {
-			$links = $this->getDocument()->getElementsByTagName('a');
-			while ($links->length) {
-				DOMUtil::removeNode($links->item(0), true);
+			foreach ($this->getXPath()->query('//a') as $link) {
+				DOMUtil::removeNode($link, true);
 			}
 		}
 		
 		if ($this->outputType !== 'text/html') {
 			// convert `<p>...</p>` into `...<br><br>`
 			$paragraphs = [];
-			// The DOMNodeList returned by `getElementsByTagName()` is live, causing a performance
-			// penalty when modifying it a lot.
-			foreach ($this->getDocument()->getElementsByTagName('p') as $node) {
-				$paragraphs[] = $node;
-			}
-			
-			foreach ($paragraphs as $paragraph) {
+			foreach ($this->getXPath()->query('//p') as $paragraph) {
 				$isLastNode = true;
 				$sibling = $paragraph;
 				while ($sibling = $sibling->nextSibling) {
@@ -147,7 +140,6 @@ class HtmlOutputNodeProcessor extends AbstractHtmlNodeProcessor {
 				
 				DOMUtil::removeNode($paragraph, true);
 			}
-			unset($paragraphs);
 			
 			if ($this->outputType === 'text/plain') {
 				// remove all `\n` first
@@ -166,10 +158,7 @@ class HtmlOutputNodeProcessor extends AbstractHtmlNodeProcessor {
 				
 				// insert a trailing newline for certain elements, such as `<br>` or `<li>`
 				foreach (self::$plainTextNewlineTags as $tagName) {
-					$elements = $this->getDocument()->getElementsByTagName($tagName);
-					while ($elements->length) {
-						$element = $elements->item(0);
-						
+					foreach ($this->getXPath()->query("//{$tagName}") as $element) {
 						$newline = $this->getDocument()->createTextNode("\n");
 						$element->parentNode->insertBefore($newline, $element->nextSibling);
 						DOMUtil::removeNode($element, true);
@@ -177,9 +166,8 @@ class HtmlOutputNodeProcessor extends AbstractHtmlNodeProcessor {
 				}
 				
 				// remove all other elements
-				$elements = $this->getDocument()->getElementsByTagName('*');
-				while ($elements->length) {
-					DOMUtil::removeNode($elements->item(0), true);
+				foreach ($this->getXPath()->query('//*') as $element) {
+					DOMUtil::removeNode($element, true);
 				}
 			}
 		}

--- a/wcfsetup/install/files/lib/system/html/output/node/HtmlOutputNodeProcessor.class.php
+++ b/wcfsetup/install/files/lib/system/html/output/node/HtmlOutputNodeProcessor.class.php
@@ -99,10 +99,14 @@ class HtmlOutputNodeProcessor extends AbstractHtmlNodeProcessor {
 		
 		if ($this->outputType !== 'text/html') {
 			// convert `<p>...</p>` into `...<br><br>`
-			$paragraphs = $this->getDocument()->getElementsByTagName('p');
-			while ($paragraphs->length) {
-				$paragraph = $paragraphs->item(0);
-				
+			$paragraphs = [];
+			// The DOMNodeList returned by `getElementsByTagName()` is live, causing a performance
+			// penalty when modifying it a lot.
+			foreach ($this->getDocument()->getElementsByTagName('p') as $node) {
+				$paragraphs[] = $node;
+			}
+			
+			foreach ($paragraphs as $paragraph) {
 				$isLastNode = true;
 				$sibling = $paragraph;
 				while ($sibling = $sibling->nextSibling) {
@@ -143,6 +147,7 @@ class HtmlOutputNodeProcessor extends AbstractHtmlNodeProcessor {
 				
 				DOMUtil::removeNode($paragraph, true);
 			}
+			unset($paragraphs);
 			
 			if ($this->outputType === 'text/plain') {
 				// remove all `\n` first

--- a/wcfsetup/install/files/lib/system/html/output/node/HtmlOutputNodeProcessor.class.php
+++ b/wcfsetup/install/files/lib/system/html/output/node/HtmlOutputNodeProcessor.class.php
@@ -98,7 +98,6 @@ class HtmlOutputNodeProcessor extends AbstractHtmlNodeProcessor {
 		
 		if ($this->outputType !== 'text/html') {
 			// convert `<p>...</p>` into `...<br><br>`
-			$paragraphs = [];
 			foreach ($this->getXPath()->query('//p') as $paragraph) {
 				$isLastNode = true;
 				$sibling = $paragraph;

--- a/wcfsetup/install/files/lib/util/DOMUtil.class.php
+++ b/wcfsetup/install/files/lib/util/DOMUtil.class.php
@@ -478,6 +478,8 @@ final class DOMUtil {
 	 * @param	boolean		$preserveChildNodes	preserve child nodes, only supported for elements
 	 */
 	public static function removeNode(\DOMNode $node, $preserveChildNodes = false) {
+		$parent = $node->parentNode ?: $node->ownerDocument;
+
 		if ($preserveChildNodes) {
 			if (!($node instanceof \DOMElement)) {
 				throw new \InvalidArgumentException("Preserving child nodes is only supported for DOMElement.");
@@ -489,11 +491,11 @@ final class DOMUtil {
 			}
 
 			foreach ($children as $child) {
-				self::insertBefore($child, $node);
+				$parent->insertBefore($child, $node);
 			}
 		}
 		
-		self::getParentNode($node)->removeChild($node);
+		$parent->removeChild($node);
 	}
 	
 	/**

--- a/wcfsetup/install/files/lib/util/DOMUtil.class.php
+++ b/wcfsetup/install/files/lib/util/DOMUtil.class.php
@@ -483,8 +483,13 @@ final class DOMUtil {
 				throw new \InvalidArgumentException("Preserving child nodes is only supported for DOMElement.");
 			}
 			
-			while ($node->hasChildNodes()) {
-				self::insertBefore($node->childNodes->item(0), $node);
+			$children = [];
+			foreach ($node->childNodes as $childNode) {
+				$children[] = $childNode;
+			}
+
+			foreach ($children as $child) {
+				self::insertBefore($child, $node);
 			}
 		}
 		


### PR DESCRIPTION
Lessons learned: `DOMElement::getElementsByTagName()` is a slow piece of garbage, `DOMXPath::query()` is extremely faster.