### PR TITLE
Unify error handling in several templates

### DIFF
--- a/com.woltlab.wcf/templates/accountManagement.tpl
+++ b/com.woltlab.wcf/templates/accountManagement.tpl
@@ -27,8 +27,11 @@
 					<input type="password" id="password" name="password" value="" required class="medium" autocomplete="current-password">
 					{if $errorField == 'password'}
 						<small class="innerError">
-							{if $errorType == 'empty'}{lang}wcf.global.form.error.empty{/lang}{/if}
-							{if $errorType == 'false'}{lang}wcf.user.password.error.false{/lang}{/if}
+							{if $errorType == 'empty'}
+								{lang}wcf.global.form.error.empty{/lang}
+							{else}
+								{lang}wcf.user.password.error.{@$errorType}{/lang}
+							{/if}
 						</small>
 					{/if}
 					<small>{lang}wcf.user.accountManagement.password.description{/lang}</small>
@@ -51,10 +54,11 @@
 						
 					{if $errorField == 'username'}
 						<small class="innerError">
-							{if $errorType == 'empty'}{lang}wcf.global.form.error.empty{/lang}{/if}
-							{if $errorType == 'invalid'}{lang}wcf.user.username.error.invalid{/lang}{/if}
-							{if $errorType == 'notUnique'}{lang}wcf.user.username.error.notUnique{/lang}{/if}
-							{if $errorType == 'alreadyRenamed'}{lang}wcf.user.username.error.alreadyRenamed{/lang}{/if}
+							{if $errorType == 'empty'}
+								{lang}wcf.global.form.error.empty{/lang}
+							{else}
+								{lang}wcf.user.username.error.{@$errorType}{/lang}
+							{/if}
 						</small>
 					{/if}
 					{if $renamePeriod > 0}
@@ -78,8 +82,11 @@
 						
 					{if $errorField == 'newPassword'}
 						<small class="innerError">
-							{if $errorType == 'empty'}{lang}wcf.global.form.error.empty{/lang}{/if}
-							{if $errorType == 'notSecure'}{lang}wcf.user.password.error.notSecure{/lang}{/if}
+							{if $errorType == 'empty'}
+								{lang}wcf.global.form.error.empty{/lang}
+							{else}
+								{lang}wcf.user.password.error.{@$errorType}{/lang}
+							{/if}
 						</small>
 					{/if}
 				</dd>
@@ -92,8 +99,11 @@
 						
 					{if $errorField == 'confirmNewPassword'}
 						<small class="innerError">
-							{if $errorType == 'empty'}{lang}wcf.global.form.error.empty{/lang}{/if}
-							{if $errorType == 'notEqual'}{lang}wcf.user.confirmPassword.error.notEqual{/lang}{/if}
+							{if $errorType == 'empty'}
+								{lang}wcf.global.form.error.empty{/lang}
+							{else}
+								{lang}wcf.user.confirmPassword.error.{@$errorType}{/lang}
+							{/if}
 						</small>
 					{/if}
 				</dd>
@@ -111,12 +121,13 @@
 				<dt><label for="email">{lang}wcf.user.newEmail{/lang}</label></dt>
 				<dd>
 					<input type="email" id="email" name="email" value="{$email}" class="medium">
-						
 					{if $errorField == 'email'}
 						<small class="innerError">
-							{if $errorType == 'empty'}{lang}wcf.global.form.error.empty{/lang}{/if}
-							{if $errorType == 'invalid'}{lang}wcf.user.email.error.invalid{/lang}{/if}
-							{if $errorType == 'notUnique'}{lang}wcf.user.email.error.notUnique{/lang}{/if}
+							{if $errorType == 'empty'}
+								{lang}wcf.global.form.error.empty{/lang}
+							{else}
+								{lang}wcf.user.email.error.{@$errorType}{/lang}
+							{/if}
 						</small>
 					{/if}
 				</dd>
@@ -129,7 +140,11 @@
 						
 					{if $errorField == 'confirmEmail'}
 						<small class="innerError">
-							{if $errorType == 'notEqual'}{lang}wcf.user.confirmEmail.error.notEqual{/lang}{/if}
+							{if $errorType == 'empty'}
+								{lang}wcf.global.form.error.empty{/lang}
+							{else}
+								{lang}wcf.user.confirmEmail.error.{@$errorType}{/lang}
+							{/if}
 						</small>
 					{/if}
 				</dd>

--- a/com.woltlab.wcf/templates/emailActivation.tpl
+++ b/com.woltlab.wcf/templates/emailActivation.tpl
@@ -10,7 +10,11 @@
 				<input type="text" id="userID" name="u" value="{@$u}" required class="medium">
 				{if $errorField == 'u'}
 					<small class="innerError">
-						{if $errorType == 'invalid'}{lang}wcf.user.userID.error.invalid{/lang}{/if}
+						{if $errorType == 'empty'}
+							{lang}wcf.global.form.error.empty{/lang}
+						{else}
+							{lang}wcf.user.userID.error.{@$errorType}{/lang}
+						{/if}
 					</small>
 				{/if}
 			</dd>
@@ -22,7 +26,11 @@
 				<input type="text" id="activationCode" maxlength="9" name="a" value="{@$a}" required class="medium">
 				{if $errorField == 'a'}
 					<small class="innerError">
