### PR TITLE
 Fix calculation of next cronjob execution for list-separated hour declarations

### DIFF
--- a/wcfsetup/install/files/lib/util/CronjobUtil.class.php
+++ b/wcfsetup/install/files/lib/util/CronjobUtil.class.php
@@ -332,8 +332,8 @@ final class CronjobUtil
     }
 
     /**
-     * Calculates hour of next execution. Returns number of days which
-     * had been added in order to match expression for hour and minutes.
+     * Calculates hour of next execution. Returns true if hour-declaration
+     * has already elapsed, thus requiring at least one day to be added.
      *
      * @param array $values
      * @param int $timeBase

--- a/wcfsetup/install/files/lib/util/CronjobUtil.class.php
+++ b/wcfsetup/install/files/lib/util/CronjobUtil.class.php
@@ -199,10 +199,10 @@ final class CronjobUtil
      */
     protected static function calculateDay(array &$values)
     {
-        $addAnDay = self::calculateHour($values, self::$timeBase);
+        $addADay = self::calculateHour($values, self::$timeBase);
         $timeBase = self::$timeBase;
 
-        if ($addAnDay) {
+        if ($addADay) {
             $date = \explode('.', \date("d.m.Y", $timeBase));
             $timeBase = \mktime(0, 0, 1, (int)$date[1], (int)$date[0] + 1, (int)$date[2]);
         }
@@ -220,7 +220,7 @@ final class CronjobUtil
 
             $timeBase = \mktime(0, 0, 1, $month, $day, $year);
 
-            if (!$addAnDay) {
+            if (!$addADay) {
                 self::calculateHour($values, $timeBase);
             }
         }
@@ -341,19 +341,19 @@ final class CronjobUtil
      */
     protected static function calculateHour(array &$values, &$timeBase)
     {
-        $addAnDay = false;
+        $addADay = false;
 
         // compare hour
         $hour = \intval(\date('G', $timeBase));
         $index = self::findKey($hour, $values['hour'], false);
         if ($index === false) {
             $index = self::findKey($hour, $values['hour']);
-            $addAnDay = true;
+            $addADay = true;
         }
         $hour = $values['hour'][$index];
 
         // calculate minutes
-        $addAnHour = self::calculateMinute($values, $timeBase, $addAnDay);
+        $addAnHour = self::calculateMinute($values, $timeBase, $addADay);
 
         if ($addAnHour) {
             $hour++;
@@ -361,7 +361,7 @@ final class CronjobUtil
 
             if ($index === false) {
                 $index = self::findKey($hour, $values['hour']);
-                $addAnDay = true;
+                $addADay = true;
 
                 $hour = $values['hour'][$index];
             }
@@ -369,7 +369,7 @@ final class CronjobUtil
 
         self::$result['hour'] = $hour;
 
-        return $addAnDay;
+        return $addADay;
     }
 
     /**
@@ -378,14 +378,14 @@ final class CronjobUtil
      *
      * @param array $values
      * @param int $timeBase
-     * @param bool $addAnDay
+     * @param bool $addADay
      * @return  bool
      */
-    protected static function calculateMinute(array &$values, &$timeBase, $addAnDay)
+    protected static function calculateMinute(array &$values, &$timeBase, $addADay)
     {
         $returnValue = false;
 
-        if ($addAnDay) {
+        if ($addADay) {
             $minute = 0;
         } else {
             $minute = \date('i', $timeBase);

--- a/wcfsetup/install/files/lib/util/CronjobUtil.class.php
+++ b/wcfsetup/install/files/lib/util/CronjobUtil.class.php
@@ -344,10 +344,10 @@ final class CronjobUtil
         $addADay = false;
 
         // compare hour
-        $hour = \intval(\date('G', $timeBase));
-        $index = self::findKey($hour, $values['hour'], false);
+        $currentHour = \intval(\date('G', $timeBase));
+        $index = self::findKey($currentHour, $values['hour'], false);
         if ($index === false) {
-            $index = self::findKey($hour, $values['hour']);
+            $index = self::findKey($currentHour, $values['hour']);
             $addADay = true;
         }
         $hour = $values['hour'][$index];
@@ -355,7 +355,8 @@ final class CronjobUtil
         // calculate minutes
         $addAnHour = self::calculateMinute($values, $timeBase, $addADay);
 
-        if ($addAnHour) {
+        // only add an hour if the current hour is the same for which the minute-declaration has already elapsed
+        if ($addAnHour && $hour == $currentHour) {
             $hour++;
             $index = self::findKey($hour, $values['hour'], false);
 

--- a/wcfsetup/install/files/lib/util/CronjobUtil.class.php
+++ b/wcfsetup/install/files/lib/util/CronjobUtil.class.php
@@ -373,8 +373,8 @@ final class CronjobUtil
     }
 
     /**
-     * Calculates minutes of next execution. Returns false if minute-declaration
-     * is past the current hour, thus requires to add at least one hour.
+     * Calculates minutes of next execution. Returns true if minute-declaration
+     * has already elapsed, thus requiring at least one hour to be added.
      *
      * @param array $values
      * @param int $timeBase
@@ -383,7 +383,7 @@ final class CronjobUtil
      */
     protected static function calculateMinute(array &$values, &$timeBase, $addADay)
     {
-        $returnValue = false;
+        $addAnHour = false;
 
         if ($addADay) {
             $minute = 0;
@@ -397,12 +397,12 @@ final class CronjobUtil
         // notify calling method that we had to increase the hour
         if ($index === false) {
             $index = self::findKey($minute, $values['minute']);
-            $returnValue = true;
+            $addAnHour = true;
         }
 
         self::$result['minute'] = $values['minute'][$index];
 
-        return $returnValue;
+        return $addAnHour;
     }
 
     /**

--- a/wcfsetup/install/files/lib/util/CronjobUtil.class.php
+++ b/wcfsetup/install/files/lib/util/CronjobUtil.class.php
@@ -355,7 +355,8 @@ final class CronjobUtil
         // calculate minutes
         $addAnHour = self::calculateMinute($values, $timeBase, $addADay);
 
-        // only add an hour if the current hour is the same for which the minute-declaration has already elapsed
+        // only add an hour (potentially a day) if the current hour is the same
+        // for which the minute-declaration has already elapsed
         if ($addAnHour && $hour == $currentHour) {
             $hour++;
             $index = self::findKey($hour, $values['hour'], false);

--- a/wcfsetup/install/files/lib/util/CronjobUtil.class.php
+++ b/wcfsetup/install/files/lib/util/CronjobUtil.class.php
@@ -337,7 +337,7 @@ final class CronjobUtil
      *
      * @param array $values
      * @param int $timeBase
-     * @return  int
+     * @return  bool
      */
     protected static function calculateHour(array &$values, &$timeBase)
     {


### PR DESCRIPTION
See https://www.woltlab.com/community/thread/294564-fehler-bei-der-berechnung-von-cronjobs/

Fixes the calculation for cronjobs such as `0 4,16 * * *`. Cronjobs like `0 1 * * *`,  `*/10 * * * *` or `0 4-16 * * *` should not be affected, but further testing may be required.

If the hour (for the next execution) is greater than the current hour, the hour must not be increased when the minute declaration has elapsed. This may only happen if the next execution is to take place at the current hour, but this being no longer possible.