### PR TITLE
Skip usersOnly permissions for the guest group during permission merge

### DIFF
--- a/wcfsetup/install/files/lib/system/cache/builder/UserGroupPermissionCacheBuilder.class.php
+++ b/wcfsetup/install/files/lib/system/cache/builder/UserGroupPermissionCacheBuilder.class.php
@@ -58,7 +58,12 @@ class UserGroupPermissionCacheBuilder extends AbstractCacheBuilder
         $conditions->add("option_value.groupID IN (?)", [$parameters]);
 
         $optionData = [];
-        $sql = "SELECT      option_table.optionName, option_table.optionType, option_value.optionValue, option_value.groupID, option_table.enableOptions
+        $sql = "SELECT      option_table.optionName,
+                            option_table.optionType,
+                            option_value.optionValue,
+                            option_value.groupID,
+                            option_table.enableOptions,
+                            option_table.usersOnly
                 FROM        wcf" . WCF_N . "_user_group_option_value option_value
                 LEFT JOIN   wcf" . WCF_N . "_user_group_option option_table
                 ON          option_table.optionID = option_value.optionID
@@ -66,6 +71,13 @@ class UserGroupPermissionCacheBuilder extends AbstractCacheBuilder
         $statement = WCF::getDB()->prepareStatement($sql);
         $statement->execute($conditions->getParameters());
         while ($row = $statement->fetchArray()) {
+            if (
+                $row['usersOnly']
+                && UserGroup::getGroupByID($row['groupID'])->groupType == UserGroup::GUESTS
+            ) {
+                continue;
+            }
+
             $optionData[$row['groupID']][$row['optionName']] = $row;
         }
 


### PR DESCRIPTION
The value of usersOnly permissions cannot be configured for the guest group
within the ACP, but the stored default value is taken into account during the
permission merge in UserGroupPermissionCacheBuilder nonetheless. This might result
in unexpected permissions for accounts that are not yet activated.

As an example taking away the “Can use conversations” for all groups might
still allow accounts that are not yet activated to use the conversations,
because of this preserved default.

Fix this issue by simply skipping the value of the guest group during the
merge, thus ignoring whatever value may be stored. This is safe, because the
resulting option list always includes the “Everyone” group.

see https://community.woltlab.com/thread/289879/