### PR TITLE
Clean up attachment tmpHash handling in WYSIWYG autosave

### DIFF
--- a/wcfsetup/install/files/js/WCF.Attachment.js
+++ b/wcfsetup/install/files/js/WCF.Attachment.js
@@ -114,11 +114,11 @@ WCF.Attachment.Upload = WCF.Upload.extend({
 				}
 				
 				// Remove any existing entries for this tmpHash.
-				data.tmpHashes = data.tmpHashes.filter((item) => item != tmpHash);
+				data.tmpHashes = data.tmpHashes.filter((item) => item !== tmpHash);
 				
 				var count = this._fileListSelector.children('li:not(.uploadFailed)').length;
 				if (count > 0) {
-					// Add a new entry for this tmpHash if successful uploads exist.
+					// Add a new entry for this tmpHash if files have been uploaded.
 					data.tmpHashes.push(tmpHash);
 				}
 			}).bind(this));

--- a/wcfsetup/install/files/js/WCF.Attachment.js
+++ b/wcfsetup/install/files/js/WCF.Attachment.js
@@ -113,16 +113,13 @@ WCF.Attachment.Upload = WCF.Upload.extend({
 					data.tmpHashes = [];
 				}
 				
-				var index = data.tmpHashes.indexOf(tmpHash);
+				// Remove any existing entries for this tmpHash.
+				data.tmpHashes = data.tmpHashes.filter((item) => item != tmpHash);
 				
 				var count = this._fileListSelector.children('li:not(.uploadFailed)').length;
 				if (count > 0) {
-					if (index === -1) {
-						data.tmpHashes.push(tmpHash);
-					}
-				}
-				else if (index !== -1) {
-					data.tmpHashes.splice(index);
+					// Add a new entry for this tmpHash if successful uploads exist.
+					data.tmpHashes.push(tmpHash);
 				}
 			}).bind(this));
 			


### PR DESCRIPTION
The previous `.splice()` call was erroneous because it might remove more
entries in case the to-be-removed entry is not the last within the array for
whatever reason.

Replace the whole logic with a modern `.filter()`, cleanly filtering out all
existing entries for the current `tmpHash` and then readding it, if it still is
required.
