### PR TITLE
Add `var_dump` to allowed enterprise functions

### DIFF
--- a/wcfsetup/install/files/lib/system/template/TemplateScriptingCompiler.class.php
+++ b/wcfsetup/install/files/lib/system/template/TemplateScriptingCompiler.class.php
@@ -141,6 +141,7 @@ class TemplateScriptingCompiler
         'ucfirst',
         'uniqid',
         'urlencode',
+        'var_dump',
         'version_compare',
         'wcfDebug',
         'wordwrap',


### PR DESCRIPTION
This function is used in ACP templates of some of my VieCode Shop plugins that are labelled as "Compatible with WoltLab Cloud" to display API responses from payment service providers.