### PR TITLE
Rerun the .DS_Store deletion script

### DIFF
--- a/com.woltlab.wcf/package.xml
+++ b/com.woltlab.wcf/package.xml
@@ -56,5 +56,7 @@
 		<instruction type="template">templates_update.tar</instruction>
 		
 		<instruction type="language"/>
+		
+		<instruction type="script">acp/update_com.woltlab.wcf_5.4.15_deleteDsStore.php</instruction>
 	</instructions>
 </package>

--- a/wcfsetup/install/files/acp/update_com.woltlab.wcf_5.4.15_deleteDsStore.php
+++ b/wcfsetup/install/files/acp/update_com.woltlab.wcf_5.4.15_deleteDsStore.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * Deletes .DS_Store and ._.DS_Store files.
+ *
+ * @author  Tim Duesterhus
+ * @copyright   2001-2021 WoltLab GmbH
+ * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @package WoltLabSuite\Core
+ */
+
+use wcf\data\application\Application;
+use wcf\system\WCF;
+
+$sql = "SELECT  *
+        FROM    wcf1_package_installation_file_log
+        WHERE   filename LIKE ?
+            OR  filename LIKE ?";
+$selectStatement = WCF::getDB()->prepare($sql);
+$selectStatement->execute([
+    '%/.DS_Store',
+    '%/._.DS_Store',
+]);
+
+$sql = "DELETE FROM wcf1_package_installation_file_log
+        WHERE       packageID = ?
+                AND filename = ?
+                AND application = ?";
+$deleteStatement = WCF::getDB()->prepare($sql);
+
+while (($row = $selectStatement->fetchArray())) {
+    $packageDir = Application::getDirectory($row['application']);
+    $fullPath = $packageDir . $row['filename'];
+
+    if (!\file_exists($fullPath) || !\is_file($fullPath)) {
+        continue;
+    }
+
+    if (
+        \basename($fullPath) !== '.DS_Store'
+        && \basename($fullPath) !== '._.DS_Store'
+    ) {
+        continue;
+    }
+
+    \unlink($fullPath);
+    $deleteStatement->execute([
+        $row['packageID'],
+        $row['filename'],
+        $row['application'],
+    ]);
+}


### PR DESCRIPTION
Apparently some installations still contain .DS_Store files assigned to
official packages. These might come from 5.3 installations that were
immediately upgraded to 5.4.4 or higher, without going through 5.4.3.

see 2bd8c2dba79878269981aac94c1ad51e94b2308e
