### PR TITLE
Add `cache-control: private` to PSR-7 responses

### DIFF
--- a/wcfsetup/install/files/lib/system/request/RequestHandler.class.php
+++ b/wcfsetup/install/files/lib/system/request/RequestHandler.class.php
@@ -158,7 +158,9 @@ class RequestHandler extends SingletonFactory
     {
         // Storing responses in a shared cache is unsafe, because they all contain session specific information.
         // Add the 'private' value to the cache-control header and remove any 'public' value.
-        $cacheControl = [];
+        $cacheControl = [
+            'private',
+        ];
         foreach ($this->splitCacheControl($response->getHeader('cache-control')) as $value) {
             [$field] = \explode('=', $value, 2);
 
@@ -174,7 +176,6 @@ class RequestHandler extends SingletonFactory
 
             $cacheControl[] = $value;
         }
-        $cacheControl[] = 'private';
 
         $response = $response->withHeader(
             'cache-control',


### PR DESCRIPTION
While we cannot rely on every controller returning a PSR-7 response, we are
also unable to reliably set `cache-control: private` without these PSR-7
responses.

For this reason this change still provides a net benefit, as it improves the
situation in some cases, while not making it worse for other cases.

-----------------

see #4273
