### PR TITLE
Add 'discarded' status to email log

### DIFF
--- a/wcfsetup/install/files/acp/templates/emailLogList.tpl
+++ b/wcfsetup/install/files/acp/templates/emailLogList.tpl
@@ -64,6 +64,7 @@
 						<option value="success"{if $filter[status] == 'success'} selected{/if}>{lang}wcf.acp.email.log.status.success{/lang}</option>
 						<option value="transient_failure"{if $filter[status] == 'transient_failure'} selected{/if}>{lang}wcf.acp.email.log.status.transient_failure{/lang}</option>
 						<option value="permanent_failure"{if $filter[status] == 'permanent_failure'} selected{/if}>{lang}wcf.acp.email.log.status.permanent_failure{/lang}</option>
+						<option value="discarded"{if $filter[status] == 'discarded'} selected{/if}>{lang}wcf.acp.email.log.status.discarded{/lang}</option>
 					</select>
 				</dd>
 			</dl>

--- a/wcfsetup/install/files/lib/data/email/log/entry/EmailLogEntry.class.php
+++ b/wcfsetup/install/files/lib/data/email/log/entry/EmailLogEntry.class.php
@@ -36,6 +36,8 @@ class EmailLogEntry extends DatabaseObject
 
     public const STATUS_PERMANENT_FAILURE = 'permanent_failure';
 
+    public const STATUS_DISCARDED = 'discarded';
+
     /**
      * Returns the formatted 'Message-ID', stripping useless information.
      */

--- a/wcfsetup/install/files/lib/system/background/job/EmailDeliveryBackgroundJob.class.php
+++ b/wcfsetup/install/files/lib/system/background/job/EmailDeliveryBackgroundJob.class.php
@@ -103,7 +103,7 @@ class EmailDeliveryBackgroundJob extends AbstractBackgroundJob
     /**
      * Updates the status of the log entry.
      */
-    private function updateStatus(string $status, string $message = ''): void
+    public function updateStatus(string $status, string $message = ''): void
     {
         (new EmailLogEntryAction([$this->emailLogEntryId], 'update', [
             'data' => [

--- a/wcfsetup/install/files/lib/system/background/job/NotificationEmailDeliveryBackgroundJob.class.php
+++ b/wcfsetup/install/files/lib/system/background/job/NotificationEmailDeliveryBackgroundJob.class.php
@@ -2,6 +2,7 @@
 
 namespace wcf\system\background\job;
 
+use wcf\data\email\log\entry\EmailLogEntry;
 use wcf\data\user\notification\UserNotification;
 use wcf\data\user\User;
 use wcf\system\session\SessionHandler;
@@ -105,6 +106,11 @@ class NotificationEmailDeliveryBackgroundJob extends AbstractBackgroundJob
 
             // Drop email if the processing dropped the notification (most likely due to a lack of permissions).
             if ($processedNotifications['count'] == 0) {
+                $this->job->updateStatus(
+                    EmailLogEntry::STATUS_DISCARDED,
+                    'lack of permissions to see notification'
+                );
+
                 return;
             }
 
@@ -125,6 +131,11 @@ class NotificationEmailDeliveryBackgroundJob extends AbstractBackgroundJob
 
             // Drop email if the notification is already confirmed.
             if ($event->isConfirmed()) {
+                $this->job->updateStatus(
+                    EmailLogEntry::STATUS_DISCARDED,
+                    'notification is confirmed'
+                );
+
                 return;
             }
         } finally {

--- a/wcfsetup/install/files/lib/system/background/job/NotificationEmailDeliveryBackgroundJob.class.php
+++ b/wcfsetup/install/files/lib/system/background/job/NotificationEmailDeliveryBackgroundJob.class.php
@@ -133,7 +133,7 @@ class NotificationEmailDeliveryBackgroundJob extends AbstractBackgroundJob
             if ($event->isConfirmed()) {
                 $this->job->updateStatus(
                     EmailLogEntry::STATUS_DISCARDED,
-                    'notification is confirmed'
+                    'obsolete, notification is already confirmed'
                 );
 
                 return;

--- a/wcfsetup/install/lang/de.xml
+++ b/wcfsetup/install/lang/de.xml
@@ -643,6 +643,7 @@
 		<item name="wcf.acp.email.log.status.transient_failure"><![CDATA[Vorübergehendes Problem]]></item>
 		<item name="wcf.acp.email.log.status.permanent_failure"><![CDATA[Endgültig fehlgeschlagen]]></item>
 		<item name="wcf.acp.email.log.status.new"><![CDATA[Wartend]]></item>
+		<item name="wcf.acp.email.log.status.discarded"><![CDATA[Verworfen]]></item>
 		<item name="wcf.acp.email.log.statusMessage.title"><![CDATA[Status-Nachricht]]></item>
 	</category>
 	<category name="wcf.acp.exceptionLog">

--- a/wcfsetup/install/lang/en.xml
+++ b/wcfsetup/install/lang/en.xml
@@ -620,6 +620,7 @@
 		<item name="wcf.acp.email.log.status.transient_failure"><![CDATA[Transient Failure]]></item>
 		<item name="wcf.acp.email.log.status.permanent_failure"><![CDATA[Ultimately Failed]]></item>
 		<item name="wcf.acp.email.log.status.new"><![CDATA[Pending]]></item>
+		<item name="wcf.acp.email.log.status.discarded"><![CDATA[Discarded]]></item>
 		<item name="wcf.acp.email.log.statusMessage.title"><![CDATA[Status Message]]></item>
 	</category>
 	<category name="wcf.acp.exceptionLog">


### PR DESCRIPTION
- Make EmailDeliveryBackgroundJob::updateStatus() public
- Add EmailLogEntry::STATUS_DISCARDED
- Update email log status to discarded when dropping notification mails
