### PR TITLE
Remove `MessageEmbeddedObjectManager::parseTemporaryMessage()`

### DIFF
--- a/wcfsetup/install/files/lib/system/message/embedded/object/MessageEmbeddedObjectManager.class.php
+++ b/wcfsetup/install/files/lib/system/message/embedded/object/MessageEmbeddedObjectManager.class.php
@@ -475,14 +475,4 @@ class MessageEmbeddedObjectManager extends SingletonFactory
 
         return $this->embeddedObjectHandlers[$objectTypeID];
     }
-
-    /**
-     * @deprecated  3.0
-     */
-    public function parseTemporaryMessage()
-    {
-        throw new \BadMethodCallException(
-            "parseTemporaryMessage() has been removed, please use registerTemporaryMessage() instead."
-        );
-    }
 }


### PR DESCRIPTION
As this method would result in an exception for many versions, it is safe to remove it.