### PR TITLE
Truncate the maximum length of the input JSON in error message when failing to decode

### DIFF
--- a/wcfsetup/install/files/lib/util/JSON.class.php
+++ b/wcfsetup/install/files/lib/util/JSON.class.php
@@ -36,11 +36,14 @@ final class JSON
      */
     public static function decode($json, $asArray = true)
     {
-        // decodes JSON
         $data = @\json_decode($json, $asArray);
 
         if ($data === null && self::getLastError() !== \JSON_ERROR_NONE) {
-            throw new SystemException('Could not decode JSON (error ' . self::getLastError() . '): ' . $json);
+            throw new SystemException(\sprintf(
+                'Could not decode JSON (error %d): %s',
+                self::getLastError(),
+                StringUtil::truncate($json, 250, StringUtil::HELLIP, true)
+            ));
         }
 
         return $data;


### PR DESCRIPTION
Stop this from bloating the error log in case of huge responses.
