### PR TITLE
Remove deprecated TagCloud-related constants and methods

### DIFF
--- a/wcfsetup/install/files/lib/data/tag/TagCloudTag.class.php
+++ b/wcfsetup/install/files/lib/data/tag/TagCloudTag.class.php
@@ -49,25 +49,4 @@ class TagCloudTag extends DatabaseObjectDecorator
     {
         return $this->weight;
     }
-
-    /**
-     * Sets the size of the tag.
-     *
-     * @param double $size
-     * @deprecated  3.0
-     */
-    public function setSize($size)
-    {
-    }
-
-    /**
-     * Returns the size of the tag.
-     *
-     * @return  double
-     * @deprecated  3.0
-     */
-    public function getSize()
-    {
-        return (($this->weight - 1) / 6) * 85 + 85;
-    }
 }

--- a/wcfsetup/install/files/lib/system/tagging/TagCloud.class.php
+++ b/wcfsetup/install/files/lib/system/tagging/TagCloud.class.php
@@ -17,20 +17,6 @@ use wcf\system\language\LanguageFactory;
 class TagCloud
 {
     /**
-     * max font size
-     * @var int
-     * @deprecated 3.0
-     */
-    const MAX_FONT_SIZE = 170;
-
-    /**
-     * min font size
-     * @var int
-     * @deprecated 3.0
-     */
-    const MIN_FONT_SIZE = 85;
-
-    /**
      * list of tags
      * @var TagCloudTag[]
      */


### PR DESCRIPTION
These constants and methods have been deprecated for several years since 3d21a963c9348a63ecafc11abbee8923efbcdcbc.