### PR TITLE
Fix writing `runStandalone` attribute to package.xml

### DIFF
--- a/wcfsetup/install/files/lib/system/devtools/package/DevtoolsPackageXmlWriter.class.php
+++ b/wcfsetup/install/files/lib/system/devtools/package/DevtoolsPackageXmlWriter.class.php
@@ -173,7 +173,7 @@ class DevtoolsPackageXmlWriter
 
             foreach ($instructions['instructions'] as $instruction) {
                 $attributes = ['type' => $instruction['pip']];
-                if (!isset($instruction['runStandalone']) && $instruction['runStandalone'] !== "0") {
+                if (isset($instruction['runStandalone']) && $instruction['runStandalone'] !== "0") {
                     $attributes['run'] = 'standalone';
                 }
                 if (!empty($instruction['application'])) {


### PR DESCRIPTION
The bug was introduced with https://github.com/WoltLab/WCF/commit/a7034b4dddb139afa2094210bbd9d898ad029d8e.