### PR TITLE
Deprecate MessageQuoteAction::markForRemoval()

### DIFF
--- a/wcfsetup/install/files/js/WCF.Message.js
+++ b/wcfsetup/install/files/js/WCF.Message.js
@@ -1551,7 +1551,7 @@ if (COMPILER_TARGET_DEFAULT) {
 		},
 		
 		/**
-		 * Marks quote ids for removal.
+		 * @deprecated 5.5 This method is no longer used since 3.0.
 		 */
 		markQuotesForRemoval: function () {
 			if (this._removeOnSubmit.length) {

--- a/wcfsetup/install/files/lib/action/MessageQuoteAction.class.php
+++ b/wcfsetup/install/files/lib/action/MessageQuoteAction.class.php
@@ -162,7 +162,7 @@ class MessageQuoteAction extends AJAXProxyAction
     }
 
     /**
-     * Marks quotes for removal.
+     * @deprecated 5.5 This method is no longer used since 3.0.
      */
     protected function markForRemoval()
     {


### PR DESCRIPTION
This method is no longer used as of commit
9d118fa4c035827b399acdcb4c6c05ad1be5f3c5 (3.0.x).
