### PR TITLE
Use is_string to validate strings

### DIFF
--- a/wcfsetup/install/files/lib/data/AbstractDatabaseObjectAction.class.php
+++ b/wcfsetup/install/files/lib/data/AbstractDatabaseObjectAction.class.php
@@ -586,6 +586,9 @@ abstract class AbstractDatabaseObjectAction implements IDatabaseObjectAction, ID
                     }
                 } else {
                     if ($structure === self::STRUCT_FLAT) {
+                        if (!\is_string($target[$variableName])) {
+                            throw new UserInputException($variableName);
+                        }
                         $target[$variableName] = StringUtil::trim($target[$variableName]);
                         if (!$allowEmpty && $target[$variableName] === '') {
                             throw new UserInputException($variableName);


### PR DESCRIPTION
Ensures that `readString()` always returns a string. Previously it was possible to pass in an array as a parameter, which resulted in error messages.