### PR TITLE
implement optional forcing decimals in `StringUtil.formatNumeric()`

### DIFF
--- a/ts/WoltLabSuite/Core/StringUtil.ts
+++ b/ts/WoltLabSuite/Core/StringUtil.ts
@@ -41,13 +41,14 @@ export function escapeRegExp(string: string): string {
 /**
  * Rounds number to given count of floating point digits, localizes decimal-point and inserts thousands separators.
  */
-export function formatNumeric(number: number, decimalPlaces?: number): string {
+export function formatNumeric(number: number, decimalPlaces?: number, forceDecimalPlaces = false): string {
   let tmp = NumberUtil.round(number, decimalPlaces || -2).toString();
   const numberParts = tmp.split(".");
 
   tmp = addThousandsSeparator(+numberParts[0]);
   if (numberParts.length > 1) {
-    tmp += _decimalPoint + numberParts[1];
+    tmp +=
+      _decimalPoint + (forceDecimalPlaces ? numberParts[1].padEnd(Math.abs(decimalPlaces || -2), "0") : numberParts[1]);
   }
 
   tmp = tmp.replace("-", "\u2212");

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/StringUtil.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/StringUtil.js
@@ -42,12 +42,13 @@ define(["require", "exports", "tslib", "./NumberUtil"], function (require, expor
     /**
      * Rounds number to given count of floating point digits, localizes decimal-point and inserts thousands separators.
      */
-    function formatNumeric(number, decimalPlaces) {
+    function formatNumeric(number, decimalPlaces, forceDecimalPlaces = false) {
         let tmp = NumberUtil.round(number, decimalPlaces || -2).toString();
         const numberParts = tmp.split(".");
         tmp = addThousandsSeparator(+numberParts[0]);
         if (numberParts.length > 1) {
-            tmp += _decimalPoint + numberParts[1];
+            tmp +=
+                _decimalPoint + (forceDecimalPlaces ? numberParts[1].padEnd(Math.abs(decimalPlaces || -2), "0") : numberParts[1]);
         }
         tmp = tmp.replace("-", "\u2212");
         return tmp;


### PR DESCRIPTION
With this change the current behavior of `StringUtil.formatNumeric()` is kept als default behavior, but it is possible to force the given number of decimals instead of treating the parameter as `$maxDecimals`.
This change makes it possible to get the same result as using `CurrencyModifierTemplatePlugin` in order to display things in a more consistent way.

see https://www.woltlab.com/community/thread/294033/