### PR TITLE
Count article comments based on ArticleContent

### DIFF
--- a/com.woltlab.wcf/templates/articleComments.tpl
+++ b/com.woltlab.wcf/templates/articleComments.tpl
@@ -1,6 +1,6 @@
 {if $commentList|count || $commentCanAdd}
 	<section id="comments" class="section sectionContainerList">
-		<h2 class="sectionTitle">{lang}wcf.global.comments{/lang}{if $article->comments} <span class="badge">{#$article->comments}</span>{/if}</h2>
+		<h2 class="sectionTitle">{lang}wcf.global.comments{/lang}{if $articleContent->comments} <span class="badge">{#$articleContent->comments}</span>{/if}</h2>
 		
 		{include file='__commentJavaScript' commentContainerID='articleCommentList'}
 		

--- a/wcfsetup/install/files/acp/database/update_com.woltlab.wcf_5.5.php
+++ b/wcfsetup/install/files/acp/database/update_com.woltlab.wcf_5.5.php
@@ -11,10 +11,23 @@
 
 use wcf\system\database\table\column\DefaultFalseBooleanDatabaseTableColumn;
 use wcf\system\database\table\column\EnumDatabaseTableColumn;
+use wcf\system\database\table\column\SmallintDatabaseTableColumn;
 use wcf\system\database\table\index\DatabaseTableIndex;
 use wcf\system\database\table\PartialDatabaseTable;
 
 return [
+    PartialDatabaseTable::create('wcf1_article')
+        ->columns([
+            SmallintDatabaseTableColumn::create('comments')
+                ->drop(),
+        ]),
+    PartialDatabaseTable::create('wcf1_article_content')
+        ->columns([
+            SmallintDatabaseTableColumn::create('comments')
+                ->length(5)
+                ->notNull()
+                ->defaultValue(0),
+        ]),
     PartialDatabaseTable::create('wcf1_blacklist_entry')
         ->indices([
             DatabaseTableIndex::create('lastSeen')

--- a/wcfsetup/install/files/lib/system/article/discussion/CommentArticleDiscussionProvider.class.php
+++ b/wcfsetup/install/files/lib/system/article/discussion/CommentArticleDiscussionProvider.class.php
@@ -3,7 +3,6 @@
 namespace wcf\system\article\discussion;
 
 use wcf\data\article\Article;
-use wcf\data\article\content\ArticleContent;
 use wcf\system\comment\CommentHandler;
 use wcf\system\WCF;
 

--- a/wcfsetup/install/files/lib/system/article/discussion/CommentArticleDiscussionProvider.class.php
+++ b/wcfsetup/install/files/lib/system/article/discussion/CommentArticleDiscussionProvider.class.php
@@ -33,7 +33,7 @@ class CommentArticleDiscussionProvider extends AbstractArticleDiscussionProvider
     {
         return WCF::getLanguage()->getDynamicVariable('wcf.article.articleComments', [
             'articleContent' => $this->articleContent ?: $this->article->getArticleContent(),
-            'article' => $this->article, // kept line for backward compatibility in 3rd party translations 
+            'article' => $this->article, // kept line for backward compatibility in 3rd party translations
         ]);
     }
 

--- a/wcfsetup/install/files/lib/system/article/discussion/CommentArticleDiscussionProvider.class.php
+++ b/wcfsetup/install/files/lib/system/article/discussion/CommentArticleDiscussionProvider.class.php
@@ -3,6 +3,7 @@
 namespace wcf\system\article\discussion;
 
 use wcf\data\article\Article;
+use wcf\data\article\content\ArticleContent;
 use wcf\system\comment\CommentHandler;
 use wcf\system\WCF;
 
@@ -22,7 +23,7 @@ class CommentArticleDiscussionProvider extends AbstractArticleDiscussionProvider
      */
     public function getDiscussionCount()
     {
-        return $this->article->comments;
+        return $this->articleContent ? $this->articleContent->comments : $this->article->getArticleContent()->comments;
     }
 
     /**
@@ -30,7 +31,10 @@ class CommentArticleDiscussionProvider extends AbstractArticleDiscussionProvider
      */
     public function getDiscussionCountPhrase()
     {
-        return WCF::getLanguage()->getDynamicVariable('wcf.article.articleComments', ['article' => $this->article]);
+        return WCF::getLanguage()->getDynamicVariable('wcf.article.articleComments', [
+            'articleContent' => $this->articleContent ?: $this->article->getArticleContent(),
+            'article' => $this->article, // kept line for backward compatibility in 3rd party translations 
+        ]);
     }
 
     /**

--- a/wcfsetup/install/files/lib/system/comment/manager/ArticleCommentManager.class.php
+++ b/wcfsetup/install/files/lib/system/comment/manager/ArticleCommentManager.class.php
@@ -2,8 +2,8 @@
 
 namespace wcf\system\comment\manager;
 
-use wcf\data\article\ArticleEditor;
 use wcf\data\article\content\ArticleContent;
+use wcf\data\article\content\ArticleContentEditor;
 use wcf\data\article\content\ArticleContentList;
 use wcf\data\object\type\ObjectTypeCache;
 use wcf\system\cache\runtime\UserProfileRuntimeCache;
@@ -97,8 +97,7 @@ class ArticleCommentManager extends AbstractCommentManager implements IViewableL
      */
     public function updateCounter($objectID, $value)
     {
-        $articleContent = new ArticleContent($objectID);
-        $editor = new ArticleEditor($articleContent->getArticle());
+        $editor = new ArticleContentEditor(new ArticleContent($objectID));
         $editor->updateCounters([
             'comments' => $value,
         ]);

--- a/wcfsetup/install/lang/de.xml
+++ b/wcfsetup/install/lang/de.xml
@@ -3302,7 +3302,7 @@ freigeschaltet. {if LANGUAGE_USE_INFORMAL_VARIANT}Du kannst{else}Sie können{/if
 		<item name="wcf.article.relatedArticles"><![CDATA[Verwandte Artikel]]></item>
 		<item name="wcf.article.moreArticles"><![CDATA[Weitere Artikel]]></item>
 		<item name="wcf.article.aboutAuthor"><![CDATA[Über den Autor]]></item>
-		<item name="wcf.article.articleComments"><![CDATA[{#$article->comments} Kommentar{if $article->comments != 1}e{/if}]]></item>
+		<item name="wcf.article.articleComments"><![CDATA[{plural value=$articleContent->comments one='1 Kommentar' other='# Kommentare'}]]></item>
 		<item name="wcf.article.articleViews"><![CDATA[{#$article->views} Mal gelesen]]></item>
 		<item name="wcf.article.recentActivity.likedArticle"><![CDATA[Hat mit <span title="{$reactionType->getTitle()}" class="jsTooltip">{@$reactionType->renderIcon()}</span> auf den Artikel <a href="{$article->getLink()}">{$article->getTitle()}</a> reagiert.]]></item>
 		<item name="wcf.article.recentActivity.articleComment"><![CDATA[Hat einen Kommentar zum Artikel <a href="{$article->getLink()}#comment{$commentID}">{$article->getTitle()}</a> geschrieben.]]></item>

--- a/wcfsetup/install/lang/de.xml
+++ b/wcfsetup/install/lang/de.xml
@@ -3302,7 +3302,7 @@ freigeschaltet. {if LANGUAGE_USE_INFORMAL_VARIANT}Du kannst{else}Sie können{/if
 		<item name="wcf.article.relatedArticles"><![CDATA[Verwandte Artikel]]></item>
 		<item name="wcf.article.moreArticles"><![CDATA[Weitere Artikel]]></item>
 		<item name="wcf.article.aboutAuthor"><![CDATA[Über den Autor]]></item>
-		<item name="wcf.article.articleComments"><![CDATA[{plural value=$articleContent->comments one='1 Kommentar' other='# Kommentare'}]]></item>
+		<item name="wcf.article.articleComments"><![CDATA[{plural value=$articleContent->comments one='# Kommentar' other='# Kommentare'}]]></item>
 		<item name="wcf.article.articleViews"><![CDATA[{#$article->views} Mal gelesen]]></item>
 		<item name="wcf.article.recentActivity.likedArticle"><![CDATA[Hat mit <span title="{$reactionType->getTitle()}" class="jsTooltip">{@$reactionType->renderIcon()}</span> auf den Artikel <a href="{$article->getLink()}">{$article->getTitle()}</a> reagiert.]]></item>
 		<item name="wcf.article.recentActivity.articleComment"><![CDATA[Hat einen Kommentar zum Artikel <a href="{$article->getLink()}#comment{$commentID}">{$article->getTitle()}</a> geschrieben.]]></item>

--- a/wcfsetup/install/lang/en.xml
+++ b/wcfsetup/install/lang/en.xml
@@ -3229,7 +3229,7 @@ Your account on the website: {@PAGE_TITLE|language} [URL:{link isEmail=true}{/li
 		<item name="wcf.article.relatedArticles"><![CDATA[Related Articles]]></item>
 		<item name="wcf.article.moreArticles"><![CDATA[More Articles]]></item>
 		<item name="wcf.article.aboutAuthor"><![CDATA[About the Author]]></item>
-		<item name="wcf.article.articleComments"><![CDATA[{#$article->comments} Comment{if $article->comments != 1}s{/if}]]></item>
+		<item name="wcf.article.articleComments"><![CDATA[{plural value=$articleContent->comments one='1 Comment' other='# Comments'}]]></item>
 		<item name="wcf.article.articleViews"><![CDATA[{#$article->views} View{if $article->views != 1}s{/if}]]></item>
 		<item name="wcf.article.recentActivity.likedArticle"><![CDATA[Reacted with <span title="{$reactionType->getTitle()}" class="jsTooltip">{@$reactionType->renderIcon()}</span> to the article <a href="{$article->getLink()}">{$article->getTitle()}</a>.]]></item>
 		<item name="wcf.article.recentActivity.articleComment"><![CDATA[Commented on article <a href="{$article->getLink()}#comment{$commentID}">{$article->getTitle()}</a>.]]></item>

--- a/wcfsetup/install/lang/en.xml
+++ b/wcfsetup/install/lang/en.xml
@@ -3229,7 +3229,7 @@ Your account on the website: {@PAGE_TITLE|language} [URL:{link isEmail=true}{/li
 		<item name="wcf.article.relatedArticles"><![CDATA[Related Articles]]></item>
 		<item name="wcf.article.moreArticles"><![CDATA[More Articles]]></item>
 		<item name="wcf.article.aboutAuthor"><![CDATA[About the Author]]></item>
-		<item name="wcf.article.articleComments"><![CDATA[{plural value=$articleContent->comments one='1 Comment' other='# Comments'}]]></item>
+		<item name="wcf.article.articleComments"><![CDATA[{plural value=$articleContent->comments one='# Comment' other='# Comments'}]]></item>
 		<item name="wcf.article.articleViews"><![CDATA[{#$article->views} View{if $article->views != 1}s{/if}]]></item>
 		<item name="wcf.article.recentActivity.likedArticle"><![CDATA[Reacted with <span title="{$reactionType->getTitle()}" class="jsTooltip">{@$reactionType->renderIcon()}</span> to the article <a href="{$article->getLink()}">{$article->getTitle()}</a>.]]></item>
 		<item name="wcf.article.recentActivity.articleComment"><![CDATA[Commented on article <a href="{$article->getLink()}#comment{$commentID}">{$article->getTitle()}</a>.]]></item>

--- a/wcfsetup/setup/db/install.sql
+++ b/wcfsetup/setup/db/install.sql
@@ -157,7 +157,6 @@ CREATE TABLE wcf1_article (
 	publicationStatus TINYINT(1) NOT NULL DEFAULT 1,
 	publicationDate INT(10) NOT NULL DEFAULT 0,
 	enableComments TINYINT(1) NOT NULL DEFAULT 1,
-	comments SMALLINT(5) NOT NULL DEFAULT 0,
 	views MEDIUMINT(7) NOT NULL DEFAULT 0,
 	cumulativeLikes MEDIUMINT(7) NOT NULL DEFAULT 0,
 	isDeleted TINYINT(1) NOT NULL DEFAULT 0,
@@ -179,6 +178,7 @@ CREATE TABLE wcf1_article_content (
 	hasEmbeddedObjects TINYINT(1) NOT NULL DEFAULT 0,
 	metaTitle VARCHAR(255) NOT NULL DEFAULT '',
 	metaDescription VARCHAR(255) NOT NULL DEFAULT '',
+	comments SMALLINT(5) NOT NULL DEFAULT 0,
 
 	UNIQUE KEY (articleID, languageID)
 );


### PR DESCRIPTION
For multilingual articles, the number of comments displayed did not match the actual comments displayed.

ref https://www.woltlab.com/community/thread/291083-bei-mehrsprachigen-artikeln-wird-die-anzahl-der-kommentare-in-allen-sprachen-ang/