### PR TITLE
Fix unpacking of the sessionId

### DIFF
--- a/wcfsetup/install/files/lib/system/session/SessionHandler.class.php
+++ b/wcfsetup/install/files/lib/system/session/SessionHandler.class.php
@@ -242,6 +242,8 @@ final class SessionHandler extends SingletonFactory
                 ));
             }
             $data = \unpack('Cversion/a20sessionId/Ctimestep', $value);
+            \assert($data['version'] === 1);
+            \assert(\strlen($data['sessionId']) === 20);
             $data['sessionId'] = Hex::encode($data['sessionId']);
 
             return $data;

--- a/wcfsetup/install/files/lib/system/session/SessionHandler.class.php
+++ b/wcfsetup/install/files/lib/system/session/SessionHandler.class.php
@@ -241,7 +241,7 @@ final class SessionHandler extends SingletonFactory
                     $length
                 ));
             }
-            $data = \unpack('Cversion/A20sessionId/Ctimestep', $value);
+            $data = \unpack('Cversion/a20sessionId/Ctimestep', $value);
             $data['sessionId'] = Hex::encode($data['sessionId']);
 
             return $data;


### PR DESCRIPTION
As documented by PHP's reference documentation:

> The "a" code now retains trailing NULL bytes.
> The "A" code now strips all trailing ASCII whitespace (spaces, tabs,
> newlines, carriage returns, and NULL bytes).

Previously, with the 'A' code, sessionIds ending in ASCII whitespace would be
incorrectly unpacked, missing their trailing bytes. This ultimately resulted in
the session not being found and the user being logged out.

Five of the 256 possible characters exhibited this bug, making this fail in
roughly 2% of the cases.

However this likely was not noticable by the typical user. Once they have a
non-affected sessionId, this Id is not going to change. What the user might've
noticed is a login not working, despite showing a success message, because they
sessionId change after a successful login handed out an affected sessionId. But
then the user would likely try again, succeeding this time and writing off the
incident as a fluke.

Test script to reproduce the issue:

    <?php

    for ($i = 0; $i <= 255; $i++) {
        $string = "foo".chr($i);

        $packed = \pack(
            'CA4',
            1,
            $string
        );
        $unpacked1 = \unpack('Cversion/A4string', $packed);
        $unpacked2 = \unpack('Cversion/a4string', $packed);

        if ($unpacked1['string'] !== $string) {
            echo "$i: unpacked1\n";
        }
        if ($unpacked2['string'] !== $string) {
            echo "$i: unpacked2\n";
        }
    }
