### PR TITLE
Clean up handling of in-use usernames and email addresses

### DIFF
--- a/wcfsetup/install/files/lib/acp/form/UserAddForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/UserAddForm.class.php
@@ -366,7 +366,7 @@ class UserAddForm extends UserOptionListForm
         }
 
         // Check if email exists already.
-        if (!UserUtil::isAvailableEmail($email)) {
+        if (User::getUserByEmail($email)->userID) {
             throw new UserInputException('email', 'notUnique');
         }
 

--- a/wcfsetup/install/files/lib/acp/form/UserAddForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/UserAddForm.class.php
@@ -3,6 +3,7 @@
 namespace wcf\acp\form;
 
 use wcf\data\user\group\UserGroup;
+use wcf\data\user\User;
 use wcf\data\user\UserAction;
 use wcf\form\AbstractForm;
 use wcf\system\bbcode\BBCodeHandler;
@@ -341,7 +342,7 @@ class UserAddForm extends UserOptionListForm
         }
 
         // Check if username exists already.
-        if (!UserUtil::isAvailableUsername($username)) {
+        if (User::getUserByUsername($username)->userID) {
             throw new UserInputException('username', 'notUnique');
         }
     }

--- a/wcfsetup/install/files/lib/acp/form/UserEditForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/UserEditForm.class.php
@@ -547,8 +547,19 @@ class UserEditForm extends UserAddForm
      */
     protected function validateUsername($username)
     {
-        if (\mb_strtolower($this->user->username) != \mb_strtolower($username)) {
-            parent::validateUsername($username);
+        try {
+            if (\mb_strtolower($this->user->username) != \mb_strtolower($username)) {
+                parent::validateUsername($username);
+            }
+        } catch (UserInputException $e) {
+            if ($e->getField() === 'username' && $e->getType() === 'notUnique') {
+                $user2 = User::getUserByUsername($username);
+                if ($user2->userID != $this->user->userID) {
+                    throw $e;
+                }
+            } else {
+                throw $e;
+            }
         }
     }
 

--- a/wcfsetup/install/files/lib/data/TMessageQuickReplyGuestDialogAction.class.php
+++ b/wcfsetup/install/files/lib/data/TMessageQuickReplyGuestDialogAction.class.php
@@ -3,12 +3,12 @@
 namespace wcf\data;
 
 use wcf\data\object\type\ObjectType;
+use wcf\data\user\User;
 use wcf\system\captcha\CaptchaHandler;
 use wcf\system\captcha\ICaptchaHandler;
 use wcf\system\exception\UserInputException;
 use wcf\system\WCF;
 use wcf\util\UserRegistrationUtil;
-use wcf\util\UserUtil;
 
 /**
  * Provides methods related to the guest dialog of message quick reply.
@@ -117,7 +117,7 @@ trait TMessageQuickReplyGuestDialogAction
             if (!UserRegistrationUtil::isValidUsername($this->parameters['data']['username'])) {
                 throw new UserInputException('username', 'invalid');
             }
-            if (!UserUtil::isAvailableUsername($this->parameters['data']['username'])) {
+            if (User::getUserByUsername($this->parameters['data']['username'])->userID) {
                 throw new UserInputException('username', 'notUnique');
             }
         } catch (UserInputException $e) {

--- a/wcfsetup/install/files/lib/data/comment/CommentAction.class.php
+++ b/wcfsetup/install/files/lib/data/comment/CommentAction.class.php
@@ -11,6 +11,7 @@ use wcf\data\comment\response\StructuredCommentResponse;
 use wcf\data\IMessageInlineEditorAction;
 use wcf\data\object\type\ObjectType;
 use wcf\data\object\type\ObjectTypeCache;
+use wcf\data\user\User;
 use wcf\system\bbcode\BBCodeHandler;
 use wcf\system\captcha\CaptchaHandler;
 use wcf\system\comment\CommentHandler;
@@ -35,7 +36,6 @@ use wcf\system\user\notification\UserNotificationHandler;
 use wcf\system\WCF;
 use wcf\util\MessageUtil;
 use wcf\util\UserRegistrationUtil;
-use wcf\util\UserUtil;
 
 /**
  * Executes comment-related actions.
@@ -1423,7 +1423,7 @@ class CommentAction extends AbstractDatabaseObjectAction implements IMessageInli
             if (!UserRegistrationUtil::isValidUsername($this->parameters['data']['username'])) {
                 throw new UserInputException('username', 'invalid');
             }
-            if (!UserUtil::isAvailableUsername($this->parameters['data']['username'])) {
+            if (User::getUserByUsername($this->parameters['data']['username'])->userID) {
                 throw new UserInputException('username', 'notUnique');
             }
         } catch (UserInputException $e) {

--- a/wcfsetup/install/files/lib/data/user/UserRegistrationAction.class.php
+++ b/wcfsetup/install/files/lib/data/user/UserRegistrationAction.class.php
@@ -60,7 +60,7 @@ class UserRegistrationAction extends UserAction
             ];
         }
 
-        if (!UserUtil::isAvailableUsername($this->parameters['username'])) {
+        if (User::getUserByUsername($this->parameters['username'])->userID) {
             return [
                 'isValid' => false,
                 'error' => 'notUnique',

--- a/wcfsetup/install/files/lib/data/user/UserRegistrationAction.class.php
+++ b/wcfsetup/install/files/lib/data/user/UserRegistrationAction.class.php
@@ -3,7 +3,6 @@
 namespace wcf\data\user;
 
 use wcf\util\UserRegistrationUtil;
-use wcf\util\UserUtil;
 
 /**
  * Executes user registration-related actions.
@@ -86,7 +85,7 @@ class UserRegistrationAction extends UserAction
             ];
         }
 
-        if (!UserUtil::isAvailableEmail($this->parameters['email'])) {
+        if (User::getUserByEmail($this->parameters['email'])->userID) {
             return [
                 'isValid' => false,
                 'error' => 'notUnique',

--- a/wcfsetup/install/files/lib/form/AccountManagementForm.class.php
+++ b/wcfsetup/install/files/lib/form/AccountManagementForm.class.php
@@ -247,7 +247,8 @@ class AccountManagementForm extends AbstractForm
                 }
 
                 // checks if user name exists already.
-                if (User::getUserByUsername($this->username)->userID) {
+                $user2 = User::getUserByUsername($this->username);
+                if ($user2->userID && $user2->userID != WCF::getUser()->userID) {
                     throw new UserInputException('username', 'notUnique');
                 }
             }

--- a/wcfsetup/install/files/lib/form/AccountManagementForm.class.php
+++ b/wcfsetup/install/files/lib/form/AccountManagementForm.class.php
@@ -16,7 +16,6 @@ use wcf\system\WCF;
 use wcf\util\JSON;
 use wcf\util\StringUtil;
 use wcf\util\UserRegistrationUtil;
-use wcf\util\UserUtil;
 
 /**
  * Shows the account management form.
@@ -293,7 +292,7 @@ class AccountManagementForm extends AbstractForm
                 }
 
                 // checks if email already exists.
-                if (!UserUtil::isAvailableEmail($this->email)) {
+                if (User::getUserByEmail($this->email)->userID) {
                     throw new UserInputException('email', 'notUnique');
                 }
             }

--- a/wcfsetup/install/files/lib/form/AccountManagementForm.class.php
+++ b/wcfsetup/install/files/lib/form/AccountManagementForm.class.php
@@ -248,7 +248,7 @@ class AccountManagementForm extends AbstractForm
                 }
 
                 // checks if user name exists already.
-                if (!UserUtil::isAvailableUsername($this->username)) {
+                if (User::getUserByUsername($this->username)->userID) {
                     throw new UserInputException('username', 'notUnique');
                 }
             }

--- a/wcfsetup/install/files/lib/form/EmailActivationForm.class.php
+++ b/wcfsetup/install/files/lib/form/EmailActivationForm.class.php
@@ -11,7 +11,6 @@ use wcf\system\exception\UserInputException;
 use wcf\system\request\LinkHandler;
 use wcf\system\WCF;
 use wcf\util\HeaderUtil;
-use wcf\util\UserUtil;
 
 /**
  * Shows the email activation form.
@@ -90,7 +89,7 @@ class EmailActivationForm extends AbstractForm
         }
 
         // check whether the new email isn't unique anymore
-        if (!UserUtil::isAvailableEmail($this->user->newEmail)) {
+        if (User::getUserByEmail($this->user->newEmail)->userID) {
             throw new NamedUserException(WCF::getLanguage()->get('wcf.user.email.error.notUnique'));
         }
 

--- a/wcfsetup/install/files/lib/form/RegisterNewActivationCodeForm.class.php
+++ b/wcfsetup/install/files/lib/form/RegisterNewActivationCodeForm.class.php
@@ -16,7 +16,6 @@ use wcf\system\WCF;
 use wcf\util\HeaderUtil;
 use wcf\util\StringUtil;
 use wcf\util\UserRegistrationUtil;
-use wcf\util\UserUtil;
 
 /**
  * Shows the new activation code form.
@@ -148,7 +147,7 @@ class RegisterNewActivationCodeForm extends AbstractForm
                 }
 
                 // Check if email exists already.
-                if (!UserUtil::isAvailableEmail($this->email)) {
+                if (User::getUserByEmail($this->email)->userID) {
                     throw new UserInputException('email', 'notUnique');
                 }
             } else {

--- a/wcfsetup/install/files/lib/system/form/builder/field/user/UsernameFormField.class.php
+++ b/wcfsetup/install/files/lib/system/form/builder/field/user/UsernameFormField.class.php
@@ -2,6 +2,7 @@
 
 namespace wcf\system\form\builder\field\user;
 
+use wcf\data\user\User;
 use wcf\system\form\builder\field\AbstractFormField;
 use wcf\system\form\builder\field\IAttributeFormField;
 use wcf\system\form\builder\field\IAutoCompleteFormField;
@@ -132,7 +133,7 @@ class UsernameFormField extends AbstractFormField implements
                         'invalid',
                         'wcf.form.field.username.error.invalid'
                     ));
-                } elseif (!UserUtil::isAvailableUsername($this->getValue())) {
+                } elseif (User::getUserByUsername($this->getValue())->userID) {
                     $this->addValidationError(new FormFieldValidationError(
                         'notUnique',
                         'wcf.form.field.username.error.notUnique'

--- a/wcfsetup/install/files/lib/util/UserUtil.class.php
+++ b/wcfsetup/install/files/lib/util/UserUtil.class.php
@@ -89,10 +89,7 @@ final class UserUtil
     }
 
     /**
-     * Returns true if the given email address is available.
-     *
-     * @param string $email
-     * @return  bool
+     * @deprecated 5.5 Check whether `User::getUserByEmail()->userID` is truthy.
      */
     public static function isAvailableEmail($email)
     {

--- a/wcfsetup/install/files/lib/util/UserUtil.class.php
+++ b/wcfsetup/install/files/lib/util/UserUtil.class.php
@@ -47,10 +47,7 @@ final class UserUtil
     }
 
     /**
-     * Returns true if the given username is available.
-     *
-     * @param string $name
-     * @return  bool
+     * @deprecated 5.5 Check whether `User::getUserByUsername()->userID` is truthy.
      */
     public static function isAvailableUsername($name)
     {


### PR DESCRIPTION
I've opted to deprecate the methods in UserUtil, instead of e.g. adding a new
`User $doNotConflictWith` parameter, because using
`User::getUserByUsername()->userID` is equally easy to understand and because
database queries to not really belong into a util class.
