### PR TITLE
Add option to disable FLoC

### DIFF
--- a/com.woltlab.wcf/option.xml
+++ b/com.woltlab.wcf/option.xml
@@ -601,6 +601,11 @@ private:wcf.acp.option.exception_privacy.private</selectoptions>
 				<optiontype>boolean</optiontype>
 				<defaultvalue>1</defaultvalue>
 			</option>
+			<option name="http_disable_floc">
+				<categoryname>general.system.http</categoryname>
+				<optiontype>boolean</optiontype>
+				<defaultvalue>1</defaultvalue>
+			</option>
 			<!-- /general.system.http -->
 			<!-- general.system.packageServer -->
 			<option name="package_server_auth_code">

--- a/wcfsetup/install/files/lib/system/WCFSetup.class.php
+++ b/wcfsetup/install/files/lib/system/WCFSetup.class.php
@@ -37,6 +37,7 @@ use wcf\util\XML;
 // define
 \define('PACKAGE_ID', 0);
 \define('HTTP_SEND_X_FRAME_OPTIONS', 0);
+\define('HTTP_DISABLE_FLOC', 0);
 \define('CACHE_SOURCE_TYPE', 'disk');
 \define('MODULE_MASTER_PASSWORD', 1);
 \define('ENABLE_DEBUG_MODE', 1);

--- a/wcfsetup/install/files/lib/util/HeaderUtil.class.php
+++ b/wcfsetup/install/files/lib/util/HeaderUtil.class.php
@@ -94,6 +94,11 @@ final class HeaderUtil
             @\header('X-Frame-Options: SAMEORIGIN');
         }
 
+        // send Permissions-Policy
+        if (HTTP_DISABLE_FLOC) {
+            @\header('Permissions-Policy: interest-cohort=()');
+        }
+
         \ob_start([self::class, 'parseOutput']);
     }
 

--- a/wcfsetup/install/files/lib/util/HeaderUtil.class.php
+++ b/wcfsetup/install/files/lib/util/HeaderUtil.class.php
@@ -96,7 +96,7 @@ final class HeaderUtil
 
         // send Permissions-Policy
         if (HTTP_DISABLE_FLOC) {
-            @\header('Permissions-Policy: interest-cohort=()');
+            @\header('permissions-policy: interest-cohort=()');
         }
 
         \ob_start([self::class, 'parseOutput']);

