### PR TITLE
Stop using mb_encode_mimeheader()

### DIFF
--- a/wcfsetup/install/files/lib/system/email/Email.class.php
+++ b/wcfsetup/install/files/lib/system/email/Email.class.php
@@ -527,7 +527,7 @@ class Email
             $headers[] = ['cc', \implode(",\r\n   ", $cc)];
         }
         if ($this->getSubject()) {
-            $headers[] = ['subject', EmailGrammar::encodeQuotedPrintableHeader($this->getSubject())];
+            $headers[] = ['subject', EmailGrammar::encodeQuotedPrintableHeader($this->getSubject(), false)];
         } else {
             throw new \LogicException("Cannot generate message headers, you must specify a subject.");
         }


### PR DESCRIPTION
- Stop using `mb_encode_mimeheader`
- Set `$isAtom` to `false` when encoding the email's subject
