### PR TITLE
Do not store package compatibility from update servers within the database

### DIFF
--- a/wcfsetup/install/files/acp/update_com.woltlab.wcf_5.5_clearPackageCompatibility.php
+++ b/wcfsetup/install/files/acp/update_com.woltlab.wcf_5.5_clearPackageCompatibility.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Clear the wcf1_package_compatibility table.
+ * Clear the wcf1_package_(update_)?compatibility table.
  *
  * see https://github.com/WoltLab/WCF/pull/4371
  *
@@ -14,5 +14,9 @@
 use wcf\system\WCF;
 
 $sql = "DELETE FROM wcf1_package_compatibility";
+$statement = WCF::getDB()->prepare($sql);
+$statement->execute();
+
+$sql = "DELETE FROM wcf1_package_update_compatibility";
 $statement = WCF::getDB()->prepare($sql);
 $statement->execute();

--- a/wcfsetup/setup/db/install.sql
+++ b/wcfsetup/setup/db/install.sql
@@ -1026,6 +1026,7 @@ CREATE TABLE wcf1_package_update (
 	UNIQUE KEY packageUpdateServerID (packageUpdateServerID, package)
 );
 
+-- @deprecated
 DROP TABLE IF EXISTS wcf1_package_update_compatibility;
 CREATE TABLE wcf1_package_update_compatibility (
 	packageUpdateVersionID INT(10) NOT NULL,


### PR DESCRIPTION
These do not appear to be used anywhere and the official package servers do not
expose them either, making them effectively empty even in current versions.

see #4371
