### PR TITLE
Add size detection for WebP smileys

### DIFF
--- a/wcfsetup/install/files/lib/data/smiley/Smiley.class.php
+++ b/wcfsetup/install/files/lib/data/smiley/Smiley.class.php
@@ -88,7 +88,7 @@ class Smiley extends DatabaseObject implements ITitledObject
             $this->height = $this->width = 0;
 
             $file = WCF_DIR . $this->smileyPath;
-            if (\file_exists($file) && \preg_match('~\.(gif|jpe?g|png)$~', $file)) {
+            if (\file_exists($file) && \preg_match('~\.(gif|jpe?g|png|webp)$~', $file)) {
                 $data = \getimagesize($file);
                 if ($data !== false) {
                     // The first two indices of `getimagesize()` represent the image dimensions.


### PR DESCRIPTION
As of now, `Smiley::getDimensions()` only returns sizes for gif, jpg & png files. It would be good, if webp files are also supported.