### PR TITLE
Use HTTP 500 in error conditions

### DIFF
--- a/wcfsetup/install/files/lib/system/WCF.class.php
+++ b/wcfsetup/install/files/lib/system/WCF.class.php
@@ -311,7 +311,7 @@ class WCF
             }
         }
 
-        @\header('HTTP/1.1 503 Service Unavailable');
+        @\header('HTTP/1.1 500 Internal Server Error');
         try {
             \wcf\functions\exception\printThrowable($e);
         } catch (\Throwable $e2) {

--- a/wcfsetup/install/files/proxy_sourcemap.php
+++ b/wcfsetup/install/files/proxy_sourcemap.php
@@ -149,7 +149,7 @@ function handle(ServerRequestInterface $request): ResponseInterface
     $body = new Stream(\fopen($cacheFilename, 'r'));
 
     if ($body->getSize() === 0) {
-        return new TextResponse('Failed to download the source map.', 503);
+        return new TextResponse('Failed to download the source map.', 500);
     }
 
     return new Response(


### PR DESCRIPTION
Sending a 500 Internal Server Error for unplanned errors is more appropriate
than a 503 Service Unavailable, as the latter is defined:

RFC 7231#6.6.4:

> The 503 (Service Unavailable) status code indicates that the server
> is currently unable to handle the request due to a temporary overload
> or scheduled maintenance, which will likely be alleviated after some
> delay.

It's not likely that the exception will resolve itself after some delay.
