### PR TITLE
Resolved side effects from previous inheritance approach

### DIFF
--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Core.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Core.js
@@ -238,7 +238,6 @@ define(["require", "exports"], function (require, exports) {
         };
     }
     exports.debounce = debounce;
-    const defaultFunctions = Object.getOwnPropertyNames(Object.getPrototypeOf({}));
     function enableLegacyInheritance(legacyClass) {
         legacyClass.call = function (thisValue, ...args) {
             if (window.ENABLE_DEVELOPER_TOOLS) {
@@ -246,15 +245,15 @@ define(["require", "exports"], function (require, exports) {
             }
             const constructed = Reflect.construct(legacyClass, args, thisValue.constructor);
             Object.entries(constructed).forEach(([key, value]) => {
+                if (typeof value === "function") {
+                    value = value.bind(thisValue);
+                }
                 thisValue[key] = value;
             });
-            let object = thisValue;
-            while ((object = Object.getPrototypeOf(object))) {
-                Object.getOwnPropertyNames(object).forEach((name) => {
-                    if (typeof object[name] === "function" && !defaultFunctions.includes(name)) {
-                        object[name] = object[name].bind(thisValue);
-                    }
-                });
+            for (const key in thisValue) {
+                if (typeof thisValue[key] === "function") {
+                    constructed[key] = thisValue[key].bind(thisValue);
+                }
             }
         };
     }


### PR DESCRIPTION
This is a follow-up for db23f8af33398c4851d6ba36436592f406b35a0d which introduced a flawed change.

The iteration over the prototype chain caused the prototype itself being bound to an object on runtime, conflicting with other objects.

The root cause was that some parts of the inherited functions were still bound to `constructed`, which was attempted to be fixed by poking the prototype chain.

This new fix is a bit weird, unless one understands that the call to `Reflect.construct()` is a bit tricky because any bound call inside the constructor of `legacyClass` will be bound to `constructed`.

This change is more of a sledge hammer approach, but it works all cases that I tested, including those that were initially the cause for the previous fix as well as new issues caused by the fix.