### PR TITLE
Do not store API compatibility information within the database

### DIFF
--- a/wcfsetup/install/files/acp/templates/package.tpl
+++ b/wcfsetup/install/files/acp/templates/package.tpl
@@ -81,18 +81,6 @@
 					<dd><a href="https://pluginstore.woltlab.com/file/{$pluginStoreFileID}/" class="externalURL">{lang}wcf.acp.pluginStore.file.link{/lang}</a></dd>
 				</dl>
 			{/if}
-			{if $package->packageID != 1}
-				<dl>
-					<dt>{lang}wcf.acp.package.apiVersions{/lang}</dt>
-					<dd>
-						{if $compatibleVersions|empty}
-							<small>{lang}wcf.acp.package.apiVersions.missing{/lang}</small>
-						{else}
-							{implode from=$compatibleVersions item=version glue=', '}{$version}{/implode}
-						{/if}
-					</dd>
-				</dl>
-			{/if}
 			
 			{event name='propertyFields'}
 		</div>

--- a/wcfsetup/install/files/acp/update_com.woltlab.wcf_5.5_clearPackageCompatibility.php
+++ b/wcfsetup/install/files/acp/update_com.woltlab.wcf_5.5_clearPackageCompatibility.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * Clear the wcf1_package_compatibility table.
+ *
+ * see https://github.com/WoltLab/WCF/pull/4371
+ *
+ * @author Tim Duesterhus
+ * @copyright 2001-2021 WoltLab GmbH
+ * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @package WoltLabSuite\Core
+ */
+
+use wcf\system\WCF;
+
+$sql = "DELETE FROM wcf1_package_compatibility";
+$statement = WCF::getDB()->prepare($sql);
+$statement->execute();

--- a/wcfsetup/install/files/lib/acp/page/PackagePage.class.php
+++ b/wcfsetup/install/files/lib/acp/page/PackagePage.class.php
@@ -23,8 +23,7 @@ class PackagePage extends AbstractPage
     public $activeMenuItem = 'wcf.acp.menu.link.package';
 
     /**
-     * list of compatible API versions
-     * @var int[]
+     * @deprecated 5.5 This array is always empty.
      */
     public $compatibleVersions = [];
 
@@ -84,20 +83,6 @@ class PackagePage extends AbstractPage
         $statement = WCF::getDB()->prepareStatement($sql);
         $statement->execute([$this->package->package]);
         $this->pluginStoreFileID = \intval($statement->fetchSingleColumn());
-
-        $sql = "SELECT      version
-                FROM        wcf" . WCF_N . "_package_compatibility
-                WHERE       packageID = ?
-                        AND version >= ?
-                ORDER BY    version";
-        $statement = WCF::getDB()->prepareStatement($sql);
-        $statement->execute([
-            $this->package->packageID,
-            WSC_API_VERSION,
-        ]);
-        while ($version = $statement->fetchColumn()) {
-            $this->compatibleVersions[] = $version;
-        }
     }
 
     /**

--- a/wcfsetup/install/files/lib/system/package/PackageInstallationDispatcher.class.php
+++ b/wcfsetup/install/files/lib/system/package/PackageInstallationDispatcher.class.php
@@ -611,21 +611,6 @@ class PackageInstallationDispatcher
             }
         }
 
-        // save compatible versions
-        if (!empty($this->getArchive()->getCompatibleVersions())) {
-            $sql = "INSERT INTO wcf" . WCF_N . "_package_compatibility
-                                (packageID, version)
-                    VALUES      (?, ?)";
-            $statement = WCF::getDB()->prepareStatement($sql);
-
-            foreach ($this->getArchive()->getCompatibleVersions() as $version) {
-                $statement->execute([
-                    $this->queue->packageID,
-                    $version,
-                ]);
-            }
-        }
-
         // insert requirements and dependencies
         $requirements = $this->getArchive()->getAllExistingRequirements();
         if (!empty($requirements)) {

--- a/wcfsetup/install/files/lib/system/package/PackageInstallationDispatcher.class.php
+++ b/wcfsetup/install/files/lib/system/package/PackageInstallationDispatcher.class.php
@@ -551,12 +551,6 @@ class PackageInstallationDispatcher
             $statement = WCF::getDB()->prepareStatement($sql);
             $statement->execute([$this->queue->packageID]);
 
-            // delete old compatibility versions
-            $sql = "DELETE FROM wcf" . WCF_N . "_package_compatibility
-                    WHERE       packageID = ?";
-            $statement = WCF::getDB()->prepareStatement($sql);
-            $statement->execute([$this->queue->packageID]);
-
             // delete old requirements and dependencies
             $sql = "DELETE FROM wcf" . WCF_N . "_package_requirement
                     WHERE       packageID = ?";

--- a/wcfsetup/setup/db/install.sql
+++ b/wcfsetup/setup/db/install.sql
@@ -934,6 +934,7 @@ CREATE TABLE wcf1_package (
 	UNIQUE KEY package (package)
 );
 
+-- @deprecated
 DROP TABLE IF EXISTS wcf1_package_compatibility;
 CREATE TABLE wcf1_package_compatibility (
 	packageID INT(10) NOT NULL,
@@ -1786,7 +1787,7 @@ CREATE TABLE wcf1_user_notification_author (
 );
 
 -- notification recipients
--- DEPRECATED
+-- @deprecated
 DROP TABLE IF EXISTS wcf1_user_notification_to_user;
 CREATE TABLE wcf1_user_notification_to_user (
 	notificationID INT(10) NOT NULL,


### PR DESCRIPTION
These are automatically converted into an exclude of Core 6.0.0 Alpha 1 in
PackageArchive and thus redundant.
