### PR TITLE
Replace empty redirect responses in notifications with link to notifi…

### DIFF
--- a/wcfsetup/install/files/lib/action/NotificationConfirmAction.class.php
+++ b/wcfsetup/install/files/lib/action/NotificationConfirmAction.class.php
@@ -8,8 +8,10 @@ use wcf\data\user\notification\event\UserNotificationEvent;
 use wcf\data\user\notification\UserNotification;
 use wcf\data\user\User;
 use wcf\data\user\UserProfile;
+use wcf\page\NotificationListPage;
 use wcf\system\exception\IllegalLinkException;
 use wcf\system\exception\PermissionDeniedException;
+use wcf\system\request\LinkHandler;
 use wcf\system\user\notification\event\IUserNotificationEvent;
 use wcf\system\user\notification\UserNotificationHandler;
 use wcf\system\WCF;
@@ -98,8 +100,14 @@ class NotificationConfirmAction extends AbstractAction
             $this->notification->additionalData
         );
 
-        return new RedirectResponse(
-            $notificationEvent->getLink()
-        );
+        // The notification link can be `null` (e.g. for some moderation notifications).
+        // This would trigger an exception further in the code, because the PSR7 redirect response
+        // expect a real URL. For this reason, we rewrite `null` with a link to the NotificationListPage.
+        $link = $notificationEvent->getLink();
+        if ($link === null) {
+            $link = LinkHandler::getInstance()->getControllerLink(NotificationListPage::class);
+        }
+
+        return new RedirectResponse($link);
     }
 }

--- a/wcfsetup/install/files/lib/system/user/notification/event/IUserNotificationEvent.class.php
+++ b/wcfsetup/install/files/lib/system/user/notification/event/IUserNotificationEvent.class.php
@@ -38,7 +38,12 @@ interface IUserNotificationEvent extends IDatabaseObjectProcessor
     /**
      * Returns object link.
      *
-     * @return  string
+     * The returned value can be `null` however, this should be avoided as much as possible.
+     * If the returned value is `null`, the NotificationListPage will be used a link, on any
+     * place, where the link is required (e.g. in the NotificationConfirmAction). After the
+     * confirmation of the notification, the notification is not clickable anymore.
+     *
+     * @return  ?string
      */
     public function getLink();
 


### PR DESCRIPTION
…cation list

The notification link can be `null` (e.g. for some moderation notifications). This would trigger an exception further in the code, because the PSR7 redirect response expect a real URL. For this reason, we rewrite `null` with a link to the NotificationListPage.