-						{if $errorType == 'invalid'}{lang}wcf.user.activationCode.error.invalid{/lang}{/if}
+						{if $errorType == 'empty'}
+							{lang}wcf.global.form.error.empty{/lang}
+						{else}
+							{lang}wcf.user.activationCode.error.{@$errorType}{/lang}
+						{/if}
 					</small>
 				{/if}
 				<small><a href="{link controller='EmailNewActivationCode'}{/link}">{lang}wcf.user.newActivationCode{/lang}</a></small>

--- a/com.woltlab.wcf/templates/lostPassword.tpl
+++ b/com.woltlab.wcf/templates/lostPassword.tpl
@@ -14,9 +14,11 @@
 				<input type="text" id="usernameInput" name="username" value="{$username}" class="medium">
 				{if $errorField == 'username'}
 					<small class="innerError">
-						{if $errorType == 'empty'}{lang}wcf.global.form.error.empty{/lang}{/if}
-						{if $errorType == 'notFound'}{lang}wcf.user.username.error.notFound{/lang}{/if}
-						{if $errorType == '3rdParty'}{lang}wcf.user.username.error.3rdParty{/lang}{/if}
+						{if $errorType == 'empty'}
+							{lang}wcf.global.form.error.empty{/lang}
+						{else}
+							{lang}wcf.user.username.error.{@$errorType}{/lang}
+						{/if}
 					</small>
 				{/if}
 			</dd>
@@ -30,8 +32,13 @@
 				<input type="email" id="emailInput" name="email" value="{$email}" class="medium">
 				{if $errorField == 'email'}
 					<small class="innerError">
-						{if $errorType == 'empty'}{lang}wcf.global.form.error.empty{/lang}{/if}
-						{if $errorType == 'notFound'}{lang}wcf.user.lostPassword.email.error.notFound{/lang}{/if}
+						{if $errorType == 'empty'}
+							{lang}wcf.global.form.error.empty{/lang}
+						{elseif $errorType == 'notFound'}
+							{lang}wcf.user.lostPassword.email.error.notFound{/lang}
+						{else}
+							{lang}wcf.user.email.error.{@$errorType}{/lang}
+						{/if}
 					</small>
 				{/if}
 			</dd>

--- a/com.woltlab.wcf/templates/newPassword.tpl
+++ b/com.woltlab.wcf/templates/newPassword.tpl
@@ -13,8 +13,11 @@
 					
 				{if $errorField == 'newPassword'}
 					<small class="innerError">
-						{if $errorType == 'empty'}{lang}wcf.global.form.error.empty{/lang}{/if}
-						{if $errorType == 'notSecure'}{lang}wcf.user.password.error.notSecure{/lang}{/if}
+						{if $errorType == 'empty'}
+							{lang}wcf.global.form.error.empty{/lang}
+						{else}
+							{lang}wcf.user.password.error.{@$errorType}{/lang}
+						{/if}
 					</small>
 				{/if}
 			</dd>
@@ -27,8 +30,11 @@
 					
 				{if $errorField == 'confirmNewPassword'}
 					<small class="innerError">
-						{if $errorType == 'empty'}{lang}wcf.global.form.error.empty{/lang}{/if}
-						{if $errorType == 'notEqual'}{lang}wcf.user.confirmPassword.error.notEqual{/lang}{/if}
+						{if $errorType == 'empty'}
+							{lang}wcf.global.form.error.empty{/lang}
+						{else}
+							{lang}wcf.user.confirmPassword.error.{@$errorType}{/lang}
+						{/if}
 					</small>
 				{/if}
 			</dd>

--- a/com.woltlab.wcf/templates/registerActivation.tpl
+++ b/com.woltlab.wcf/templates/registerActivation.tpl
@@ -12,7 +12,11 @@
 				<input type="text" id="username" name="username" value="{$username}" required class="medium">
 				{if $errorField == 'username'}
 					<small class="innerError">
-						{if $errorType == 'notFound'}{lang}wcf.user.username.error.notFound{/lang}{/if}
+						{if $errorType == 'empty'}
+							{lang}wcf.global.form.error.empty{/lang}
+						{else}
+							{lang}wcf.user.username.error.{@$errorType}{/lang}
+						{/if}
 					</small>
 				{/if}
 			</dd>
@@ -24,7 +28,11 @@
 				<input type="text" id="activationCode" maxlength="9" name="activationCode" value="{@$activationCode}" required class="medium">
 				{if $errorField == 'activationCode'}
 					<small class="innerError">
-						{if $errorType == 'invalid'}{lang}wcf.user.activationCode.error.invalid{/lang}{/if}
+						{if $errorType == 'empty'}
+							{lang}wcf.global.form.error.empty{/lang}
+						{else}
+							{lang}wcf.user.activationCode.error.{@$errorType}{/lang}
+						{/if}
 					</small>
 				{/if}
 				<small><a href="{link controller='RegisterNewActivationCode'}{/link}">{lang}wcf.user.newActivationCode{/lang}</a></small>


### PR DESCRIPTION
As of now, not every template allows setting custom error types for input fields, which is pretty inflexible. Trying it (without dirty JS hacks) results in a broken output:

![image](https://user-images.githubusercontent.com/81188/129230757-78fcaac3-3c6c-458e-8a18-b7375adfb658.png)

Within WSC, this affects multiple templates.

/cc @TimWolla 