### PR TITLE
Lazily load trophy images

### DIFF
--- a/com.woltlab.wcf/templates/trophyImage.tpl
+++ b/com.woltlab.wcf/templates/trophyImage.tpl
@@ -5,4 +5,5 @@
 	{if $showTooltip}title="{$trophy->getTitle()}"{/if}
 	class="trophyIcon{if $showTooltip} jsTooltip{/if}"
 	data-trophy-id="{$trophy->getObjectID()}"
+	loading="lazy"
 />

--- a/com.woltlab.wcf/templates/trophyImage.tpl
+++ b/com.woltlab.wcf/templates/trophyImage.tpl
@@ -1,6 +1,7 @@
 <img
 	src="{@$__wcf->getPath()}images/trophy/{$trophy->iconFile}"
-	style="width:{$size}px;height:{$size}px"
+	width="{$size}"
+	height="{$size}"
 	{if $showTooltip}title="{$trophy->getTitle()}"{/if}
 	class="trophyIcon{if $showTooltip} jsTooltip{/if}"
 	data-trophy-id="{$trophy->getObjectID()}"

--- a/wcfsetup/install/files/acp/templates/trophyImage.tpl
+++ b/wcfsetup/install/files/acp/templates/trophyImage.tpl
@@ -5,4 +5,5 @@
 	{if $showTooltip}title="{$trophy->getTitle()}"{/if}
 	class="trophyIcon{if $showTooltip} jsTooltip{/if}"
 	data-trophy-id="{$trophy->getObjectID()}"
+	loading="lazy"
 />

--- a/wcfsetup/install/files/acp/templates/trophyImage.tpl
+++ b/wcfsetup/install/files/acp/templates/trophyImage.tpl
@@ -1,6 +1,7 @@
 <img
 	src="{@$__wcf->getPath()}images/trophy/{$trophy->iconFile}"
-	style="width:{$size}px;height:{$size}px"
+	width="{$size}"
+	height="{$size}"
 	{if $showTooltip}title="{$trophy->getTitle()}"{/if}
 	class="trophyIcon{if $showTooltip} jsTooltip{/if}"
 	data-trophy-id="{$trophy->getObjectID()}"


### PR DESCRIPTION
- Use width / height attributes instead of inline CSS in trophyImage.tpl
- Lazily load trophy images
