### PR TITLE
Protect the XSRF token against BREACH attacks

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,7 +30,8 @@ module.exports = {
     "@typescript-eslint/no-unsafe-return": 0,
     "@typescript-eslint/no-unused-vars": [
       "error", {
-        "argsIgnorePattern": "^_"
+        "argsIgnorePattern": "^_",
+        "varsIgnorePattern": "^_"
       }
     ],
     "@typescript-eslint/no-misused-promises": [

--- a/com.woltlab.wcf/templates/headIncludeJavaScript.tpl
+++ b/com.woltlab.wcf/templates/headIncludeJavaScript.tpl
@@ -6,7 +6,7 @@
 	var SID_ARG_2ND	= '';
 	var WCF_PATH = '{@$__wcf->getPath()}';
 	var WSC_API_URL = '{@$__wcf->getActivePath()}';
-	var SECURITY_TOKEN = '{csrfToken type=raw}';
+	{* The SECURITY_TOKEN is defined in wcf.globalHelper.js *}
 	var LANGUAGE_ID = {@$__wcf->getLanguage()->languageID};
 	var LANGUAGE_USE_INFORMAL_VARIANT = {if LANGUAGE_USE_INFORMAL_VARIANT}true{else}false{/if};
 	var TIME_NOW = {@TIME_NOW};

--- a/ts/WoltLabSuite/Core/Bootstrap.ts
+++ b/ts/WoltLabSuite/Core/Bootstrap.ts
@@ -4,7 +4,7 @@
  * and runs modules that are needed on page load.
  *
  * @author  Tim Duesterhus
- * @copyright  2001-2019 WoltLab GmbH
+ * @copyright  2001-2022 WoltLab GmbH
  * @license  GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
  * @module  WoltLabSuite/Core/Bootstrap
  */
@@ -16,6 +16,7 @@ import Devtools from "./Devtools";
 import DomChangeListener from "./Dom/Change/Listener";
 import * as Environment from "./Environment";
 import * as EventHandler from "./Event/Handler";
+import * as XsrfToken from "./Form/XsrfToken";
 import * as Language from "./Language";
 import * as StringUtil from "./StringUtil";
 import UiDialog from "./Ui/Dialog";
@@ -79,6 +80,8 @@ export function setup(options: BoostrapOptions): void {
     },
     options,
   ) as BoostrapOptions;
+
+  XsrfToken.setup();
 
   StringUtil.setupI18n({
     decimalPoint: Language.get("wcf.global.decimalPoint"),

--- a/ts/WoltLabSuite/Core/Core.ts
+++ b/ts/WoltLabSuite/Core/Core.ts
@@ -294,5 +294,14 @@ export function enableLegacyInheritance<T>(legacyClass: T): void {
 }
 
 export function getXsrfToken(): string {
-  return (window as any).SECURITY_TOKEN;
+  const cookies = document.cookie.split(";").map((c) => c.trim());
+  const xsrfToken = cookies.find((c) => c.startsWith("XSRF-TOKEN="));
+
+  if (xsrfToken === undefined) {
+    return "COOKIE_NOT_FOUND";
+  }
+
+  const [_key, value] = xsrfToken.split(/=/, 2);
+
+  return decodeURIComponent(value.trim());
 }

--- a/ts/WoltLabSuite/Core/Form/XsrfToken.ts
+++ b/ts/WoltLabSuite/Core/Form/XsrfToken.ts
@@ -1,0 +1,51 @@
+/**
+ * Manages the values of the hidden form inputs storing the XsrfToken.
+ *
+ * @author  Tim Duesterhus
+ * @copyright 2001-2022 WoltLab GmbH
+ * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @module  WoltLabSuite/Core/Form/XsrfToken
+ * @since 5.5
+ */
+
+import { getXsrfToken } from "../Core";
+
+function isInput(node: Node): node is HTMLInputElement {
+  return node.nodeName === "INPUT";
+}
+
+function createObserver(): void {
+  const observer = new MutationObserver((mutations) => {
+    const token = getXsrfToken();
+
+    mutations.forEach((mutation) => {
+      mutation.addedNodes.forEach((node) => {
+        if (!isInput(node)) {
+          return;
+        }
+        if (!node.classList.contains("xsrfTokenInput")) {
+          return;
+        }
+
+        node.value = token;
+        node.classList.add("xsrfTokenInputHandled");
+      });
+    });
+  });
+
+  observer.observe(document, { subtree: true, childList: true });
+}
+
+export function setup(): void {
+  createObserver();
+
+  const token = getXsrfToken();
+  document.querySelectorAll(".xsrfTokenInput").forEach((node) => {
+    if (!isInput(node)) {
+      return;
+    }
+
+    node.value = token;
+    node.classList.add("xsrfTokenInputHandled");
+  });
+}

--- a/wcfsetup/install/files/acp/templates/header.tpl
+++ b/wcfsetup/install/files/acp/templates/header.tpl
@@ -32,7 +32,7 @@
 		var SID_ARG_2ND = '';
 		var WCF_PATH = '{@$__wcf->getPath()}';
 		var WSC_API_URL = '{@$__wcf->getActivePath()}acp/';
-		var SECURITY_TOKEN = '{csrfToken type=raw}';
+		{* The SECURITY_TOKEN is defined in wcf.globalHelper.js *}
 		var LANGUAGE_ID = {@$__wcf->getLanguage()->languageID};
 		var LANGUAGE_USE_INFORMAL_VARIANT = {if LANGUAGE_USE_INFORMAL_VARIANT}true{else}false{/if};
 		var TIME_NOW = {@TIME_NOW};

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Bootstrap.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Bootstrap.js
@@ -4,11 +4,11 @@
  * and runs modules that are needed on page load.
  *
  * @author  Tim Duesterhus
- * @copyright  2001-2019 WoltLab GmbH
+ * @copyright  2001-2022 WoltLab GmbH
  * @license  GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
  * @module  WoltLabSuite/Core/Bootstrap
  */
-define(["require", "exports", "tslib", "./Core", "./Date/Picker", "./Date/Time/Relative", "./Devtools", "./Dom/Change/Listener", "./Environment", "./Event/Handler", "./Language", "./StringUtil", "./Ui/Dialog", "./Ui/Dropdown/Simple", "./Ui/Mobile", "./Ui/Page/Action", "./Ui/TabMenu", "./Ui/Tooltip", "./Ui/Page/JumpTo", "./Ui/Password", "./Ui/Empty", "./Ui/Object/Action", "./Ui/Object/Action/Delete", "./Ui/Object/Action/Toggle", "./Ui/Search", "perfect-scrollbar"], function (require, exports, tslib_1, Core, Picker_1, DateTimeRelative, Devtools_1, Listener_1, Environment, EventHandler, Language, StringUtil, Dialog_1, Simple_1, UiMobile, UiPageAction, UiTabMenu, UiTooltip, UiPageJumpTo, UiPassword, UiEmpty, UiObjectAction, UiObjectActionDelete, UiObjectActionToggle, Search_1) {
+define(["require", "exports", "tslib", "./Core", "./Date/Picker", "./Date/Time/Relative", "./Devtools", "./Dom/Change/Listener", "./Environment", "./Event/Handler", "./Form/XsrfToken", "./Language", "./StringUtil", "./Ui/Dialog", "./Ui/Dropdown/Simple", "./Ui/Mobile", "./Ui/Page/Action", "./Ui/TabMenu", "./Ui/Tooltip", "./Ui/Page/JumpTo", "./Ui/Password", "./Ui/Empty", "./Ui/Object/Action", "./Ui/Object/Action/Delete", "./Ui/Object/Action/Toggle", "./Ui/Search", "perfect-scrollbar"], function (require, exports, tslib_1, Core, Picker_1, DateTimeRelative, Devtools_1, Listener_1, Environment, EventHandler, XsrfToken, Language, StringUtil, Dialog_1, Simple_1, UiMobile, UiPageAction, UiTabMenu, UiTooltip, UiPageJumpTo, UiPassword, UiEmpty, UiObjectAction, UiObjectActionDelete, UiObjectActionToggle, Search_1) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.setup = void 0;
@@ -19,6 +19,7 @@ define(["require", "exports", "tslib", "./Core", "./Date/Picker", "./Date/Time/R
     Listener_1 = (0, tslib_1.__importDefault)(Listener_1);
     Environment = (0, tslib_1.__importStar)(Environment);
     EventHandler = (0, tslib_1.__importStar)(EventHandler);
+    XsrfToken = (0, tslib_1.__importStar)(XsrfToken);
     Language = (0, tslib_1.__importStar)(Language);
     StringUtil = (0, tslib_1.__importStar)(StringUtil);
     Dialog_1 = (0, tslib_1.__importDefault)(Dialog_1);
@@ -65,6 +66,7 @@ define(["require", "exports", "tslib", "./Core", "./Date/Picker", "./Date/Time/R
             enableMobileMenu: true,
             pageMenuMainProvider: undefined,
         }, options);
+        XsrfToken.setup();
         StringUtil.setupI18n({
             decimalPoint: Language.get("wcf.global.decimalPoint"),
             thousandsSeparator: Language.get("wcf.global.thousandsSeparator"),

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Core.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Core.js
@@ -259,7 +259,13 @@ define(["require", "exports"], function (require, exports) {
     }
     exports.enableLegacyInheritance = enableLegacyInheritance;
     function getXsrfToken() {
-        return window.SECURITY_TOKEN;
+        const cookies = document.cookie.split(";").map((c) => c.trim());
+        const xsrfToken = cookies.find((c) => c.startsWith("XSRF-TOKEN="));
+        if (xsrfToken === undefined) {
+            return "COOKIE_NOT_FOUND";
+        }
+        const [_key, value] = xsrfToken.split(/=/, 2);
+        return decodeURIComponent(value.trim());
     }
     exports.getXsrfToken = getXsrfToken;
 });

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Form/XsrfToken.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Form/XsrfToken.js
@@ -1,0 +1,47 @@
+/**
+ * Manages the values of the hidden form inputs storing the XsrfToken.
+ *
+ * @author  Tim Duesterhus
+ * @copyright 2001-2022 WoltLab GmbH
+ * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @module  WoltLabSuite/Core/Form/XsrfToken
+ * @since 5.5
+ */
+define(["require", "exports", "../Core"], function (require, exports, Core_1) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.setup = void 0;
+    function isInput(node) {
+        return node.nodeName === "INPUT";
+    }
+    function createObserver() {
+        const observer = new MutationObserver((mutations) => {
+            const token = (0, Core_1.getXsrfToken)();
+            mutations.forEach((mutation) => {
+                mutation.addedNodes.forEach((node) => {
+                    if (!isInput(node)) {
+                        return;
+                    }
+                    if (!node.classList.contains("xsrfTokenInput")) {
+                        return;
+                    }
+                    node.value = token;
+                    node.classList.add("xsrfTokenInputHandled");
+                });
+            });
+        });
+        observer.observe(document, { subtree: true, childList: true });
+    }
+    function setup() {
+        createObserver();
+        const token = (0, Core_1.getXsrfToken)();
+        document.querySelectorAll(".xsrfTokenInput").forEach((node) => {
+            if (!isInput(node)) {
+                return;
+            }
+            node.value = token;
+            node.classList.add("xsrfTokenInputHandled");
+        });
+    }
+    exports.setup = setup;
+});

--- a/wcfsetup/install/files/js/wcf.globalHelper.js
+++ b/wcfsetup/install/files/js/wcf.globalHelper.js
@@ -391,4 +391,24 @@
 		
 		return $hash;
 	};
+
+	Object.defineProperty(
+		window,
+		'SECURITY_TOKEN',
+		{
+			configurable: false,
+			get() {
+				const cookies = document.cookie.split(';').map(c => c.trim());
+				const xsrfToken = cookies.find(c => c.startsWith('XSRF-TOKEN='));
+
+				if (xsrfToken === undefined) {
+					return 'COOKIE_NOT_FOUND';
+				}
+
+				const [key, value] = xsrfToken.split(/=/, 2);
+
+				return decodeURIComponent(value.trim());
+			}
+		}
+	);
 })(window, document);

--- a/wcfsetup/install/files/js/wcf.globalHelper.js
+++ b/wcfsetup/install/files/js/wcf.globalHelper.js
@@ -398,6 +398,10 @@
 		{
 			configurable: false,
 			get() {
+				// This implementation effectively is a copy of WoltLabSuite/Core/Core#getXsrfToken, but
+				// we can't use this here for compatibility reasons. Use of the global SECURITY_TOKEN
+				// property is deprecated anyway.
+
 				const cookies = document.cookie.split(';').map(c => c.trim());
 				const xsrfToken = cookies.find(c => c.startsWith('XSRF-TOKEN='));
 
@@ -405,7 +409,7 @@
 					return 'COOKIE_NOT_FOUND';
 				}
 
-				const [key, value] = xsrfToken.split(/=/, 2);
+				const [_key, value] = xsrfToken.split(/=/, 2);
 
 				return decodeURIComponent(value.trim());
 			}

--- a/wcfsetup/install/files/lib/system/session/SessionHandler.class.php
+++ b/wcfsetup/install/files/lib/system/session/SessionHandler.class.php
@@ -450,7 +450,7 @@ final class SessionHandler extends SingletonFactory
         if (!\defined('SECURITY_TOKEN_INPUT_TAG')) {
             \define(
                 'SECURITY_TOKEN_INPUT_TAG',
-                '<input type="hidden" name="t" value="' . $this->getSecurityToken() . '">'
+                '<input type="hidden" name="t" class="xsrfTokenInput" value="' . $this->getSecurityToken() . '">'
             );
         }
     }

--- a/wcfsetup/install/files/lib/system/session/SessionHandler.class.php
+++ b/wcfsetup/install/files/lib/system/session/SessionHandler.class.php
@@ -450,7 +450,7 @@ final class SessionHandler extends SingletonFactory
         if (!\defined('SECURITY_TOKEN_INPUT_TAG')) {
             \define(
                 'SECURITY_TOKEN_INPUT_TAG',
-                '<input type="hidden" name="t" class="xsrfTokenInput" value="' . $this->getSecurityToken() . '">'
+                '<input type="hidden" name="t" class="xsrfTokenInput" value="NOT_MODIFIED">'
             );
         }
     }

--- a/wcfsetup/install/files/lib/system/template/plugin/CsrfTokenFunctionTemplatePlugin.class.php
+++ b/wcfsetup/install/files/lib/system/template/plugin/CsrfTokenFunctionTemplatePlugin.class.php
@@ -35,7 +35,7 @@ class CsrfTokenFunctionTemplatePlugin implements IFunctionTemplatePlugin
             case 'url':
                 return \rawurlencode($token);
             case 'form':
-                return \sprintf('<input type="hidden" name="t" value="%s">', $token);
+                return \sprintf('<input type="hidden" name="t" class="xsrfTokenInput" value="%s">', $token);
             default:
                 throw new SystemException("Invalid type '" . $type . "' given.");
         }

--- a/wcfsetup/install/files/lib/system/template/plugin/CsrfTokenFunctionTemplatePlugin.class.php
+++ b/wcfsetup/install/files/lib/system/template/plugin/CsrfTokenFunctionTemplatePlugin.class.php
@@ -35,7 +35,7 @@ class CsrfTokenFunctionTemplatePlugin implements IFunctionTemplatePlugin
             case 'url':
                 return \rawurlencode($token);
             case 'form':
-                return \sprintf('<input type="hidden" name="t" class="xsrfTokenInput" value="%s">', $token);
+                return \sprintf('<input type="hidden" name="t" class="xsrfTokenInput" value="%s">', 'NOT_MODIFIED');
             default:
                 throw new SystemException("Invalid type '" . $type . "' given.");
         }

--- a/wcfsetup/install/files/lib/system/template/plugin/CsrfTokenPrefilterTemplatePlugin.class.php
+++ b/wcfsetup/install/files/lib/system/template/plugin/CsrfTokenPrefilterTemplatePlugin.class.php
@@ -24,7 +24,7 @@ class CsrfTokenPrefilterTemplatePlugin implements IPrefilterTemplatePlugin
         return \strtr($sourceContent, [
             '{csrfToken type=raw}' => \sprintf('{@%s}', $getToken),
             '{csrfToken type=url}' => \sprintf('{@%s|rawurlencode}', $getToken),
-            '{csrfToken}' => \sprintf('<input type="hidden" name="t" value="{@%s}">', $getToken),
+            '{csrfToken}' => \sprintf('<input type="hidden" name="t" class="xsrfTokenInput" value="{@%s}">', $getToken),
         ]);
     }
 }

