### PR TITLE
Move `<meta charset="utf-8">` from headInclude.tpl to header.tpl

### DIFF
--- a/com.woltlab.wcf/templates/headInclude.tpl
+++ b/com.woltlab.wcf/templates/headInclude.tpl
@@ -1,4 +1,3 @@
-<meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="format-detection" content="telephone=no">
 {include file='headIncludeRobotsMetaTag'}

--- a/com.woltlab.wcf/templates/header.tpl
+++ b/com.woltlab.wcf/templates/header.tpl
@@ -1,6 +1,7 @@
 {include file='documentHeader'}
 
 <head>
+	<meta charset="utf-8">
 	{if !$pageTitle|isset}
 		{assign var='pageTitle' value=''}
 		{if (!$__wcf->isLandingPage() || !USE_PAGE_TITLE_ON_LANDING_PAGE) && $__wcf->getActivePage() != null && $__wcf->getActivePage()->getTitle()}


### PR DESCRIPTION
New version of #3998, #4543. `header.tpl` already received changes for the content interaction buttons, so this is safe enough to apply for 5.5.