### PR TITLE
Remove `WCF.Message.UserMention`

### DIFF
--- a/wcfsetup/install/files/js/WCF.Message.js
+++ b/wcfsetup/install/files/js/WCF.Message.js
@@ -1827,15 +1827,6 @@ WCF.Message.Share.Page = Class.extend({
 });
 
 /**
- * @deprecated 3.0
- */
-WCF.Message.UserMention = Class.extend({
-	init: function() {
-		throw new Error("Support for mentions in Redactor are now enabled by adding the attribute 'data-support-mention=\"true\"' to the textarea element.");
-	}
-});
-
-/**
  * Provides a specialized tab menu used for message options, integrates better into the editor.
  */
 $.widget('wcf.messageTabMenu', {


### PR DESCRIPTION
This component has been deprecated for many years since d3cbe17e57fb2111af02ca7e11d9c60dce3c6de7 and has only been throwing an error since then.