### PR TITLE
handle available api of form builder buttons (correctly)

### DIFF
--- a/com.woltlab.wcf/templates/__emptyFormFieldDependency.tpl
+++ b/com.woltlab.wcf/templates/__emptyFormFieldDependency.tpl
@@ -1,7 +1,7 @@
 require(['WoltLabSuite/Core/Form/Builder/Field/Dependency/Empty'], function(EmptyFieldDependency) {
 	// dependency '{@$dependency->getId()}'
 	new EmptyFieldDependency(
-		'{@$dependency->getDependentNode()->getPrefixedId()}Container',
+		'{@$dependency->getDependentPrefixedId()}',
 		'{@$dependency->getField()->getPrefixedId()}'
 	);
 });

--- a/com.woltlab.wcf/templates/__formButton.tpl
+++ b/com.woltlab.wcf/templates/__formButton.tpl
@@ -13,3 +13,5 @@
 		*}{if $button->getAccessKey()} accesskey="{$button->getAccessKey()}"{/if}{*
 	*}>{$button->getLabel()}</button>
 {/if}
+
+{include file='__formButtonDependencies'}

--- a/com.woltlab.wcf/templates/__formButtonDependencies.tpl
+++ b/com.woltlab.wcf/templates/__formButtonDependencies.tpl
@@ -1,0 +1,7 @@
+{if !$button->getDependencies()|empty}
+	<script data-relocate="true">
+		{foreach from=$button->getDependencies() item=dependency}
+			{@$dependency->getHtml()}
+		{/foreach}
+	</script>
+{/if}

--- a/com.woltlab.wcf/templates/__isNotClickedFormFieldDependency.tpl
+++ b/com.woltlab.wcf/templates/__isNotClickedFormFieldDependency.tpl
@@ -1,7 +1,7 @@
 require(['WoltLabSuite/Core/Form/Builder/Field/Dependency/IsNotClicked'], ({ IsNotClicked }) => {
 	// dependency '{@$dependency->getId()}'
 	new IsNotClicked(
-		'{@$dependency->getDependentNode()->getPrefixedId()}Container',
+		'{@$dependency->getDependentPrefixedId()}',
 		'{@$dependency->getField()->getPrefixedId()}'
 	);
 });

--- a/com.woltlab.wcf/templates/__nonEmptyFormFieldDependency.tpl
+++ b/com.woltlab.wcf/templates/__nonEmptyFormFieldDependency.tpl
@@ -1,7 +1,7 @@
 require(['WoltLabSuite/Core/Form/Builder/Field/Dependency/NonEmpty'], function(NonEmptyFieldDependency) {
 	// dependency '{@$dependency->getId()}'
 	new NonEmptyFieldDependency(
-		'{@$dependency->getDependentNode()->getPrefixedId()}Container',
+		'{@$dependency->getDependentPrefixedId()}',
 		'{@$dependency->getField()->getPrefixedId()}'
 	);
 });

