### PR TITLE
Deprecate StringUtil::getHash()

### DIFF
--- a/wcfsetup/install/files/lib/data/I18nDatabaseObjectList.class.php
+++ b/wcfsetup/install/files/lib/data/I18nDatabaseObjectList.class.php
@@ -3,7 +3,6 @@
 namespace wcf\data;
 
 use wcf\system\WCF;
-use wcf\util\StringUtil;
 
 /**
  * Abstract class for a list of database objects with better sorting of i18n-based columns.
@@ -52,7 +51,7 @@ abstract class I18nDatabaseObjectList extends DatabaseObjectList
                     throw new \DomainException("Array keys and values of '" . $this->className . "::\$i18nFields' must start with a small letter and consist of letters and number only.");
                 }
 
-                $matchTable = 'i18n_' . StringUtil::getHash($key);
+                $matchTable = 'i18n_' . \sha1($key);
 
                 $this->sqlSelects .= (!empty($this->sqlSelects) ? ', ' : '') . "COALESCE(" . $matchTable . ".languageItemValue, " . $this->getDatabaseTableAlias() . "." . $key . ") AS " . $value;
                 $this->sqlJoins .= "

--- a/wcfsetup/install/files/lib/form/SearchForm.class.php
+++ b/wcfsetup/install/files/lib/form/SearchForm.class.php
@@ -289,7 +289,7 @@ class SearchForm extends AbstractCaptchaForm
         }
 
         // build search hash
-        $this->searchHash = StringUtil::getHash(\serialize([
+        $this->searchHash = \sha1(\serialize([
             $this->query,
             $this->selectedObjectTypes,
             !$this->subjectOnly,

--- a/wcfsetup/install/files/lib/system/html/output/node/HtmlOutputNodePre.class.php
+++ b/wcfsetup/install/files/lib/system/html/output/node/HtmlOutputNodePre.class.php
@@ -278,7 +278,7 @@ class HtmlOutputNodePre extends AbstractHtmlOutputNode
         $i = -1;
         // find an unused codeID
         do {
-            $codeID = $prefix . \mb_substr(StringUtil::getHash($code), 0, 6) . (++$i ? '_' . $i : '');
+            $codeID = $prefix . \mb_substr(\sha1($code), 0, 6) . (++$i ? '_' . $i : '');
         } while (isset(self::$codeIDs[$codeID]));
 
         // mark codeID as used

--- a/wcfsetup/install/files/lib/system/worker/ImportWorker.class.php
+++ b/wcfsetup/install/files/lib/system/worker/ImportWorker.class.php
@@ -7,7 +7,6 @@ use wcf\system\exception\SystemException;
 use wcf\system\exporter\IExporter;
 use wcf\system\importer\ImportHandler;
 use wcf\system\WCF;
-use wcf\util\StringUtil;
 
 /**
  * Worker implementation for data import.
@@ -76,7 +75,7 @@ class ImportWorker extends AbstractWorker
         ImportHandler::getInstance()->setUserMergeMode($this->importData['userMergeMode']);
 
         ImportHandler::getInstance()->setImportHash(\substr(
-            StringUtil::getHash(
+            \sha1(
                 $this->importData['dbHost'] . $this->importData['dbName'] . $this->importData['dbPrefix']
             ),
             0,

--- a/wcfsetup/install/files/lib/util/StringUtil.class.php
+++ b/wcfsetup/install/files/lib/util/StringUtil.class.php
@@ -37,10 +37,7 @@ final class StringUtil
     const MINUS = "\u{2212}";
 
     /**
-     * Alias to php sha1() function.
-     *
-     * @param string $value
-     * @return  string
+     * @deprecated 5.5 - Use \sha1() directly.
      */
     public static function getHash($value)
     {


### PR DESCRIPTION
This method was a simple alias to `\sha1()` and also defined as such. Users of
this method relied on the output of this method not changing, making it
entirely useless, because there is no benefit to use this method over `sha1()`
directly.

Deprecate `StringUtil::getHash()` and update the users to use `sha1()`.
