### PR TITLE
Assorted cleanup

### DIFF
--- a/wcfsetup/install/files/acp/js/WCF.ACP.js
+++ b/wcfsetup/install/files/acp/js/WCF.ACP.js
@@ -589,21 +589,13 @@ WCF.ACP.Package.Uninstallation = WCF.ACP.Package.Installation.extend({
 	_packageID: 0,
 	
 	/**
-	 * URL of WCF package list
-	 * @var	string
-	 */
-	_wcfPackageListURL: '',
-	
-	/**
 	 * Initializes the WCF.ACP.Package.Uninstallation class.
 	 * 
 	 * @param	jQuery		elements
-	 * @param	string		wcfPackageListURL
 	 */
-	init: function(elements, wcfPackageListURL) {
+	init: function(elements) {
 		this._elements = elements;
 		this._packageID = 0;
-		this._wcfPackageListURL = wcfPackageListURL;
 		
 		if (this._elements !== undefined && this._elements.length) {
 			this._super(0, 'UninstallPackage');
@@ -639,11 +631,6 @@ WCF.ACP.Package.Uninstallation = WCF.ACP.Package.Installation.extend({
 	 */
 	_showConfirmationDialog: function(event) {
 		var $element = $(event.currentTarget);
-		
-		if ($element.data('isApplication') && this._wcfPackageListURL) {
-			window.location = WCF.String.unescapeHTML(this._wcfPackageListURL.replace(/{packageID}/, $element.data('objectID')));
-			return;
-		}
 		
 		var self = this;
 		WCF.System.Confirmation.show($element.data('confirmMessage'), function(action) {

--- a/wcfsetup/install/files/acp/templates/package.tpl
+++ b/wcfsetup/install/files/acp/templates/package.tpl
@@ -6,7 +6,7 @@
 			'wcf.acp.package.uninstallation.title': '{jslang}wcf.acp.package.uninstallation.title{/jslang}'
 		});
 		
-		new WCF.ACP.Package.Uninstallation($('.jsUninstallButton'), {if PACKAGE_ID > 1}'{link controller='PackageList' forceWCF=true encode=false}packageID={literal}{packageID}{/literal}{/link}'{else}null{/if});
+		new WCF.ACP.Package.Uninstallation($('.jsUninstallButton'), {if PACKAGE_ID > 1}'{link controller='PackageList' encode=false}packageID={literal}{packageID}{/literal}{/link}'{else}null{/if});
 	});
 </script>
 

--- a/wcfsetup/install/files/acp/templates/package.tpl
+++ b/wcfsetup/install/files/acp/templates/package.tpl
@@ -6,7 +6,7 @@
 			'wcf.acp.package.uninstallation.title': '{jslang}wcf.acp.package.uninstallation.title{/jslang}'
 		});
 		
-		new WCF.ACP.Package.Uninstallation($('.jsUninstallButton'), null);
+		new WCF.ACP.Package.Uninstallation($('.jsUninstallButton'));
 	});
 </script>
 

--- a/wcfsetup/install/files/acp/templates/package.tpl
+++ b/wcfsetup/install/files/acp/templates/package.tpl
@@ -6,7 +6,7 @@
 			'wcf.acp.package.uninstallation.title': '{jslang}wcf.acp.package.uninstallation.title{/jslang}'
 		});
 		
-		new WCF.ACP.Package.Uninstallation($('.jsUninstallButton'), {if PACKAGE_ID > 1}'{link controller='PackageList' encode=false}packageID={literal}{packageID}{/literal}{/link}'{else}null{/if});
+		new WCF.ACP.Package.Uninstallation($('.jsUninstallButton'), null);
 	});
 </script>
 

--- a/wcfsetup/install/files/acp/templates/packageList.tpl
+++ b/wcfsetup/install/files/acp/templates/packageList.tpl
@@ -14,7 +14,6 @@
 		
 		{if $__wcf->session->getPermission('admin.configuration.package.canUninstallPackage')}
 			new WCF.ACP.Package.Uninstallation($('.jsPackageRow .jsUninstallButton'), null);			
-			new WCF.ACP.Package.Uninstallation($('.jsPluginContainer .jsUninstallButton'));
 		{/if}
 		
 		{if $__wcf->session->getPermission('admin.configuration.package.canUpdatePackage')}

--- a/wcfsetup/install/files/acp/templates/packageList.tpl
+++ b/wcfsetup/install/files/acp/templates/packageList.tpl
@@ -13,14 +13,7 @@
 		});
 		
 		{if $__wcf->session->getPermission('admin.configuration.package.canUninstallPackage')}
