### PR TITLE
Remove deprecated avatar-cropping related methods

### DIFF
--- a/wcfsetup/install/files/lib/data/user/avatar/DefaultAvatar.class.php
+++ b/wcfsetup/install/files/lib/data/user/avatar/DefaultAvatar.class.php
@@ -121,22 +121,6 @@ SVG;
     }
 
     /**
-     * @deprecated  3.0
-     */
-    public function canCrop()
-    {
-        return false;
-    }
-
-    /**
-     * @deprecated  3.0
-     */
-    public function getCropImageTag($size = null)
-    {
-        return '';
-    }
-
-    /**
      * Returns the perceived luminance of the given color.
      *
      * @param int $r

--- a/wcfsetup/install/files/lib/data/user/avatar/UserAvatar.class.php
+++ b/wcfsetup/install/files/lib/data/user/avatar/UserAvatar.class.php
@@ -141,20 +141,4 @@ class UserAvatar extends DatabaseObject implements IUserAvatar, ISafeFormatAvata
     {
         return $this->height;
     }
-
-    /**
-     * @deprecated  3.0
-     */
-    public function getCropImageTag($size = null)
-    {
-        return '';
-    }
-
-    /**
-     * @deprecated  3.0
-     */
-    public function canCrop()
-    {
-        return false;
-    }
 }


### PR DESCRIPTION
These methods are useless and have been deprecated for several years since 2772d4eb46511bc1cdc431bb80c184f8172dd500.