--- a/com.woltlab.wcf/templates/__valueFormFieldDependency.tpl
+++ b/com.woltlab.wcf/templates/__valueFormFieldDependency.tpl
@@ -1,7 +1,7 @@
 require(['WoltLabSuite/Core/Form/Builder/Field/Dependency/Value'], function(ValueFieldDependency) {
 	// dependency '{@$dependency->getId()}'
 	new ValueFieldDependency(
-		'{@$dependency->getDependentNode()->getPrefixedId()}Container',
+		'{@$dependency->getDependentPrefixedId()}',
 		'{@$dependency->getField()->getPrefixedId()}'
 	).values([ {implode from=$dependency->getValues() item=dependencyValue}'{$dependencyValue|encodeJS}'{/implode} ])
 	.negate({if $dependency->isNegated()}true{else}false{/if});

--- a/wcfsetup/install/files/acp/templates/__emptyFormFieldDependency.tpl
+++ b/wcfsetup/install/files/acp/templates/__emptyFormFieldDependency.tpl
@@ -1,7 +1,7 @@
 require(['WoltLabSuite/Core/Form/Builder/Field/Dependency/Empty'], function(EmptyFieldDependency) {
 	// dependency '{@$dependency->getId()}'
 	new EmptyFieldDependency(
-		'{@$dependency->getDependentNode()->getPrefixedId()}Container',
+		'{@$dependency->getDependentPrefixedId()}',
 		'{@$dependency->getField()->getPrefixedId()}'
 	);
 });

--- a/wcfsetup/install/files/acp/templates/__formButton.tpl
+++ b/wcfsetup/install/files/acp/templates/__formButton.tpl
@@ -13,3 +13,5 @@
 		*}{if $button->getAccessKey()} accesskey="{$button->getAccessKey()}"{/if}{*
 	*}>{$button->getLabel()}</button>
 {/if}
+
+{include file='__formButtonDependencies'}

--- a/wcfsetup/install/files/acp/templates/__formButtonDependencies.tpl
+++ b/wcfsetup/install/files/acp/templates/__formButtonDependencies.tpl
@@ -1,0 +1,7 @@
+{if !$button->getDependencies()|empty}
+	<script data-relocate="true">
+		{foreach from=$button->getDependencies() item=dependency}
+			{@$dependency->getHtml()}
+		{/foreach}
+	</script>
+{/if}

--- a/wcfsetup/install/files/acp/templates/__isNotClickedFormFieldDependency.tpl
+++ b/wcfsetup/install/files/acp/templates/__isNotClickedFormFieldDependency.tpl
@@ -1,7 +1,7 @@
 require(['WoltLabSuite/Core/Form/Builder/Field/Dependency/IsNotClicked'], ({ IsNotClicked }) => {
 	// dependency '{@$dependency->getId()}'
 	new IsNotClicked(
-		'{@$dependency->getDependentNode()->getPrefixedId()}Container',
+		'{@$dependency->getDependentPrefixedId()}',
 		'{@$dependency->getField()->getPrefixedId()}'
 	);
 });

--- a/wcfsetup/install/files/acp/templates/__nonEmptyFormFieldDependency.tpl
+++ b/wcfsetup/install/files/acp/templates/__nonEmptyFormFieldDependency.tpl
@@ -1,7 +1,7 @@
 require(['WoltLabSuite/Core/Form/Builder/Field/Dependency/NonEmpty'], function(NonEmptyFieldDependency) {
 	// dependency '{@$dependency->getId()}'
 	new NonEmptyFieldDependency(
-		'{@$dependency->getDependentNode()->getPrefixedId()}Container',
+		'{@$dependency->getDependentPrefixedId()}',
 		'{@$dependency->getField()->getPrefixedId()}'
 	);
 });

--- a/wcfsetup/install/files/acp/templates/__valueFormFieldDependency.tpl
+++ b/wcfsetup/install/files/acp/templates/__valueFormFieldDependency.tpl
@@ -1,7 +1,7 @@
 require(['WoltLabSuite/Core/Form/Builder/Field/Dependency/Value'], function(ValueFieldDependency) {
 	// dependency '{@$dependency->getId()}'
 	new ValueFieldDependency(
-		'{@$dependency->getDependentNode()->getPrefixedId()}Container',
+		'{@$dependency->getDependentPrefixedId()}',
 		'{@$dependency->getField()->getPrefixedId()}'
 	).values([ {implode from=$dependency->getValues() item=dependencyValue}'{$dependencyValue|encodeJS}'{/implode} ])
 	.negate({if $dependency->isNegated()}true{else}false{/if});

--- a/wcfsetup/install/files/lib/system/form/builder/FormDocument.class.php
+++ b/wcfsetup/install/files/lib/system/form/builder/FormDocument.class.php
@@ -243,6 +243,8 @@ class FormDocument implements IFormDocument
             } else {
                 $nodeIds[] = $button->getId();
             }
+
+            $button->populate();
         }
 
         if (!empty($doubleNodeIds)) {
@@ -781,6 +783,14 @@ class FormDocument implements IFormDocument
             $this->errorMessage('wcf.global.form.error.securityToken');
         } else {
             $this->traitValidate();
+        }
+
+        foreach ($this->getButtons() as $button) {
+            if (!$button->isAvailable() || !$button->checkDependencies()) {
+                continue;
+            }
+
+            $button->validate();
         }
     }
 }

--- a/wcfsetup/install/files/lib/system/form/builder/button/FormButton.class.php
+++ b/wcfsetup/install/files/lib/system/form/builder/button/FormButton.class.php
@@ -116,6 +116,14 @@ class FormButton implements IFormButton
 
     /**
      * @inheritDoc
+     */
+    public function requiresLabel()
+    {
+        return true;
+    }
+
+    /**
+     * @inheritDoc
      * @throws  \BadMethodCallException
      */
     public function description($languageItem = null, array $variables = [])

--- a/wcfsetup/install/files/lib/system/form/builder/button/FormButton.class.php
+++ b/wcfsetup/install/files/lib/system/form/builder/button/FormButton.class.php
@@ -113,4 +113,13 @@ class FormButton implements IFormButton
     {
         // does nothing
     }
+
+    /**
+     * @inheritDoc
+     * @throws  \BadMethodCallException
+     */
+    public function description($languageItem = null, array $variables = [])
+    {
+        throw new \BadMethodCallException('Method description() is not supported by ' . \get_class($this));
+    }
 }

--- a/wcfsetup/install/files/lib/system/form/builder/field/dependency/AbstractFormFieldDependency.class.php
+++ b/wcfsetup/install/files/lib/system/form/builder/field/dependency/AbstractFormFieldDependency.class.php
@@ -102,6 +102,22 @@ abstract class AbstractFormFieldDependency implements IFormFieldDependency
     }
 
     /**
+     * Returns the id of the node whose availability depends on the value of a field.
+     *
+     * @return string
+     */
+    public function getDependentPrefixedId()
+    {
+        $dependent = $this->getDependentNode();
+
+        if ($dependent instanceof IFormField) {
+            return $dependent->getPrefixedId() . 'Container';
+        }
+
+        return $dependent->getPrefixedId();
+    }
+
+    /**
      * @inheritDoc
      */
     public function getField()


### PR DESCRIPTION
Before buttons did support the addition of dependencies, validation-methods and adding a description without any usage of those features.

Setting descriptions for `FormButtons` will be disabled with this PR and are going to throw a `BadMethodCallException`. Child-classes might override this and implement a handling for descriptions.
In favor of the current layout of the `formSubmit`-part of forms I decided to not implement descriptions of buttons by default since I didn't find an appropriate way to present them (besides using `jsTooltip`).

`FormButton`s require a label now. Creating a button of `FormButton` without a label would't make sense, but was (theoretically) possible.

Dependencies of button are now handled correctly as well as the execution of buttons' `validate()` method has been added.