### PR TITLE
Fix displaying `runStandalone` in devtools

### DIFF
--- a/ts/WoltLabSuite/Core/Acp/Form/Builder/Field/Devtools/Project/Instructions.ts
+++ b/ts/WoltLabSuite/Core/Acp/Form/Builder/Field/Devtools/Project/Instructions.ts
@@ -393,7 +393,7 @@ class Instructions {
               {
                 application: listItem.dataset.application,
                 pip: listItem.dataset.pip,
-                runStandalone: listItem.dataset.runStandalone,
+                runStandalone: Core.stringToBool(listItem.dataset.runStandalone),
                 value: listItem.dataset.value,
               },
             );

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Acp/Form/Builder/Field/Devtools/Project/Instructions.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Acp/Form/Builder/Field/Devtools/Project/Instructions.js
@@ -269,7 +269,7 @@ define(["require", "exports", "tslib", "../../../../../../Core", "../../../../..
                             listItem.querySelector(".jsDevtoolsProjectInstruction").innerHTML = Language.get("wcf.acp.devtools.project.instruction.instruction", {
                                 application: listItem.dataset.application,
                                 pip: listItem.dataset.pip,
-                                runStandalone: listItem.dataset.runStandalone,
+                                runStandalone: Core.stringToBool(listItem.dataset.runStandalone),
                                 value: listItem.dataset.value,
                             });
                             Listener_1.default.trigger();


### PR DESCRIPTION
After editing an instruction it is always shown that this instruction is run standalone.