### PR TITLE
Remove add() and update() from ISearchIndexManager

### DIFF
--- a/wcfsetup/install/files/lib/system/search/ISearchIndexManager.class.php
+++ b/wcfsetup/install/files/lib/system/search/ISearchIndexManager.class.php
@@ -38,58 +38,6 @@ interface ISearchIndexManager
     );
 
     /**
-     * Adds a new entry.
-     *
-     * @param string $objectType
-     * @param int $objectID
-     * @param string $message
-     * @param string $subject
-     * @param int $time
-     * @param int $userID
-     * @param string $username
-     * @param int $languageID
-     * @param string $metaData
-     * @deprecated  3.0 - please use `set()` instead
-     */
-    public function add(
-        $objectType,
-        $objectID,
-        $message,
-        $subject,
-        $time,
-        $userID,
-        $username,
-        $languageID = null,
-        $metaData = ''
-    );
-
-    /**
-     * Updates the search index.
-     *
-     * @param string $objectType
-     * @param int $objectID
-     * @param string $message
-     * @param string $subject
-     * @param int $time
-     * @param int $userID
-     * @param string $username
-     * @param int $languageID
-     * @param string $metaData
-     * @deprecated  3.0 - please use `set() instead`
-     */
-    public function update(
-        $objectType,
-        $objectID,
-        $message,
-        $subject,
-        $time,
-        $userID,
-        $username,
-        $languageID = null,
-        $metaData = ''
-    );
-
-    /**
      * Deletes search index entries.
      *
      * @param string $objectType

--- a/wcfsetup/install/files/lib/system/search/SearchIndexManager.class.php
+++ b/wcfsetup/install/files/lib/system/search/SearchIndexManager.class.php
@@ -130,7 +130,6 @@ class SearchIndexManager extends SingletonFactory implements ISearchIndexManager
     }
 
     /**
-     * @inheritDoc
      * @deprecated  3.0 - please use `set() instead`
      */
     public function add(
@@ -148,7 +147,6 @@ class SearchIndexManager extends SingletonFactory implements ISearchIndexManager
     }
 
     /**
-     * @inheritDoc
      * @deprecated  3.0 - please use `set() instead`
      */
     public function update(


### PR DESCRIPTION
These methods are long-deprecated, remove them from the interface to not force
search engine authors to implement these.

It is expected that code consuming the search API uses the `SearchIndexManager`
class instead of directly accessing a specific `*SearchIndexManager`. The
`SearchIndexManager` only uses `->set()` on the underlying actual
`*SearchIndexManager`. Thus no compatibility break is expected.
