### PR TITLE
Fix Image width of the unfurl card images

### DIFF
--- a/wcfsetup/install/files/style/ui/unfurlUrl.scss
+++ b/wcfsetup/install/files/style/ui/unfurlUrl.scss
@@ -17,7 +17,7 @@
 			height: 200px !important;
 			object-fit: cover;
 			object-position: center;
-			width: 600px;
+			width: 400px;
 		}
 	}
 


### PR DESCRIPTION
Looks like it was missed while uniufying the width of the card itself, see:
https://github.com/WoltLab/WCF/commit/533e1ed2861322b3b598797492f2a99f8d06841a