### PR TITLE
Remove `{csrfToken}` from pageHeaderSearch

### DIFF
--- a/com.woltlab.wcf/templates/pageHeaderSearch.tpl
+++ b/com.woltlab.wcf/templates/pageHeaderSearch.tpl
@@ -60,8 +60,6 @@
 			<div id="pageHeaderSearchParameters"></div>
 			
 			{if !$__searchStaticOptions|empty}{@$__searchStaticOptions}{/if}
-			
-			{csrfToken}
 		</div>
 	</form>
 </div>


### PR DESCRIPTION
The submission of the form is intercepted by WoltLabSuite/Core/Ui/Search/Page
and then converted into a GET redirect that does not contain the `t` parameter,
making it useless.
