### PR TITLE
Remove deprecated `Category::$permissions`

### DIFF
--- a/wcfsetup/install/files/lib/data/category/Category.class.php
+++ b/wcfsetup/install/files/lib/data/category/Category.class.php
@@ -59,13 +59,6 @@ class Category extends ProcessibleDatabaseObject implements IPermissionObject, I
     protected $parentCategory;
 
     /**
-     * acl permissions of this category for the active user
-     * @deprecated
-     * @var bool[]
-     */
-    protected $permissions;
-
-    /**
      * acl permissions of this category grouped by the id of the user they
      * belong to
      * @var array
@@ -218,10 +211,6 @@ class Category extends ProcessibleDatabaseObject implements IPermissionObject, I
         if (!isset($this->userPermissions[$user->userID])) {
             $this->userPermissions[$user->userID] = CategoryPermissionHandler::getInstance()
                 ->getPermissions($this, $user);
-
-            if ($user->userID == WCF::getUser()->userID) {
-                $this->permissions = $this->userPermissions[$user->userID];
-            }
         }
 
         if (isset($this->userPermissions[$user->userID][$permission])) {


### PR DESCRIPTION
This property has been deprecated for many years (since 2b59736b2592a01ee880f0cc4439622b437acd85) and is just an (internal) copy of `$this->userPermissions[$user->userID]`.