### PR TITLE
Fix the replacing of WCF_N in PHP DDL during app installation

### DIFF
--- a/wcfsetup/install/files/lib/system/database/table/DatabaseTable.class.php
+++ b/wcfsetup/install/files/lib/system/database/table/DatabaseTable.class.php
@@ -49,7 +49,7 @@ class DatabaseTable {
 	 * @param	string		$name	name of the database table
 	 */
 	protected function __construct($name) {
-		$this->name = ApplicationHandler::insertRealDatabaseTableNames($name);
+		$this->name = ApplicationHandler::insertRealDatabaseTableNames($name, true);
 	}
 	
 	/**

--- a/wcfsetup/install/files/lib/system/database/table/index/DatabaseTableForeignKey.class.php
+++ b/wcfsetup/install/files/lib/system/database/table/index/DatabaseTableForeignKey.class.php
@@ -251,7 +251,7 @@ class DatabaseTableForeignKey {
 	 * @return	$this					this foreign key
 	 */
 	public function referencedTable($referencedTable) {
-		$this->referencedTable = ApplicationHandler::insertRealDatabaseTableNames($referencedTable);
+		$this->referencedTable = ApplicationHandler::insertRealDatabaseTableNames($referencedTable, true);
 		
 		return $this;
 	}


### PR DESCRIPTION
During app installation the newly installed app might not yet be stored within
the application cache, thus failing to replace the `1` within the table
structure definition.

Fix this by setting the `skipCache` parameter to `true`. This will increase the
number of database queries, because applications will be checked once for each
defined table and for each defined FOREIGN KEY, but I don't see a simple fix
for this issue that avoids this increase in query count. Specifically we cannot
simply reset the application cache after inserting the application into
wcf1_application.
