### PR TITLE
Add '; like Twitterbot' to URL Unfurling User-Agent

### DIFF
--- a/wcfsetup/install/files/lib/system/io/HttpFactory.class.php
+++ b/wcfsetup/install/files/lib/system/io/HttpFactory.class.php
@@ -34,7 +34,7 @@ final class HttpFactory
     public static function getDefaultUserAgent(?string $comment = null): string
     {
         if ($comment) {
-            if (!Regex::compile("^[a-zA-Z0-9_:/\\. -]+$")->match($comment)) {
+            if (!Regex::compile("^[a-zA-Z0-9_:;,/\\. -]+$")->match($comment)) {
                 throw new InvalidArgumentException("Invalid comment for user agent given.");
             }
 

--- a/wcfsetup/install/files/lib/system/message/unfurl/UnfurlResponse.class.php
+++ b/wcfsetup/install/files/lib/system/message/unfurl/UnfurlResponse.class.php
@@ -333,7 +333,7 @@ final class UnfurlResponse
                 RequestOptions::TIMEOUT => 10,
                 RequestOptions::STREAM => true,
                 RequestOptions::HEADERS => [
-                    'user-agent' => HttpFactory::getDefaultUserAgent("URL Unfurling"),
+                    'user-agent' => HttpFactory::getDefaultUserAgent("URL Unfurling; like Twitterbot"),
                 ],
                 RequestOptions::ALLOW_REDIRECTS => [
                     'on_redirect' => new RedirectGuard(),


### PR DESCRIPTION
- Allow commas and semicolons in the comment in HttpFactory::getDefaultUserAgent()
- Add '; like Twitterbot' to URL Unfurling User-Agent
