### PR TITLE
Simplified the admin panel‘s user header

### DIFF
--- a/wcfsetup/install/files/acp/templates/pageHeaderUser.tpl
+++ b/wcfsetup/install/files/acp/templates/pageHeaderUser.tpl
@@ -9,15 +9,8 @@
 					</ul>
 				</li>
 				
-				<li id="jumpToPage" class="dropdown">
-					<a href="{link forceFrontend=true}{/link}" class="dropdownToggle jsTooltip" title="{lang}wcf.global.jumpToPage{/lang}"><span class="icon icon32 fa-home"></span></a>
-					<ul class="dropdownMenu dropdownMenuUserPanel" data-dropdown-alignment-horizontal="right">
-						{foreach from=$__wcf->getFrontendMenu()->getMenuItemNodeList() item=_menuItem}
-							{if !$_menuItem->parentItemID && $_menuItem->getPage()}
-								<li><a href="{$_menuItem->getURL()}">{$_menuItem->getTitle()}</a></li>
-							{/if}
-						{/foreach}
-					</ul>
+				<li id="jumpToPage">
+					<a href="{link forceFrontend=true}{/link}" class="jsTooltip" title="{lang}wcf.global.jumpToPage{/lang}"><span class="icon icon32 fa-home"></span></a>
 				</li>
 				
 				{if $__wcf->session->getPermission('admin.configuration.package.canUpdatePackage') && $__wcf->getAvailableUpdates()}

--- a/wcfsetup/install/files/acp/templates/pageHeaderUser.tpl
+++ b/wcfsetup/install/files/acp/templates/pageHeaderUser.tpl
@@ -5,13 +5,6 @@
 				<li id="userMenu" class="dropdown">
 					<a href="#" class="dropdownToggle jsTooltip" title="{$__wcf->user->username}">{@$__wcf->getUserProfileHandler()->getAvatar()->getImageTag(32)}</a>
 					<ul class="dropdownMenu dropdownMenuUserPanel" data-dropdown-alignment-horizontal="right">
-						<li><a href="{$__wcf->user->getLink()}">{lang}wcf.user.myProfile{/lang}</a></li>
-						{if $__wcf->getUserProfileHandler()->canEditOwnProfile()}<li><a href="{link controller='User' object=$__wcf->user forceFrontend=true}editOnInit=true#about{/link}">{lang}wcf.user.editProfile{/lang}</a></li>{/if}
-						<li><a href="{link controller='Settings' forceFrontend=true}{/link}">{lang}wcf.user.menu.settings{/lang}</a></li>
-						
-						{event name='userMenuItems'}
-						
-						<li class="dropdownDivider"></li>
 						<li><a href="{link controller='Logout'}t={csrfToken type=url}{/link}">{lang}wcf.user.logout{/lang}</a></li>
 					</ul>
 				</li>

--- a/wcfsetup/install/files/lib/system/WCFACP.class.php
+++ b/wcfsetup/install/files/lib/system/WCFACP.class.php
@@ -2,8 +2,6 @@
 
 namespace wcf\system;
 
-use wcf\data\menu\Menu;
-use wcf\data\menu\MenuCache;
 use wcf\system\application\ApplicationHandler;
 use wcf\system\cache\builder\ACPSearchProviderCacheBuilder;
 use wcf\system\event\EventHandler;
@@ -75,17 +73,6 @@ class WCFACP extends WCF
         $this->initAuth();
 
         EventHandler::getInstance()->fireAction($this, 'initialized');
-    }
-
-    /**
-     * Returns the main menu object.
-     *
-     * @return  Menu|null   menu object
-     * @since   3.0
-     */
-    public function getFrontendMenu()
-    {
-        return MenuCache::getInstance()->getMainMenu();
     }
 
     /**
@@ -221,7 +208,8 @@ class WCFACP extends WCF
                 // thus we are unable to use the trait directly.
                 //
                 // Workaround this issue by using an anonymous class.
-                (new class {
+                (new class
+                {
                     use TMultifactorRequirementEnforcer {
                         enforceMultifactorAuthentication as public enforce;
                     }

--- a/wcfsetup/install/files/lib/system/WCFACP.class.php
+++ b/wcfsetup/install/files/lib/system/WCFACP.class.php
@@ -208,8 +208,7 @@ class WCFACP extends WCF
                 // thus we are unable to use the trait directly.
                 //
                 // Workaround this issue by using an anonymous class.
-                (new class
-                {
+                (new class {
                     use TMultifactorRequirementEnforcer {
                         enforceMultifactorAuthentication as public enforce;
                     }


### PR DESCRIPTION
The drop-down menu for the user is still a bit awkward, because it only contains the logout link for now. Possibly we can rework the header to better show the logged-in user and to offer a dedicated logout button. However, this is out of scope for now.

Fixes #4809 