### PR TITLE
Make `categoryMultiSelectOptionType.tpl` behave like `categoryOptionList.tpl`

### DIFF
--- a/wcfsetup/install/files/acp/templates/categoryMultiSelectOptionType.tpl
+++ b/wcfsetup/install/files/acp/templates/categoryMultiSelectOptionType.tpl
@@ -1,11 +1,7 @@
 <select id="{$option->optionName}" name="values[{$option->optionName}][]" multiple size="10">
-	{foreach from=$categoryList item=categoryItem}
-		<option value="{@$categoryItem->categoryID}"{if $categoryItem->categoryID|in_array:$value} selected{/if}>{$categoryItem->getTitle()}</option>
-		
-		{if $categoryItem->hasChildren()}
-			{foreach from=$categoryItem item=subCategoryItem}
-				<option value="{@$subCategoryItem->categoryID}"{if $subCategoryItem->categoryID|in_array:$value} selected{/if}>&nbsp;&nbsp;&nbsp;&nbsp;{$subCategoryItem->getTitle()}</option>
-			{/foreach}
+	{foreach from=$categoryList item='category'}
+		{if !$maximumNestingLevel|isset || $maximumNestingLevel == -1 || $categoryNodeList->getDepth() < $maximumNestingLevel}
+			<option value="{$category->categoryID}"{if $category->categoryID|in_array:$value} selected{/if}>{section name=i loop=$categoryList->getDepth()}&nbsp;&nbsp;&nbsp;&nbsp;{/section}{$category->getTitle()}</option>
 		{/if}
 	{/foreach}
 </select>

--- a/wcfsetup/install/files/lib/system/option/AbstractCategoryMultiSelectOptionType.class.php
+++ b/wcfsetup/install/files/lib/system/option/AbstractCategoryMultiSelectOptionType.class.php
@@ -35,7 +35,6 @@ abstract class AbstractCategoryMultiSelectOptionType extends AbstractOptionType 
 		/** @var CategoryNodeTree $categoryTree */
 		$categoryTree = new $this->nodeTreeClassname($this->objectType);
 		$categoryList = $categoryTree->getIterator();
-		$categoryList->setMaxDepth(0);
 		
 		WCF::getTPL()->assign([
 			'categoryList' => $categoryList,


### PR DESCRIPTION
Currently the `categoryMultiSelectOptionType.tpl` outputs nodes of depth 0 and depth 1,
but article categories for example can be nested deeper than that.
The `categoryOptionList.tpl` as used by the category add forms handles arbitrary nesting levels already,
so I’ve ported the template logic over to the multi select option template.
I’ve kept the `$maximumNestingLevel` checks, in case someone decides to override the `getFormElement()` function in their own option type.

The maximum nesting depth in the `AbstractCategoryMultiSelectOptionType.class.php` has been changed
to the default value (-1) to allow for infinite nesting depths.