### PR TITLE
Remove `BBCodeParser::validateBBCodes()`

### DIFF
--- a/wcfsetup/install/files/lib/system/bbcode/BBCodeParser.class.php
+++ b/wcfsetup/install/files/lib/system/bbcode/BBCodeParser.class.php
@@ -599,19 +599,6 @@ class BBCodeParser extends SingletonFactory
     }
 
     /**
-     * Validates the used BBCodes in the given text by the given allowed
-     * BBCodes and returns a list of used disallowed BBCodes.
-     *
-     * @param string $text
-     * @param string[] $allowedBBCodes
-     * @deprecated  3.0 - please use HtmlInputProcessor::validate() instead
-     */
-    public function validateBBCodes($text, array $allowedBBCodes)
-    {
-        throw new \RuntimeException("validateBBCodes() is no longer supported, please use HtmlInputProcessor::validate() instead.");
-    }
-
-    /**
      * Removes code bbcode occurrences in given message.
      *
      * @param string $message


### PR DESCRIPTION
This method has been deprecated for many years since 25863cff5dcb31c893b073aedf678b778a14d9fa and has resulted in an exception since then.