### PR TITLE
Mark the SMTP email transport as recommended

### DIFF
--- a/wcfsetup/install/lang/de.xml
+++ b/wcfsetup/install/lang/de.xml
@@ -1364,7 +1364,7 @@ ACHTUNG: Die oben genannten Meldungen sind stark gekürzt. Sie können Details z
 		<item name="wcf.acp.option.mail_send_method.debug"><![CDATA[Debug (mbox)]]></item>
 		<item name="wcf.acp.option.mail_send_method.debugFolder"><![CDATA[Debug (Ordner mit .eml-Dateien)]]></item>
 		<item name="wcf.acp.option.mail_send_method.php"><![CDATA[PHP]]></item>
-		<item name="wcf.acp.option.mail_send_method.smtp"><![CDATA[SMTP]]></item>
+		<item name="wcf.acp.option.mail_send_method.smtp"><![CDATA[SMTP (empfohlen)]]></item>
 		<item name="wcf.acp.option.mail_signature"><![CDATA[Signatur (Text)]]></item>
 		<item name="wcf.acp.option.mail_signature.description"><![CDATA[Die Signatur wird an jede automatisch generierte E-Mail angehängt.]]></item>
 		<item name="wcf.acp.option.mail_signature_html"><![CDATA[Signatur (HTML)]]></item>

--- a/wcfsetup/install/lang/en.xml
+++ b/wcfsetup/install/lang/en.xml
@@ -1342,7 +1342,7 @@ ATTENTION: The messages listed above are greatly shortened. You can view details
 		<item name="wcf.acp.option.mail_send_method.debug"><![CDATA[Use Debug (mbox)]]></item>
 		<item name="wcf.acp.option.mail_send_method.debugFolder"><![CDATA[Use Debug (Folder with .eml files)]]></item>
 		<item name="wcf.acp.option.mail_send_method.php"><![CDATA[Use PHP]]></item>
-		<item name="wcf.acp.option.mail_send_method.smtp"><![CDATA[Use SMTP]]></item>
+		<item name="wcf.acp.option.mail_send_method.smtp"><![CDATA[Use SMTP (recommended)]]></item>
 		<item name="wcf.acp.option.mail_signature"><![CDATA[Sender’s Signature (Text)]]></item>
 		<item name="wcf.acp.option.mail_signature.description"><![CDATA[The signature that will be appended to every message.]]></item>
 		<item name="wcf.acp.option.mail_signature_html"><![CDATA[Sender’s Signature (HTML)]]></item>


### PR DESCRIPTION
It appears to be a constant source of discussion which of the supported email
transports is the best one. Mark the SMTP transport as recommended to solve
this issue. The SMTP transport gives the best insight into the delivery process
for the software and thus is preferred.
