### PR TITLE
Reduce the size of the Mailbox objects

### DIFF
--- a/wcfsetup/install/files/lib/system/email/Mailbox.class.php
+++ b/wcfsetup/install/files/lib/system/email/Mailbox.class.php
@@ -32,9 +32,9 @@ class Mailbox
 
     /**
      * The preferred language of this mailbox.
-     * @var Language
+     * @var int
      */
-    protected $language;
+    protected $languageID;
 
     /**
      * Creates a new Mailbox.
@@ -81,11 +81,10 @@ class Mailbox
         $this->address = $address;
         $this->name = $name;
         if ($language === null) {
-            $language = LanguageFactory::getInstance()->getLanguage(
-                LanguageFactory::getInstance()->getDefaultLanguageID()
-            );
+            $this->languageID = LanguageFactory::getInstance()->getDefaultLanguageID();
+        } else {
+            $this->languageID = $language->languageID;
         }
-        $this->language = $language;
     }
 
     /**
@@ -116,7 +115,7 @@ class Mailbox
      */
     public function getLanguage()
     {
-        return $this->language;
+        return LanguageFactory::getInstance()->getLanguage($this->languageID);
     }
 
     /**

--- a/wcfsetup/install/files/lib/system/email/UserMailbox.class.php
+++ b/wcfsetup/install/files/lib/system/email/UserMailbox.class.php
@@ -3,6 +3,7 @@
 namespace wcf\system\email;
 
 use wcf\data\user\User;
+use wcf\system\cache\runtime\UserRuntimeCache;
 
 /**
  * Default implementation of the IUserMailbox interface.
@@ -16,10 +17,10 @@ use wcf\data\user\User;
 class UserMailbox extends Mailbox implements IUserMailbox
 {
     /**
-     * User object belonging to this Mailbox
-     * @var User
+     * User belonging to this Mailbox
+     * @var int
      */
-    protected $user;
+    protected $userID;
 
     /**
      * Creates a new Mailbox.
@@ -30,7 +31,7 @@ class UserMailbox extends Mailbox implements IUserMailbox
     {
         parent::__construct($user->email, $user->username, $user->getLanguage());
 
-        $this->user = $user;
+        $this->userID = $user->userID;
     }
 
     /**
@@ -38,6 +39,6 @@ class UserMailbox extends Mailbox implements IUserMailbox
      */
     public function getUser(): User
     {
-        return $this->user;
+        return UserRuntimeCache::getInstance()->getObject($this->userID);
     }
 }


### PR DESCRIPTION
This introduces a small BC break for classes inheriting from Mailbox or
UserMailbox that directly access the `language` or `user` properties instead of
the getter methods. But this is easily fixed.

Resolves #4387
