### PR TITLE
Fix handling of CMS pages in sitemap

### DIFF
--- a/wcfsetup/install/files/lib/system/sitemap/object/MultilingualPageSitemapObject.class.php
+++ b/wcfsetup/install/files/lib/system/sitemap/object/MultilingualPageSitemapObject.class.php
@@ -7,7 +7,6 @@ use wcf\data\page\content\PageContent;
 use wcf\data\page\content\PageContentList;
 use wcf\data\page\Page;
 use wcf\page\AbstractPage;
-use wcf\system\acl\simple\SimpleAclResolver;
 use wcf\system\exception\IllegalLinkException;
 use wcf\system\exception\PermissionDeniedException;
 
@@ -58,23 +57,15 @@ class MultilingualPageSitemapObject extends AbstractSitemapObjectObjectType
         /** @var $object PageContent */
         $page = new Page($object->pageID);
 
-        if ($page->isDisabled) {
-            return false;
-        }
-
         if ($page->requireObjectID) {
             return false;
         }
 
-        if (!$page->validateOptions()) {
+        if (!$page->isVisible()) {
             return false;
         }
 
-        if (!$page->validatePermissions()) {
-            return false;
-        }
-
-        if (!SimpleAclResolver::getInstance()->canAccess('com.woltlab.wcf.page', $object->pageID)) {
+        if (!$page->isAccessible()) {
             return false;
         }
 

--- a/wcfsetup/install/files/lib/system/sitemap/object/SimplePageSitemapObject.class.php
+++ b/wcfsetup/install/files/lib/system/sitemap/object/SimplePageSitemapObject.class.php
@@ -6,7 +6,6 @@ use wcf\data\DatabaseObject;
 use wcf\data\page\Page;
 use wcf\data\page\PageList;
 use wcf\page\AbstractPage;
-use wcf\system\acl\simple\SimpleAclResolver;
 use wcf\system\exception\IllegalLinkException;
 use wcf\system\exception\PermissionDeniedException;
 
@@ -47,24 +46,17 @@ class SimplePageSitemapObject extends AbstractSitemapObjectObjectType
      */
     public function canView(DatabaseObject $object)
     {
-        /** @var Page $object */
-        if ($object->isDisabled) {
-            return false;
-        }
+        \assert($object instanceof Page);
 
         if ($object->requireObjectID) {
             return false;
         }
 
-        if (!$object->validateOptions()) {
+        if (!$object->isVisible()) {
             return false;
         }
 
-        if (!$object->validatePermissions()) {
-            return false;
-        }
-
-        if (!SimpleAclResolver::getInstance()->canAccess('com.woltlab.wcf.page', $object->pageID)) {
+        if (!$object->isAccessible()) {
             return false;
         }
 


### PR DESCRIPTION
Delegate the visibility control and access control to the appropriate methods
in \wcf\data\page\Page instead of reimplementing it from scratch. Most notably
the inversion of the page ACL was not implemented correctly within the sitemap.

see 92fba0538afc1d88f411db1a80553af2d17c09b4
Closes #4767

/cc @mutec
