### PR TITLE
Add preview image for image upload component

### DIFF
--- a/com.woltlab.wcf/templates/uploadFieldComponent.tpl
+++ b/com.woltlab.wcf/templates/uploadFieldComponent.tpl
@@ -14,7 +14,7 @@
 				<li class="box64 uploadedFile" data-unique-file-id="{$file->getUniqueFileId()}">
 					{if $file->isImage()}
 						<a href="{$file->getImage()}" class="jsImageViewer">
-							<img src="{$file->getImage()}" loading="lazy" alt="" class="formUploadHandlerContentListImage">
+							<img src="{$file->getImage()}" width="{$file->getWidth()}" height="{$file->getHeight()}" loading="lazy" alt="" class="formUploadHandlerContentListImage">
 						</a>
 					{else}
 						<span class="icon icon64 fa-{$file->getIconName()}"></span>

--- a/com.woltlab.wcf/templates/uploadFieldComponent.tpl
+++ b/com.woltlab.wcf/templates/uploadFieldComponent.tpl
@@ -12,7 +12,13 @@
 		<ul class="formUploadHandlerList" id="{$uploadFieldId}uploadFileList" data-internal-id="{$uploadField->getInternalId()}">
 			{foreach from=$uploadFieldFiles item=file}
 				<li class="box64 uploadedFile" data-unique-file-id="{$file->getUniqueFileId()}">
-					<span class="icon icon64 fa-{$file->getIconName()}"></span>
+					{if $file->isImage()}
+						<a href="{$file->getImage()}" class="jsImageViewer">
+							<img src="{$file->getImage()}" loading="lazy" alt="" class="formUploadHandlerContentListImage">
+						</a>
+					{else}
+						<span class="icon icon64 fa-{$file->getIconName()}"></span>
+					{/if}
 					
 					<div>
 						<div>

--- a/ts/WoltLabSuite/Core/Ui/File/Upload.ts
+++ b/ts/WoltLabSuite/Core/Ui/File/Upload.ts
@@ -172,10 +172,21 @@ class FileUpload extends Upload<FileUploadOptions> implements FileUploadHandler 
         } else {
           fileElement.dataset.uniqueFileId = fileData.uniqueFileId;
           fileElement.querySelector("small")!.textContent = fileData.filesize.toString();
-
           const icon = fileElement.querySelector(".icon") as HTMLElement;
-          icon.classList.remove("fa-spinner");
-          icon.classList.add(`fa-${fileData.icon}`);
+
+          if (fileData.image !== null) {
+            const a = document.createElement("a");
+            a.classList.add("jsImageViewer");
+            a.href = fileData.image;
+            const image = document.createElement("img");
+            image.classList.add("formUploadHandlerContentListImage");
+            image.src = fileData.image;
+            a.appendChild(image);
+            icon.replaceWith(a);
+          } else {
+            icon.classList.remove("fa-spinner");
+            icon.classList.add(`fa-${fileData.icon}`);
+          }
         }
       } else if (data.error[index] !== undefined) {
         const errorData = data["error"][index];

--- a/ts/WoltLabSuite/Core/Ui/File/Upload.ts
+++ b/ts/WoltLabSuite/Core/Ui/File/Upload.ts
@@ -31,6 +31,8 @@ interface FileData {
   filesize: number;
   icon: string;
   image: string | null;
+  imageHeight: number | null;
+  imageWidth: number | null;
   uniqueFileId: string;
 }
 
@@ -181,6 +183,8 @@ class FileUpload extends Upload<FileUploadOptions> implements FileUploadHandler 
             const image = document.createElement("img");
             image.classList.add("formUploadHandlerContentListImage");
             image.src = fileData.image;
+            image.width = fileData.imageWidth!;
+            image.height = fileData.imageHeight!;
             a.appendChild(image);
             icon.replaceWith(a);
           } else {

--- a/wcfsetup/install/files/acp/templates/styleAdd.tpl
+++ b/wcfsetup/install/files/acp/templates/styleAdd.tpl
@@ -42,6 +42,10 @@
 	});
 </script>
 
