### PR TITLE
Add Message-ID to MFA emails

### DIFF
--- a/wcfsetup/install/files/lib/form/MultifactorManageForm.class.php
+++ b/wcfsetup/install/files/lib/form/MultifactorManageForm.class.php
@@ -252,6 +252,12 @@ class MultifactorManageForm extends AbstractFormBuilderForm
     {
         $email = new SimpleEmail();
         $email->setRecipient(WCF::getUser());
+        $email->setMessageID(\sprintf(
+            'com.woltlab.wcf.multifactorSetup/%d/%d/%s',
+            WCF::getUser()->userID,
+            TIME_NOW,
+            \bin2hex(\random_bytes(8))
+        ));
 
         $email->setSubject(
             WCF::getLanguage()->getDynamicVariable('wcf.user.security.multifactor.setupEmail.subject', [

--- a/wcfsetup/install/files/lib/system/email/SimpleEmail.class.php
+++ b/wcfsetup/install/files/lib/system/email/SimpleEmail.class.php
@@ -121,6 +121,16 @@ class SimpleEmail
     }
 
     /**
+     * Sets the part left of the at sign (@) in the email's 'Message-Id'.
+     *
+     * @see Email::setMessageID()
+     */
+    public function setMessageID(?string $messageId): void
+    {
+        $this->email->setMessageID($messageId);
+    }
+
+    /**
      * Queues this email for delivery.
      *
      * @see Email::send()

--- a/wcfsetup/install/files/lib/system/user/multifactor/BackupMultifactorMethod.class.php
+++ b/wcfsetup/install/files/lib/system/user/multifactor/BackupMultifactorMethod.class.php
@@ -363,6 +363,12 @@ final class BackupMultifactorMethod implements IMultifactorMethod
 
         $email = new SimpleEmail();
         $email->setRecipient($setup->getUser());
+        $email->setMessageID(\sprintf(
+            'com.woltlab.wcf.multifactor.backup.used/%d/%d/%s',
+            $setup->getUser()->userID,
+            TIME_NOW,
+            \bin2hex(\random_bytes(8))
+        ));
 
         $email->setSubject(
             WCF::getLanguage()->getDynamicVariable(

--- a/wcfsetup/install/files/lib/system/user/multifactor/EmailMultifactorMethod.class.php
+++ b/wcfsetup/install/files/lib/system/user/multifactor/EmailMultifactorMethod.class.php
@@ -110,6 +110,12 @@ final class EmailMultifactorMethod implements IMultifactorMethod
     {
         $email = new SimpleEmail();
         $email->setRecipient($setup->getUser());
+        $email->setMessageID(\sprintf(
+            'com.woltlab.wcf.multifactor.email/%d/%d/%s',
+            $setup->getUser()->userID,
+            TIME_NOW,
+            \bin2hex(\random_bytes(8))
+        ));
 
         $email->setSubject(
             WCF::getLanguage()->getDynamicVariable('wcf.user.security.multifactor.email.subject', [


### PR DESCRIPTION
- Add SimpleEmail::setMessageID()
- Set explicit Message-ID in MultifactorManageForm::sendEmail()
- Set explicit Message-ID in BackupMultifactorMethod::sendAuthenticationEmail()
- Set explicit Message-ID in EmailMultifactorMethod::sendEmail()
