### PR TITLE
Add `CheckedVoid` form builder data handler for CheckboxFormField

### DIFF
--- a/ts/WoltLabSuite/Core/Form/Builder/Field/CheckedVoid.ts
+++ b/ts/WoltLabSuite/Core/Form/Builder/Field/CheckedVoid.ts
@@ -1,0 +1,29 @@
+/**
+ * Data handler for a form builder field in an Ajax form that stores its value via a checkbox being
+ * checked or not.
+ *
+ * This differs from `Checked` by not sending any value if the checkbox is not checked.
+ *
+ * @author  Tim Duesterhus
+ * @copyright 2001-2022 WoltLab GmbH
+ * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @module  WoltLabSuite/Core/Form/Builder/Field/CheckedVoid
+ * @since 5.4
+ */
+
+import Field from "./Field";
+import { FormBuilderData } from "../Data";
+
+export class CheckedVoid extends Field {
+  protected _getData(): FormBuilderData {
+    if ((this._field as HTMLInputElement).checked) {
+      return {
+        [this._fieldId]: 1,
+      };
+    } else {
+      return {};
+    }
+  }
+}
+
+export default CheckedVoid;

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Form/Builder/Field/CheckedVoid.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Form/Builder/Field/CheckedVoid.js
@@ -1,0 +1,32 @@
+/**
+ * Data handler for a form builder field in an Ajax form that stores its value via a checkbox being
+ * checked or not.
+ *
+ * This differs from `Checked` by not sending any value if the checkbox is not checked.
+ *
+ * @author  Tim Duesterhus
+ * @copyright 2001-2022 WoltLab GmbH
+ * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @module  WoltLabSuite/Core/Form/Builder/Field/CheckedVoid
+ * @since 5.4
+ */
+define(["require", "exports", "tslib", "./Field"], function (require, exports, tslib_1, Field_1) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.CheckedVoid = void 0;
+    Field_1 = (0, tslib_1.__importDefault)(Field_1);
+    class CheckedVoid extends Field_1.default {
+        _getData() {
+            if (this._field.checked) {
+                return {
+                    [this._fieldId]: 1,
+                };
+            }
+            else {
+                return {};
+            }
+        }
+    }
+    exports.CheckedVoid = CheckedVoid;
+    exports.default = CheckedVoid;
+});

--- a/wcfsetup/install/files/lib/system/form/builder/field/CheckboxFormField.class.php
+++ b/wcfsetup/install/files/lib/system/form/builder/field/CheckboxFormField.class.php
@@ -18,6 +18,11 @@ class CheckboxFormField extends BooleanFormField
     /**
      * @inheritDoc
      */
+    protected $javaScriptDataHandlerModule = 'WoltLabSuite/Core/Form/Builder/Field/CheckedVoid';
+
+    /**
+     * @inheritDoc
+     */
     public function readValue()
     {
         $this->value = $this->getDocument()->hasRequestData($this->getPrefixedId());


### PR DESCRIPTION
The `Checked` data handler is not usable for the CheckboxFormField, because its
behavior differs from the non-AJAX behavior by always sending a value whereas
checkboxes that are not checked will not send anything within a regular form.

It was considered to simply reuse the `readValue()` implementation in
BooleanFormField, because it appears to do the right thing at a glance. However
this would effectively revert 7d36c55726af2b5b9d9ab1706a05ccf5e52e84b8 which is
a fix to allow unchecking checkboxes that are checked by default.

Also matching the behavior of AJAX and non-AJAX forms 100% is considered a good
thing, so a new JavaScript module to handle this, is the best solution.