--- a/wcfsetup/install/files/options.inc.php
+++ b/wcfsetup/install/files/options.inc.php
@@ -23,6 +23,7 @@ if (\file_exists(WCF_DIR . 'cookiePrefix.txt')) {
 \define('COOKIE_DOMAIN', '');
 
 \define('HTTP_SEND_X_FRAME_OPTIONS', 0);
+\define('HTTP_DISABLE_FLOC', 0);
 
 \define('BLACKLIST_IP_ADDRESSES', '');
 \define('BLACKLIST_USER_AGENTS', '');

--- a/wcfsetup/install/lang/de.xml
+++ b/wcfsetup/install/lang/de.xml
@@ -1329,6 +1329,8 @@ ACHTUNG: Die oben genannten Meldungen sind stark gekürzt. Sie können Details z
 		<item name="wcf.acp.option.error.tooShort"><![CDATA[Der eingegebene Text ist zu kurz.]]></item>
 		<item name="wcf.acp.option.http_send_x_frame_options"><![CDATA[Einbindung in einem Frame verhindern]]></item>
 		<item name="wcf.acp.option.http_send_x_frame_options.description"><![CDATA[Sendet den <a href="https://de.wikipedia.org/wiki/Clickjacking" class="externalURL">„X-Frame-Options“</a> Header, um die Einbettung dieser Seite in einem Frame zu verhindern (sendet „SAMEORIGIN“).]]></item>
+		<item name="wcf.acp.option.http_disable_floc"><![CDATA[Besucher-Tracking mittels FLoC verhindern]]></item>
+		<item name="wcf.acp.option.http_disable_floc.description"><![CDATA[Verhindert das Tracking mittels des von Google eingeführten <a href="https://de.wikipedia.org/wiki/Federated_Learning_of_Cohorts">„FLoC“</a> durch senden des „Permissions-Policy“ Headers (sendet „interest-cohort=()“).]]></item>
 		<item name="wcf.acp.option.image_adapter_type"><![CDATA[Grafik-Bibliothek]]></item>
 		<item name="wcf.acp.option.image_adapter_type.gd"><![CDATA[GD Graphics Library (Standard)]]></item>
 		<item name="wcf.acp.option.image_adapter_type.imagick"><![CDATA[ImageMagick]]></item>

--- a/wcfsetup/install/lang/de.xml
+++ b/wcfsetup/install/lang/de.xml
@@ -1330,7 +1330,7 @@ ACHTUNG: Die oben genannten Meldungen sind stark gekürzt. Sie können Details z
 		<item name="wcf.acp.option.http_send_x_frame_options"><![CDATA[Einbindung in einem Frame verhindern]]></item>
 		<item name="wcf.acp.option.http_send_x_frame_options.description"><![CDATA[Sendet den <a href="https://de.wikipedia.org/wiki/Clickjacking" class="externalURL">„X-Frame-Options“</a> Header, um die Einbettung dieser Seite in einem Frame zu verhindern (sendet „SAMEORIGIN“).]]></item>
 		<item name="wcf.acp.option.http_disable_floc"><![CDATA[Besucher-Tracking mittels FLoC verhindern]]></item>
-		<item name="wcf.acp.option.http_disable_floc.description"><![CDATA[Verhindert das Tracking mittels des von Google eingeführten <a href="https://de.wikipedia.org/wiki/Federated_Learning_of_Cohorts">„FLoC“</a> durch senden des „Permissions-Policy“ Headers (sendet „interest-cohort=()“).]]></item>
+		<item name="wcf.acp.option.http_disable_floc.description"><![CDATA[Verhindert das Tracking mittels des von Google eingeführten <a href="https://de.wikipedia.org/wiki/Federated_Learning_of_Cohorts">„FLoC“</a> durch Senden des „Permissions-Policy“ Headers (sendet „interest-cohort=()“).]]></item>
 		<item name="wcf.acp.option.image_adapter_type"><![CDATA[Grafik-Bibliothek]]></item>
 		<item name="wcf.acp.option.image_adapter_type.gd"><![CDATA[GD Graphics Library (Standard)]]></item>
 		<item name="wcf.acp.option.image_adapter_type.imagick"><![CDATA[ImageMagick]]></item>

--- a/wcfsetup/install/lang/en.xml
+++ b/wcfsetup/install/lang/en.xml
@@ -1307,6 +1307,8 @@ ATTENTION: The messages listed above are greatly shortened. You can view details
 		<item name="wcf.acp.option.error.tooShort"><![CDATA[The entered text is too short.]]></item>
 		<item name="wcf.acp.option.http_send_x_frame_options"><![CDATA[Disallow embedding in a frame]]></item>
 		<item name="wcf.acp.option.http_send_x_frame_options.description"><![CDATA[Sends the <a href="https://en.wikipedia.org/wiki/Clickjacking" class="externalURL">“X-Frame-Options”</a> header to prevent 3rd party sites from embedding this site in a frame (sends “SAMEORIGIN”).]]></item>
+		<item name="wcf.acp.option.http_disable_floc"><![CDATA[Disallow user tracking via FLoC]]></item>
+		<item name="wcf.acp.option.http_disable_floc.description"><![CDATA[Prevents tracking using the <a href="https://de.wikipedia.org/wiki/Federated_Learning_of_Cohorts">“FLoC”</a> technique introduced by Google by sending the “Permissions-Policy” header (sends “interest-cohort=()”).]]></item>
 		<item name="wcf.acp.option.image_adapter_type"><![CDATA[Graphics Library]]></item>
 		<item name="wcf.acp.option.image_adapter_type.gd"><![CDATA[Use GD Graphics Library (default)]]></item>
 		<item name="wcf.acp.option.image_adapter_type.imagick"><![CDATA[Use ImageMagick]]></item>


### PR DESCRIPTION
Google is rolling out Federated Learning of Cohorts (FLoC) for the Chrome browser.

As the Electronic Frontier Foundation explains in their post “[Google’s FLoC is a terrible idea](https://www.eff.org/deeplinks/2021/03/googles-floc-terrible-idea)“, placing people in groups based on their browsing habits is likely to facilitate employment, housing and other types of discrimination, as well as predatory targeting of unsophisticated consumers.

This is in addition to the privacy concerns of tracking people and sharing their data, seemingly without informed consent – and making it more difficult for legislators and regulators to protect people.

TL;DR: FLoC places people in groups based on their browsing habits to target advertising.

Website administrators can disable this new tracking technique by sending a `Permissions-Policy: interest-cohort=()` header. This commit adds a new option to send this header, which is enabled by default. Administrators can disable it, especially in cases, where the underlying webserver is already configured to send the `Permissions-Policy` header.