### PR TITLE
Deprecate MathUtil::getRandomValue()

### DIFF
--- a/wcfsetup/install/files/lib/util/MathUtil.class.php
+++ b/wcfsetup/install/files/lib/util/MathUtil.class.php
@@ -13,11 +13,7 @@ namespace wcf\util;
 final class MathUtil
 {
     /**
-     * Generates a random value.
-     *
-     * @param int $min
-     * @param int $max
-     * @return  int
+     * @deprecated 5.5 - Use `\random_int()` or `\mt_rand()` directly.
      */
     public static function getRandomValue($min = null, $max = null)
     {


### PR DESCRIPTION
This method is a thin wrapper around `\mt_rand()` without any usability
benefits. Users of this method should either switch to `\random_int()` or
`\mt_rand()` directly.
