### PR TITLE
Fix visibility check in `Condition/Page/Dependence`

### DIFF
--- a/ts/WoltLabSuite/Core/Controller/Condition/Page/Dependence.ts
+++ b/ts/WoltLabSuite/Core/Controller/Condition/Page/Dependence.ts
@@ -33,7 +33,7 @@ function checkVisibility(): void {
       }
     });
 
-    const irrelevantPageIds = checkedPageIds.filter((pageId) => pageIds.includes(pageId));
+    const irrelevantPageIds = checkedPageIds.filter((pageId) => !pageIds.includes(pageId));
 
     if (!checkedPageIds.length || irrelevantPageIds.length) {
       hideDependentElement(dependentElement);

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Controller/Condition/Page/Dependence.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Controller/Condition/Page/Dependence.js
@@ -31,7 +31,7 @@ define(["require", "exports", "tslib", "../../../Dom/Util", "../../../Event/Hand
                     checkedPageIds.push(~~page.value);
                 }
             });
-            const irrelevantPageIds = checkedPageIds.filter((pageId) => pageIds.includes(pageId));
+            const irrelevantPageIds = checkedPageIds.filter((pageId) => !pageIds.includes(pageId));
             if (!checkedPageIds.length || irrelevantPageIds.length) {
                 hideDependentElement(dependentElement);
             }


### PR DESCRIPTION
In the original js implementation the filter condition was `return pageIds.indexOf(pageId) === -1;`.