### PR TITLE
Fix suffix declaration in XSD

### DIFF
--- a/XSD/option.xsd
+++ b/XSD/option.xsd
@@ -41,7 +41,6 @@
 					<xs:element name="showorder" type="xs:unsignedInt" minOccurs="0" />
 					<xs:element name="options" type="woltlab_varchar_nullable" minOccurs="0" />
 					<xs:element name="permissions" type="woltlab_varchar_nullable" minOccurs="0" />
-					<xs:element name="suffix" type="xs:string" minOccurs="0" />
 				</xs:all>
 			</xs:extension>
 		</xs:complexContent>
@@ -70,6 +69,7 @@
 					<xs:element name="options" type="xs:string" minOccurs="0" />
 					<xs:element name="permissions" type="xs:string" minOccurs="0" />
 					<xs:element name="supporti18n" type="woltlab_boolean" minOccurs="0" />
+					<xs:element name="suffix" type="xs:string" minOccurs="0" />
 				</xs:all>
 			</xs:extension>
 		</xs:complexContent>


### PR DESCRIPTION
As of now, a suffix is only allowed for option categories, which is wrong, because a suffix can only be applied to an option itself.