### PR TITLE
Fix `this` value for `Core.enableLegacyInheritance()`

### DIFF
--- a/ts/WoltLabSuite/Core/Core.ts
+++ b/ts/WoltLabSuite/Core/Core.ts
@@ -270,11 +270,26 @@ export function debounce<F extends DebounceCallback>(
   };
 }
 
+const defaultFunctions = Object.getOwnPropertyNames(Object.getPrototypeOf({}));
+
 export function enableLegacyInheritance<T>(legacyClass: T): void {
   (legacyClass as any).call = function (thisValue, ...args) {
+    if (window.ENABLE_DEVELOPER_TOOLS) {
+      console.log("Relying on legacy inheritance for ", legacyClass, thisValue);
+    }
+
     const constructed = Reflect.construct(legacyClass as any, args, thisValue.constructor);
     Object.entries(constructed).forEach(([key, value]) => {
       thisValue[key] = value;
     });
+
+    let object = thisValue;
+    while ((object = Object.getPrototypeOf(object))) {
+      Object.getOwnPropertyNames(object).forEach((name) => {
+        if (typeof object[name] === "function" && !defaultFunctions.includes(name)) {
+          object[name] = object[name].bind(thisValue);
+        }
+      });
+    }
   };
 }

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Core.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Core.js
@@ -238,12 +238,24 @@ define(["require", "exports"], function (require, exports) {
         };
     }
     exports.debounce = debounce;
+    const defaultFunctions = Object.getOwnPropertyNames(Object.getPrototypeOf({}));
     function enableLegacyInheritance(legacyClass) {
         legacyClass.call = function (thisValue, ...args) {
+            if (window.ENABLE_DEVELOPER_TOOLS) {
+                console.log("Relying on legacy inheritance for ", legacyClass, thisValue);
+            }
             const constructed = Reflect.construct(legacyClass, args, thisValue.constructor);
             Object.entries(constructed).forEach(([key, value]) => {
                 thisValue[key] = value;
             });
+            let object = thisValue;
+            while ((object = Object.getPrototypeOf(object))) {
+                Object.getOwnPropertyNames(object).forEach((name) => {
+                    if (typeof object[name] === "function" && !defaultFunctions.includes(name)) {
+                        object[name] = object[name].bind(thisValue);
+                    }
+                });
+            }
         };
     }
     exports.enableLegacyInheritance = enableLegacyInheritance;


### PR DESCRIPTION
Without explicitly binding `this` to `thisValue`, it will be `constructed` resulting in missing data only present in `thisValue`.