### PR TITLE
Do not process the pageLogo in StyleAction::updateVariables() if it is unchanged

### DIFF
--- a/wcfsetup/install/files/lib/data/style/StyleAction.class.php
+++ b/wcfsetup/install/files/lib/data/style/StyleAction.class.php
@@ -191,13 +191,15 @@ class StyleAction extends AbstractDatabaseObjectAction implements IToggleAction 
 				}
 				
 				if ($file !== null) {
-					$fileLocation = $file->getLocation();
-					$extension = pathinfo($file->getFilename(), PATHINFO_EXTENSION);
-					$newName = $type.'-'.\bin2hex(\random_bytes(4)).'.'.$extension;
-					$newLocation = $style->getAssetPath().$newName;
-					rename($fileLocation, $newLocation);
-					$this->parameters['variables'][$type] = $newName;
-					$file->setProcessed($newLocation);
+					if (!$file->isProcessed()) {
+						$fileLocation = $file->getLocation();
+						$extension = pathinfo($file->getFilename(), PATHINFO_EXTENSION);
+						$newName = $type.'-'.\bin2hex(\random_bytes(4)).'.'.$extension;
+						$newLocation = $style->getAssetPath().$newName;
+						rename($fileLocation, $newLocation);
+						$this->parameters['variables'][$type] = $newName;
+						$file->setProcessed($newLocation);
+					}
 				}
 				else {
 					$this->parameters['variables'][$type] = '';


### PR DESCRIPTION
This change ensures that the filename of the logo remains the same, unless the
file actually is modified.

A fix for this issue was initially attempted in
cc17f302902fb62c78b4411dadc3243913f18c74. However that commit was much more
complex and it introduced additional bugs, because it no longer passed an
explicit `null` for removed files, thus breaking the update of the related
database columns. It was subsequently reverted in
dd7c98858d406f8ca9824770ae8a68edde451493.
