### PR TITLE
Configure emergency timeout in HTTPRequest

### DIFF
--- a/wcfsetup/install/files/lib/util/HTTPRequest.class.php
+++ b/wcfsetup/install/files/lib/util/HTTPRequest.class.php
@@ -167,6 +167,12 @@ final class HTTPRequest {
 		};
 		
 		$options = [
+			// We cannot use the 'timeout' value as the overall timeout for compatibility with
+			// pre-Guzzle users. However the combined connect and read timeout is not sufficient to
+			// reliably terminate all requests timely. Thus we configure a large emergency timeout to
+			// either the configured timeout or 10 minutes (whichever is larger). This ensures that the
+			// request terminates eventually and the PHP worker will be freed.
+			'timeout' => \max($this->options['timeout'], 10 * 60),
 			'connect_timeout' => $this->options['timeout'],
 			'read_timeout' => $this->options['timeout'],
 			'allow_redirects' => [


### PR DESCRIPTION
The connect and read timeouts might not reliably trigger in all cases.
Configure a large overall timeout to ensure PHP workers will terminate
eventually.

/cc @SoftCreatR
