### PR TITLE
Enforce a consistent return type

### DIFF
--- a/wcfsetup/install/files/lib/system/html/node/AbstractHtmlNodeProcessor.class.php
+++ b/wcfsetup/install/files/lib/system/html/node/AbstractHtmlNodeProcessor.class.php
@@ -265,21 +265,21 @@ abstract class AbstractHtmlNodeProcessor implements IHtmlNodeProcessor
      */
     public function parseAttributes($attributes)
     {
-        if (empty($attributes)) {
-            return [];
-        }
+        if (!empty($attributes)) {
+            $parsedAttributes = \base64_decode($attributes, true);
+            if ($parsedAttributes !== false) {
+                try {
+                    $parsedAttributes = JSON::decode($parsedAttributes);
+                } catch (SystemException $e) {
+                    /* parse errors can occur if user provided malicious content - ignore them */
+                    $parsedAttributes = [];
+                }
 
-        $parsedAttributes = \base64_decode($attributes, true);
-        if ($parsedAttributes !== false) {
-            try {
-                $parsedAttributes = JSON::decode($parsedAttributes);
-            } catch (SystemException $e) {
-                /* parse errors can occur if user provided malicious content - ignore them */
-                $parsedAttributes = [];
+                return $parsedAttributes;
             }
         }
 
-        return $parsedAttributes;
+        return [];
     }
 
     /**


### PR DESCRIPTION
The method was designed to always return an array. If the `\base64_code()` fails, it returned `false` instead, which was both unexpected and could fail in PHP 8.1 (autovivification on false, https://wiki.php.net/rfc/autovivification_false).

**It is recommended to ignore whitespace changes.**