### PR TITLE
Prevent StyleEditForm from creating phrases with empty name

### DIFF
--- a/com.woltlab.wcf/package.xml
+++ b/com.woltlab.wcf/package.xml
@@ -140,18 +140,8 @@ tar cvf com.woltlab.wcf/files_pre.tar -C wcfsetup/install/files/ \
 		<instruction type="script">acp/update_com.woltlab.wcf_5.4_deleteLanguageItems.php</instruction>
 	</instructions>
 
-	<instructions type="update" fromversion="5.4.2">
-		<instruction type="acpTemplate">acptemplates_update.tar</instruction>
-		<instruction type="file">files_update.tar</instruction>
-		<instruction type="template">templates_update.tar</instruction>
-		
-		<instruction type="language" />
-
-		<instruction type="script" run="standalone">acp/update_com.woltlab.wcf_5.4.3_deleteDsStore.php</instruction>
-		<instruction type="script" run="standalone">acp/update_com.woltlab.wcf_5.4.3_resetAvatarCache.php</instruction>
-	</instructions>
-
-	<instructions type="update" fromversion="5.4.3">
-		<instruction type="file">files_update.tar</instruction>
+	<instructions type="update" fromversion="5.4.4">
+		<!-- Delete the empty phrase once again. It might have been re-injected using the I18n functionality. -->
+		<instruction type="script">acp/update_com.woltlab.wcf_5.4_deleteLanguageItems.php</instruction>
 	</instructions>
 </package>

--- a/wcfsetup/install/files/lib/acp/form/StyleEditForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/StyleEditForm.class.php
@@ -4,6 +4,7 @@ namespace wcf\acp\form;
 
 use wcf\data\style\Style;
 use wcf\data\style\StyleAction;
+use wcf\data\style\StyleEditor;
 use wcf\form\AbstractForm;
 use wcf\system\exception\IllegalLinkException;
 use wcf\system\exception\UserInputException;
@@ -346,7 +347,16 @@ class StyleEditForm extends StyleAddForm
         }
 
         // save description
-        I18nHandler::getInstance()->save('styleDescription', $this->style->styleDescription, 'wcf.style');
+        I18nHandler::getInstance()->save(
+            'styleDescription',
+            'wcf.style.styleDescription' . $this->style->styleID,
+            'wcf.style'
+        );
+
+        $styleEditor = new StyleEditor($this->style);
+        $styleEditor->update([
+            'styleDescription' => 'wcf.style.styleDescription' . $this->style->styleID,
+        ]);
 
         // call saved event
         $this->saved();

--- a/wcfsetup/install/files/lib/data/language/LanguageEditor.class.php
+++ b/wcfsetup/install/files/lib/data/language/LanguageEditor.class.php
@@ -361,24 +361,7 @@ class LanguageEditor extends DatabaseObjectEditor implements IEditableCachedObje
                 foreach ($elements as $element) {
                     $itemName = $element->getAttribute('name');
 
-                    // Safeguard against malformed phrases, an empty name has a strange side effect.
-                    if (empty($itemName)) {
-                        throw new \InvalidArgumentException("The name attribute is missing or empty.");
-                    }
-
-                    if ($itemName !== $categoryName && \strpos($itemName, $categoryName . '.') !== 0) {
-                        throw new \InvalidArgumentException(WCF::getLanguage()->getDynamicVariable(
-                            'wcf.acp.language.import.error.categoryMismatch',
-                            [
-                                'categoryName' => $categoryName,
-                                'languageItem' => $itemName,
-                            ]
-                        ));
-                    }
-
-                    if (StringUtil::trim($itemName) !== $itemName) {
-                        throw new \InvalidArgumentException("The name '{$itemName}' contains leading or trailing whitespaces.");
-                    }
+                    self::validateItemName($itemName, $categoryName);
 
                     $itemValue = $element->nodeValue;
 
@@ -608,6 +591,34 @@ class LanguageEditor extends DatabaseObjectEditor implements IEditableCachedObje
 
         // delete relevant template compilations
         $this->deleteCompiledTemplates();
+    }
+
+    /**
+     * Verifies that the given variable is a valid variable within the given category.
+     * Throws an exception otherwise.
+     *
+     * @since 5.4
+     */
+    final public static function validateItemName(string $itemName, string $categoryName): void
+    {
+        // Safeguard against malformed phrases, an empty name has a strange side effect.
+        if (empty($itemName)) {
+            throw new \InvalidArgumentException("The name attribute is missing or empty.");
+        }
+
+        if ($itemName !== $categoryName && \strpos($itemName, $categoryName . '.') !== 0) {
+            throw new \InvalidArgumentException(WCF::getLanguage()->getDynamicVariable(
+                'wcf.acp.language.import.error.categoryMismatch',
+                [
+                    'categoryName' => $categoryName,
+                    'languageItem' => $itemName,
+                ]
+            ));
+        }
+
+        if (StringUtil::trim($itemName) !== $itemName) {
+            throw new \InvalidArgumentException("The name '{$itemName}' contains leading or trailing whitespaces.");
+        }
     }
 
     /**

--- a/wcfsetup/install/files/lib/system/language/I18nHandler.class.php
+++ b/wcfsetup/install/files/lib/system/language/I18nHandler.class.php
@@ -3,6 +3,7 @@
 namespace wcf\system\language;
 
 use wcf\data\language\Language;
+use wcf\data\language\LanguageEditor;
 use wcf\system\database\util\PreparedStatementConditionBuilder;
 use wcf\system\exception\SystemException;
 use wcf\system\Regex;
@@ -305,6 +306,8 @@ class I18nHandler extends SingletonFactory
      */
     public function save($elementID, $languageVariable, $languageCategory, $packageID = PACKAGE_ID)
     {
+        LanguageEditor::validateItemName($languageVariable, $languageCategory);
+
         // get language category id
         $sql = "SELECT  languageCategoryID
                 FROM    wcf" . WCF_N . "_language_category


### PR DESCRIPTION
- Store deterministic language variable for style description in StyleEditForm
- Add LanguageEditor::validateItemName()
- Validate the languageVariable in I18nHandler::save()
- Delete the empty phrase when updating to 5.4.5
