### PR TITLE
Fix handling of cover photos in UserRebuildDataWorker

### DIFF
--- a/wcfsetup/install/files/lib/system/worker/UserRebuildDataWorker.class.php
+++ b/wcfsetup/install/files/lib/system/worker/UserRebuildDataWorker.class.php
@@ -300,6 +300,21 @@ class UserRebuildDataWorker extends AbstractRebuildDataWorker
             foreach ($userProfiles as $userProfile) {
                 $editor = new UserEditor($userProfile->getDecoratedObject());
                 $coverPhoto = $userProfile->getCoverPhoto(true);
+
+                // If neither the regular, nor the WebP variant is readable then the
+                // cover photo is missing and we must clear the database information.
+                if (
+                    !\is_readable($coverPhoto->getLocation(false))
+                    && !\is_readable($coverPhoto->getLocation(true))
+                ) {
+                    $editor->update([
+                        'coverPhotoHash' => null,
+                        'coverPhotoExtension' => '',
+                    ]);
+
+                    continue;
+                }
+
                 if ($coverPhoto instanceof IWebpUserCoverPhoto) {
                     $coverPhoto->createWebpVariant();
                     $editor->update([

--- a/wcfsetup/install/files/lib/system/worker/UserRebuildDataWorker.class.php
+++ b/wcfsetup/install/files/lib/system/worker/UserRebuildDataWorker.class.php
@@ -297,9 +297,13 @@ class UserRebuildDataWorker extends AbstractRebuildDataWorker
             $userProfiles->getConditionBuilder()->add("user_table.coverPhotoHash IS NOT NULL");
             $userProfiles->readObjects();
             foreach ($userProfiles as $userProfile) {
+                $editor = new UserEditor($userProfile->getDecoratedObject());
                 $coverPhoto = $userProfile->getCoverPhoto(true);
                 if ($coverPhoto instanceof IWebpUserCoverPhoto) {
                     $coverPhoto->createWebpVariant();
+                    $editor->update([
+                        'coverPhotoHasWebP' => 1,
+                    ]);
                 }
             }
         }

--- a/wcfsetup/install/files/lib/system/worker/UserRebuildDataWorker.class.php
+++ b/wcfsetup/install/files/lib/system/worker/UserRebuildDataWorker.class.php
@@ -295,6 +295,7 @@ class UserRebuildDataWorker extends AbstractRebuildDataWorker
             $userProfiles = new UserProfileList();
             $userProfiles->getConditionBuilder()->add("user_table.userID IN (?)", [$userIDs]);
             $userProfiles->getConditionBuilder()->add("user_table.coverPhotoHash IS NOT NULL");
+            $userProfiles->getConditionBuilder()->add("user_table.coverPhotoHasWebP = ?", [0]);
             $userProfiles->readObjects();
             foreach ($userProfiles as $userProfile) {
                 $editor = new UserEditor($userProfile->getDecoratedObject());


### PR DESCRIPTION
- Update `coverPhotoHasWebP` in UserRebuilDataWorker
- Check `coverPhotoHasWebP` in UserRebuildDataWorker
- Remove records of unreadable cover photos in UserRebuildDataWorker
