### PR TITLE
Deprecate the escapeString() helper

### DIFF
--- a/wcfsetup/install/files/lib/core.functions.php
+++ b/wcfsetup/install/files/lib/core.functions.php
@@ -18,7 +18,7 @@ namespace {
 	spl_autoload_register([WCF::class, 'autoload']);
 	
 	/**
-	 * @deprecated 5.5 Use prepared statements if possible. Directly WCF::getDB()->escapeString() if prepared statements cannot be used.
+	 * @deprecated 5.5 Use prepared statements if possible. Directly call WCF::getDB()->escapeString() if prepared statements cannot be used.
 	 */
 	function escapeString($string) {
 		return WCF::getDB()->escapeString($string);

--- a/wcfsetup/install/files/lib/core.functions.php
+++ b/wcfsetup/install/files/lib/core.functions.php
@@ -18,11 +18,7 @@ namespace {
 	spl_autoload_register([WCF::class, 'autoload']);
 	
 	/**
-	 * Escapes a string for use in sql query.
-	 * 
-	 * @see	\wcf\system\database\Database::escapeString()
-	 * @param	string		$string
-	 * @return	string
+	 * @deprecated 5.5 Use prepared statements if possible. Directly WCF::getDB()->escapeString() if prepared statements cannot be used.
 	 */
 	function escapeString($string) {
 		return WCF::getDB()->escapeString($string);


### PR DESCRIPTION
Developers are strongly encouraged to use prepared statements. If this is not
possible for compatibility reasons, they should use the `->escapeString()`
method directly.

Deprecating the helper ultimately allows cleaning up core.functions.php which
has become a dumping ground for all type of stuff over time.
