### PR TITLE
Remove the WCF_N input in WCFSetup

### DIFF
--- a/extra/examples/wsc-dev-config-55.json
+++ b/extra/examples/wsc-dev-config-55.json
@@ -4,8 +4,7 @@
             "auto": true,
             "host": "localhost",
             "password": "root",
-            "username": "root",
-            "dbNumber": "2"
+            "username": "root"
         },
         "useDefaultInstallPath": true,
         "forceStaticCookiePrefix": true

--- a/wcfsetup/install/files/lib/system/devtools/DevtoolsSetup.class.php
+++ b/wcfsetup/install/files/lib/system/devtools/DevtoolsSetup.class.php
@@ -79,7 +79,6 @@ class DevtoolsSetup extends SingletonFactory
             'password' => $dbConfig['password'],
             'username' => $dbConfig['username'],
             'dbName' => $dbName,
-            'dbNumber' => $dbConfig['dbNumber'],
         ];
     }
 

--- a/wcfsetup/setup/lang/setup_de.xml
+++ b/wcfsetup/setup/lang/setup_de.xml
@@ -61,11 +61,9 @@
 		<item name="wcf.global.configureDB.password"><![CDATA[Kennwort]]></item>
 		<item name="wcf.global.configureDB.database"><![CDATA[Datenbankname]]></item>
 		<item name="wcf.global.configureDB.database.description"><![CDATA[Die spezifizierte Datenbank muss bereits angelegt sein.]]></item>
-		<item name="wcf.global.configureDB.number"><![CDATA[Installationsnummer]]></item>
-		<item name="wcf.global.configureDB.number.description"><![CDATA[Die Installationsnummer erlaubt Ihnen mehrere Installationen der Software in der gleichen Datenbank zu speichern. Wenn dies Ihre erste Installation der Software in dieser Datenbank ist, sollten Sie hier den Wert <em>1</em> wählen.]]></item>
 		<item name="wcf.global.configureDB.error"><![CDATA[Beim Verbindungsversuch mit der Datenbank ist folgender Fehler aufgetreten:
 		<br><strong>{$exception->getMessage()}{if $exception->getPrevious()}<br>{$exception->getPrevious()->getMessage()}{/if}</strong>]]></item>
-		<item name="wcf.global.configureDB.conflictedTables"><![CDATA[Folgende Tabelle{if $conflictedTables|count > 1}n{/if} existier{if $conflictedTables|count > 1}en{else}t{/if} schon in der Datenbank „{$dbName}“:<br>{implode from=$conflictedTables item="table"}{$table}{/implode}.<br><br>Um dieses Problem zu beheben, können Sie:<br>1. diese Tabelle{if $conflictedTables|count > 1}n{/if} manuell löschen und die „Weiter“ Schaltfläche betätigen, oder<br>2. Sie geben die Daten einer anderen Datenbank ein und betätigen die „Weiter“ Schaltfläche, oder<br>3. Sie geben eine von „{$dbNumber}“ unterschiedliche Installationsnummer an und betätigen die „Weiter“ Schaltfläche.]]></item>
+		<item name="wcf.global.configureDB.conflictedTables"><![CDATA[Folgende Tabelle{if $conflictedTables|count > 1}n{/if} existier{if $conflictedTables|count > 1}en{else}t{/if} schon in der Datenbank „{$dbName}“:<br>{implode from=$conflictedTables item="table"}{$table}{/implode}.<br><br>Um dieses Problem zu beheben, können Sie:<br>1. diese Tabelle{if $conflictedTables|count > 1}n{/if} manuell löschen und die „Weiter“ Schaltfläche betätigen, oder<br>2. Sie geben die Daten einer anderen Datenbank ein und betätigen die „Weiter“ Schaltfläche.]]></item>
 		<item name="wcf.global.createUser"><![CDATA[Administrator erstellen]]></item>
 		<item name="wcf.global.createUser.description"><![CDATA[Der Installationsassistent erstellt nun ein Administrator-Konto für Sie. Bitte geben Sie dazu einen Benutzernamen, eine E-Mail-Adresse und ein Kennwort ein.]]></item>
 		<item name="wcf.global.createUser.username"><![CDATA[Benutzername]]></item>

--- a/wcfsetup/setup/lang/setup_en.xml
+++ b/wcfsetup/setup/lang/setup_en.xml
@@ -61,11 +61,9 @@
 		<item name="wcf.global.configureDB.password"><![CDATA[Password]]></item>
 		<item name="wcf.global.configureDB.database"><![CDATA[Database Name]]></item>
 		<item name="wcf.global.configureDB.database.description"><![CDATA[The database must already exist.]]></item>
-		<item name="wcf.global.configureDB.number"><![CDATA[Installation Number]]></item>
-		<item name="wcf.global.configureDB.number.description"><![CDATA[The installation number allows you to install multiple installations of this software into the same database. If this is your first installation in this database, you should enter <em>1</em>.]]></item>
 		<item name="wcf.global.configureDB.error"><![CDATA[An error has occurred while trying to connect to your database:
 		<br><strong>{$exception->getMessage()}{if $exception->getPrevious()}<br>{$exception->getPrevious()->getMessage()}{/if}</strong>]]></item>
-		<item name="wcf.global.configureDB.conflictedTables"><![CDATA[The following table{if $conflictedTables|count > 1}s{/if} already exist{if $conflictedTables|count == 1}s{/if} within your “{$dbName}” Database:<br>{implode from=$conflictedTables item="table"}{$table}{/implode}.<br><br>To solve this problem, please do one of the following:<br>1. Remove the table{if $conflictedTables|count > 1}s{/if} manually and continue the installation with the “Next” button or<br>2. You re-enter the database access information, but to a different database and continue the installation with the “Next” button or<br>3. Enter a new installation number, not forgetting to continue the installation with the “Next” Button.]]></item>
+		<item name="wcf.global.configureDB.conflictedTables"><![CDATA[The following table{if $conflictedTables|count > 1}s{/if} already exist{if $conflictedTables|count == 1}s{/if} within your “{$dbName}” Database:<br>{implode from=$conflictedTables item="table"}{$table}{/implode}.<br><br>To solve this problem, please do one of the following:<br>1. Remove the table{if $conflictedTables|count > 1}s{/if} manually and continue the installation with the “Next” button or<br>2. You re-enter the database access information, but to a different database and continue the installation with the “Next” button.]]></item>
 		<item name="wcf.global.createUser"><![CDATA[Create an Administrator]]></item>
 		<item name="wcf.global.createUser.description"><![CDATA[The installation will now generate an administrator account for you. Please provide username, email address and password.]]></item>
 		<item name="wcf.global.createUser.username"><![CDATA[Username]]></item>

--- a/wcfsetup/setup/template/stepConfigureDB.tpl
+++ b/wcfsetup/setup/template/stepConfigureDB.tpl
@@ -37,14 +37,6 @@
 				<small>{lang}wcf.global.configureDB.database.description{/lang}</small>
 			</dd>
 		</dl>
-		
-		<dl>
-			<dt><label for="dbNumber">{lang}wcf.global.configureDB.number{/lang}</label></dt>
-			<dd>
-				<input type="number" id="dbNumber" name="dbNumber" value="{$dbNumber}" required min="1" class="short">
-				<small>{lang}wcf.global.configureDB.number.description{/lang}</small>
-			</dd>
-		</dl>
 	</section>
 		
 	<div class="formSubmit">


### PR DESCRIPTION
Users should install separate instances into separate databases for security
reasons. This also avoids issues with users running a non-standard number and
any existing guides / queries not working, because the database tables have a
different name.
