### PR TITLE
Add IUserMailbox interface

### DIFF
--- a/wcfsetup/install/files/lib/system/background/job/EmailDeliveryBackgroundJob.class.php
+++ b/wcfsetup/install/files/lib/system/background/job/EmailDeliveryBackgroundJob.class.php
@@ -5,10 +5,10 @@ namespace wcf\system\background\job;
 use wcf\data\email\log\entry\EmailLogEntry;
 use wcf\data\email\log\entry\EmailLogEntryAction;
 use wcf\system\email\Email;
+use wcf\system\email\IUserMailbox;
 use wcf\system\email\Mailbox;
 use wcf\system\email\transport\exception\PermanentFailure;
 use wcf\system\email\transport\IStatusReportingEmailTransport;
-use wcf\system\email\UserMailbox;
 use wcf\util\StringUtil;
 
 /**
@@ -94,7 +94,7 @@ class EmailDeliveryBackgroundJob extends AbstractBackgroundJob
                     true
                 ),
                 'recipient' => $this->envelopeTo->getAddress(),
-                'recipientID' => ($this->envelopeTo instanceof UserMailbox) ? $this->envelopeTo->getUser()->userID : null,
+                'recipientID' => ($this->envelopeTo instanceof IUserMailbox) ? $this->envelopeTo->getUser()->userID : null,
                 'status' => EmailLogEntry::STATUS_NEW,
             ],
         ]))->executeAction()['returnValues'];

--- a/wcfsetup/install/files/lib/system/email/Email.class.php
+++ b/wcfsetup/install/files/lib/system/email/Email.class.php
@@ -672,7 +672,7 @@ class Email
         foreach ($this->recipients as $recipient) {
             $mail = clone $this;
 
-            if ($recipient['mailbox'] instanceof UserMailbox) {
+            if ($recipient['mailbox'] instanceof IUserMailbox) {
                 $mail->addHeader('X-WoltLab-Suite-Recipient', $recipient['mailbox']->getUser()->username);
             }
 

--- a/wcfsetup/install/files/lib/system/email/IUserMailbox.class.php
+++ b/wcfsetup/install/files/lib/system/email/IUserMailbox.class.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace wcf\system\email;
+
+use wcf\data\user\User;
+
+/**
+ * Represents mailbox belonging to a specific registered user.
+ *
+ * @author  Tim Duesterhus
+ * @copyright   2001-2021 WoltLab GmbH
+ * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @package WoltLabSuite\Core\System\Email
+ * @since   5.4
+ */
+interface IUserMailbox
+{
+    /**
+     * Returns the User object belonging to this Mailbox.
+     */
+    public function getUser(): User;
+}

--- a/wcfsetup/install/files/lib/system/email/UserMailbox.class.php
+++ b/wcfsetup/install/files/lib/system/email/UserMailbox.class.php
@@ -5,15 +5,15 @@ namespace wcf\system\email;
 use wcf\data\user\User;
 
 /**
- * Represents mailbox belonging to a specific registered user.
+ * Default implementation of the IUserMailbox interface.
  *
  * @author  Tim Duesterhus
- * @copyright   2001-2019 WoltLab GmbH
+ * @copyright   2001-2021 WoltLab GmbH
  * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
  * @package WoltLabSuite\Core\System\Email
  * @since   3.0
  */
-class UserMailbox extends Mailbox
+class UserMailbox extends Mailbox implements IUserMailbox
 {
     /**
      * User object belonging to this Mailbox
@@ -35,10 +35,8 @@ class UserMailbox extends Mailbox
 
     /**
      * Returns the User object belonging to this Mailbox.
-     *
-     * @return  User
      */
-    public function getUser()
+    public function getUser(): User
     {
         return $this->user;
     }


### PR DESCRIPTION
This cleans up the OO design a bit, because consumers may check against the
interface instead of a concrete class. This allows for additional mailboxes
belonging to an user, e.g. for emergency contacts or separate billing
addresses.
