### PR TITLE
fix application management in multi domain setups

### DIFF
--- a/wcfsetup/install/files/lib/acp/form/ApplicationManagementForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/ApplicationManagementForm.class.php
@@ -103,11 +103,11 @@ final class ApplicationManagementForm extends AbstractForm
             if (!empty($this->cookieDomain) || !empty($this->domainName)) {
                 throw new PermissionDeniedException();
             }
-        }
-
-        if (empty($this->domainName)) {
-            throw new UserInputException('domainName');
         } else {
+            if (empty($this->domainName)) {
+                throw new UserInputException('domainName');
+            }
+
             $regex = new Regex('^https?\://');
             $this->domainName = FileUtil::removeTrailingSlash($regex->replace($this->domainName, ''));
             $this->cookieDomain = FileUtil::removeTrailingSlash($regex->replace($this->cookieDomain, ''));


### PR DESCRIPTION
Changing the landing pages of apps was failing since the domain name for single-domain-setups was validated for any case, but is not set when using a multi-domain-setup.
This lead to an un-meaningful error-message saying something is incorrect.