### PR TITLE
Remove deprecated `PackageArchive::getPhpRequirements`

### DIFF
--- a/wcfsetup/install/files/lib/system/package/PackageArchive.class.php
+++ b/wcfsetup/install/files/lib/system/package/PackageArchive.class.php
@@ -981,15 +981,4 @@ class PackageArchive
     {
         return $this->instructions[$type] ?? null;
     }
-
-    /**
-     * Returns a list of php requirements for current package.
-     *
-     * @return  mixed[][]
-     * @deprecated  3.0
-     */
-    public function getPhpRequirements()
-    {
-        return [];
-    }
 }


### PR DESCRIPTION
This method has been deprecated for several years since 89a60e0e4942e48904999ec75cec782ba3fe03cf.