### PR TITLE
Add TypeScript function to retrieve the XSRF-TOKEN

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -16,7 +16,6 @@ declare global {
     REACTION_TYPES: {
       [key: string]: Reaction;
     };
-    SECURITY_TOKEN: string;
     TIME_NOW: number;
     WCF_PATH: string;
     WSC_API_URL: string;

--- a/ts/WoltLabSuite/Core/Acp/Ui/Worker.ts
+++ b/ts/WoltLabSuite/Core/Acp/Ui/Worker.ts
@@ -148,7 +148,7 @@ class AcpUiWorker implements AjaxCallbackObject, DialogCallbackObject {
         parameters: this.options.parameters,
       },
       silent: true,
-      url: "index.php?worker-proxy/&t=" + window.SECURITY_TOKEN,
+      url: "index.php?worker-proxy/&t=" + Core.getXsrfToken(),
     };
   }
 

--- a/ts/WoltLabSuite/Core/Ajax.ts
+++ b/ts/WoltLabSuite/Core/Ajax.ts
@@ -10,6 +10,7 @@
 
 import AjaxRequest from "./Ajax/Request";
 import { AjaxCallbackObject, CallbackSuccess, CallbackFailure, RequestData, RequestOptions } from "./Ajax/Data";
+import { getXsrfToken } from "./Core";
 
 const _cache = new WeakMap();
 
