### PR TITLE
Remove obsolete social media privacy settings-related methods

### DIFF
--- a/wcfsetup/install/files/lib/data/user/User.class.php
+++ b/wcfsetup/install/files/lib/data/user/User.class.php
@@ -623,22 +623,6 @@ final class User extends DatabaseObject implements IPopoverObject, IRouteControl
     }
 
     /**
-     * Returns the social network privacy settings of the user.
-     * @return  bool[]
-     * @deprecated 3.0
-     *
-     */
-    public function getSocialNetworkPrivacySettings()
-    {
-        return [
-            'facebook' => false,
-            'google' => false,
-            'reddit' => false,
-            'twitter' => false,
-        ];
-    }
-
-    /**
      * Returns the registration ip address, attempts to convert to IPv4.
      *
      * @return      string

--- a/wcfsetup/install/files/lib/data/user/UserAction.class.php
+++ b/wcfsetup/install/files/lib/data/user/UserAction.class.php
@@ -1131,42 +1131,6 @@ class UserAction extends AbstractDatabaseObjectAction implements IClipboardActio
     }
 
     /**
-     * Validates parameters to retrieve the social network privacy settings.
-     * @deprecated 3.0
-     */
-    public function validateGetSocialNetworkPrivacySettings()
-    {
-        // does nothing
-    }
-
-    /**
-     * Returns the social network privacy settings.
-     * @deprecated 3.0
-     */
-    public function getSocialNetworkPrivacySettings()
-    {
-        // does nothing
-    }
-
-    /**
-     * Validates the 'saveSocialNetworkPrivacySettings' action.
-     * @deprecated 3.0
-     */
-    public function validateSaveSocialNetworkPrivacySettings()
-    {
-        // does nothing
-    }
-
-    /**
-     * Saves the social network privacy settings.
-     * @deprecated 3.0
-     */
-    public function saveSocialNetworkPrivacySettings()
-    {
-        // does nothing
-    }
-
-    /**
      * @since 5.3
      */
     public function validateSaveUserConsent()


### PR DESCRIPTION
These methods have had no effect for several years (since 527a8fc63908aa175c60b08b4d3ee368dbfdb274).