### PR TITLE
Properly show the label form field's selection if it has a value upon load

### DIFF
--- a/com.woltlab.wcf/templates/__labelFormField.tpl
+++ b/com.woltlab.wcf/templates/__labelFormField.tpl
@@ -32,7 +32,7 @@
 		
 		new FormBuilderFieldLabel(
 			'{@$field->getPrefixedId()}',
-			{if $field->getValue()}{@$field->getValue()}{else}null{/if},
+			{if $field->getValue()}'{$field->getValue()|encodeJS}'{else}null{/if},
 			{
 				forceSelection: {if $field->getLabelGroup()->forceSelection}true{else}false{/if}
 			}

--- a/wcfsetup/install/files/acp/templates/__labelFormField.tpl
+++ b/wcfsetup/install/files/acp/templates/__labelFormField.tpl
@@ -32,7 +32,7 @@
 		
 		new FormBuilderFieldLabel(
 			'{@$field->getPrefixedId()}',
-			{if $field->getValue()}{@$field->getValue()}{else}null{/if},
+			{if $field->getValue()}'{$field->getValue()|encodeJS}'{else}null{/if},
 			{
 				forceSelection: {if $field->getLabelGroup()->forceSelection}true{else}false{/if}
 			}


### PR DESCRIPTION
This got broken during the TypeScript migration, because the constructor's
`labelId` parameter is typed as string, but in reality it was passed an
integer. This broke a `===` comparison with the `data-label-id` property of the
list items, thus failing to properly select the label.
