### PR TITLE
Add deletion support for language PIP

### DIFF
--- a/XSD/language.xsd
+++ b/XSD/language.xsd
@@ -7,14 +7,32 @@
 	<!-- data element -->
 	<xs:element name="language">
 		<xs:complexType>
-			 <xs:sequence>
+			<!-- deprecated since 5.5 -->
+			<xs:sequence>
 				<xs:element name="category" type="category" maxOccurs="unbounded" />
 			</xs:sequence>
+			<!-- /deprecated since 5.5 -->
+			<xs:element name="import" type="import" minOccurs="0" />
+			<xs:element name="delete" type="delete" minOccurs="0" />
 			<xs:attribute name="languagecode" type="woltlab_varchar" use="required" />
 			<xs:attribute name="languagename" type="woltlab_varchar" use="optional" />
 			<xs:attribute name="countrycode" type="woltlab_varchar" use="optional" />
 		</xs:complexType>
 	</xs:element>
+	
+	<!-- import element -->
+	<xs:complexType name="import">
+		<xs:sequence>
+			<xs:element name="category" type="category" maxOccurs="unbounded" />
+		</xs:sequence>
+	</xs:complexType>
+	
+	<!-- delete element -->
+	<xs:complexType name="delete">
+		<xs:sequence>
+			<xs:element name="item" type="item" maxOccurs="unbounded" />
+		</xs:sequence>
+	</xs:complexType>
 	
 	<!-- language category element type -->
 	<xs:complexType name="category">


### PR DESCRIPTION
**Preface:** The current

```xml
<language>
  <category name="…">
    <item name="…">…</item>
  </category>
</language
```

structure remains supported with these changes but is considered deprecated.

---

To support deleting phrases with this PIP, support for a `delete` element is added just like in the other XML-based PIPs:

```xml
<language>
  <delete>
    <item name="…"/>
  </delete>
</language
```

There are no `category` elements between the `delete` element and the `item` elements as for deletion, the category of the phrase is irrelevant as its name is unique globally.

To keep this PIP's structure in sync with other PIPs, in addition to the new support for the `delete` element, the imported phrases can now also be added to a `import` element like in the other XML-based PIPs:

```xml
<language>
  <import>
    <category name="…">
      <item name="…">…</item>
    </category>
  </import>
</language
```

While the old structure without the intermediate `import` element is compatible with the new support for a `delete` element, i.e.

```xml
<language>
  <category name="…">
    <item name="…">…</item>
  </category>
  <delete>
    <item name="…"/>
  </delete>
</language
```

imports and deletes the relevant phrases.

Using `import` and `category` siblings like this

```xml
<language>
  <import>
    <category name="…">
      <item name="…">…</item>
    </category>
  </import>
  <category name="…">
    <item name="…">…</item>
  </category>
</language
```

however, is not supported. Once an `import` element exists, only its phrases are imported and any `category` *siblings*  are ignored.

See #4178