### PR TITLE
Fix conditions for MultiSelectOptionType

### DIFF
--- a/wcfsetup/install/files/lib/system/option/MultiSelectOptionType.class.php
+++ b/wcfsetup/install/files/lib/system/option/MultiSelectOptionType.class.php
@@ -103,16 +103,23 @@ class MultiSelectOptionType extends SelectOptionType
         }
         $value = ArrayUtil::trim($value, false);
 
-        $value = \array_map(static function ($value) {
-            return escapeString(\preg_quote($value));
-        }, $value);
-
-        $conditions->add(
-            "option_value.userOption" . $option->optionID . " REGEXP '" . '(^|\n)' . \implode(
-                '\n([^\n]*\n)*',
-                $value
-            ) . '($|\n)' . "'"
-        );
+        foreach ($value as $entry) {
+            $escapedEntry = \addcslashes($entry, '%_');
+            $conditions->add(
+                "(
+                    option_value.userOption" . $option->optionID . " LIKE ?
+                    OR option_value.userOption" . $option->optionID . " LIKE ?
+                    OR option_value.userOption" . $option->optionID . " LIKE ?
+                    OR option_value.userOption" . $option->optionID . " = ?
+                )",
+                [
+                    "%\n{$escapedEntry}\n%",
+                    "%\n{$escapedEntry}",
+                    "{$escapedEntry}\n%",
+                    $entry,
+                ]
+            );
+        }
 
         return true;
     }
@@ -127,16 +134,23 @@ class MultiSelectOptionType extends SelectOptionType
         }
         $value = ArrayUtil::trim($value, false);
 
-        $value = \array_map(static function ($value) {
-            return escapeString(\preg_quote($value));
-        }, $value);
-
-        $userList->getConditionBuilder()->add(
-            "user_option_value.userOption" . $option->optionID . " REGEXP '" . '(^|\n)' . \implode(
-                '\n([^\n]*\n)*',
-                $value
-            ) . '($|\n)' . "'"
-        );
+        foreach ($value as $entry) {
+            $escapedEntry = \addcslashes($entry, '%_');
+            $userList->getConditionBuilder()->add(
+                "(
+                    user_option_value.userOption" . $option->optionID . " LIKE ?
+                    OR user_option_value.userOption" . $option->optionID . " LIKE ?
+                    OR user_option_value.userOption" . $option->optionID . " LIKE ?
+                    OR user_option_value.userOption" . $option->optionID . " = ?
+                )",
+                [
+                    "%\n{$escapedEntry}\n%",
+                    "%\n{$escapedEntry}",
+                    "{$escapedEntry}\n%",
+                    $entry,
+                ]
+            );
+        }
     }
 
     /**


### PR DESCRIPTION
This cleans up the SQL conditions used for searching for users with a specific
selection and fixes the following issues:

- It avoids the use of `escapeString()` in favor of proper prepared statements.
- It avoids the use of `preg_quote()` to escape a regular expression for use in
  MySQL, which might not be safe.
- It fixes matching when the options are later reordered, as the saved value is
  not being normalized and instead reused the order of the options within the
  select.

The generated query does not look great, but is not really worse than the
regular expression either.

In the future it might be possible to migrate this option type to a JSON based
storage and to use `JSON_CONTAINS()`.
