### PR TITLE
Move the reset of the import mapping into a dedicated JavaScript module

### DIFF
--- a/ts/WoltLabSuite/Core/Acp/Ui/DataImport/MappingReset.ts
+++ b/ts/WoltLabSuite/Core/Acp/Ui/DataImport/MappingReset.ts
@@ -1,0 +1,36 @@
+/**
+ * Provides the program logic for the import mapping reset.
+ *
+ * @author  Tim Duesterhus
+ * @copyright  2001-2022 WoltLab GmbH
+ * @license  GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @module  WoltLabSuite/Core/Acp/Ui/DataImport/MappingReset
+ * @woltlabExcludeBundle all
+ */
+
+import * as Ajax from "../../../Ajax";
+import * as Core from "../../../Core";
+import * as UiConfirmation from "../../../Ui/Confirmation";
+
+export function setup(): void {
+  const link = document.getElementById("deleteMapping")!;
+
+  link.addEventListener("click", (event) => {
+    event.preventDefault();
+    UiConfirmation.show({
+      confirm() {
+        Ajax.apiOnce({
+          data: {
+            actionName: "resetMapping",
+            className: "wcf\\system\\importer\\ImportHandler",
+          },
+          success() {
+            window.location.reload();
+          },
+          url: "index.php?ajax-invoke&t=" + Core.getXsrfToken(),
+        });
+      },
+      message: link.dataset.confirmMessage!,
+    });
+  });
+}

--- a/wcfsetup/install/files/acp/templates/dataImport.tpl
+++ b/wcfsetup/install/files/acp/templates/dataImport.tpl
@@ -60,26 +60,8 @@
 		{if $showMappingNotice}
 			<p class="warning">{lang}wcf.acp.dataImport.existingMapping.notice{/lang}</p>
 			<script data-relocate="true">
