### PR TITLE
Moved the notification list into the global space

### DIFF
--- a/com.woltlab.wcf/page.xml
+++ b/com.woltlab.wcf/page.xml
@@ -431,7 +431,6 @@
 			<name language="de">Benachrichtigungen</name>
 			<name language="en">Notifications</name>
 			<hasFixedParent>1</hasFixedParent>
-			<parent>com.woltlab.wcf.AccountManagement</parent>
 			<content language="en">
 				<title>Notifications</title>
 			</content>
@@ -877,4 +876,8 @@ E-Mail: [E-Mail-Adresse der verantwortlichen Stelle]</p><p><br></p><p>Verantwort
 			</content>
 		</page>
 	</import>
+	<delete>
+		<!-- The notification list is no longer part of the user menu. -->
+		<page identifier="com.woltlab.wcf.NotificationList"/>
+	</delete>
 </data>

--- a/com.woltlab.wcf/templates/notificationList.tpl
+++ b/com.woltlab.wcf/templates/notificationList.tpl
@@ -1,26 +1,8 @@
-{capture assign='contentHeader'}
-	<header class="contentHeader">
-		<div class="contentHeaderTitle">
-			<h1 class="contentTitle">{$__wcf->getActivePage()->getTitle()} <span class="badge jsNotificationsBadge">{#$__wcf->getUserNotificationHandler()->countAllNotifications()}</span></h1>
-		</div>
-		
-		{hascontent}
-			<nav class="contentHeaderNavigation">
-				<ul>
-					{content}
-						{event name='contentHeaderNavigation'}
-					{/content}
-				</ul>
-			</nav>
-		{/hascontent}
-	</header>
-{/capture}
+{capture assign='contentTitleBadge'}<span class="badge jsNotificationsBadge">{#$__wcf->getUserNotificationHandler()->countAllNotifications()}</span>{/capture}
 
 {capture assign='headContent'}
 	<link rel="alternate" type="application/rss+xml" title="{lang}wcf.global.button.rss{/lang}" href="{link controller='NotificationFeed'}at={@$__wcf->getUser()->userID}-{@$__wcf->getUser()->accessToken}{/link}">
 {/capture}
-
-{include file='userMenuSidebar'}
 
 {capture assign='contentInteractionPagination'}
 	{pages print=true assign=pagesLinks controller='NotificationList' link="pageNo=%d"}

--- a/com.woltlab.wcf/userMenu.xml
+++ b/com.woltlab.wcf/userMenu.xml
@@ -50,20 +50,18 @@
 			<showorder>3</showorder>
 			<iconclassname>fa-globe</iconclassname>
 		</usermenuitem>
-		<usermenuitem name="wcf.user.menu.community.notification">
-			<controller>wcf\page\NotificationListPage</controller>
-			<parent>wcf.user.menu.community</parent>
-			<showorder>1</showorder>
-		</usermenuitem>
 		<usermenuitem name="wcf.user.menu.community.following">
 			<controller>wcf\page\FollowingPage</controller>
 			<parent>wcf.user.menu.community</parent>
-			<showorder>2</showorder>
+			<showorder>1</showorder>
 		</usermenuitem>
 		<usermenuitem name="wcf.user.menu.community.ignoredUsers">
 			<controller>wcf\page\IgnoredUsersPage</controller>
 			<parent>wcf.user.menu.community</parent>
-			<showorder>3</showorder>
+			<showorder>2</showorder>
 		</usermenuitem>
 	</import>
+	<delete>
+		<usermenuitem name="wcf.user.menu.community.notification"/>
+	</delete>
 </data>

--- a/wcfsetup/install/files/lib/page/NotificationListPage.class.php
+++ b/wcfsetup/install/files/lib/page/NotificationListPage.class.php
@@ -2,7 +2,6 @@
 
 namespace wcf\page;
 
-use wcf\system\menu\user\UserMenu;
 use wcf\system\user\notification\UserNotificationHandler;
 use wcf\system\WCF;
 
@@ -73,16 +72,5 @@ class NotificationListPage extends MultipleLinkPage
         WCF::getTPL()->assign([
             'notifications' => $this->notifications,
         ]);
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function show()
-    {
-        // set active tab
-        UserMenu::getInstance()->setActiveMenuItem('wcf.user.menu.community.notification');
-
-        parent::show();
     }
 }


### PR DESCRIPTION
The notification list was placed in the user menu a long time ago, but never really fitted in there. The link was already (and continues to be) reachable through the drop-down menu, removing the need of an additional location.

Moving the notification list into the global page space makes more sense and aligns with similar lists such as the conversations.