### PR TITLE
Support ES 6 default exports for form builder field JavaScript data handlers

### DIFF
--- a/com.woltlab.wcf/templates/__formFieldDataHandler.tpl
+++ b/com.woltlab.wcf/templates/__formFieldDataHandler.tpl
@@ -1,15 +1,19 @@
 {if $field->getDocument()->isAjax() && !$field->getJavaScriptDataHandlerModule()|empty}
 	<script data-relocate="true">
 		require([
+			'tslib',
 			'{$field->getJavaScriptDataHandlerModule()}',
 			'WoltLabSuite/Core/Form/Builder/Manager'
 		], function(
+			tslib,
 			FormBuilderField,
 			FormBuilderManager
 		) {
+			FormBuilderField = tslib.__importDefault(FormBuilderField);
+
 			FormBuilderManager.registerField(
 				'{@$field->getDocument()->getId()}',
-				new FormBuilderField('{@$field->getPrefixedId()}')
+				new (FormBuilderField.default)('{@$field->getPrefixedId()}')
 			);
 		});
 	</script>

--- a/wcfsetup/install/files/acp/templates/__formFieldDataHandler.tpl
+++ b/wcfsetup/install/files/acp/templates/__formFieldDataHandler.tpl
@@ -1,15 +1,19 @@
 {if $field->getDocument()->isAjax() && !$field->getJavaScriptDataHandlerModule()|empty}
 	<script data-relocate="true">
 		require([
+			'tslib',
 			'{$field->getJavaScriptDataHandlerModule()}',
 			'WoltLabSuite/Core/Form/Builder/Manager'
 		], function(
+			tslib,
 			FormBuilderField,
 			FormBuilderManager
 		) {
+			FormBuilderField = tslib.__importDefault(FormBuilderField);
+
 			FormBuilderManager.registerField(
 				'{@$field->getDocument()->getId()}',
-				new FormBuilderField('{@$field->getPrefixedId()}')
+				new (FormBuilderField.default)('{@$field->getPrefixedId()}')
 			);
 		});
 	</script>


### PR DESCRIPTION
For legacy exports the value loaded by `require()` (`FormBuilderField`) will be
whatever the module author returned within the module definition. ES 6 modules
on the other hand will be passed as an object containing the exported values,
with the default export residing in the `default` key.

tslib's `__importDefault` will transform a legacy export into a ES 6 module, by
putting the exported value into the `default` key of an freshly created object.

This allows us to handle both legacy as well as ES 6 default exports identically
by simply using the `default` value of the `FormBuilderField` variable.