### PR TITLE
use default captcha type when creating `CaptchaFormField`

### DIFF
--- a/wcfsetup/install/files/lib/system/form/builder/field/CaptchaFormField.class.php
+++ b/wcfsetup/install/files/lib/system/form/builder/field/CaptchaFormField.class.php
@@ -49,6 +49,14 @@ class CaptchaFormField extends AbstractFormField implements IObjectTypeFormNode
     /**
      * @inheritDoc
      */
+    public function __construct()
+    {
+        $this->objectType(CAPTCHA_TYPE);
+    }
+
+    /**
+     * @inheritDoc
+     */
     public function cleanup()
     {
         try {


### PR DESCRIPTION
I assume by default one would want to use the captcha type selected by the administrator, so this might require one line less custom code than before.
When one needs a specific captcha type, he/she still can set it manually as done before.