### PR TITLE
Replace charset directly after head

### DIFF
--- a/com.woltlab.wcf/templates/headInclude.tpl
+++ b/com.woltlab.wcf/templates/headInclude.tpl
@@ -1,4 +1,3 @@
-<meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="format-detection" content="telephone=no">
 {if $allowSpidersToIndexThisPage|empty && ($__wcf->getActivePage() == null || !$__wcf->getActivePage()->allowSpidersToIndex)}<meta name="robots" content="noindex,nofollow">{/if}

--- a/com.woltlab.wcf/templates/header.tpl
+++ b/com.woltlab.wcf/templates/header.tpl
@@ -1,6 +1,7 @@
 {include file='documentHeader'}
 
 <head>
+	<meta charset="utf-8">
 	{if !$pageTitle|isset}
 		{assign var='pageTitle' value=''}
 		{if (!$__wcf->isLandingPage() || !USE_PAGE_TITLE_ON_LANDING_PAGE) && $__wcf->getActivePage() != null && $__wcf->getActivePage()->getTitle()}


### PR DESCRIPTION
The `charset` meta element should be the first thing in `<head>`.
Further reading: https://webhint.io/docs/user-guide/hints/hint-meta-charset-utf-8/