### PR TITLE
Remove X-XSS-Protection response header

### DIFF
--- a/wcfsetup/install/files/lib/acp/form/AdAddForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/AdAddForm.class.php
@@ -275,16 +275,4 @@ class AdAddForm extends AbstractForm
             }
         }
     }
-
-    /**
-     * @inheritDoc
-     */
-    public function show()
-    {
-        // work-around for a known Chrome bug that causes the XSS auditor
-        // to incorrectly detect JavaScript inside a textarea
-        @\header('X-XSS-Protection: 0');
-
-        parent::show();
-    }
 }

--- a/wcfsetup/install/files/lib/acp/form/TemplateAddForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/TemplateAddForm.class.php
@@ -265,16 +265,4 @@ class TemplateAddForm extends AbstractForm
             'copy' => $this->copy,
         ]);
     }
-
-    /**
-     * @inheritDoc
-     */
-    public function show()
-    {
-        // work-around for a known Chrome bug that causes the XSS auditor
-        // to incorrectly detect JavaScript inside a textarea
-        @\header('X-XSS-Protection: 0');
-
-        parent::show();
-    }
 }

--- a/wcfsetup/install/files/lib/acp/form/UserMailForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/UserMailForm.class.php
@@ -255,16 +255,4 @@ class UserMailForm extends AbstractForm
             'userList' => $this->userList,
         ]);
     }
-
-    /**
-     * @inheritDoc
-     */
-    public function show()
-    {
-        // work-around for a known Chrome bug that causes the XSS auditor
-        // to incorrectly detect JavaScript inside a textarea
-        @\header('X-XSS-Protection: 0');
-
-        parent::show();
-    }
 }


### PR DESCRIPTION
The XSS auditor has been removed in all web browsers by now, making this header
useless.
