### PR TITLE
Rename TOTP code form field to `onetimecode`

### DIFF
--- a/wcfsetup/install/files/lib/system/user/multifactor/TotpMultifactorMethod.class.php
+++ b/wcfsetup/install/files/lib/system/user/multifactor/TotpMultifactorMethod.class.php
@@ -234,7 +234,7 @@ final class TotpMultifactorMethod implements IMultifactorMethod
                 Hex::encode(\random_bytes(16)),
                 $deviceName,
                 $formData['data']['secret'],
-                $formData['data']['code']['minCounter'],
+                $formData['data']['onetimecode']['minCounter'],
                 \TIME_NOW,
             ]);
 
@@ -377,10 +377,10 @@ final class TotpMultifactorMethod implements IMultifactorMethod
         $statement = WCF::getDB()->prepareStatement($sql);
         $statement->execute([
             \TIME_NOW,
-            $formData['data']['code']['minCounter'],
+            $formData['data']['onetimecode']['minCounter'],
             $setup->getId(),
             $formData['data']['deviceID'],
-            $formData['data']['code']['minCounter'],
+            $formData['data']['onetimecode']['minCounter'],
         ]);
 
         if ($statement->getAffectedRows() !== 1) {

--- a/wcfsetup/install/files/lib/system/user/multifactor/totp/CodeFormField.class.php
+++ b/wcfsetup/install/files/lib/system/user/multifactor/totp/CodeFormField.class.php
@@ -73,6 +73,6 @@ class CodeFormField extends TextFormField
      */
     protected static function getDefaultId(): string
     {
-        return 'code';
+        return 'onetimecode';
     }
 }


### PR DESCRIPTION
The name `code` for the form field is too generic and should be specified. `onetimecode` is a more fitting identifier for the input name. In addition, 1password fills the totp code automatically, if the field is named `onetimecode` (See https://1password.community/discussion/comment/604200/#Comment_604200).