-			new WCF.ACP.Package.Uninstallation($('.jsPackageRow .jsUninstallButton'), null);
-			{if $packageID}
-				new WCF.PeriodicalExecuter(function(pe) {
-					pe.stop();
-					$('.jsUninstallButton[data-object-id={@$packageID}]').trigger('click');
-				}, 250);
-			{/if}
-			
+			new WCF.ACP.Package.Uninstallation($('.jsPackageRow .jsUninstallButton'), null);			
 			new WCF.ACP.Package.Uninstallation($('.jsPluginContainer .jsUninstallButton'));
 		{/if}
 		

--- a/wcfsetup/install/files/acp/templates/packageList.tpl
+++ b/wcfsetup/install/files/acp/templates/packageList.tpl
@@ -13,7 +13,7 @@
 		});
 		
 		{if $__wcf->session->getPermission('admin.configuration.package.canUninstallPackage')}
-			new WCF.ACP.Package.Uninstallation($('.jsPackageRow .jsUninstallButton'), {if PACKAGE_ID > 1}'{link controller='PackageList' encode=false}packageID={literal}{packageID}{/literal}{/link}'{else}null{/if});
+			new WCF.ACP.Package.Uninstallation($('.jsPackageRow .jsUninstallButton'), null);
 			{if $packageID}
 				new WCF.PeriodicalExecuter(function(pe) {
 					pe.stop();

--- a/wcfsetup/install/files/acp/templates/packageList.tpl
+++ b/wcfsetup/install/files/acp/templates/packageList.tpl
@@ -13,7 +13,7 @@
 		});
 		
 		{if $__wcf->session->getPermission('admin.configuration.package.canUninstallPackage')}
-			new WCF.ACP.Package.Uninstallation($('.jsPackageRow .jsUninstallButton'), null);			
+			new WCF.ACP.Package.Uninstallation($('.jsPackageRow .jsUninstallButton'));
 		{/if}
 		
 		{if $__wcf->session->getPermission('admin.configuration.package.canUpdatePackage')}

--- a/wcfsetup/install/files/acp/templates/packageList.tpl
+++ b/wcfsetup/install/files/acp/templates/packageList.tpl
@@ -13,7 +13,7 @@
 		});
 		
 		{if $__wcf->session->getPermission('admin.configuration.package.canUninstallPackage')}
-			new WCF.ACP.Package.Uninstallation($('.jsPackageRow .jsUninstallButton'), {if PACKAGE_ID > 1}'{link controller='PackageList' forceWCF=true encode=false}packageID={literal}{packageID}{/literal}{/link}'{else}null{/if});
+			new WCF.ACP.Package.Uninstallation($('.jsPackageRow .jsUninstallButton'), {if PACKAGE_ID > 1}'{link controller='PackageList' encode=false}packageID={literal}{packageID}{/literal}{/link}'{else}null{/if});
 			{if $packageID}
 				new WCF.PeriodicalExecuter(function(pe) {
 					pe.stop();

--- a/wcfsetup/install/files/lib/acp/page/PackageListPage.class.php
+++ b/wcfsetup/install/files/lib/acp/page/PackageListPage.class.php
@@ -50,12 +50,6 @@ class PackageListPage extends SortablePage
     public $defaultSortOrder = 'DESC';
 
     /**
-     * package id for uninstallation
-     * @var int
-     */
-    public $packageID = 0;
-
-    /**
      * @inheritDoc
      */
     public $validSortFields = [
@@ -81,18 +75,6 @@ class PackageListPage extends SortablePage
     /**
      * @inheritDoc
      */
-    public function readParameters()
-    {
-        parent::readParameters();
-
-        if (isset($_GET['packageID'])) {
-            $this->packageID = \intval($_GET['packageID']);
-        }
-    }
-
-    /**
-     * @inheritDoc
-     */
     public function assignVariables()
     {
         parent::assignVariables();
@@ -108,7 +90,6 @@ class PackageListPage extends SortablePage
 
         WCF::getTPL()->assign([
             'recentlyDisabledCustomValues' => LanguageFactory::getInstance()->countRecentlyDisabledCustomValues(),
-            'packageID' => $this->packageID,
             'taintedApplications' => $taintedApplications,
             'availableUpgradeVersion' => WCF::AVAILABLE_UPGRADE_VERSION,
             'upgradeOverrideEnabled' => PackageUpdateServer::isUpgradeOverrideEnabled(),


### PR DESCRIPTION
- Remove use of deprecated `forceWCF` parameter to LinkHandler::getLink()
- Remove PACKAGE_ID check for WCF.ACP.Package.Uninstallation
- Remove `packageID` parameter from PackageListPage
- Remove dead code in packageList.tpl
- Remove obsolete wcfPackageListURL property from WCF.ACP.Package.Uninstallation
