### PR TITLE
Delete the empty phrase during update from 5.3 to 5.4

### DIFF
--- a/wcfsetup/install/files/acp/update_com.woltlab.wcf_5.4_deleteLanguageItems.php
+++ b/wcfsetup/install/files/acp/update_com.woltlab.wcf_5.4_deleteLanguageItems.php
@@ -4,6 +4,8 @@ use wcf\data\language\item\LanguageItemAction;
 use wcf\data\language\item\LanguageItemList;
 
 $languageItems = [
+    // The empty phrase. See: https://github.com/WoltLab/WCF/commit/9e280cb5c1dd3e398a3096b55f6d88be4baa6923
+    '',
     'wcf.acp.group.option.user.attachment.allowedExtensions.description',
     'wcf.acp.group.option.user.contactForm.attachment.allowedExtensions.description',
     'wcf.acp.group.option.user.signature.attachment.allowedExtensions.description',


### PR DESCRIPTION
see 9e280cb5c1dd3e398a3096b55f6d88be4baa6923
see https://community.woltlab.com/thread/289955/
