### PR TITLE
Prefixed CSS First

### DIFF
--- a/wcfsetup/install/files/style/bbcode/inlineCode.scss
+++ b/wcfsetup/install/files/style/bbcode/inlineCode.scss
@@ -11,8 +11,8 @@ kbd {
 	background-color: rgba(255, 255, 255, 1) !important;
 	border: 1px solid rgba(196, 196, 196, 1) !important;
 	border-radius: 2px;
-	box-decoration-break: clone;
 	-webkit-box-decoration-break: clone;
+	box-decoration-break: clone;
 	color: rgba(68, 68, 68, 1) !important;
 	display: inline;
 	font-family: $wcfFontFamilyMonospace;

--- a/wcfsetup/install/files/style/layout/global.scss
+++ b/wcfsetup/install/files/style/layout/global.scss
@@ -23,8 +23,8 @@
 }
 
 .grayscale {
-	filter: gray;
 	-webkit-filter: grayscale(1);
+	filter: gray;
 }
 
 .monospace {

--- a/wcfsetup/install/files/style/ui/imageViewer.scss
+++ b/wcfsetup/install/files/style/ui/imageViewer.scss
@@ -144,8 +144,8 @@ $wcfImageViewerFontColor: rgba(211, 211, 211, 1);
 	> header,
 	> div,
 	> footer {
-		box-sizing: border-box;
 		-moz-box-sizing: border-box;
+		box-sizing: border-box;
 		left: 0;
 		position: fixed;
 		right: 0;
@@ -313,8 +313,8 @@ $wcfImageViewerFontColor: rgba(211, 211, 211, 1);
 		padding: 10px;
 
 		&:hover > div > ul > li > img {
-			filter: none;
 			-webkit-filter: none;
+			filter: none;
 		}
 
 		> span {
@@ -377,8 +377,8 @@ $wcfImageViewerFontColor: rgba(211, 211, 211, 1);
 					}
 
 					&.active > img {
-						filter: none;
 						-webkit-filter: none;
+						filter: none;
 					}
 
 					&.loading {


### PR DESCRIPTION
Ensure vendor-prefixed versions of a CSS property are listed before the standardized, unprefixed version.

When multiple versions of the same CSS property are specified, the last supported one will be used due to how browsers handle fallback values. This means the order matters when using both vendor-prefixed and unprefixed versions of the same property. Specifically, the unprefixed version must be listed last to ensure standardized behavior takes precedence.