### PR TITLE
PHP DDL Fixes

### DIFF
--- a/wcfsetup/install/files/lib/system/database/table/DatabaseTableChangeProcessor.class.php
+++ b/wcfsetup/install/files/lib/system/database/table/DatabaseTableChangeProcessor.class.php
@@ -456,7 +456,7 @@ class DatabaseTableChangeProcessor {
 						$this->splitNodeMessage .= "Added foreign key '{$tableName}." . implode(',', $foreignKey->getColumns()) . "'.";
 						break 2;
 					}
-					else if (!empty(array_diff($foreignKey->getData(), $matchingExistingForeignKey->getData()))) {
+					else if (!empty(array_diff_assoc($foreignKey->getData(), $matchingExistingForeignKey->getData()))) {
 						if (!isset($this->foreignKeysToDrop[$tableName])) {
 							$this->foreignKeysToDrop[$tableName] = [];
 						}

--- a/wcfsetup/install/files/lib/system/database/table/DatabaseTableChangeProcessor.class.php
+++ b/wcfsetup/install/files/lib/system/database/table/DatabaseTableChangeProcessor.class.php
@@ -427,7 +427,7 @@ class DatabaseTableChangeProcessor {
 				foreach ($table->getForeignKeys() as $foreignKey) {
 					$matchingExistingForeignKey = null;
 					foreach ($existingForeignKeys as $existingForeignKey) {
-						if (empty(array_diff($foreignKey->getDiffData(), $existingForeignKey->getDiffData()))) {
+						if (empty(array_diff_assoc($foreignKey->getDiffData(), $existingForeignKey->getDiffData()))) {
 							$matchingExistingForeignKey = $existingForeignKey;
 							break;
 						}


### PR DESCRIPTION
The use of `array_diff()` in the PHP based DDL API is bogus. This PR fixes the
first two locations where a bug could clearly be reproduced. The reproducer is
explained within the commit message of each commit. The other locations will be
adjusted later, once a reproducer is written and the fix is tested.

see #4434