### PR TITLE
Do not store optional information from update servers within the database

### DIFF
--- a/wcfsetup/install/files/acp/update_com.woltlab.wcf_5.5_clearPackageDeprecations.php
+++ b/wcfsetup/install/files/acp/update_com.woltlab.wcf_5.5_clearPackageDeprecations.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Clear the wcf1_package_(update_)?compatibility table.
+ * Clear the wcf1_package_(update_)?compatibility, wcf1_package_update_optional tables.
  *
  * see https://github.com/WoltLab/WCF/pull/4371
  *
@@ -18,5 +18,9 @@ $statement = WCF::getDB()->prepare($sql);
 $statement->execute();
 
 $sql = "DELETE FROM wcf1_package_update_compatibility";
+$statement = WCF::getDB()->prepare($sql);
+$statement->execute();
+
+$sql = "DELETE FROM wcf1_package_update_optional";
 $statement = WCF::getDB()->prepare($sql);
 $statement->execute();

--- a/wcfsetup/install/files/lib/system/package/PackageUpdateDispatcher.class.php
+++ b/wcfsetup/install/files/lib/system/package/PackageUpdateDispatcher.class.php
@@ -524,7 +524,7 @@ class PackageUpdateDispatcher extends SingletonFactory
      */
     protected function savePackageUpdates(array &$allNewPackages, $packageUpdateServerID)
     {
-        $excludedPackagesParameters = $optionalInserts = $requirementInserts = [];
+        $excludedPackagesParameters = $requirementInserts = [];
         $sql = "INSERT INTO wcf" . WCF_N . "_package_update
                             (packageUpdateServerID, package, packageName, packageDescription, author, authorURL, isApplication, pluginStoreFileID)
                 VALUES      (?, ?, ?, ?, ?, ?, ?, ?)";
@@ -602,15 +602,6 @@ class PackageUpdateDispatcher extends SingletonFactory
                     }
                 }
 
-                if (isset($versionData['optionalPackages'])) {
-                    foreach ($versionData['optionalPackages'] as $optionalPackage) {
-                        $optionalInserts[] = [
-                            'packageUpdateVersionID' => $packageUpdateVersionID,
-                            'package' => $optionalPackage,
-                        ];
-                    }
-                }
-
                 if (isset($versionData['excludedPackages'])) {
                     foreach ($versionData['excludedPackages'] as $excludedIdentifier => $exclusion) {
                         $excludedPackagesParameters[] = [
@@ -675,21 +666,6 @@ class PackageUpdateDispatcher extends SingletonFactory
                     $requirement['packageUpdateVersionID'],
                     $requirement['package'],
                     $requirement['minversion'],
-                ]);
-            }
-            WCF::getDB()->commitTransaction();
-        }
-
-        if (!empty($optionalInserts)) {
-            $sql = "INSERT INTO wcf" . WCF_N . "_package_update_optional
-                                (packageUpdateVersionID, package)
-                    VALUES      (?, ?)";
-            $statement = WCF::getDB()->prepareStatement($sql);
-            WCF::getDB()->beginTransaction();
-            foreach ($optionalInserts as $requirement) {
-                $statement->execute([
-                    $requirement['packageUpdateVersionID'],
-                    $requirement['package'],
                 ]);
             }
             WCF::getDB()->commitTransaction();

--- a/wcfsetup/setup/db/install.sql
+++ b/wcfsetup/setup/db/install.sql
@@ -1049,6 +1049,7 @@ CREATE TABLE wcf1_package_update_fromversion (
 	UNIQUE KEY packageUpdateVersionID (packageUpdateVersionID, fromversion)
 );
 
+-- @deprecated
 DROP TABLE IF EXISTS wcf1_package_update_optional;
 CREATE TABLE wcf1_package_update_optional (
 	packageUpdateVersionID INT(10) NOT NULL DEFAULT 0,


### PR DESCRIPTION
These do not appear to be used anywhere and the official package servers do not
expose them either, making them effectively empty even in current versions.

see fd3511448663b86f4428e848bbefa07b93bf4bad
see #4371
see #4385
