### PR TITLE
Include an explicit `NULL` within a column definition unless the column is NOT NULL

### DIFF
--- a/wcfsetup/install/files/lib/system/database/editor/MySQLDatabaseEditor.class.php
+++ b/wcfsetup/install/files/lib/system/database/editor/MySQLDatabaseEditor.class.php
@@ -466,6 +466,8 @@ class MySQLDatabaseEditor extends DatabaseEditor
         // not null / null
         if (!empty($columnData['notNull'])) {
             $definition .= " NOT NULL";
+        } else {
+            $definition .= " NULL";
         }
         // default
         if (isset($columnData['default']) && $columnData['default'] !== '') {


### PR DESCRIPTION
This improves error detection, because MySQL will not silently make the column
`NOT NULL` if it is part of a `PRIMARY KEY`. Instead it will error out:

> SQLSTATE[42000]: Syntax error or access violation: 1171 All parts of a
> PRIMARY KEY must be NOT NULL; if you need NULL in a key, use UNIQUE instead
