### PR TITLE
provide files-property for `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@woltlab/wcf",
   "version": "5.4.0",
+  "files": [
+    "ts/**/*",
+    "global.d.ts"
+  ],
   "devDependencies": {
     "@types/googlemaps": "^3.43.0",
     "@types/perfect-scrollbar": "^0.6.1",


### PR DESCRIPTION
Prevent reading the whole repository when this repository is a dependency. This down-loads `ts/*` and `global.d.ts` only.