### PR TITLE
Deprecate ILoggingAwareException

### DIFF
--- a/wcfsetup/install/files/lib/core.functions.php
+++ b/wcfsetup/install/files/lib/core.functions.php
@@ -246,6 +246,7 @@ namespace wcf\functions\exception {
 		// let the Exception know it has been logged
 		$prev = $e;
 		do {
+			/** @deprecated 5.5 The ILoggingAwareException interface and feature is deprecated. See the interface for details. */
 			if (
 				$prev instanceof ILoggingAwareException
 				|| (method_exists($prev, 'finalizeLog') && is_callable([$prev, 'finalizeLog']))

--- a/wcfsetup/install/files/lib/system/exception/ILoggingAwareException.class.php
+++ b/wcfsetup/install/files/lib/system/exception/ILoggingAwareException.class.php
@@ -3,13 +3,7 @@
 namespace wcf\system\exception;
 
 /**
- * Indicates that the exception should be let known if it was logged.
- *
- * @author      Tim Duesterhus
- * @copyright   2001-2021 WoltLab GmbH
- * @license     GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
- * @package     WoltLabSuite\Core\System\Exception
- * @since       5.4
+ * @deprecated 5.5 Either use 'IExtraInformationException' or include the necessary information within the message.
  */
 interface ILoggingAwareException extends \Throwable
 {


### PR DESCRIPTION
The `finalizeLog()` method was initially added to support
com.woltlab.wcf.elasticSearch, as it logged the full - possibly huge -
Elasticsearch response, allowing it to log the response into a separate log
file.

This came with severe usability issues, as this log file is not readily
available from the ACP.

The Elasticsearch package was completely cleaned up, relying on the regular
Guzzle exceptions, and errors during JSON decoding no longer include the full
JSON.

Letting the Exception know that they've been logged is a layering violation
that will not play along nicely with #4342. The current method signature also
is pretty much limited to logging into files only.

Deprecate the interface, now that the only known user is gone.