-				require(['Ajax', 'Ui/Confirmation'], (Ajax, UiConfirmation) => {
-					document.getElementById('deleteMapping').addEventListener('click', () => {
-						UiConfirmation.show({
-							confirm() {
-								Ajax.apiOnce({
-									data: {
-										actionName: 'resetMapping',
-										className: 'wcf\\system\\importer\\ImportHandler',
-									},
-									success() {
-										window.location.reload();
-									},
-									url: 'index.php/AJAXInvoke/?t=' + SECURITY_TOKEN,
-								});
-							},
-							message: '{jslang}wcf.acp.dataImport.existingMapping.confirmMessage{/jslang}'
-						});
-						
-						return false;
-					});
+				require(['WoltLabSuite/Core/Acp/Ui/DataImport/MappingReset'], (MappingReset) => {
+					MappingReset.setup();
 				});
 			</script>
 		{/if}

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Acp/Ui/DataImport/MappingReset.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Acp/Ui/DataImport/MappingReset.js
@@ -1,0 +1,39 @@
+/**
+ * Provides the program logic for the import mapping reset.
+ *
+ * @author  Tim Duesterhus
+ * @copyright  2001-2022 WoltLab GmbH
+ * @license  GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @module  WoltLabSuite/Core/Acp/Ui/DataImport/MappingReset
+ * @woltlabExcludeBundle all
+ */
+define(["require", "exports", "tslib", "../../../Ajax", "../../../Core", "../../../Ui/Confirmation"], function (require, exports, tslib_1, Ajax, Core, UiConfirmation) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.setup = void 0;
+    Ajax = (0, tslib_1.__importStar)(Ajax);
+    Core = (0, tslib_1.__importStar)(Core);
+    UiConfirmation = (0, tslib_1.__importStar)(UiConfirmation);
+    function setup() {
+        const link = document.getElementById("deleteMapping");
+        link.addEventListener("click", (event) => {
+            event.preventDefault();
+            UiConfirmation.show({
+                confirm() {
+                    Ajax.apiOnce({
+                        data: {
+                            actionName: "resetMapping",
+                            className: "wcf\\system\\importer\\ImportHandler",
+                        },
+                        success() {
+                            window.location.reload();
+                        },
+                        url: "index.php?ajax-invoke&t=" + Core.getXsrfToken(),
+                    });
+                },
+                message: link.dataset.confirmMessage,
+            });
+        });
+    }
+    exports.setup = setup;
+});

--- a/wcfsetup/install/lang/de.xml
+++ b/wcfsetup/install/lang/de.xml
@@ -409,8 +409,7 @@
 		<item name="wcf.acp.dataImport.data.com.woltlab.wcf.userTrophy"><![CDATA[Vergebene Trophäen]]></item>
 		<item name="wcf.acp.dataImport.data.com.woltlab.wcf.reactionType"><![CDATA[Reaktions-Typen]]></item>
 		<item name="wcf.acp.dataImport.data.com.woltlab.wcf.page"><![CDATA[CMS-Seiten]]></item>
-		<item name="wcf.acp.dataImport.existingMapping.confirmMessage"><![CDATA[{if LANGUAGE_USE_INFORMAL_VARIANT}Willst du{else}Wollen Sie{/if} die bestehenden Zuordnungen wirklich löschen?]]></item>
-		<item name="wcf.acp.dataImport.existingMapping.notice"><![CDATA[Es existieren Zuordnungen eines früheren Import-Vorganges, diese werden verwendet, um Inhalte aus dem importierten Forum einwandfrei zuzuordnen. Wenn {if LANGUAGE_USE_INFORMAL_VARIANT}du{else}Sie{/if} den Import-Vorgang vollständig abgeschlossen {if LANGUAGE_USE_INFORMAL_VARIANT}hast{else}haben{/if}, {if LANGUAGE_USE_INFORMAL_VARIANT}kannst du{else}können Sie{/if} diese Zuordnungen <a id="deleteMapping">löschen</a>. {if LANGUAGE_USE_INFORMAL_VARIANT}Du solltest{else}Sie sollten{/if} die Zuordnungen nicht löschen, wenn {if LANGUAGE_USE_INFORMAL_VARIANT}du{else}Sie{/if} jetzt oder zukünftig noch weitere Inhalte aus dem selben Forum übernehmen {if LANGUAGE_USE_INFORMAL_VARIANT}willst{else}wollen{/if}. Diese Zuordnungen können nicht genutzt werden, um einzelne Inhalte inkrementell zu übernehmen. Sie sind dazu gedacht, um weitere Arten von Inhalten in separaten Vorgängen zu übernehmen, beispielsweise unter Zuhilfenahme von Importern aus installierten Plugins.]]></item>
+		<item name="wcf.acp.dataImport.existingMapping.notice"><![CDATA[Es existieren Zuordnungen eines früheren Import-Vorganges, diese werden verwendet, um Inhalte aus dem importierten Forum einwandfrei zuzuordnen. Wenn {if LANGUAGE_USE_INFORMAL_VARIANT}du{else}Sie{/if} den Import-Vorgang vollständig abgeschlossen {if LANGUAGE_USE_INFORMAL_VARIANT}hast{else}haben{/if}, {if LANGUAGE_USE_INFORMAL_VARIANT}kannst du{else}können Sie{/if} <a href="#" role="button" id="deleteMapping" data-confirm-message="{if LANGUAGE_USE_INFORMAL_VARIANT}Willst du{else}Wollen Sie{/if} die bestehenden Zuordnungen wirklich löschen?">diese Zuordnungen löschen</a>. {if LANGUAGE_USE_INFORMAL_VARIANT}Du solltest{else}Sie sollten{/if} die Zuordnungen nicht löschen, wenn {if LANGUAGE_USE_INFORMAL_VARIANT}du{else}Sie{/if} jetzt oder zukünftig noch weitere Inhalte aus dem selben Forum übernehmen {if LANGUAGE_USE_INFORMAL_VARIANT}willst{else}wollen{/if}. Diese Zuordnungen können nicht genutzt werden, um einzelne Inhalte inkrementell zu übernehmen. Sie sind dazu gedacht, um weitere Arten von Inhalten in separaten Vorgängen zu übernehmen, beispielsweise unter Zuhilfenahme von Importern aus installierten Plugins.]]></item>
 		<item name="wcf.acp.dataImport.exporter"><![CDATA[Datenquelle]]></item>
 		<item name="wcf.acp.dataImport.selectExporter"><![CDATA[Datenquelle wählen]]></item>
 		<item name="wcf.acp.dataImport.selectExporter.error.invalid"><![CDATA[Die ausgewählte Datenquelle ist ungültig.]]></item>
@@ -5602,5 +5601,6 @@ Benachrichtigungen auf <a href="{link isHtmlEmail=true}{/link}">{PAGE_TITLE|phra
 	<item name="wcf.search.error.noMatches" />
 	<item name="wcf.search.error.user.noMatches" />
 	<item name="wcf.user.logout.sure"/>
+	<item name="wcf.acp.dataImport.existingMapping.confirmMessage"/>
 </delete>
 </language>

--- a/wcfsetup/install/lang/en.xml
+++ b/wcfsetup/install/lang/en.xml
@@ -387,8 +387,7 @@
 		<item name="wcf.acp.dataImport.data.com.woltlab.wcf.userTrophy"><![CDATA[Assigned trophies]]></item>
 		<item name="wcf.acp.dataImport.data.com.woltlab.wcf.reactionType"><![CDATA[Reaction Types]]></item>
 		<item name="wcf.acp.dataImport.data.com.woltlab.wcf.page"><![CDATA[CMS pages]]></item>
-		<item name="wcf.acp.dataImport.existingMapping.confirmMessage"><![CDATA[Do you really want to delete the existing import mappings?]]></item>
-		<item name="wcf.acp.dataImport.existingMapping.notice"><![CDATA[There are import mappings created by a previous import process, these mappings are used to properly handle connections between data from the imported forum and this one. In case you have imported all the desired data, you can <a id="deleteMapping">delete</a> the mappings. It is strongly recommended to keep these mappings as long as there is still data to be imported now or in the future. These mappings cannot be used to perform incremental imports of the same type of data. Instead their purpose is to import different types of data using multiple import processes, possibly using importers provided by a plugin.]]></item>
+		<item name="wcf.acp.dataImport.existingMapping.notice"><![CDATA[There are import mappings created by a previous import process, these mappings are used to properly handle connections between data from the imported forum and this one. In case you have imported all the desired data, you can <a href="#" role="button" id="deleteMapping" data-confirm-message="Do you really want to delete the existing import mappings?">delete the mappings</a>. It is strongly recommended to keep these mappings as long as there is still data to be imported now or in the future. These mappings cannot be used to perform incremental imports of the same type of data. Instead their purpose is to import different types of data using multiple import processes, possibly using importers provided by a plugin.]]></item>
 		<item name="wcf.acp.dataImport.exporter"><![CDATA[Data Source]]></item>
 		<item name="wcf.acp.dataImport.selectExporter"><![CDATA[Select Data Source]]></item>
 		<item name="wcf.acp.dataImport.selectExporter.error.invalid"><![CDATA[The selected data source is invalid.]]></item>
@@ -5604,5 +5603,6 @@ your notifications on <a href="{link isHtmlEmail=true}{/link}">{PAGE_TITLE|phras
 	<item name="wcf.search.error.noMatches" />
 	<item name="wcf.search.error.user.noMatches" />
 	<item name="wcf.user.logout.sure"/>
+	<item name="wcf.acp.dataImport.existingMapping.confirmMessage"/>
 </delete>
 </language>


### PR DESCRIPTION
This removes a non-trivial amount of JavaScript and specifically:

- Fixes the use of the legacy `index.php/AJAXInvoke` syntax.
- Avoids the use of the deprecated SECURITY_TOKEN pseudo-constant.
