### PR TITLE
Add style default cover photo

### DIFF
--- a/com.woltlab.wcf/templates/boxArticleList.tpl
+++ b/com.woltlab.wcf/templates/boxArticleList.tpl
@@ -32,6 +32,8 @@
 				<a href="{$boxArticle->getLink()}">
 					{if $boxArticle->getTeaserImage() && $boxArticle->getTeaserImage()->hasThumbnail('small')}
 						<div class="articleListImage">{@$boxArticle->getTeaserImage()->getThumbnailTag('small')}</div>
+					{else}
+						<div class="articleListImage">{$__wcf->getStyleHandler()->getStyle()->getCoverPhotoURL()}</div>
 					{/if}
 					
 					<h3 class="articleListTitle">{$boxArticle->getTitle()}</h3>


### PR DESCRIPTION
Added the style default cover photo for articles in footer boxes.

Fixes https://community.woltlab.com/thread/291063-artikel-standardbild-wird-in-box-in-fu%C3%9Fzeile-nicht-angezeigt/