### PR TITLE
Always restrict valid template modifiers to an allow list

### DIFF
--- a/wcfsetup/install/files/lib/system/template/TemplateScriptingCompiler.class.php
+++ b/wcfsetup/install/files/lib/system/template/TemplateScriptingCompiler.class.php
@@ -32,30 +32,10 @@ class TemplateScriptingCompiler
     protected $unknownPHPFunctions = ['isset', 'unset', 'empty'];
 
     /**
-     * PHP functions that can not be used in the modifier syntax
+     * PHP functions that may be used as a template modifier
      * @var string[]
      */
-    protected $disabledPHPFunctions = [
-        'system',
-        'exec',
-        'passthru',
-        'shell_exec', // command line execution
-        'include',
-        'require',
-        'include_once',
-        'require_once', // includes
-        'eval',
-        'virtual',
-        'call_user_func_array',
-        'call_user_func',
-        'assert', // code execution
-    ];
-
-    /**
-     * PHP functions and modifiers that can be used in enterprise mode
-     * @var string[]
-     */
-    protected $enterpriseFunctions = [
+    protected $allowedModifierFunctions = [
         'abs',
         'addslashes',
         'array_diff',
@@ -1622,12 +1602,9 @@ class TemplateScriptingCompiler
                                 $this->currentIdentifier,
                                 $this->currentLineNo
                             ));
-                        } elseif (
-                            \in_array($modifierData['name'], $this->disabledPHPFunctions)
-                            || (ENABLE_ENTERPRISE_MODE && !\in_array($modifierData['name'], $this->enterpriseFunctions))
-                        ) {
+                        } elseif (!\in_array($modifierData['name'], $this->allowedModifierFunctions)) {
                             throw new SystemException(static::formatSyntaxError(
-                                "disabled function '" . $values[$i] . "'",
+                                "function '" . $values[$i] . "' may not be called within a template",
                                 $this->currentIdentifier,
                                 $this->currentLineNo
                             ));


### PR DESCRIPTION
Previously this allow list was only used in enterprise mode, but it is
generally a useful security feature. Thus the allow list previously known as
`$enterpriseFunctions` is applied in call cases.

This also makes it easier for developers, as there will be less differences
between the enterprise mode and the non-enterprise mode.

As before this allow list can easily be extended if a useful function is
missing from it.
