### PR TITLE
Clean all directories that match the tmp naming pattern at the end of WCFSetup

### DIFF
--- a/wcfsetup/install.php
+++ b/wcfsetup/install.php
@@ -619,7 +619,7 @@ class BasicFileUtil {
 	 * Returns the temp folder for the installation.
 	 */
 	public static function getInstallTempFolder(): string {
-		$dir = __DIR__ . '/WCFSetup-' . TMP_FILE_PREFIX . '/';
+		$dir = INSTALL_SCRIPT_DIR . '/WCFSetup-' . TMP_FILE_PREFIX . '/';
 		@mkdir($dir);
 		self::makeWritable($dir);
 		


### PR DESCRIPTION
Since e41dfd007b12baed65ab7679fb679e53bcd2adf5 the temporary directory for
WCFSetup resides in the webroot instead of some system internal temporary
directory. As such temporary files might remain in the webroot and likely will
never be cleaned if the install.php is accessed multiple times before the setup
is completed.

Fix this by deleting all directories that match the pattern for the name of the
temporary directory once the setup is completed successfully.
