### PR TITLE
force `LF` line endings for generated JavaScript

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
     "esModuleInterop": true,
     "noImplicitThis": true,
     "strictBindCallApply": true,
-    "importHelpers": true
+    "importHelpers": true,
+    "newLine": "lf"
   }
 }


### PR DESCRIPTION
using Windows the generated JavaScript would be formatted using `CRLF` which is pretty much time wasting