### PR TITLE
Don't leak an account's activation status

### DIFF
--- a/wcfsetup/install/files/lib/form/RegisterNewActivationCodeForm.class.php
+++ b/wcfsetup/install/files/lib/form/RegisterNewActivationCodeForm.class.php
@@ -72,7 +72,7 @@ class RegisterNewActivationCodeForm extends AbstractForm {
 		$this->validatePassword();
 		
 		// activation state
-		validateActivationState();
+		$this->validateActivationState();
 		
 		// email
 		$this->validateEmail();

--- a/wcfsetup/install/files/lib/form/RegisterNewActivationCodeForm.class.php
+++ b/wcfsetup/install/files/lib/form/RegisterNewActivationCodeForm.class.php
@@ -71,6 +71,9 @@ class RegisterNewActivationCodeForm extends AbstractForm {
 		// password
 		$this->validatePassword();
 		
+		// activation state
+		validateActivationState();
+		
 		// email
 		$this->validateEmail();
 	}
@@ -87,10 +90,6 @@ class RegisterNewActivationCodeForm extends AbstractForm {
 		if (!$this->user->userID) {
 			throw new UserInputException('username', 'notFound');
 		}
-		
-		if ($this->user->activationCode == 0) {
-			throw new UserInputException('username', 'alreadyEnabled');
-		}
 	}
 	
 	/**
@@ -106,7 +105,17 @@ class RegisterNewActivationCodeForm extends AbstractForm {
 			throw new UserInputException('password', 'false');
 		}
 	}
-	
+
+	/**
+	 * Validates the activation state.
+	 */
+	public function validateActivationState() {
+		// check if user is already enabled
+		if ($this->user->activationCode == 0) {
+			throw new UserInputException('username', 'alreadyEnabled');
+		}
+	}
+
 	/**
 	 * Validates the email address.
 	 */


### PR DESCRIPTION
By entering a username and a random password, it is possible to get information, whether an account is activated, or not. While this isn't much of a security issue, I would authenticate the user first to ensure that the information is not disclosed to everyone.