### PR TITLE
Remove autoloader compatibility layer mapping Leafo to Scssphp

### DIFF
--- a/wcfsetup/install/files/lib/core.functions.php
+++ b/wcfsetup/install/files/lib/core.functions.php
@@ -17,16 +17,6 @@ namespace {
 	// set autoload function
 	spl_autoload_register([WCF::class, 'autoload']);
 	
-	spl_autoload_register(function ($className) {
-		/**
-		 * @deprecated 5.3 This file is a compatibility layer mapping from Leafo\\ to ScssPhp\\
-		 */
-		$leafo = 'Leafo\\';
-		if (substr($className, 0, strlen($leafo)) === $leafo) {
-			class_alias('ScssPhp\\'.substr($className, strlen($leafo)), $className, true);
-		}
-	});
-	
 	/**
 	 * Escapes a string for use in sql query.
 	 * 


### PR DESCRIPTION
It's unlikely that anything depends on this and as outlined in the commit
9bfa7303627983c13607536aae839e7e0ebb0968 that initially added it, the
compatibility is incomplete as it cannot map Exceptions.

With scssphp 1.5 (WoltLab/WCF#4274) further changes will be introduced by the
upstream library that definitely will require adjustments in consumers. So
let's clean this up.
