### PR TITLE
Update `htmlspecialchars` flags for PHP 8.1 default

### DIFF
--- a/wcfsetup/install/files/lib/util/StringUtil.class.php
+++ b/wcfsetup/install/files/lib/util/StringUtil.class.php
@@ -143,12 +143,12 @@ final class StringUtil
      */
     public static function encodeJSON($string)
     {
-        $string = self::encodeJS($string);
+        $string = self::unifyNewlines($string);
 
-        $string = self::encodeHTML($string);
+        // This differs from encodeJS() by not encoding the single quote.
+        $string = \str_replace(["\\", '"', "\n", "/"], ["\\\\", '\\"', '\\n', '\\/'], $string);
 
-        // single quotes must be encoded as HTML entity
-        return \str_replace("\\'", "&#39;", $string);
+        return self::encodeHTML($string);
     }
 
     /**

--- a/wcfsetup/install/files/lib/util/StringUtil.class.php
+++ b/wcfsetup/install/files/lib/util/StringUtil.class.php
@@ -119,7 +119,11 @@ final class StringUtil
      */
     public static function encodeHTML($string)
     {
-        return @\htmlspecialchars((string)$string, \ENT_COMPAT, 'UTF-8');
+        return @\htmlspecialchars(
+            (string)$string,
+            \ENT_QUOTES | \ENT_SUBSTITUTE | \ENT_HTML401,
+            'UTF-8'
+        );
     }
 
     /**


### PR DESCRIPTION
This change:

- Encodes `'` as `&#039;`, whereas it previously was not touched.
- Inserts the Unicode replacement character instead of returning an empty
  string when an invalid UTF-8 sequence is passed.

The first change might slightly improve security, whereas the second change
might improve debugging.

see also: https://php.watch/versions/8.1/html-entity-default-value-changes
