### PR TITLE
Remove `BBCodeHandler::setAllowedBBCodes()`

### DIFF
--- a/wcfsetup/install/files/lib/system/bbcode/BBCodeHandler.class.php
+++ b/wcfsetup/install/files/lib/system/bbcode/BBCodeHandler.class.php
@@ -115,15 +115,6 @@ class BBCodeHandler extends SingletonFactory
     }
 
     /**
-     * @param string[] $bbcodes
-     * @deprecated 3.0 - please use setDisallowedBBCodes() instead
-     */
-    public function setAllowedBBCodes(array $bbcodes)
-    {
-        throw new \RuntimeException("setAllowedBBCodes() is no longer supported, please use setDisallowedBBCodes() instead.");
-    }
-
-    /**
      * Sets the disallowed BBCodes.
      *
      * @param string[] $bbCodes


### PR DESCRIPTION
This method has been deprecated for many years since 25863cff5dcb31c893b073aedf678b778a14d9fa and has resulted in an exception since then.