### PR TITLE
Remove unneeded usage of `mb_strpos`

### DIFF
--- a/wcfsetup/install/files/lib/acp/form/UserGroupAddForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/UserGroupAddForm.class.php
@@ -154,7 +154,7 @@ class UserGroupAddForm extends AbstractOptionListForm
                     throw new UserInputException('groupName', 'multilingual');
                 }
             }
-            if (\mb_strpos($this->userOnlineMarking, '%s') === false) {
+            if (!\str_contains($this->userOnlineMarking, '%s')) {
                 throw new UserInputException('userOnlineMarking', 'invalid');
             }
         } catch (UserInputException $e) {

--- a/wcfsetup/install/files/lib/acp/page/ExceptionLogViewPage.class.php
+++ b/wcfsetup/install/files/lib/acp/page/ExceptionLogViewPage.class.php
@@ -110,7 +110,7 @@ class ExceptionLogViewPage extends MultipleLinkPage
             foreach ($this->logFiles as $logFile) {
                 $contents = \file_get_contents($logFile);
 
-                if (\mb_strpos($contents, '<<<<<<<<' . $this->exceptionID . '<<<<') !== false) {
+                if (\str_contains($contents, '<<<<<<<<' . $this->exceptionID . '<<<<')) {
                     $fileNameRegex->match($logFile);
                     $matches = $fileNameRegex->getMatches();
                     $this->logFile = $matches[0];

--- a/wcfsetup/install/files/lib/data/option/Option.class.php
+++ b/wcfsetup/install/files/lib/data/option/Option.class.php
@@ -150,7 +150,7 @@ class Option extends DatabaseObject
         $options = \explode("\n", StringUtil::trim(StringUtil::unifyNewlines($this->selectOptions)));
         foreach ($options as $option) {
             $key = $value = $option;
-            if (\mb_strpos($option, ':') !== false) {
+            if (\str_contains($option, ':')) {
                 $optionData = \explode(':', $option);
                 $key = \array_shift($optionData);
                 $value = \implode(':', $optionData);
@@ -174,7 +174,7 @@ class Option extends DatabaseObject
             $options = \explode("\n", StringUtil::trim(StringUtil::unifyNewlines($this->enableOptions)));
             $key = -1;
             foreach ($options as $option) {
-                if (\mb_strpos($option, ':') !== false) {
+                if (\str_contains($option, ':')) {
                     $optionData = \explode(':', $option);
                     $key = \array_shift($optionData);
                     $value = \implode(':', $optionData);

--- a/wcfsetup/install/files/lib/data/package/Package.class.php
+++ b/wcfsetup/install/files/lib/data/package/Package.class.php
@@ -386,7 +386,7 @@ class Package extends DatabaseObject implements ILinkableObject, IRouteControlle
      */
     public static function checkFromversion($currentVersion, $fromVersion)
     {
-        if (\mb_strpos($fromVersion, '*') !== false) {
+        if (\str_contains($fromVersion, '*')) {
             // from version with wildcard
             // use regular expression
             $fromVersion = \str_replace('\*', '.*', \preg_quote($fromVersion, '!'));

--- a/wcfsetup/install/files/lib/page/AbstractPage.class.php
+++ b/wcfsetup/install/files/lib/page/AbstractPage.class.php
@@ -332,10 +332,8 @@ abstract class AbstractPage implements IPage
                     }
 
                     if (!empty($rQueryString)) {
-                        $redirectURL .= (\mb_strpos(
-                            $redirectURL,
-                            '?'
-                        ) === false ? '?' : '&') . \http_build_query($rQueryString, '', '&');
+                        $redirectURL .= !\str_contains($redirectURL, '?') ? '?' : '&';
+                        $redirectURL .= \http_build_query($rQueryString, '', '&');
                     }
                 }
 

--- a/wcfsetup/install/files/lib/page/MembersListPage.class.php
+++ b/wcfsetup/install/files/lib/page/MembersListPage.class.php
@@ -91,10 +91,9 @@ class MembersListPage extends SortablePage
 
         // letter
         if (
-            isset($_REQUEST['letter']) && \mb_strlen($_REQUEST['letter']) == 1 && \mb_strpos(
-                self::$availableLetters,
-                $_REQUEST['letter']
-            ) !== false
+            isset($_REQUEST['letter'])
+            && \mb_strlen($_REQUEST['letter']) == 1
+            && \str_contains(self::$availableLetters, $_REQUEST['letter'])
         ) {
             $this->letter = $_REQUEST['letter'];
         }

--- a/wcfsetup/install/files/lib/system/WCFSetup.class.php
+++ b/wcfsetup/install/files/lib/system/WCFSetup.class.php
@@ -600,7 +600,7 @@ class WCFSetup extends WCF
             $relativePath = FileUtil::getRelativePath($documentRoot, INSTALL_SCRIPT_DIR);
             foreach ($packages as $application => $packageData) {
                 $dir = $relativePath . ($application === 'wcf' ? '' : $packageData['directory'] . '/');
-                if (\mb_strpos($dir, './') === 0) {
+                if (\str_starts_with($dir, './')) {
                     $dir = \mb_substr($dir, 1);
                 }
 
@@ -1174,7 +1174,7 @@ class WCFSetup extends WCF
         $otherPackages = [];
         $tar = new Tar(SETUP_FILE);
         foreach ($tar->getContentList() as $file) {
-            if ($file['type'] != 'folder' && \mb_strpos($file['filename'], 'install/packages/') === 0) {
+            if ($file['type'] != 'folder' && \str_starts_with($file['filename'], 'install/packages/')) {
                 $packageFile = \basename($file['filename']);
 
                 // ignore any files which aren't an archive
@@ -1393,7 +1393,7 @@ class WCFSetup extends WCF
         $packageNames = [];
         $tar = new Tar(SETUP_FILE);
         foreach ($tar->getContentList() as $file) {
-            if ($file['type'] != 'folder' && \mb_strpos($file['filename'], 'install/packages/') === 0) {
+            if ($file['type'] != 'folder' && \str_starts_with($file['filename'], 'install/packages/')) {
                 $packageFile = \basename($file['filename']);
 
                 try {

--- a/wcfsetup/install/files/lib/system/bbcode/SimpleMessageParser.class.php
+++ b/wcfsetup/install/files/lib/system/bbcode/SimpleMessageParser.class.php
@@ -163,7 +163,7 @@ class SimpleMessageParser extends SingletonFactory
         $text = \preg_replace_callback($urlPattern, [$this, 'cacheURLsCallback'], $text);
 
         // parse emails
-        if (\mb_strpos($text, '@') !== false) {
+        if (\str_contains($text, '@')) {
             $text = \preg_replace_callback($emailPattern, [$this, 'cacheEmailsCallback'], $text);
         }
 

--- a/wcfsetup/install/files/lib/system/bbcode/highlighter/PhpHighlighter.class.php
+++ b/wcfsetup/install/files/lib/system/bbcode/highlighter/PhpHighlighter.class.php
@@ -44,7 +44,7 @@ class PhpHighlighter extends Highlighter
     {
         // add starting php tag
         $phpTagsAdded = false;
-        if (\mb_strpos($string, '<?') === false) {
+        if (!\str_contains($string, '<?')) {
             $phpTagsAdded = true;
             $string = '<?php ' . $string . ' ?>';
         }

--- a/wcfsetup/install/files/lib/system/condition/UserEmailCondition.class.php
+++ b/wcfsetup/install/files/lib/system/condition/UserEmailCondition.class.php
@@ -54,7 +54,7 @@ class UserEmailCondition extends AbstractTextCondition implements
      */
     public function checkUser(Condition $condition, User $user)
     {
-        return \mb_strpos($user->email, $condition->email) !== false;
+        return \str_contains($user->email, $condition->email);
     }
 
     /**

--- a/wcfsetup/install/files/lib/system/condition/UserUsernameCondition.class.php
+++ b/wcfsetup/install/files/lib/system/condition/UserUsernameCondition.class.php
@@ -54,7 +54,7 @@ class UserUsernameCondition extends AbstractTextCondition implements
      */
     public function checkUser(Condition $condition, User $user)
     {
-        return \mb_strpos($user->username, $condition->username) !== false;
+        return \str_contains($user->username, $condition->username);
     }
 
     /**

--- a/wcfsetup/install/files/lib/system/exception/ValidateActionException.class.php
+++ b/wcfsetup/install/files/lib/system/exception/ValidateActionException.class.php
@@ -32,7 +32,7 @@ class ValidateActionException extends \Exception
     public function __construct($fieldName, $errorMessage = 'empty', array $variables = [])
     {
         $this->errorMessage = $errorMessage;
-        if (\mb_strpos($this->errorMessage, '.') === false) {
+        if (!\str_contains($this->errorMessage, '.')) {
             if (\preg_match('~^[a-zA-Z0-9-_]+$~', $this->errorMessage)) {
                 $this->errorMessage = WCF::getLanguage()
                     ->getDynamicVariable('wcf.global.form.error.' . $this->errorMessage);

--- a/wcfsetup/install/files/lib/system/form/FormDocument.class.php
+++ b/wcfsetup/install/files/lib/system/form/FormDocument.class.php
@@ -116,7 +116,7 @@ class FormDocument
         $variables = [];
 
         foreach ($_REQUEST as $key => $value) {
-            if (\mb_strpos($key, $this->getName() . '_') !== false) {
+            if (\str_contains($key, $this->getName() . '_')) {
                 $key = \str_replace($this->getName() . '_', '', $key);
                 $variables[$key] = $value;
             }

--- a/wcfsetup/install/files/lib/system/html/input/node/HtmlInputNodeTextParser.class.php
+++ b/wcfsetup/install/files/lib/system/html/input/node/HtmlInputNodeTextParser.class.php
@@ -235,7 +235,7 @@ class HtmlInputNodeTextParser
      */
     protected function detectMention(\DOMText $text, $value, array &$usernames)
     {
-        if (\mb_strpos($value, '@') === false) {
+        if (!\str_contains($value, '@')) {
             return;
         }
 
@@ -271,7 +271,7 @@ class HtmlInputNodeTextParser
         $exactValues = [];
         $likeValues = [];
         foreach ($usernames as $username) {
-            if (\mb_strpos($username, ' ') !== false) {
+            if (\str_contains($username, ' ')) {
                 // string contains a whitespace, account for names that
                 // are built up with more than two words
                 $likeValues[] = $username;
@@ -365,7 +365,7 @@ class HtmlInputNodeTextParser
      */
     protected function parseMention(\DOMText $text, $value, array $users, array $groups)
     {
-        if (\mb_strpos($value, '@') === false) {
+        if (!\str_contains($value, '@')) {
             return $value;
         }
 
@@ -475,7 +475,7 @@ class HtmlInputNodeTextParser
      */
     protected function parseEmail(\DOMText $text, $value)
     {
-        if (\mb_strpos($value, '@') === false) {
+        if (!\str_contains($value, '@')) {
             return $value;
         }
 

--- a/wcfsetup/install/files/lib/system/html/metacode/converter/CodeMetacodeConverter.class.php
+++ b/wcfsetup/install/files/lib/system/html/metacode/converter/CodeMetacodeConverter.class.php
@@ -33,7 +33,7 @@ class CodeMetacodeConverter extends AbstractMetacodeConverter
             case 1:
                 if (\is_numeric($attributes[0])) {
                     $line = \intval($attributes[0]);
-                } elseif (\mb_strpos($attributes[0], '.') === false) {
+                } elseif (!\str_contains($attributes[0], '.')) {
                     $highlighter = $attributes[0];
                 } else {
                     $file = $attributes[0];
@@ -43,7 +43,7 @@ class CodeMetacodeConverter extends AbstractMetacodeConverter
             case 2:
                 if (\is_numeric($attributes[0])) {
                     $line = \intval($attributes[0]);
-                    if (\mb_strpos($attributes[1], '.') === false) {
+                    if (!\str_contains($attributes[1], '.')) {
                         $highlighter = $attributes[1];
                     } else {
                         $file = $attributes[1];
@@ -76,7 +76,7 @@ class CodeMetacodeConverter extends AbstractMetacodeConverter
         $replaceNodes = [];
         /** @var \DOMText $textNode */
         foreach ($xpath->query('.//text()', $element) as $textNode) {
-            if (\mb_strpos($textNode->textContent, "\n") !== false) {
+            if (\str_contains($textNode->textContent, "\n")) {
                 $replaceNodes[] = $textNode;
             }
         }

--- a/wcfsetup/install/files/lib/system/html/metacode/converter/ListMetacodeConverter.class.php
+++ b/wcfsetup/install/files/lib/system/html/metacode/converter/ListMetacodeConverter.class.php
@@ -35,7 +35,7 @@ class ListMetacodeConverter extends AbstractMetacodeConverter
         $xpath = new \DOMXPath($element->ownerDocument);
         /** @var \DOMText $node */
         foreach ($xpath->query('.//text()', $element) as $node) {
-            if (\mb_strpos($node->textContent, '[*]') !== false && !$this->isInsideList($node)) {
+            if (\str_contains($node->textContent, '[*]') && !$this->isInsideList($node)) {
                 $nodes[] = $node;
             }
         }

--- a/wcfsetup/install/files/lib/system/html/metacode/converter/UrlMetacodeConverter.class.php
+++ b/wcfsetup/install/files/lib/system/html/metacode/converter/UrlMetacodeConverter.class.php
@@ -34,7 +34,7 @@ class UrlMetacodeConverter extends AbstractMetacodeConverter
         }
 
         $href = StringUtil::decodeHTML($href);
-        if (\mb_strpos($href, '//') === 0) {
+        if (\str_starts_with($href, '//')) {
             // dynamic protocol, treat as https
             $href = "https:{$href}";
         } elseif (\preg_match('~^(?P<schema>[a-z0-9]+)://~', $href, $match)) {
@@ -42,7 +42,7 @@ class UrlMetacodeConverter extends AbstractMetacodeConverter
                 // invalid schema, replace it with `http`
                 $href = 'http' . \mb_substr($href, \strlen($match['schema']));
             }
-        } elseif (\mb_strpos($href, 'index.php') === false) {
+        } elseif (!\str_contains($href, 'index.php')) {
             // unless it's a relative `index.php` link, assume it is missing the protocol
             $href = "http://{$href}";
         }

--- a/wcfsetup/install/files/lib/system/html/node/AbstractHtmlNodeProcessor.class.php
+++ b/wcfsetup/install/files/lib/system/html/node/AbstractHtmlNodeProcessor.class.php
@@ -95,7 +95,7 @@ abstract class AbstractHtmlNodeProcessor implements IHtmlNodeProcessor
             foreach ($pre->childNodes as $node) {
                 if (
                     $node->nodeType === \XML_TEXT_NODE
-                    && \mb_strpos($node->textContent, '@@@WCF_PRE_LINEBREAK@@@') !== false
+                    && \str_contains($node->textContent, '@@@WCF_PRE_LINEBREAK@@@')
                 ) {
                     $node->nodeValue = \str_replace('@@@WCF_PRE_LINEBREAK@@@', "\n", $node->textContent);
                 }
@@ -126,16 +126,14 @@ abstract class AbstractHtmlNodeProcessor implements IHtmlNodeProcessor
                     $string = $obj->replaceTag($data['data']);
 
                     if (!isset($data['data']['skipInnerContent']) || $data['data']['skipInnerContent'] !== true) {
-                        if (\mb_strpos($string, '<!-- META_CODE_INNER_CONTENT -->') !== false) {
+                        if (\str_contains($string, '<!-- META_CODE_INNER_CONTENT -->')) {
                             return \str_replace('<!-- META_CODE_INNER_CONTENT -->', $matches['content'], $string);
-                        } else {
-                            if (\mb_strpos($string, '&lt;!-- META_CODE_INNER_CONTENT --&gt;') !== false) {
-                                return \str_replace(
-                                    '&lt;!-- META_CODE_INNER_CONTENT --&gt;',
-                                    $matches['content'],
-                                    $string
-                                );
-                            }
+                        } elseif (\str_contains($string, '&lt;!-- META_CODE_INNER_CONTENT --&gt;')) {
+                            return \str_replace(
+                                '&lt;!-- META_CODE_INNER_CONTENT --&gt;',
+                                $matches['content'],
+                                $string
+                            );
                         }
                     }
 

--- a/wcfsetup/install/files/lib/system/html/output/node/HtmlOutputNodePre.class.php
+++ b/wcfsetup/install/files/lib/system/html/output/node/HtmlOutputNodePre.class.php
@@ -166,45 +166,45 @@ class HtmlOutputNodePre extends AbstractHtmlOutputNode
     public function guessHighlighter($content)
     {
         // PHP at the beginning is almost surely PHP.
-        if (\mb_strpos($content, '<?php') === 0) {
+        if (\str_starts_with($content, '<?php')) {
             return 'php';
         }
 
         if (
-            \mb_strpos($content, 'SELECT') === 0
-            || \mb_strpos($content, 'UPDATE') === 0
-            || \mb_strpos($content, 'INSERT') === 0
-            || \mb_strpos($content, 'DELETE') === 0
+            \str_starts_with($content, 'SELECT')
+            || \str_starts_with($content, 'UPDATE')
+            || \str_starts_with($content, 'INSERT')
+            || \str_starts_with($content, 'DELETE')
         ) {
             return 'sql';
         }
 
-        if (\mb_strpos($content, 'import java.') !== false) {
+        if (\str_contains($content, 'import java.')) {
             return 'java';
         }
 
-        if (\mb_strpos($content, 'using System;') !== false) {
+        if (\str_contains($content, 'using System;')) {
             return 'csharp';
         }
 
         if (
-            \mb_strpos($content, "---") !== false
-            && \mb_strpos($content, "\n+++") !== false
+            \str_contains($content, "---")
+            && \str_contains($content, "\n+++")
         ) {
             return 'diff';
         }
 
-        if (\mb_strpos($content, "\n#include ") !== false) {
+        if (\str_contains($content, "\n#include ")) {
             return 'c';
         }
 
-        if (\mb_strpos($content, '#!/usr/bin/perl') === 0) {
+        if (\str_starts_with($content, '#!/usr/bin/perl')) {
             return 'perl';
         }
 
         if (
-            \mb_strpos($content, '#!/usr/bin/python') === 0
-            || \mb_strpos($content, 'def __init__(self') !== false
+            \str_starts_with($content, '#!/usr/bin/python')
+            || \str_contains($content, 'def __init__(self')
             || Regex::compile("from (\\S+) import (\\S+)")->match($content)
         ) {
             return 'python';
@@ -215,51 +215,53 @@ class HtmlOutputNodePre extends AbstractHtmlOutputNode
         }
 
         if (
-            \mb_strpos($content, 'FROM') === 0
-            && \mb_strpos($content, "RUN") !== false
+            \str_starts_with($content, 'FROM')
+            && \str_contains($content, "RUN")
         ) {
             return 'docker';
         }
 
         if (
-            \mb_stripos($content, "RewriteRule") !== false
-            || \mb_stripos($content, "RewriteEngine On") !== false
-            || \mb_stripos($content, "AuthUserFile") !== false
+            \stripos($content, "RewriteRule") !== false
+            || \stripos($content, "RewriteEngine On") !== false
+            || \stripos($content, "AuthUserFile") !== false
         ) {
             return 'apacheconf';
         }
 
-        if (\mb_strpos($content, '\\documentclass') !== false) {
+        if (\str_contains($content, '\\documentclass')) {
             return 'latex';
         }
 
         // PHP somewhere later might not necessarily be PHP, it could also be
         // a .patch or a Dockerfile.
-        if (\mb_strpos($content, '<?php') !== false) {
+        if (\str_contains($content, '<?php')) {
             return 'php';
         }
 
         if (
-            \mb_strpos($content, '{/if}') !== false
-            && (\mb_strpos($content, '<div') !== false
-                || \mb_strpos($content, '<span') !== false)
+            \str_contains($content, '{/if}')
+            && (
+                \str_contains($content, '<div')
+                || \str_contains($content, '<span')
+            )
         ) {
             return 'smarty';
         }
 
-        if (\mb_strpos($content, '<html') !== false) {
+        if (\str_contains($content, '<html')) {
             return 'html';
         }
 
-        if (\mb_strpos($content, '<?xml') === 0) {
+        if (\str_starts_with($content, '<?xml')) {
             return 'xml';
         }
 
-        if (\mb_strpos($content, '@mixin') !== false) {
+        if (\str_contains($content, '@mixin')) {
             return 'scss';
         }
 
-        if (\mb_strpos($content, '!important;') !== false) {
+        if (\str_contains($content, '!important;')) {
             return 'css';
         }
 

--- a/wcfsetup/install/files/lib/system/html/output/node/HtmlOutputNodeWoltlabQuote.class.php
+++ b/wcfsetup/install/files/lib/system/html/output/node/HtmlOutputNodeWoltlabQuote.class.php
@@ -46,7 +46,7 @@ class HtmlOutputNodeWoltlabQuote extends AbstractHtmlOutputNode
                     }
 
                     $link = $element->getAttribute('data-link');
-                    if (\mb_strpos($link, 'index.php') === 0) {
+                    if (\str_starts_with($link, 'index.php')) {
                         $link = WCF::getPath() . $link;
                     }
 

--- a/wcfsetup/install/files/lib/system/message/censorship/Censorship.class.php
+++ b/wcfsetup/install/files/lib/system/message/censorship/Censorship.class.php
@@ -101,7 +101,7 @@ class Censorship extends SingletonFactory
 
                     continue 2;
                 } // check for asterisk matches ("*badword*" == "FooBadwordBar")
-                elseif (\mb_strpos($censoredWord, '*') !== false) {
+                elseif (\str_contains($censoredWord, '*')) {
                     $censoredWord = \str_replace('\*', '.*', \preg_quote($censoredWord, '!'));
                     if (\preg_match('!^' . $censoredWord . '$!', $word)) {
                         // store censored word
@@ -114,7 +114,7 @@ class Censorship extends SingletonFactory
                         continue 2;
                     }
                 } // check for partial matches ("~badword~" == "bad-word")
-                elseif (\mb_strpos($censoredWord, '~') !== false) {
+                elseif (\str_contains($censoredWord, '~')) {
                     $censoredWord = \str_replace('~', '', $censoredWord);
                     if (($position = \mb_strpos($censoredWord, $word)) !== false) {
                         if ($position > 0) {
@@ -203,9 +203,9 @@ class Censorship extends SingletonFactory
     protected function lookAhead($index, $search)
     {
         if (isset($this->words[$index])) {
-            if (\mb_strpos($this->words[$index], $search) === 0) {
+            if (\str_starts_with($this->words[$index], $search)) {
                 return $index;
-            } elseif (\mb_strpos($search, $this->words[$index]) === 0) {
+            } elseif (\str_starts_with($search, $this->words[$index])) {
                 return $this->lookAhead($index + 1, \mb_substr($search, \mb_strlen($this->words[$index])));
             }
         }

--- a/wcfsetup/install/files/lib/system/option/RadioButtonOptionType.class.php
+++ b/wcfsetup/install/files/lib/system/option/RadioButtonOptionType.class.php
@@ -166,7 +166,7 @@ class RadioButtonOptionType extends AbstractOptionType implements
 
         $i = 0;
         foreach ($valueToOptions as $valueToOption) {
-            if (\mb_strpos($valueToOption, ':') !== false) {
+            if (\str_contains($valueToOption, ':')) {
                 $optionData = \explode(':', $valueToOption);
                 $key = \array_shift($optionData);
                 $enableOptionValues = \implode(':', $optionData);

--- a/wcfsetup/install/files/lib/system/option/user/SelectOptionsUserOptionOutput.class.php
+++ b/wcfsetup/install/files/lib/system/option/user/SelectOptionsUserOptionOutput.class.php
@@ -52,7 +52,7 @@ class SelectOptionsUserOptionOutput implements IUserOptionOutput
         $options = OptionUtil::parseSelectOptions($option->selectOptions);
 
         // multiselect
-        if (\mb_strpos($value, "\n") !== false) {
+        if (\str_contains($value, "\n")) {
             $values = \explode("\n", $value);
             $result = [];
             foreach ($values as $value) {

--- a/wcfsetup/install/files/lib/system/setup/Installer.class.php
+++ b/wcfsetup/install/files/lib/system/setup/Installer.class.php
@@ -133,7 +133,7 @@ class Installer
         $directories = [];
         $files = [];
         foreach ($tar->getContentList() as $index => $file) {
-            if (empty($this->folder) || \mb_strpos($file['filename'], $this->folder) === 0) {
+            if (empty($this->folder) || \str_starts_with($file['filename'], $this->folder)) {
                 if (!empty($this->folder)) {
                     $file['filename'] = \str_replace($this->folder, '', $file['filename']);
                 }

--- a/wcfsetup/install/files/lib/system/template/TemplateScriptingCompiler.class.php
+++ b/wcfsetup/install/files/lib/system/template/TemplateScriptingCompiler.class.php
@@ -1190,12 +1190,12 @@ class TemplateScriptingCompiler
 
             // reinserts strings
             foreach (StringStack::getStack('singleQuote') as $hash => $value) {
-                if (\mb_strpos($string, $hash) !== false) {
+                if (\str_contains($string, $hash)) {
                     $string = \str_replace($hash, $value, $string);
                 }
             }
             foreach (StringStack::getStack('doubleQuote') as $hash => $value) {
-                if (\mb_strpos($string, $hash) !== false) {
+                if (\str_contains($string, $hash)) {
                     $string = \str_replace($hash, $value, $string);
                 }
             }
@@ -2194,7 +2194,7 @@ class TemplateScriptingCompiler
      */
     public function replacePHPTags($string)
     {
-        if (\mb_strpos($string, '<?') !== false) {
+        if (\str_contains($string, '<?')) {
             $string = \str_replace('<?php', '@@PHP_START_TAG@@', $string);
             $string = \str_replace('<?', '@@PHP_SHORT_START_TAG@@', $string);
             $string = \str_replace('?>', '@@PHP_END_TAG@@', $string);

--- a/wcfsetup/install/files/lib/util/CronjobUtil.class.php
+++ b/wcfsetup/install/files/lib/util/CronjobUtil.class.php
@@ -460,7 +460,7 @@ final class CronjobUtil
         elseif ($char == '*') {
             $step = 1;
 
-            if (\mb_strpos($fieldValue, '/') !== false) {
+            if (\str_contains($fieldValue, '/')) {
                 $rangeData = \explode('/', $fieldValue);
                 $step = $rangeData[1];
             }
@@ -481,7 +481,7 @@ final class CronjobUtil
      */
     protected static function getListItems($fieldValue)
     {
-        if (\mb_strpos($fieldValue, ',') !== false) {
+        if (\str_contains($fieldValue, ',')) {
             return \explode(',', $fieldValue);
         }
 
@@ -497,12 +497,12 @@ final class CronjobUtil
     protected static function getRanges($value)
     {
         // this is a single value
-        if (\mb_strpos($value, '-') === false) {
+        if (!\str_contains($value, '-')) {
             return [$value];
         }
 
         $step = 1;
-        if (\mb_strpos($value, '/') !== false) {
+        if (\str_contains($value, '/')) {
             $data = \explode('/', $value);
             $step = $data[1];
             $value = $data[0];

--- a/wcfsetup/install/files/lib/util/HeaderUtil.class.php
+++ b/wcfsetup/install/files/lib/util/HeaderUtil.class.php
@@ -62,10 +62,10 @@ final class HeaderUtil
     public static function getCookieDomain(): ?string
     {
         $application = ApplicationHandler::getInstance()->getActiveApplication();
-        $addDomain = (\mb_strpos(
+        $addDomain = (!\str_contains(
             $application->cookieDomain,
             '.'
-        ) === false || \str_ends_with(
+        ) || \str_ends_with(
             $application->cookieDomain,
             '.lan'
         ) || \str_ends_with($application->cookieDomain, '.local')) ? false : true;

--- a/wcfsetup/install/files/lib/util/OptionUtil.class.php
+++ b/wcfsetup/install/files/lib/util/OptionUtil.class.php
@@ -24,7 +24,7 @@ final class OptionUtil
         $options = \explode("\n", StringUtil::trim(StringUtil::unifyNewlines($selectOptions)));
         foreach ($options as $option) {
             $key = $value = $option;
-            if (\mb_strpos($option, ':') !== false) {
+            if (\str_contains($option, ':')) {
                 $optionData = \explode(':', $option);
                 $key = \array_shift($optionData);
                 $value = \implode(':', $optionData);
@@ -49,7 +49,7 @@ final class OptionUtil
             $options = \explode("\n", StringUtil::trim(StringUtil::unifyNewlines($enableOptions)));
             $key = -1;
             foreach ($options as $option) {
-                if (\mb_strpos($option, ':') !== false) {
+                if (\str_contains($option, ':')) {
                     $optionData = \explode(':', $option);
                     $key = \array_shift($optionData);
                     $value = \implode(':', $optionData);

--- a/wcfsetup/install/files/lib/util/StringStack.class.php
+++ b/wcfsetup/install/files/lib/util/StringStack.class.php
@@ -57,7 +57,7 @@ final class StringStack
     {
         if (isset(self::$stringStack[$type])) {
             foreach (self::$stringStack[$type] as $hash => $value) {
-                if (\mb_strpos($string, $hash) !== false) {
+                if (\str_contains($string, $hash)) {
                     $string = \str_replace($hash, $value, $string);
                     unset(self::$stringStack[$type][$hash]);
                 }

--- a/wcfsetup/install/files/lib/util/StringUtil.class.php
+++ b/wcfsetup/install/files/lib/util/StringUtil.class.php
@@ -577,7 +577,7 @@ final class StringUtil
                     continue;
                 }
 
-                if (\mb_strpos($forbiddenName, '*') !== false) {
+                if (\str_contains($forbiddenName, '*')) {
                     $forbiddenName = \str_replace('\*', '.*', \preg_quote($forbiddenName, '/'));
                     if (\preg_match('/^' . $forbiddenName . '$/s', $word)) {
                         return false;

--- a/wcfsetup/install/files/lib/util/Url.class.php
+++ b/wcfsetup/install/files/lib/util/Url.class.php
@@ -180,9 +180,9 @@ final class Url implements \ArrayAccess
         $hosts = [];
         foreach ($hostnames as $host) {
             $isWildcard = false;
-            if (\mb_strpos($host, '*') !== false) {
+            if (\str_contains($host, '*')) {
                 $host = \preg_replace('~^(\*\.)+~', '', $host);
-                if (\mb_strpos($host, '*') !== false || $host === '') {
+                if (\str_contains($host, '*') || $host === '') {
                     // bad host
                     continue;
                 }
@@ -205,7 +205,7 @@ final class Url implements \ArrayAccess
             } else {
                 // check wildcard hosts
                 foreach ($hosts as $host => $isWildcard) {
-                    if ($isWildcard && \mb_strpos($hostname, $host) !== false) {
+                    if ($isWildcard && \str_contains($hostname, $host)) {
                         // the prepended dot will ensure that `example.com` matches only
                         // on domains like `foo.example.com` but not on `bar-example.com`
                         if (\str_ends_with($hostname, '.' . $host)) {


### PR DESCRIPTION
If the return value of `mb_strpos` is only compared to `false` then there is no
need to use the multibyte engine, instead `str_contains()` does example the
same and is clearer.

The same applies if the return value is compared to `0`, in this case the size
of multibyte characters cannot have affected the offset. `str_starts_with()`
can be used instead.
