### PR TITLE
Flip only the file name casing on AbstractFileDeletePackageInstallationPlugin::isFilesystemCaseSensitive()

### DIFF
--- a/wcfsetup/install/files/lib/system/package/plugin/AbstractFileDeletePackageInstallationPlugin.class.php
+++ b/wcfsetup/install/files/lib/system/package/plugin/AbstractFileDeletePackageInstallationPlugin.class.php
@@ -136,10 +136,14 @@ abstract class AbstractFileDeletePackageInstallationPlugin extends AbstractXMLPa
         if ($isFilesystemCaseSensitive === null) {
             $testFilePath = __FILE__;
 
-            $invertedCase = \strtr(
-                $testFilePath,
-                "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz",
-                "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+            $invertedCase = \sprintf(
+                '%s/%s',
+                \dirname($testFilePath),
+                \strtr(
+                    \basename($testFilePath),
+                    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz",
+                    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                )
             );
 
             $isFilesystemCaseSensitive = !\file_exists($invertedCase);


### PR DESCRIPTION
Flipping the whole path does not provide any real benefit, because we only care
about whether the file system where WoltLab Suite resides is case sensitive or
not. It does however break when `open_basedir` is configured.
