### PR TITLE
Help TSC understand the data flow in Dropdown/Simple#toggle

### DIFF
--- a/ts/WoltLabSuite/Core/Ui/Dropdown/Simple.ts
+++ b/ts/WoltLabSuite/Core/Ui/Dropdown/Simple.ts
@@ -176,7 +176,6 @@ function toggle(
   _activeTargetId = "";
   _dropdowns.forEach((dropdown, containerId) => {
     const menu = _menus.get(containerId) as HTMLElement;
-    let firstListItem: HTMLLIElement | null = null;
 
     if (dropdown.classList.contains("dropdownOpen")) {
       if (!preventToggle) {
@@ -222,16 +221,19 @@ function toggle(
 
       notifyCallbacks(containerId, "open");
 
+      let firstListItem: HTMLLIElement | null = null;
       if (!disableAutoFocus) {
         menu.setAttribute("role", "menu");
         menu.tabIndex = -1;
         menu.removeEventListener("keydown", dropdownMenuKeyDown);
         menu.addEventListener("keydown", dropdownMenuKeyDown);
-        menu.querySelectorAll("li").forEach((listItem) => {
-          if (!listItem.clientHeight) return;
-          if (firstListItem === null) firstListItem = listItem;
-          else if (listItem.classList.contains("active")) firstListItem = listItem;
 
+        const nonEmptyListItems = Array.from(menu.querySelectorAll("li")).filter(
+          (listItem) => listItem.clientHeight > 0,
+        );
+        const activeListItem = nonEmptyListItems.find((listItem) => listItem.classList.contains("active"));
+        firstListItem = activeListItem || nonEmptyListItems[0] || null;
+        nonEmptyListItems.forEach((listItem) => {
           listItem.setAttribute("role", "menuitem");
           listItem.tabIndex = -1;
         });
@@ -243,7 +245,7 @@ function toggle(
         firstListItem.focus();
 
         if (isKeyboardClick) {
-          (firstListItem as HTMLLIElement).classList.add("focus-visible");
+          firstListItem.classList.add("focus-visible");
         }
       }
     }

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Dropdown/Simple.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Dropdown/Simple.js
@@ -154,7 +154,6 @@ define(["require", "exports", "tslib", "../../CallbackList", "../../Core", "../.
         _activeTargetId = "";
         _dropdowns.forEach((dropdown, containerId) => {
             const menu = _menus.get(containerId);
-            let firstListItem = null;
             if (dropdown.classList.contains("dropdownOpen")) {
                 if (!preventToggle) {
                     dropdown.classList.remove("dropdownOpen");
@@ -194,18 +193,16 @@ define(["require", "exports", "tslib", "../../CallbackList", "../../Core", "../.
                     itemList.classList[itemList.scrollHeight > itemList.clientHeight ? "add" : "remove"]("forceScrollbar");
                 }
                 notifyCallbacks(containerId, "open");
+                let firstListItem = null;
                 if (!disableAutoFocus) {
                     menu.setAttribute("role", "menu");
                     menu.tabIndex = -1;
                     menu.removeEventListener("keydown", dropdownMenuKeyDown);
                     menu.addEventListener("keydown", dropdownMenuKeyDown);
-                    menu.querySelectorAll("li").forEach((listItem) => {
-                        if (!listItem.clientHeight)
-                            return;
-                        if (firstListItem === null)
-                            firstListItem = listItem;
-                        else if (listItem.classList.contains("active"))
-                            firstListItem = listItem;
+                    const nonEmptyListItems = Array.from(menu.querySelectorAll("li")).filter((listItem) => listItem.clientHeight > 0);
+                    const activeListItem = nonEmptyListItems.find((listItem) => listItem.classList.contains("active"));
+                    firstListItem = activeListItem || nonEmptyListItems[0] || null;
+                    nonEmptyListItems.forEach((listItem) => {
                         listItem.setAttribute("role", "menuitem");
                         listItem.tabIndex = -1;
                     });


### PR DESCRIPTION
Newer TSC versions determine that `firstListItem` must always be `null`, thus
resulting in `firstListItem` being of type `never` within the `if
(firstListItem !== null)` condition, ultimately complaining about calling
`.focus()` on a `never` type:

> Property 'focus' does not exist on type 'never'.

The issue lies in the TypeScript compiler not properly understanding the
semantics of the `.forEach()`, assuming it might not synchronously call the
callback function.

Rewrite this logic to support TSC in understanding the code and to also make
the intent clearer to the human reader by adding additional helper variables.
