### PR TITLE
Remove `ModerationQueueEditor::markAsDone`

### DIFF
--- a/wcfsetup/install/files/lib/data/moderation/queue/ModerationQueueEditor.class.php
+++ b/wcfsetup/install/files/lib/data/moderation/queue/ModerationQueueEditor.class.php
@@ -25,19 +25,6 @@ class ModerationQueueEditor extends DatabaseObjectEditor
     protected static $baseClass = ModerationQueue::class;
 
     /**
-     * Marks this entry as done.
-     *
-     * @deprecated  2.1 - Please use markAsConfirmed() or markAsRejected()
-     */
-    public function markAsDone()
-    {
-        $this->update(['status' => ModerationQueue::STATUS_DONE]);
-
-        // reset moderation count
-        ModerationQueueManager::getInstance()->resetModerationCount();
-    }
-
-    /**
      * Marks this entry as confirmed, e.g. report was justified and content was deleted or
      * content was approved.
      */


### PR DESCRIPTION
This method has been deprecated for many years since 35e19e581a5e61f13d37e536710604283b1f0ebf.