### PR TITLE
Improve performance of SystemCheckPage::validateWritableDirectories()

### DIFF
--- a/wcfsetup/install/files/lib/acp/page/SystemCheckPage.class.php
+++ b/wcfsetup/install/files/lib/acp/page/SystemCheckPage.class.php
@@ -415,21 +415,9 @@ class SystemCheckPage extends AbstractPage
         foreach ($this->directories as $abbreviation => $directories) {
             $basePath = Application::getDirectory($abbreviation);
             foreach ($directories as $directory) {
-                $recursive = false;
-                if (\preg_match('~(.*)/\*$~', $directory, $matches)) {
-                    $recursive = true;
-                    $directory = $matches[1];
-                }
-
-                $path = $basePath . FileUtil::removeLeadingSlash(FileUtil::addTrailingSlash($directory));
-                if ($this->checkDirectory($path) && $recursive) {
-                    $rdi = new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS);
-                    $it = new \RecursiveIteratorIterator($rdi, \RecursiveIteratorIterator::SELF_FIRST);
-                    /** @var \SplFileInfo $item */
-                    foreach ($it as $item) {
-                        if ($item->isDir()) {
-                            $this->makeDirectoryWritable($item->getPathname());
-                        }
+                foreach (\glob($basePath . FileUtil::removeLeadingSlash($directory)) as $file) {
+                    if (\is_dir($file) && !\is_writable($file)) {
+                        $this->makeDirectoryWritable($file);
                     }
                 }
             }


### PR DESCRIPTION
The previous implementation resulted in a syscall hell for large attachment or
image directories. RecursiveDirectoryIterator requires two syscalls for
directory entry just for iteration and that does not yet include any custom
logic.

Replace the implementation by a simple `glob()`. This is a small behavior
change, as a `*` will only check the files immediately below the directory in
question instead of recursing all the way down. However this likely is what was
intended anyway.