+<script data-relocate="true" src="{@$__wcf->getPath()}js/WCF.ImageViewer.js?v={@LAST_UPDATE_TIME}"></script>
+
+{include file="imageViewer"}
+
 <header class="contentHeader">
 	<div class="contentHeaderTitle">
 		<h1 class="contentTitle">{lang}wcf.acp.style.{$action}{/lang}</h1>

--- a/wcfsetup/install/files/acp/templates/uploadFieldComponent.tpl
+++ b/wcfsetup/install/files/acp/templates/uploadFieldComponent.tpl
@@ -14,7 +14,7 @@
 				<li class="box64 uploadedFile" data-unique-file-id="{$file->getUniqueFileId()}">
 					{if $file->isImage()}
 						<a href="{$file->getImage()}" class="jsImageViewer">
-							<img src="{$file->getImage()}" loading="lazy" alt="" class="formUploadHandlerContentListImage">
+							<img src="{$file->getImage()}" width="{$file->getWidth()}" height="{$file->getHeight()}" loading="lazy" alt="" class="formUploadHandlerContentListImage">
 						</a>
 					{else}
 						<span class="icon icon64 fa-{$file->getIconName()}"></span>

--- a/wcfsetup/install/files/acp/templates/uploadFieldComponent.tpl
+++ b/wcfsetup/install/files/acp/templates/uploadFieldComponent.tpl
@@ -12,7 +12,13 @@
 		<ul class="formUploadHandlerList" id="{$uploadFieldId}uploadFileList" data-internal-id="{$uploadField->getInternalId()}">
 			{foreach from=$uploadFieldFiles item=file}
 				<li class="box64 uploadedFile" data-unique-file-id="{$file->getUniqueFileId()}">
-					<span class="icon icon64 fa-{$file->getIconName()}"></span>
+					{if $file->isImage()}
+						<a href="{$file->getImage()}" class="jsImageViewer">
+							<img src="{$file->getImage()}" loading="lazy" alt="" class="formUploadHandlerContentListImage">
+						</a>
+					{else}
+						<span class="icon icon64 fa-{$file->getIconName()}"></span>
+					{/if}
 					
 					<div>
 						<div>

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/File/Upload.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/File/Upload.js
@@ -111,8 +111,20 @@ define(["require", "exports", "tslib", "../../Core", "./Delete", "../../Dom/Util
                         fileElement.dataset.uniqueFileId = fileData.uniqueFileId;
                         fileElement.querySelector("small").textContent = fileData.filesize.toString();
                         const icon = fileElement.querySelector(".icon");
-                        icon.classList.remove("fa-spinner");
-                        icon.classList.add(`fa-${fileData.icon}`);
+                        if (fileData.image !== null) {
+                            const a = document.createElement("a");
+                            a.classList.add("jsImageViewer");
+                            a.href = fileData.image;
+                            const image = document.createElement("img");
+                            image.classList.add("formUploadHandlerContentListImage");
+                            image.src = fileData.image;
+                            a.appendChild(image);
+                            icon.replaceWith(a);
+                        }
+                        else {
+                            icon.classList.remove("fa-spinner");
+                            icon.classList.add(`fa-${fileData.icon}`);
+                        }
                     }
                 }
                 else if (data.error[index] !== undefined) {

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/File/Upload.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/File/Upload.js
@@ -118,6 +118,8 @@ define(["require", "exports", "tslib", "../../Core", "./Delete", "../../Dom/Util
                             const image = document.createElement("img");
                             image.classList.add("formUploadHandlerContentListImage");
                             image.src = fileData.image;
+                            image.width = fileData.imageWidth;
+                            image.height = fileData.imageHeight;
                             a.appendChild(image);
                             icon.replaceWith(a);
                         }

--- a/wcfsetup/install/files/lib/acp/form/StyleEditForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/StyleEditForm.class.php
@@ -281,7 +281,7 @@ class StyleEditForm extends StyleAddForm
             }
 
             UploadHandler::getInstance()->registerFilesByField('customAssets', \array_map(static function ($filename) {
-                return new UploadFile($filename, \basename($filename), false, true, true);
+                return new UploadFile($filename, \basename($filename), true, true, true);
             }, \glob($this->style->getAssetPath() . 'custom/*')));
         }
     }

