### PR TITLE
Remove link from requestURI in acpSessionLog

### DIFF
--- a/wcfsetup/install/files/acp/templates/acpSessionLog.tpl
+++ b/wcfsetup/install/files/acp/templates/acpSessionLog.tpl
@@ -43,7 +43,7 @@
 						<td class="columnURL columnIpAddress{if $sessionAccessLog->ipAddress != $sessionLog->ipAddress} hot{/if}">{$sessionAccessLog->getIpAddress()}</td>
 						<td class="columnDate columnTime">{@$sessionAccessLog->time|time}</td>
 						<td class="columnText columnClassName">{$sessionAccessLog->className}</td>
-						<td class="columnURL columnRequestURI" title="{$sessionAccessLog->requestURI}">{if !$sessionAccessLog->hasProtectedURI()}<a href="{$sessionAccessLog->requestURI}">{$sessionAccessLog->requestURI|truncate:50|tableWordwrap}</a>{else}{$sessionAccessLog->requestURI|truncate:50|tableWordwrap}{/if}</td>
+						<td class="columnURL columnRequestURI" title="{$sessionAccessLog->requestURI}">{$sessionAccessLog->requestURI|truncate:50|tableWordwrap}</td>
 						<td class="columnText columnRequestMethod">{$sessionAccessLog->requestMethod}</td>
 						
 						{event name='columns'}

--- a/wcfsetup/install/files/lib/data/acp/session/access/log/ACPSessionAccessLog.class.php
+++ b/wcfsetup/install/files/lib/data/acp/session/access/log/ACPSessionAccessLog.class.php
@@ -29,17 +29,11 @@ class ACPSessionAccessLog extends DatabaseObject
     protected static $databaseTableIndexName = 'sessionAccessLogID';
 
     /**
-     * Returns true if the URI of this log entry is protected.
-     *
-     * @return  bool
+     * @since 5.5 This method is long broken.
      */
     public function hasProtectedURI()
     {
-        if ($this->requestMethod != 'GET' || !\preg_match('/(\?|&)(page|form)=/', $this->requestURI)) {
-            return true;
-        }
-
-        return false;
+        return true;
     }
 
     /**


### PR DESCRIPTION
The link has been non-functional since ages, because `hasProtectedURI()`
effectively always returned `true`, as the `page` and `form` query parameters
are no longer in use.

With WoltLab Suite 5.4 the `requestURI` might also contain a request ID and the
link length is also limited to 255 characters.

All in all it appears that supporting a link within the log is non-trivial,
with the benefit being rather small.

Resolves #4524
