### PR TITLE
Always check exclusions in PackageUpdateAction::createQueue()

### DIFF
--- a/wcfsetup/install/files/lib/data/package/update/PackageUpdateAction.class.php
+++ b/wcfsetup/install/files/lib/data/package/update/PackageUpdateAction.class.php
@@ -757,19 +757,17 @@ class PackageUpdateAction extends AbstractDatabaseObjectAction
         }
 
         // validate exclusions
-        if ($queueType == 'update') {
-            $excludedPackages = $scheduler->getExcludedPackages();
+        $excludedPackages = $scheduler->getExcludedPackages();
 
-            if (!empty($excludedPackages)) {
-                return [
-                    'template' => WCF::getTPL()->fetch(
-                        'packageUpdateExcludedPackages',
-                        'wcf',
-                        ['excludedPackages' => $excludedPackages]
-                    ),
-                    'type' => 'conflict',
-                ];
-            }
+        if (!empty($excludedPackages)) {
+            return [
+                'template' => WCF::getTPL()->fetch(
+                    'packageUpdateExcludedPackages',
+                    'wcf',
+                    ['excludedPackages' => $excludedPackages]
+                ),
+                'type' => 'conflict',
+            ];
         }
 
         $stack = $scheduler->getPackageInstallationStack();


### PR DESCRIPTION
Ever since the method checked for package exclusions in
1d7f1d205ee64fd2723877c1f296c592518e516d it only applied the check to updates,
not to fresh installs. It's not clear why it did so, I assume this to be an
oversight.

Change this to always run the exclusion check, otherwise exclusions might be
circumvented using PackageUpdateAction::prepareInstallation() with a
package+version combination that would regularly be excluded.
