### PR TITLE
Immediately destroy the session for banned users

### DIFF
--- a/wcfsetup/install/files/lib/system/WCF.class.php
+++ b/wcfsetup/install/files/lib/system/WCF.class.php
@@ -156,12 +156,6 @@ class WCF
     protected static $zendOpcacheEnabled;
 
     /**
-     * force logout during destructor call
-     * @var bool
-     */
-    protected static $forceLogout = false;
-
-    /**
      * Calls all init functions of the WCF class.
      */
     public function __construct()
@@ -218,12 +212,7 @@ class WCF
 
             // update session
             if (\is_object(self::getSession())) {
-                if (self::$forceLogout) {
-                    // do logout
-                    self::getSession()->delete();
-                } else {
-                    self::getSession()->update();
-                }
+                self::getSession()->update();
             }
 
             // execute shutdown actions of storage handlers
@@ -567,7 +556,7 @@ class WCF
                     AJAXException::INSUFFICIENT_PERMISSIONS
                 );
             } else {
-                self::$forceLogout = true;
+                self::getSession()->delete();
 
                 throw new NamedUserException(self::getLanguage()->getDynamicVariable('wcf.user.error.isBanned'));
             }


### PR DESCRIPTION
The forced logout for banned users was introduced in
ab84d9cab2f864c23f0b18dbeb67e7ea79b1fe9f and only destroyed the session during
shutdown.

At the point where this check runs the request effectively is fully booted up
and in any case the NamedUserException would abort any further booting, thus it
is safe to simply destroy the session immediately to keep all the necessary
logic in a single location.
