### PR TITLE
fix missing brackets and make sure languageID is valid in `I18nDatabaseObjectList`

### DIFF
--- a/wcfsetup/install/files/lib/data/I18nDatabaseObjectList.class.php
+++ b/wcfsetup/install/files/lib/data/I18nDatabaseObjectList.class.php
@@ -39,7 +39,7 @@ abstract class I18nDatabaseObjectList extends DatabaseObjectList
         parent::__construct();
 
         if ($languageID === null) {
-            $languageID = WCF::getUser()->languageID;
+            $languageID = WCF::getLanguage()->languageID;
         }
 
         if (!empty($this->i18nFields)) {

--- a/wcfsetup/install/files/lib/data/I18nDatabaseObjectList.class.php
+++ b/wcfsetup/install/files/lib/data/I18nDatabaseObjectList.class.php
@@ -57,8 +57,8 @@ abstract class I18nDatabaseObjectList extends DatabaseObjectList
                 $this->sqlSelects .= (!empty($this->sqlSelects) ? ', ' : '') . "COALESCE(" . $matchTable . ".languageItemValue, " . $this->getDatabaseTableAlias() . "." . $key . ") AS " . $value;
                 $this->sqlJoins .= "
                     LEFT JOIN   wcf" . WCF_N . "_language_item " . $matchTable . "
-                    ON          " . $matchTable . ".languageItem = " . $this->getDatabaseTableAlias() . "." . $key . "
-                            AND " . $matchTable . ".languageID = " . $languageID;
+                    ON (        " . $matchTable . ".languageItem = " . $this->getDatabaseTableAlias() . "." . $key . "
+                            AND " . $matchTable . ".languageID = " . $languageID . ")";
             }
         }
     }


### PR DESCRIPTION
Missing brackets might lead to strange behavior.
I experienced some issues with an empty `languageID` which lead to an syntax error.