@@ -37,7 +38,7 @@ export function api(
     options.callbackObject = callbackObject;
 
     if (!options.url) {
-      options.url = "index.php?ajax-proxy/&t=" + window.SECURITY_TOKEN;
+      options.url = "index.php?ajax-proxy/&t=" + getXsrfToken();
       options.withCredentials = true;
     }
 
@@ -78,7 +79,7 @@ export function apiOnce(options: RequestOptions): void {
   options.pinData = false;
   options.callbackObject = null;
   if (!options.url) {
-    options.url = "index.php?ajax-proxy/&t=" + window.SECURITY_TOKEN;
+    options.url = "index.php?ajax-proxy/&t=" + getXsrfToken();
     options.withCredentials = true;
   }
 

--- a/ts/WoltLabSuite/Core/Ajax.ts
+++ b/ts/WoltLabSuite/Core/Ajax.ts
@@ -10,7 +10,7 @@
 
 import AjaxRequest from "./Ajax/Request";
 import { AjaxCallbackObject, CallbackSuccess, CallbackFailure, RequestData, RequestOptions } from "./Ajax/Data";
-import { getXsrfToken } from "./Core";
+import * as Core from "./Core";
 
 const _cache = new WeakMap();
 
@@ -38,7 +38,7 @@ export function api(
     options.callbackObject = callbackObject;
 
     if (!options.url) {
-      options.url = "index.php?ajax-proxy/&t=" + getXsrfToken();
+      options.url = "index.php?ajax-proxy/&t=" + Core.getXsrfToken();
       options.withCredentials = true;
     }
 
@@ -79,7 +79,7 @@ export function apiOnce(options: RequestOptions): void {
   options.pinData = false;
   options.callbackObject = null;
   if (!options.url) {
-    options.url = "index.php?ajax-proxy/&t=" + getXsrfToken();
+    options.url = "index.php?ajax-proxy/&t=" + Core.getXsrfToken();
     options.withCredentials = true;
   }
 

--- a/ts/WoltLabSuite/Core/Core.ts
+++ b/ts/WoltLabSuite/Core/Core.ts
@@ -292,3 +292,7 @@ export function enableLegacyInheritance<T>(legacyClass: T): void {
     }
   };
 }
+
+export function getXsrfToken(): string {
+  return (window as any).SECURITY_TOKEN;
+}

--- a/ts/WoltLabSuite/Core/Form/Builder/Dialog.ts
+++ b/ts/WoltLabSuite/Core/Form/Builder/Dialog.ts
@@ -87,7 +87,7 @@ class FormBuilderDialog implements AjaxCallbackObject, DialogCallbackObject {
     // By default, `AJAXProxyAction` is used which relies on an `IDatabaseObjectAction` object; if
     // no such object is used but an `IAJAXInvokeAction` object, `AJAXInvokeAction` has to be used.
     if (!this._options.usesDboAction) {
-      options.url = "index.php?ajax-invoke/&t=" + window.SECURITY_TOKEN;
+      options.url = "index.php?ajax-invoke/&t=" + Core.getXsrfToken();
       options.withCredentials = true;
     }
 

--- a/ts/WoltLabSuite/Core/Ui/File/Delete.ts
+++ b/ts/WoltLabSuite/Core/Ui/File/Delete.ts
@@ -170,7 +170,7 @@ class UiFileDelete implements AjaxCallbackObject {
 
   _ajaxSetup(): ReturnType<AjaxCallbackSetup> {
     return {
-      url: "index.php?ajax-file-delete/&t=" + window.SECURITY_TOKEN,
+      url: "index.php?ajax-file-delete/&t=" + Core.getXsrfToken(),
     };
   }
 }

--- a/ts/WoltLabSuite/Core/Ui/File/Upload.ts
+++ b/ts/WoltLabSuite/Core/Ui/File/Upload.ts
@@ -63,7 +63,7 @@ class FileUpload extends Upload<FileUploadOptions> implements FileUploadHandler 
         // Dummy value, because it is checked in the base method, without using it with this upload handler.
         className: "invalid",
         // url
-        url: `index.php?ajax-file-upload/&t=${window.SECURITY_TOKEN}`,
+        url: `index.php?ajax-file-upload/&t=${Core.getXsrfToken()}`,
       },
       options,
     );

--- a/ts/WoltLabSuite/Core/Ui/User/Session/Delete.ts
+++ b/ts/WoltLabSuite/Core/Ui/User/Session/Delete.ts
@@ -13,6 +13,7 @@ import { AjaxCallbackObject, AjaxCallbackSetup, DatabaseObjectActionResponse } f
 import * as UiNotification from "../../Notification";
 import * as UiConfirmation from "../../Confirmation";
 import * as Language from "../../../Language";
+import { getXsrfToken } from "../../../Core";
 
 export class UiUserSessionDelete implements AjaxCallbackObject {
   private readonly knownElements = new Map<string, HTMLElement>();
@@ -66,7 +67,7 @@ export class UiUserSessionDelete implements AjaxCallbackObject {
 
   _ajaxSetup(): ReturnType<AjaxCallbackSetup> {
     return {
-      url: "index.php?delete-session/&t=" + window.SECURITY_TOKEN,
+      url: "index.php?delete-session/&t=" + getXsrfToken(),
     };
   }
 }

--- a/ts/WoltLabSuite/Core/Ui/User/Session/Delete.ts
+++ b/ts/WoltLabSuite/Core/Ui/User/Session/Delete.ts
@@ -13,7 +13,7 @@ import { AjaxCallbackObject, AjaxCallbackSetup, DatabaseObjectActionResponse } f
 import * as UiNotification from "../../Notification";
 import * as UiConfirmation from "../../Confirmation";
 import * as Language from "../../../Language";
-import { getXsrfToken } from "../../../Core";
+import * as Core from "../../../Core";
 
 export class UiUserSessionDelete implements AjaxCallbackObject {
   private readonly knownElements = new Map<string, HTMLElement>();
@@ -67,7 +67,7 @@ export class UiUserSessionDelete implements AjaxCallbackObject {
 
   _ajaxSetup(): ReturnType<AjaxCallbackSetup> {
     return {
-      url: "index.php?delete-session/&t=" + getXsrfToken(),
+      url: "index.php?delete-session/&t=" + Core.getXsrfToken(),
     };
   }
 }

--- a/ts/WoltLabSuite/Core/Upload.ts
+++ b/ts/WoltLabSuite/Core/Upload.ts
@@ -46,7 +46,7 @@ abstract class Upload<TOptions extends UploadOptions = UploadOptions> {
         // is true if every file from a multi-file selection is uploaded in its own request
         singleFileRequests: false,
         // url for uploading file
-        url: `index.php?ajax-upload/&t=${window.SECURITY_TOKEN}`,
+        url: `index.php?ajax-upload/&t=${Core.getXsrfToken()}`,
       },
       options,
     ) as TOptions;

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Acp/Ui/Worker.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Acp/Ui/Worker.js
@@ -97,7 +97,7 @@ define(["require", "exports", "tslib", "../../Ajax", "../../Core", "../../Langua
                     parameters: this.options.parameters,
                 },
                 silent: true,
-                url: "index.php?worker-proxy/&t=" + window.SECURITY_TOKEN,
+                url: "index.php?worker-proxy/&t=" + Core.getXsrfToken(),
             };
         }
         _dialogSetup() {

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ajax.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ajax.js
@@ -7,11 +7,12 @@
  * @module  Ajax (alias)
  * @module  WoltLabSuite/Core/Ajax
  */
-define(["require", "exports", "tslib", "./Ajax/Request", "./Core"], function (require, exports, tslib_1, Request_1, Core_1) {
+define(["require", "exports", "tslib", "./Ajax/Request", "./Core"], function (require, exports, tslib_1, Request_1, Core) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.getRequestObject = exports.apiOnce = exports.api = void 0;
     Request_1 = (0, tslib_1.__importDefault)(Request_1);
+    Core = (0, tslib_1.__importStar)(Core);
     const _cache = new WeakMap();
     /**
      * Shorthand function to perform a request against the WCF-API with overrides
@@ -29,7 +30,7 @@ define(["require", "exports", "tslib", "./Ajax/Request", "./Core"], function (re
             options.pinData = true;
             options.callbackObject = callbackObject;
             if (!options.url) {
-                options.url = "index.php?ajax-proxy/&t=" + (0, Core_1.getXsrfToken)();
+                options.url = "index.php?ajax-proxy/&t=" + Core.getXsrfToken();
                 options.withCredentials = true;
             }
             request = new Request_1.default(options);
@@ -65,7 +66,7 @@ define(["require", "exports", "tslib", "./Ajax/Request", "./Core"], function (re
         options.pinData = false;
         options.callbackObject = null;
         if (!options.url) {
-            options.url = "index.php?ajax-proxy/&t=" + (0, Core_1.getXsrfToken)();
+            options.url = "index.php?ajax-proxy/&t=" + Core.getXsrfToken();
             options.withCredentials = true;
         }
         const request = new Request_1.default(options);

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ajax.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ajax.js
@@ -7,7 +7,7 @@
  * @module  Ajax (alias)
  * @module  WoltLabSuite/Core/Ajax
  */
-define(["require", "exports", "tslib", "./Ajax/Request"], function (require, exports, tslib_1, Request_1) {
+define(["require", "exports", "tslib", "./Ajax/Request", "./Core"], function (require, exports, tslib_1, Request_1, Core_1) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.getRequestObject = exports.apiOnce = exports.api = void 0;
@@ -29,7 +29,7 @@ define(["require", "exports", "tslib", "./Ajax/Request"], function (require, exp
             options.pinData = true;
             options.callbackObject = callbackObject;
             if (!options.url) {
-                options.url = "index.php?ajax-proxy/&t=" + window.SECURITY_TOKEN;
+                options.url = "index.php?ajax-proxy/&t=" + (0, Core_1.getXsrfToken)();
                 options.withCredentials = true;
             }
             request = new Request_1.default(options);
@@ -65,7 +65,7 @@ define(["require", "exports", "tslib", "./Ajax/Request"], function (require, exp
         options.pinData = false;
         options.callbackObject = null;
         if (!options.url) {
-            options.url = "index.php?ajax-proxy/&t=" + window.SECURITY_TOKEN;
+            options.url = "index.php?ajax-proxy/&t=" + (0, Core_1.getXsrfToken)();
             options.withCredentials = true;
         }
         const request = new Request_1.default(options);

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Core.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Core.js
@@ -10,7 +10,7 @@
 define(["require", "exports"], function (require, exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
-    exports.enableLegacyInheritance = exports.debounce = exports.stringToBool = exports.getStoragePrefix = exports.triggerEvent = exports.serialize = exports.getUuid = exports.getType = exports.isPlainObject = exports.inherit = exports.extend = exports.convertLegacyUrl = exports.clone = void 0;
+    exports.getXsrfToken = exports.enableLegacyInheritance = exports.debounce = exports.stringToBool = exports.getStoragePrefix = exports.triggerEvent = exports.serialize = exports.getUuid = exports.getType = exports.isPlainObject = exports.inherit = exports.extend = exports.convertLegacyUrl = exports.clone = void 0;
     const _clone = function (variable) {
         if (typeof variable === "object" && (Array.isArray(variable) || isPlainObject(variable))) {
             return _cloneObject(variable);
@@ -258,4 +258,8 @@ define(["require", "exports"], function (require, exports) {
         };
     }
     exports.enableLegacyInheritance = enableLegacyInheritance;
+    function getXsrfToken() {
+        return window.SECURITY_TOKEN;
+    }
+    exports.getXsrfToken = getXsrfToken;
 });

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Form/Builder/Dialog.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Form/Builder/Dialog.js
@@ -54,7 +54,7 @@ define(["require", "exports", "tslib", "../../Core", "../../Ui/Dialog", "../../A
             // By default, `AJAXProxyAction` is used which relies on an `IDatabaseObjectAction` object; if
             // no such object is used but an `IAJAXInvokeAction` object, `AJAXInvokeAction` has to be used.
             if (!this._options.usesDboAction) {
-                options.url = "index.php?ajax-invoke/&t=" + window.SECURITY_TOKEN;
+                options.url = "index.php?ajax-invoke/&t=" + Core.getXsrfToken();
                 options.withCredentials = true;
             }
             return options;

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/File/Delete.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/File/Delete.js
@@ -123,7 +123,7 @@ define(["require", "exports", "tslib", "../../Ajax", "../../Core", "../../Dom/Ch
         }
         _ajaxSetup() {
             return {
-                url: "index.php?ajax-file-delete/&t=" + window.SECURITY_TOKEN,
+                url: "index.php?ajax-file-delete/&t=" + Core.getXsrfToken(),
             };
         }
     }

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/File/Upload.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/File/Upload.js
@@ -30,7 +30,7 @@ define(["require", "exports", "tslib", "../../Core", "./Delete", "../../Dom/Util
                 // Dummy value, because it is checked in the base method, without using it with this upload handler.
                 className: "invalid",
                 // url
-                url: `index.php?ajax-file-upload/&t=${window.SECURITY_TOKEN}`,
+                url: `index.php?ajax-file-upload/&t=${Core.getXsrfToken()}`,
             }, options);
             options.multiple = options.maxFiles === null || options.maxFiles > 1;
             super(buttonContainerId, targetId, options);

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/User/Session/Delete.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/User/Session/Delete.js
@@ -7,7 +7,7 @@
  * @module  WoltLabSuite/Core/Ui/User/Session/Delete
  * @woltlabExcludeBundle all
  */
-define(["require", "exports", "tslib", "../../../Ajax", "../../Notification", "../../Confirmation", "../../../Language", "../../../Core"], function (require, exports, tslib_1, Ajax, UiNotification, UiConfirmation, Language, Core_1) {
+define(["require", "exports", "tslib", "../../../Ajax", "../../Notification", "../../Confirmation", "../../../Language", "../../../Core"], function (require, exports, tslib_1, Ajax, UiNotification, UiConfirmation, Language, Core) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.UiUserSessionDelete = void 0;
@@ -15,6 +15,7 @@ define(["require", "exports", "tslib", "../../../Ajax", "../../Notification", ".
     UiNotification = (0, tslib_1.__importStar)(UiNotification);
     UiConfirmation = (0, tslib_1.__importStar)(UiConfirmation);
     Language = (0, tslib_1.__importStar)(Language);
+    Core = (0, tslib_1.__importStar)(Core);
     class UiUserSessionDelete {
         /**
          * Initializes the session delete buttons.
@@ -57,7 +58,7 @@ define(["require", "exports", "tslib", "../../../Ajax", "../../Notification", ".
         }
         _ajaxSetup() {
             return {
-                url: "index.php?delete-session/&t=" + (0, Core_1.getXsrfToken)(),
+                url: "index.php?delete-session/&t=" + Core.getXsrfToken(),
             };
         }
     }

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/User/Session/Delete.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/User/Session/Delete.js
@@ -7,7 +7,7 @@
  * @module  WoltLabSuite/Core/Ui/User/Session/Delete
  * @woltlabExcludeBundle all
  */
-define(["require", "exports", "tslib", "../../../Ajax", "../../Notification", "../../Confirmation", "../../../Language"], function (require, exports, tslib_1, Ajax, UiNotification, UiConfirmation, Language) {
+define(["require", "exports", "tslib", "../../../Ajax", "../../Notification", "../../Confirmation", "../../../Language", "../../../Core"], function (require, exports, tslib_1, Ajax, UiNotification, UiConfirmation, Language, Core_1) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.UiUserSessionDelete = void 0;
@@ -57,7 +57,7 @@ define(["require", "exports", "tslib", "../../../Ajax", "../../Notification", ".
         }
         _ajaxSetup() {
             return {
-                url: "index.php?delete-session/&t=" + window.SECURITY_TOKEN,
+                url: "index.php?delete-session/&t=" + (0, Core_1.getXsrfToken)(),
             };
         }
     }

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Upload.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Upload.js
@@ -38,7 +38,7 @@ define(["require", "exports", "tslib", "./Ajax/Request", "./Core", "./Dom/Change
                 // is true if every file from a multi-file selection is uploaded in its own request
                 singleFileRequests: false,
                 // url for uploading file
-                url: `index.php?ajax-upload/&t=${window.SECURITY_TOKEN}`,
+                url: `index.php?ajax-upload/&t=${Core.getXsrfToken()}`,
             }, options);
             this._options.url = Core.convertLegacyUrl(this._options.url);
             if (this._options.url.indexOf("index.php") === 0) {


### PR DESCRIPTION
This is intended to ease future changes, e.g. by allowing the code to always
retrieve the latest token from the cookie, instead of relying on the
effectively immutable value set at page load. In the long run this will also
allow to reduce the number of globals on the `window` object.

On the PHP side the use of the `SECURITY_TOKEN` constants have already been
deprecated in 5.4.

see #3609
see 3f6a261b1e6a3804370eb1e2a046ea6c666dbedd
