### PR TITLE
Move all of the style deletion logic into StyleEditor

### DIFF
--- a/wcfsetup/install/files/lib/data/style/StyleAction.class.php
+++ b/wcfsetup/install/files/lib/data/style/StyleAction.class.php
@@ -127,35 +127,7 @@ class StyleAction extends AbstractDatabaseObjectAction implements IToggleAction
     }
 
     /**
-     * @inheritDoc
-     */
-    public function delete()
-    {
-        $count = parent::delete();
-
-        foreach ($this->getObjects() as $style) {
-            // remove custom images
-            if ($style->imagePath && $style->imagePath != 'images/') {
-                $this->removeDirectory($style->imagePath);
-            }
-
-            // remove preview image
-            $previewImage = WCF_DIR . 'images/' . $style->image;
-            if (\file_exists($previewImage)) {
-                @\unlink($previewImage);
-            }
-
-            // remove stylesheet
-            StyleHandler::getInstance()->resetStylesheet($style->getDecoratedObject());
-        }
-
-        return $count;
-    }
-
-    /**
-     * Recursively removes a directory and all it's contents.
-     *
-     * @param string $pathComponent
+     * @deprecated 5.4 This method is unused.
      */
     protected function removeDirectory($pathComponent)
     {


### PR DESCRIPTION
This ensures that all the files on the filesystem are deleted no matter how the
style is deleted. Previously the style's image folder remained when
StyleEditor::delete() was used, for example within the style PIP.