--- a/wcfsetup/install/files/lib/action/AJAXFileUploadAction.class.php
+++ b/wcfsetup/install/files/lib/action/AJAXFileUploadAction.class.php
@@ -137,6 +137,8 @@ class AJAXFileUploadAction extends AbstractSecureAction
                 'icon' => $file->getIconName(),
                 'filesize' => FileUtil::formatFilesize($file->filesize),
                 'image' => $file->viewableImage ? $file->getImage() : null,
+                'imageWidth' => $file->getWidth(),
+                'imageHeight' => $file->getHeight(),
                 'uniqueFileId' => $file->getUniqueFileId(),
             ];
         }

--- a/wcfsetup/install/files/lib/system/file/upload/UploadFile.class.php
+++ b/wcfsetup/install/files/lib/system/file/upload/UploadFile.class.php
@@ -72,6 +72,12 @@ class UploadFile
     private $uniqueId;
 
     /**
+     * The return value of `getimagesize`.
+     * @var array
+     */
+    private $imageData;
+
+    /**
      * UploadFile constructor.
      *
      * @param string $location
@@ -98,9 +104,10 @@ class UploadFile
         $this->viewableImage = $viewableImage;
         $this->uniqueId = StringUtil::getRandomID();
         $this->detectSvgAsImage = $detectSvgAsImage;
+        $this->imageData = @\getimagesize($location);
 
         if (
-            @\getimagesize($location) !== false || ($detectSvgAsImage && \in_array(FileUtil::getMimeType($location), [
+            $this->imageData !== false || ($detectSvgAsImage && \in_array(FileUtil::getMimeType($location), [
                 'image/svg',
                 'image/svg+xml',
             ]))
@@ -139,10 +146,8 @@ class UploadFile
                 return $this->imageLink;
             }
         } else {
-            $imageData = @\getimagesize($this->location);
-
-            if ($imageData !== false) {
-                return 'data:' . $imageData['mime'] . ';base64,' . \base64_encode(\file_get_contents($this->location));
+            if ($this->imageData !== false) {
+                return 'data:' . $this->imageData['mime'] . ';base64,' . \base64_encode(\file_get_contents($this->location));
             }
 
             if (
@@ -232,6 +237,30 @@ class UploadFile
     public function isProcessed()
     {
         return $this->processed;
+    }
+
+    /**
+     * @since 5.5
+     */
+    public function getWidth(): ?int
+    {
+        if ($this->imageData === false) {
+            return null;
+        }
+
+        return $this->imageData[0];
+    }
+
+    /**
+     * @since 5.5
+     */
+    public function getHeight(): ?int
+    {
+        if ($this->imageData === false) {
+            return null;
+        }
+
+        return $this->imageData[1];
     }
 
     /**

--- a/wcfsetup/install/files/style/ui/uploadHandler.scss
+++ b/wcfsetup/install/files/style/ui/uploadHandler.scss
@@ -30,6 +30,12 @@
 	}
 }
 
+.formUploadHandlerContentListImage {
+	max-height: 64px;
+	max-width: 64px;
+	object-fit: cover;
+}
+
 .selectedImagePreview {
 	> img {
 		margin-bottom: 5px;


### PR DESCRIPTION
Previously, no thumbnails were displayed during the upload process if it was possible to upload multiple images. This change adds this functionality and displays the images together with the ImageViewer.