### PR TITLE
Uninstalling from the package details

### DIFF
--- a/wcfsetup/install/files/acp/templates/package.tpl
+++ b/wcfsetup/install/files/acp/templates/package.tpl
@@ -18,7 +18,15 @@
 	{hascontent}
 		<nav class="contentHeaderNavigation">
 			<ul>
-				{content}{event name='contentHeaderNavigation'}{/content}
+				{content}
+					{if $package->canUninstall()}
+						<li><a class="button jsUninstallButton jsTooltip" role="button" tabindex="0" data-object-id="{@$package->packageID}" data-confirm-message="{lang __encode=true}wcf.acp.package.uninstallation.confirm{/lang}" data-is-required="{if $package->isRequired()}true{else}false{/if}" data-is-application="{if $package->isApplication}true{else}false{/if}"><span class="icon icon16 fa-times"></span> <span>{lang}wcf.acp.package.button.uninstall{/lang}</span></a></li>
+					{else}
+						<li><a class="button jsUninstallButton disabled jsTooltip" role="button" tabindex="0" data-object-id="{@$package->packageID}" data-confirm-message="{lang __encode=true}wcf.acp.package.uninstallation.confirm{/lang}" data-is-required="{if $package->isRequired()}true{else}false{/if}" data-is-application="{if $package->isApplication}true{else}false{/if}"><span class="icon icon16 fa-times"></span> <span>{lang}wcf.acp.package.button.uninstall{/lang}</span></a></li>
+					{/if}
+					
+					{event name='contentHeaderNavigation'}
+				{/content}
 			</ul>
 		</nav>
 	{/hascontent}


### PR DESCRIPTION
Just a QOL-Feature: Adds a button to uninstall a package on the details page. 
1:1 like the following plugin: https://www.woltlab.com/pluginstore/file/7106-uninstall-button/

Maybe a feature for the 5.5? Otherwise please move to the correct branch/tag.