### PR TITLE
Ensure that the creating of related rows uses up to date article fields

### DIFF
--- a/wcfsetup/install/files/lib/data/article/ArticleAction.class.php
+++ b/wcfsetup/install/files/lib/data/article/ArticleAction.class.php
@@ -232,9 +232,9 @@ class ArticleAction extends AbstractDatabaseObjectAction {
 						$articleContent->articleContentID,
 						isset($content['content']) ? $content['content'] : $articleContent->content,
 						isset($content['title']) ? $content['title'] : $articleContent->title,
-						$article->time,
-						$article->userID,
-						$article->username, 
+						$this->parameters['data']['time'] ?? $article->time,
+						$this->parameters['data']['userID'] ?? $article->userID,
+						$this->parameters['data']['username'] ?? $article->username,
 						$languageID ?: null,
 						isset($content['teaser']) ? $content['teaser'] : $articleContent->teaser
 					);
@@ -288,7 +288,13 @@ class ArticleAction extends AbstractDatabaseObjectAction {
 							new ArticleUserNotificationObject($articleEditor->getDecoratedObject())
 						);
 						
-						UserActivityEventHandler::getInstance()->fireEvent('com.woltlab.wcf.article.recentActivityEvent', $articleEditor->articleID, null, $articleEditor->userID, $articleEditor->time);
+						UserActivityEventHandler::getInstance()->fireEvent(
+							'com.woltlab.wcf.article.recentActivityEvent',
+							$articleEditor->articleID,
+							null,
+							$this->parameters['data']['userID'] ?? $articleEditor->userID,
+							$this->parameters['data']['time'] ?? $articleEditor->time
+						);
 					}
 					else {
 						$resetArticleIDs[] = $articleEditor->articleID;


### PR DESCRIPTION
Previously the code would store outdated data in the search index and recent
activities when changing the article's timestamp while publishing the article
or when changing the article's author.
