### PR TITLE
Fix PHP 8.1 compatibility when saving I18n options

### DIFF
--- a/wcfsetup/install/files/lib/system/option/OptionHandler.class.php
+++ b/wcfsetup/install/files/lib/system/option/OptionHandler.class.php
@@ -393,18 +393,22 @@ class OptionHandler implements IOptionHandler
         // get new value
         $newValue = $this->rawValues[$option->optionName] ?? null;
 
-        // get save value
-        $this->optionValues[$option->optionName] = $typeObj->getData($option, $newValue);
+        // Skip validation for I18n options. They are special cased and are not provided
+        // within the `rawValues`, thus causing validation to be effectively useless.
+        if (!$this->supportI18n || !$option->supportI18n) {
+            // get save value
+            $this->optionValues[$option->optionName] = $typeObj->getData($option, $newValue);
 
-        // validate with pattern
-        if ($option->validationPattern) {
-            if (
-                !\preg_match(
-                    '~' . \str_replace('~', '\~', $option->validationPattern) . '~',
-                    $this->optionValues[$option->optionName]
-                )
-            ) {
-                throw new UserInputException($option->optionName, 'validationFailed');
+            // validate with pattern
+            if ($option->validationPattern) {
+                if (
+                    !\preg_match(
+                        '~' . \str_replace('~', '\~', $option->validationPattern) . '~',
+                        $this->optionValues[$option->optionName]
+                    )
+                ) {
+                    throw new UserInputException($option->optionName, 'validationFailed');
+                }
             }
         }
 


### PR DESCRIPTION
Really not sure whether this is the best way to fix this, or if a special
`null` check should be added to each option type. It's really evident here that
the option handling shows its age when looking at control and data flow.

------

As I18n options are special-cased, they will not be provided in `rawValues`,
thus passing `null` to `->getData()`, which the option types are not prepared
to handle. Before PHP 8.1 this was implicitly treated as an empty string, with
the types introduced to native functions, e.g. `explode()` or `preg_replace()`
this will result in an error.
