### PR TITLE
Deprecate `WCF.Search.Message.KeywordList`

### DIFF
--- a/wcfsetup/install/files/js/WCF.Search.Message.js
+++ b/wcfsetup/install/files/js/WCF.Search.Message.js
@@ -6,9 +6,7 @@
 WCF.Search.Message = {};
 
 /**
- * Provides quick search for search keywords.
- * 
- * @see	WCF.Search.Base
+ * @deprecated  5.5 - The base class is deprecated since 3.0 and this code is no longer in use in WoltLab Suite.
  */
 WCF.Search.Message.KeywordList = WCF.Search.Base.extend({
 	/**


### PR DESCRIPTION
This ideally would have happened a long time ago, as the base class already is
deprecated.
