### PR TITLE
Remove return value for AbstractSearchIndexManager::createSearchIndex()

### DIFF
--- a/wcfsetup/install/files/lib/system/search/AbstractSearchIndexManager.class.php
+++ b/wcfsetup/install/files/lib/system/search/AbstractSearchIndexManager.class.php
@@ -58,11 +58,7 @@ abstract class AbstractSearchIndexManager extends SingletonFactory implements IS
     }
 
     /**
-     * Creates the search index for given object type. Returns true if the
-     * index was created, otherwise false.
-     *
-     * @param ObjectType $objectType
-     * @return  bool
+     * Creates the search index for given object type.
      */
     abstract protected function createSearchIndex(ObjectType $objectType);
 


### PR DESCRIPTION
Returning this boolean value does not appear to be useful at all, as there is
no reason why the state after this method finishes should be that the INDEX
does not actually exist (except in case of an Exception). Whether or not it
previously existed is irrelevant.

In fact this method is `protected` and the return value is not used at all,
thus it is safe to remove this requirement.
