### PR TITLE
Graceful handling of incoherent update paths

### DIFF
--- a/wcfsetup/install/files/lib/data/package/update/PackageUpdateAction.class.php
+++ b/wcfsetup/install/files/lib/data/package/update/PackageUpdateAction.class.php
@@ -752,7 +752,7 @@ class PackageUpdateAction extends AbstractDatabaseObjectAction
         } catch (PackageUpdateUnauthorizedException $e) {
             return [
                 'template' => $e->getRenderedTemplate(),
-                'type' => 'authenticationRequired',
+                'type' => 'authorizationRequired',
             ];
         }
 

--- a/wcfsetup/install/files/lib/system/package/exception/IncoherentUpdatePath.class.php
+++ b/wcfsetup/install/files/lib/system/package/exception/IncoherentUpdatePath.class.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace wcf\system\package\exception;
+
+use wcf\data\package\PackageCache;
+use wcf\system\WCF;
+
+/**
+ * Caused by gaps in the update path where a never version is requested but
+ * there are no updates in-between that would allow a step-by-step update
+ * to the requested version.
+ *
+ * @author Alexander Ebert
+ * @copyright 2001-2022 WoltLab GmbH
+ * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @package WoltLabSuite\Core\System\Package\Exception
+ * @since 5.5
+ */
+final class IncoherentUpdatePath extends \Exception
+{
+    public function __construct(string $package, string $currentVersion, string $newVersion)
+    {
+        parent::__construct(
+            WCF::getLanguage()->getDynamicVariable(
+                'wcf.acp.package.update.path.incoherent',
+                [
+                    'currentVersion' => $currentVersion,
+                    'newVersion' => $newVersion,
+                    'package' => $package,
+                    'packageName' => PackageCache::getInstance()->getPackageByIdentifier($package)->getName(),
+                ]
+            )
+        );
+    }
+}

--- a/wcfsetup/install/files/lib/system/package/exception/UnknownUpdatePath.class.php
+++ b/wcfsetup/install/files/lib/system/package/exception/UnknownUpdatePath.class.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace wcf\system\package\exception;
+
+use wcf\data\package\PackageCache;
+use wcf\system\WCF;
+
+/**
+ * Triggered when the requested package version does not exist or is unvailable.
+ *
+ * @author Alexander Ebert
+ * @copyright 2001-2022 WoltLab GmbH
+ * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @package WoltLabSuite\Core\System\Package\Exception
+ * @since 5.5
+ */
+final class UnknownUpdatePath extends \Exception
+{
+    public function __construct(string $package, string $currentVersion, string $newVersion)
+    {
+        parent::__construct(
+            WCF::getLanguage()->getDynamicVariable('wcf.acp.package.update.path.unknown', [
+                'currentVersion' => $currentVersion,
+                'newVersion' => $newVersion,
+                'package' => $package,
+                'packageName' => PackageCache::getInstance()->getPackageByIdentifier($package)->getName(),
+            ])
+        );
+    }
+}


### PR DESCRIPTION
Some packages have multiple update paths from version X to version Y, but some of these paths might be incoherent. The previous code would reject such an update, even though not all paths might have been exhausted.

Internal test case: https://www.woltlab.com/community/thread/294248/