### PR TITLE
Decrease the session cookie lifetime leeway to 1 week

### DIFF
--- a/wcfsetup/install/files/lib/system/session/SessionHandler.class.php
+++ b/wcfsetup/install/files/lib/system/session/SessionHandler.class.php
@@ -396,7 +396,7 @@ final class SessionHandler extends SingletonFactory
         HeaderUtil::setCookie(
             'user_session',
             $this->getCookieValue(),
-            TIME_NOW + (self::USER_SESSION_LIFETIME * 2)
+            TIME_NOW + (self::USER_SESSION_LIFETIME + (7 * 86400))
         );
     }
 
@@ -1094,7 +1094,7 @@ final class SessionHandler extends SingletonFactory
             HeaderUtil::setCookie(
                 'user_session',
                 $this->getCookieValue(),
-                TIME_NOW + (self::USER_SESSION_LIFETIME * 2)
+                TIME_NOW + (self::USER_SESSION_LIFETIME + (7 * 86400))
             );
         }
     }


### PR DESCRIPTION
With the increase of the user session lifetime to 2 months, simply multiplying
by two results in an excessive cookie lifetime.

Decrease this to a constant leeway of 1 week. If the cookie in the browser
expires, the session on the server should be long gone, even for wildly
incorrect local clocks.
