### PR TITLE
Deprecate StringUtil::(starts|ends)With()

### DIFF
--- a/wcfsetup/install/files/acp/update_com.woltlab.wcf_5.5_starttls.php
+++ b/wcfsetup/install/files/acp/update_com.woltlab.wcf_5.5_starttls.php
@@ -13,14 +13,13 @@ use wcf\data\option\OptionAction;
 use wcf\system\email\Email;
 use wcf\system\email\transport\exception\TransientFailure;
 use wcf\system\io\RemoteFile;
-use wcf\util\StringUtil;
 
 if (MAIL_SMTP_STARTTLS != 'may') {
     return;
 }
 
 $value = 'encrypt';
-if (StringUtil::startsWith(MAIL_SMTP_HOST, 'ssl://')) {
+if (\str_starts_with(MAIL_SMTP_HOST, 'ssl://')) {
     // Anything using proper SSL can't use STARTTLS.
     $value = 'none';
 } elseif (MAIL_SMTP_PORT == 465) {

--- a/wcfsetup/install/files/lib/acp/form/ApplicationEditForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/ApplicationEditForm.class.php
@@ -171,7 +171,7 @@ class ApplicationEditForm extends AbstractForm
             $this->cookieDomain = $regex->replace($this->cookieDomain, '');
 
             // check if cookie domain shares the same domain (may exclude subdomains)
-            if (!StringUtil::endsWith($regex->replace($this->domainName, ''), $this->cookieDomain)) {
+            if (!\str_ends_with($regex->replace($this->domainName, ''), $this->cookieDomain)) {
                 throw new UserInputException('cookieDomain', 'invalid');
             }
         }

--- a/wcfsetup/install/files/lib/acp/form/ApplicationManagementForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/ApplicationManagementForm.class.php
@@ -125,7 +125,7 @@ final class ApplicationManagementForm extends AbstractForm
             $this->cookieDomain = $regex->replace($this->cookieDomain, '');
 
             // check if cookie domain shares the same domain (may exclude subdomains)
-            if (!StringUtil::endsWith($regex->replace($this->domainName, ''), $this->cookieDomain)) {
+            if (!\str_ends_with($regex->replace($this->domainName, ''), $this->cookieDomain)) {
                 throw new UserInputException('cookieDomain', 'invalid');
             }
         }

--- a/wcfsetup/install/files/lib/acp/form/PackageUpdateServerAddForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/PackageUpdateServerAddForm.class.php
@@ -93,7 +93,7 @@ class PackageUpdateServerAddForm extends AbstractForm
             throw new UserInputException('serverURL', 'invalid');
         }
 
-        if (StringUtil::endsWith(Url::parse($this->serverURL)['host'], '.woltlab.com', true)) {
+        if (\str_ends_with(Url::parse($this->serverURL)['host'], '.woltlab.com', true)) {
             throw new UserInputException('serverURL', 'woltlab');
         }
 

--- a/wcfsetup/install/files/lib/action/ImageProxyAction.class.php
+++ b/wcfsetup/install/files/lib/action/ImageProxyAction.class.php
@@ -117,7 +117,7 @@ class ImageProxyAction extends AbstractAction
                     // rewrite schemaless URLs to https
                     $scheme = Url::parse($url)['scheme'];
                     if (!$scheme) {
-                        if (StringUtil::startsWith($url, '//')) {
+                        if (\str_starts_with($url, '//')) {
                             $url = 'https:' . $url;
                         } else {
                             throw new \DomainException("Refusing to proxy a schemaless URL that does not start with //");

--- a/wcfsetup/install/files/lib/data/application/ApplicationAction.class.php
+++ b/wcfsetup/install/files/lib/data/application/ApplicationAction.class.php
@@ -7,7 +7,6 @@ use wcf\system\cache\builder\ApplicationCacheBuilder;
 use wcf\system\language\LanguageFactory;
 use wcf\system\Regex;
 use wcf\system\WCF;
-use wcf\util\StringUtil;
 
 /**
  * Executes application-related actions.
@@ -53,7 +52,7 @@ class ApplicationAction extends AbstractDatabaseObjectAction
         WCF::getDB()->beginTransaction();
         foreach ($this->getObjects() as $application) {
             $domainName = $application->domainName;
-            if (StringUtil::endsWith($regex->replace($domainName, ''), $application->cookieDomain)) {
+            if (\str_ends_with($regex->replace($domainName, ''), $application->cookieDomain)) {
                 $domainName = $application->cookieDomain;
             }
 

--- a/wcfsetup/install/files/lib/data/attachment/Attachment.class.php
+++ b/wcfsetup/install/files/lib/data/attachment/Attachment.class.php
@@ -10,7 +10,6 @@ use wcf\system\request\IRouteController;
 use wcf\system\request\LinkHandler;
 use wcf\system\WCF;
 use wcf\util\FileUtil;
-use wcf\util\StringUtil;
 
 /**
  * Represents an attachment.
@@ -199,7 +198,7 @@ class Attachment extends DatabaseObject implements ILinkableObject, IRouteContro
                 $this->getThumbnailLocation('tiny'),
             ] as $location
         ) {
-            if (!StringUtil::endsWith($location, '.bin')) {
+            if (!\str_ends_with($location, '.bin')) {
                 \rename($location, $location . '.bin');
             }
         }

--- a/wcfsetup/install/files/lib/data/style/StyleEditor.class.php
+++ b/wcfsetup/install/files/lib/data/style/StyleEditor.class.php
@@ -545,7 +545,7 @@ class StyleEditor extends DatabaseObjectEditor implements IEditableCachedObject
 
                         // copy templates
                         foreach ($templates as $template) {
-                            if (!StringUtil::endsWith($template['filename'], '.tpl')) {
+                            if (!\str_ends_with($template['filename'], '.tpl')) {
                                 continue;
                             }
 

--- a/wcfsetup/install/files/lib/data/user/UserProfile.class.php
+++ b/wcfsetup/install/files/lib/data/user/UserProfile.class.php
@@ -1015,7 +1015,7 @@ class UserProfile extends DatabaseObjectDecorator implements ITitledLinkObject
      */
     public function isConnectedWithFacebook()
     {
-        return StringUtil::startsWith($this->authData, 'facebook:');
+        return \str_starts_with($this->authData, 'facebook:');
     }
 
     /**
@@ -1023,7 +1023,7 @@ class UserProfile extends DatabaseObjectDecorator implements ITitledLinkObject
      */
     public function isConnectedWithGithub()
     {
-        return StringUtil::startsWith($this->authData, 'github:');
+        return \str_starts_with($this->authData, 'github:');
     }
 
     /**
@@ -1031,7 +1031,7 @@ class UserProfile extends DatabaseObjectDecorator implements ITitledLinkObject
      */
     public function isConnectedWithGoogle()
     {
-        return StringUtil::startsWith($this->authData, 'google:');
+        return \str_starts_with($this->authData, 'google:');
     }
 
     /**
@@ -1039,7 +1039,7 @@ class UserProfile extends DatabaseObjectDecorator implements ITitledLinkObject
      */
     public function isConnectedWithTwitter()
     {
-        return StringUtil::startsWith($this->authData, 'twitter:');
+        return \str_starts_with($this->authData, 'twitter:');
     }
 
     /**

--- a/wcfsetup/install/files/lib/form/AccountManagementForm.class.php
+++ b/wcfsetup/install/files/lib/form/AccountManagementForm.class.php
@@ -438,7 +438,7 @@ class AccountManagementForm extends AbstractForm
                 WCF::getSession()->unregister('__oauthUser');
             }
         }
-        if ($this->githubDisconnect && StringUtil::startsWith(WCF::getUser()->authData, 'github:')) {
+        if ($this->githubDisconnect && \str_starts_with(WCF::getUser()->authData, 'github:')) {
             $updateParameters['authData'] = '';
             $success[] = 'wcf.user.3rdparty.github.disconnect.success';
         }
@@ -456,7 +456,7 @@ class AccountManagementForm extends AbstractForm
                 WCF::getSession()->unregister('__oauthUser');
             }
         }
-        if ($this->twitterDisconnect && StringUtil::startsWith(WCF::getUser()->authData, 'twitter:')) {
+        if ($this->twitterDisconnect && \str_starts_with(WCF::getUser()->authData, 'twitter:')) {
             $updateParameters['authData'] = '';
             $success[] = 'wcf.user.3rdparty.twitter.disconnect.success';
         }
@@ -474,7 +474,7 @@ class AccountManagementForm extends AbstractForm
                 WCF::getSession()->unregister('__oauthUser');
             }
         }
-        if ($this->facebookDisconnect && StringUtil::startsWith(WCF::getUser()->authData, 'facebook:')) {
+        if ($this->facebookDisconnect && \str_starts_with(WCF::getUser()->authData, 'facebook:')) {
             $updateParameters['authData'] = '';
             $success[] = 'wcf.user.3rdparty.facebook.disconnect.success';
         }
@@ -492,7 +492,7 @@ class AccountManagementForm extends AbstractForm
                 WCF::getSession()->unregister('__oauthUser');
             }
         }
-        if ($this->googleDisconnect && StringUtil::startsWith(WCF::getUser()->authData, 'google:')) {
+        if ($this->googleDisconnect && \str_starts_with(WCF::getUser()->authData, 'google:')) {
             $updateParameters['authData'] = '';
             $success[] = 'wcf.user.3rdparty.google.disconnect.success';
         }

--- a/wcfsetup/install/files/lib/system/acl/ACLHandler.class.php
+++ b/wcfsetup/install/files/lib/system/acl/ACLHandler.class.php
@@ -14,7 +14,6 @@ use wcf\system\database\util\PreparedStatementConditionBuilder;
 use wcf\system\exception\SystemException;
 use wcf\system\SingletonFactory;
 use wcf\system\WCF;
-use wcf\util\StringUtil;
 
 /**
  * Handles ACL permissions.
@@ -446,7 +445,7 @@ class ACLHandler extends SingletonFactory
     {
         $optionList = new ACLOptionList();
         if (!empty($categoryName)) {
-            if (StringUtil::endsWith($categoryName, '.*')) {
+            if (\str_ends_with($categoryName, '.*')) {
                 $categoryName = \mb_substr($categoryName, 0, -1) . '%';
                 $optionList->getConditionBuilder()->add("acl_option.categoryName LIKE ?", [$categoryName]);
             } else {

--- a/wcfsetup/install/files/lib/system/email/Email.class.php
+++ b/wcfsetup/install/files/lib/system/email/Email.class.php
@@ -483,7 +483,7 @@ class Email
     public function addHeader($header, $value)
     {
         $header = \mb_strtolower($header);
-        if (!StringUtil::startsWith($header, 'x-')) {
+        if (!\str_starts_with($header, 'x-')) {
             throw new \DomainException(
                 "The header '{$header}' may not be set. You may only set user defined headers (starting with 'X-')."
             );

--- a/wcfsetup/install/files/lib/system/email/mime/AbstractMultipartMimePart.class.php
+++ b/wcfsetup/install/files/lib/system/email/mime/AbstractMultipartMimePart.class.php
@@ -139,7 +139,10 @@ abstract class AbstractMultipartMimePart extends AbstractMimePart implements IRe
                 );
             }
 
-            if (!StringUtil::startsWith($header[0], 'x-') && !StringUtil::startsWith($header[0], 'content-')) {
+            if (
+                !\str_starts_with($header[0], 'x-')
+                && !\str_starts_with($header[0], 'content-')
+            ) {
                 throw new \DomainException("The header '" . $header[0] . "' may not be set. You may only set headers starting with 'X-' or 'Content-'.");
             }
         }

--- a/wcfsetup/install/files/lib/system/email/transport/SmtpEmailTransport.class.php
+++ b/wcfsetup/install/files/lib/system/email/transport/SmtpEmailTransport.class.php
@@ -442,7 +442,7 @@ class SmtpEmailTransport implements IStatusReportingEmailTransport
             // o  Before sending a line of mail text, the SMTP client checks the
             //    first character of the line.  If it is a period, one additional
             //    period is inserted at the beginning of the line.
-            if (StringUtil::startsWith($item, '.')) {
+            if (\str_starts_with($item, '.')) {
                 return '.' . $item;
             }
 

--- a/wcfsetup/install/files/lib/system/style/StyleCompiler.class.php
+++ b/wcfsetup/install/files/lib/system/style/StyleCompiler.class.php
@@ -586,7 +586,7 @@ EOT;
     protected function compileStylesheet(string $scss, array $variables): string
     {
         foreach ($variables as &$value) {
-            if (StringUtil::startsWith($value, '../')) {
+            if (\str_starts_with($value, '../')) {
                 $value = '"' . $value . '"';
             }
         }

--- a/wcfsetup/install/files/lib/util/HeaderUtil.class.php
+++ b/wcfsetup/install/files/lib/util/HeaderUtil.class.php
@@ -65,10 +65,10 @@ final class HeaderUtil
         $addDomain = (\mb_strpos(
             $application->cookieDomain,
             '.'
-        ) === false || StringUtil::endsWith(
+        ) === false || \str_ends_with(
             $application->cookieDomain,
             '.lan'
-        ) || StringUtil::endsWith($application->cookieDomain, '.local')) ? false : true;
+        ) || \str_ends_with($application->cookieDomain, '.local')) ? false : true;
 
         if (!$addDomain) {
             return null;

--- a/wcfsetup/install/files/lib/util/StringUtil.class.php
+++ b/wcfsetup/install/files/lib/util/StringUtil.class.php
@@ -342,13 +342,7 @@ final class StringUtil
     }
 
     /**
-     * Checks whether $haystack starts with $needle, or not.
-     *
-     * @param string $haystack The string to be checked for starting with $needle
-     * @param string $needle The string to be found at the start of $haystack
-     * @param bool $ci Case insensitive or not. Default = false.
-     *
-     * @return  bool                True, if $haystack starts with $needle, false otherwise.
+     * @deprecated 5.5 Use \str_starts_with() instead. If a case-insensitive comparison is desired, manually call \mb_strtolower on both parameters.
      */
     public static function startsWith($haystack, $needle, $ci = false)
     {
@@ -361,12 +355,7 @@ final class StringUtil
     }
 
     /**
-     * Returns true if $haystack ends with $needle or if the length of $needle is 0.
-     *
-     * @param string $haystack
-     * @param string $needle
-     * @param bool $ci case insensitive
-     * @return  bool
+     * @deprecated 5.5 Use \str_ends_with() instead. If a case-insensitive comparison is desired, manually call \mb_strtolower on both parameters.
      */
     public static function endsWith($haystack, $needle, $ci = false)
     {

--- a/wcfsetup/install/files/lib/util/Url.class.php
+++ b/wcfsetup/install/files/lib/util/Url.class.php
@@ -208,7 +208,7 @@ final class Url implements \ArrayAccess
                     if ($isWildcard && \mb_strpos($hostname, $host) !== false) {
                         // the prepended dot will ensure that `example.com` matches only
                         // on domains like `foo.example.com` but not on `bar-example.com`
-                        if (StringUtil::endsWith($hostname, '.' . $host)) {
+                        if (\str_ends_with($hostname, '.' . $host)) {
                             $validHosts[$hostname] = $hostname;
 
                             return true;


### PR DESCRIPTION
- Deprecate `StringUtil::(starts|ends)With()`
- Replace use of `StringUtil::startsWith()` by `\str_starts_with()`
- Replace use of `StringUtil::endsWith()` by `\str_ends_with()`
