### PR TITLE
Improve phrasing for XSRF token error messages

### DIFF
--- a/wcfsetup/install/lang/de.xml
+++ b/wcfsetup/install/lang/de.xml
@@ -3297,7 +3297,7 @@ freigeschaltet. {if LANGUAGE_USE_INFORMAL_VARIANT}Du kannst{else}Sie können{/if
 		<item name="wcf.ajax.error.badRequest"><![CDATA[Die Anfrage war unvollständig und konnte nicht verarbeitet werden.]]></item>
 		<item name="wcf.ajax.error.internalError"><![CDATA[Es ist ein Fehler bei der Verarbeitung aufgetreten, bitte {if LANGUAGE_USE_INFORMAL_VARIANT}versuche{else}versuchen Sie{/if} es später erneut.]]></item>
 		<item name="wcf.ajax.error.permissionDenied"><![CDATA[{if LANGUAGE_USE_INFORMAL_VARIANT}Du besitzt{else}Sie besitzen{/if} leider nicht die notwendigen Zugriffsrechte, um diese Aktion auszuführen.]]></item>
-		<item name="wcf.ajax.error.sessionExpired"><![CDATA[{if LANGUAGE_USE_INFORMAL_VARIANT}Deine{else}Ihre{/if} Sitzung ist abgelaufen, bitte {if LANGUAGE_USE_INFORMAL_VARIANT}lade{else}laden Sie{/if} die Seite neu.]]></item>
+		<item name="wcf.ajax.error.sessionExpired"><![CDATA[Die Gültigkeit der Anfrage konnte aufgrund eines fehlerhaften XSRF-Tokens nicht verifiziert werden. Bitte {if LANGUAGE_USE_INFORMAL_VARIANT}lade{else}laden Sie{/if} die Seite neu und {if LANGUAGE_USE_INFORMAL_VARIANT}führe{else}führen Sie{/if} die Aktion erneut aus.]]></item>
 	</category>
 	<category name="wcf.article">
 		<item name="wcf.article.nextArticle"><![CDATA[Nächster Artikel]]></item>

--- a/wcfsetup/install/lang/de.xml
+++ b/wcfsetup/install/lang/de.xml
@@ -4012,7 +4012,7 @@ Dateianhänge:
 		<item name="wcf.global.form.error.lessThan"><![CDATA[Der eingegebene Wert muss kleiner sein als {#$lessThan}.]]></item>
 		<item name="wcf.global.form.error.multilingual"><![CDATA[Bitte {if LANGUAGE_USE_INFORMAL_VARIANT}fülle{else}füllen Sie{/if} dieses Eingabefeld für jede Sprache aus.]]></item>
 		<item name="wcf.global.form.error.noValidSelection"><![CDATA[{if LANGUAGE_USE_INFORMAL_VARIANT}Wähle{else}Wählen Sie{/if} eine der angebotenen Optionen aus.]]></item>
-		<item name="wcf.global.form.error.securityToken"><![CDATA[{if LANGUAGE_USE_INFORMAL_VARIANT}Deine{else}Ihre{/if} Sitzung ist abgelaufen, bitte {if LANGUAGE_USE_INFORMAL_VARIANT}sende{else}senden Sie{/if} das Formular erneut ab.]]></item>
+		<item name="wcf.global.form.error.securityToken"><![CDATA[Die Gültigkeit der Anfrage konnte aufgrund eines fehlerhaften XSRF-Tokens nicht verifiziert werden. Bitte {if LANGUAGE_USE_INFORMAL_VARIANT}sende{else}senden Sie{/if} das Formular erneut ab.]]></item>
 		<item name="wcf.global.form.input.maxItems"><![CDATA[Maximale Anzahl erreicht]]></item>
 		<!-- deprecated since 2.1 -->
 		<item name="wcf.global.form.error.lessThan.javaScript"><![CDATA[{literal}Der eingegebene Wert muss kleiner sein als {#$lessThan}.{/literal}]]></item>

--- a/wcfsetup/install/lang/en.xml
+++ b/wcfsetup/install/lang/en.xml
@@ -3223,7 +3223,7 @@ Your account on the website: {@PAGE_TITLE|language} [URL:{link isEmail=true}{/li
 		<item name="wcf.ajax.error.badRequest"><![CDATA[The server was unable to process your request due to an incomplete request.]]></item>
 		<item name="wcf.ajax.error.internalError"><![CDATA[The server encountered an unresolvable problem, please try again later.]]></item>
 		<item name="wcf.ajax.error.permissionDenied"><![CDATA[You are not authorized to execute this action.]]></item>
-		<item name="wcf.ajax.error.sessionExpired"><![CDATA[Your session has expired, please reload this page.]]></item>
+		<item name="wcf.ajax.error.sessionExpired"><![CDATA[The validity of your request could not be verified, because the XSRF token was invalid. Please reload the page and try performing the action again.]]></item>
 	</category>
 	<category name="wcf.article">
 		<item name="wcf.article.nextArticle"><![CDATA[Next Article]]></item>

--- a/wcfsetup/install/lang/en.xml
+++ b/wcfsetup/install/lang/en.xml
@@ -3959,7 +3959,7 @@ Attachments:
 		<item name="wcf.global.form.error.lessThan"><![CDATA[The entered value has to be less than {#$lessThan}.]]></item>
 		<item name="wcf.global.form.error.multilingual"><![CDATA[Please fill in this field for all languages.]]></item>
 		<item name="wcf.global.form.error.noValidSelection"><![CDATA[Choose one of the available options.]]></item>
-		<item name="wcf.global.form.error.securityToken"><![CDATA[Your session has expired, please submit the form again.]]></item>
+		<item name="wcf.global.form.error.securityToken"><![CDATA[The validity of your request could not be verified, because the XSRF token was invalid. Please submit the form again.]]></item>
 		<item name="wcf.global.form.input.maxItems"><![CDATA[Maximum items reached]]></item>
 		<!-- deprecated since 2.1 -->
 		<item name="wcf.global.form.error.greaterThan.javaScript"><![CDATA[{literal}The entered value has to be greater than {#$greaterThan}.{/literal}]]></item>


### PR DESCRIPTION
I intentionally included the acronym XSRF within the error message, because it
allows the user / administrator to Google what the error is about. Just telling
them “could not be verified” is a bit unclear and can imply an technical issue
on the server.

Resolves #4501
