### PR TITLE
Fix `{foreach}` loops when the to-be-iterated value is empty

### DIFF
--- a/wcfsetup/install/files/lib/system/template/TemplateScriptingCompiler.class.php
+++ b/wcfsetup/install/files/lib/system/template/TemplateScriptingCompiler.class.php
@@ -801,6 +801,12 @@ class TemplateScriptingCompiler {
 		$phpCode = "<?php\n";
 		$phpCode .= $foreachHash." = ".$args['from'].";\n";
 		
+		$itemVar = mb_substr($args['item'], 0, 1) != '$' ? "\$this->v[".$args['item']."]" : $args['item'];
+		$foreachData['itemVar'] = $itemVar;
+		
+		$phpCode .= "\$this->foreachVars['{$hash}'] = [];\n";
+		$phpCode .= "\$this->foreachVars['{$hash}']['item'] = {$itemVar} ?? null;\n";
+
 		if (empty($foreachProp)) {
 			$phpCode .= "if ((is_countable(".$foreachHash.") && count(".$foreachHash.") > 0) || (!is_countable(".$foreachHash.") && ".$foreachHash.")) {\n";
 		}
@@ -814,12 +820,6 @@ class TemplateScriptingCompiler {
 			$phpCode .= $foreachProp."['iteration'] = 0;\n";
 			$phpCode .= "if (".$foreachHash."_cnt > 0) {\n";
 		}
-		
-		$itemVar = mb_substr($args['item'], 0, 1) != '$' ? "\$this->v[".$args['item']."]" : $args['item'];
-		$foreachData['itemVar'] = $itemVar;
-		
-		$phpCode .= "\$this->foreachVars['{$hash}'] = [];\n";
-		$phpCode .= "\$this->foreachVars['{$hash}']['item'] = {$itemVar} ?? null;\n";
 		
 		if (isset($args['key'])) {
 			$keyVar = mb_substr($args['key'], 0, 1) != '$' ? "\$this->v[".$args['key']."]" : $args['key'];


### PR DESCRIPTION
The restoring of the `item` value failed, because the necessary data in
`foreachVars` was only being filled when the `foreach()` loop was actually
entered. Move this saving of the old value up to ensure it always happens.

see 75ce18bc18904d1215c7d021ac0ac18c0a7a5d42
see #4425