--- a/wcfsetup/install/files/lib/system/template/plugin/CsrfTokenPrefilterTemplatePlugin.class.php
+++ b/wcfsetup/install/files/lib/system/template/plugin/CsrfTokenPrefilterTemplatePlugin.class.php
@@ -24,7 +24,7 @@ class CsrfTokenPrefilterTemplatePlugin implements IPrefilterTemplatePlugin
         return \strtr($sourceContent, [
             '{csrfToken type=raw}' => \sprintf('{@%s}', $getToken),
             '{csrfToken type=url}' => \sprintf('{@%s|rawurlencode}', $getToken),
-            '{csrfToken}' => \sprintf('<input type="hidden" name="t" class="xsrfTokenInput" value="{@%s}">', $getToken),
+            '{csrfToken}' => \sprintf('<input type="hidden" name="t" class="xsrfTokenInput" value="{@%s}">', "'NOT_MODIFIED'"),
         ]);
     }
 }


### PR DESCRIPTION
- Read the `SECURITY_TOKEN` from the cookie to protect it against BREACH
- Implement WoltLabSuite/Core/Core#getXsrfToken without relying on SECURITY_TOKEN
- Add WoltLabSuite/Core/Form/XsrfToken.ts to automatically insert the XSRF-TOKEN into matching inputs
- Add the `xsrfTokenInput` class to the XSRF token form fields
