### PR TITLE
Add SensitiveArgument attribute

### DIFF
--- a/wcfsetup/install/files/lib/core.functions.php
+++ b/wcfsetup/install/files/lib/core.functions.php
@@ -717,13 +717,13 @@ EXPLANATION;
 			if (!isset($item['args'])) $item['args'] = [];
 
 			if ($item['class']) {
-				$f = new \ReflectionMethod($item['class'], $item['function']);
+				$function = new \ReflectionMethod($item['class'], $item['function']);
 			}
 			else {
-				$f = new \ReflectionFunction($item['function']);
+				$function = new \ReflectionFunction($item['function']);
 			}
 
-			$parameters = $f->getParameters();
+			$parameters = $function->getParameters();
 			$i = 0;
 			foreach ($parameters as $parameter) {
 				$isSensitive = false;

--- a/wcfsetup/install/files/lib/core.functions.php
+++ b/wcfsetup/install/files/lib/core.functions.php
@@ -733,6 +733,12 @@ EXPLANATION;
 				) {
 					$isSensitive = true;
 				}
+				if (\preg_match(
+					'/(?:^(?:password|passphrase|secret)|(?:Password|Passphrase|Secret))/',
+					$parameter->getName()
+				)) {
+					$isSensitive = true;
+				}
 
 				if ($isSensitive && isset($item['args'][$i])) {
 					$item['args'][$i] = '[redacted]';

--- a/wcfsetup/install/files/lib/core.functions.php
+++ b/wcfsetup/install/files/lib/core.functions.php
@@ -116,6 +116,11 @@ namespace wcf {
 	function getMinorVersion(): string {
 		return preg_replace('/^(\d+\.\d+)\..*$/', '\\1', WCF_VERSION);
 	}
+
+	#[Attribute(\Attribute::TARGET_PARAMETER)]
+	class SensitiveArgument
+	{
+	}
 }
 
 namespace wcf\functions\exception {
@@ -710,6 +715,30 @@ EXPLANATION;
 			if (!isset($item['class'])) $item['class'] = '';
 			if (!isset($item['type'])) $item['type'] = '';
 			if (!isset($item['args'])) $item['args'] = [];
+
+			if ($item['class']) {
+				$f = new \ReflectionMethod($item['class'], $item['function']);
+			}
+			else {
+				$f = new \ReflectionFunction($item['function']);
+			}
+
+			$parameters = $f->getParameters();
+			$i = 0;
+			foreach ($parameters as $parameter) {
+				$isSensitive = false;
+				if (
+					\method_exists($parameter, 'getAttributes')
+					&& !empty($parameter->getAttributes(\wcf\SensitiveArgument::class))
+				) {
+					$isSensitive = true;
+				}
+
+				if ($isSensitive && isset($item['args'][$i])) {
+					$item['args'][$i] = '[redacted]';
+				}
+				$i++;
+			}
 			
 			// strip database credentials
 			if (preg_match('~\\\\?wcf\\\\system\\\\database\\\\[a-zA-Z]*Database~', $item['class']) || $item['class'] === 'PDO') {

--- a/wcfsetup/install/files/lib/data/user/User.class.php
+++ b/wcfsetup/install/files/lib/data/user/User.class.php
@@ -152,8 +152,13 @@ final class User extends DatabaseObject implements IPopoverObject, IRouteControl
      * @param string $password
      * @return  bool        password correct
      */
-    public function checkPassword($password)
-    {
+    public function checkPassword(
+        // phpcs:disable Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingAfterHint
+        // phpcs:disable Squiz.Functions.MultiLineFunctionDeclaration.FirstParamSpacing
+        // https://github.com/squizlabs/PHP_CodeSniffer/pull/3320
+        #[\wcf\SensitiveArgument()]
+        $password
+    ) {
         $isValid = false;
 
         $manager = PasswordAlgorithmManager::getInstance();

--- a/wcfsetup/install/files/lib/system/user/authentication/DefaultUserAuthentication.class.php
+++ b/wcfsetup/install/files/lib/system/user/authentication/DefaultUserAuthentication.class.php
@@ -34,8 +34,14 @@ class DefaultUserAuthentication extends AbstractUserAuthentication
     /**
      * @inheritDoc
      */
-    public function loginManually($username, $password, $userClassname = User::class)
-    {
+    public function loginManually(
+        $username,
+        // phpcs:disable Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingAfterHint
+        // https://github.com/squizlabs/PHP_CodeSniffer/pull/3320
+        #[\wcf\SensitiveArgument()]
+        $password,
+        $userClassname = User::class
+    ) {
         $user = $this->getUserByLogin($username);
         $userSession = (\get_class($user) == $userClassname ? $user : new $userClassname(null, null, $user));
 


### PR DESCRIPTION
- Add \wcf\SensitiveArgument attribute
- Consider parameters with password|passphrase|secret in their name to be sensitive
- Make use of \wcf\SensitiveArgument attribute
