### PR TITLE
Remove enforced redirect of `login` and `index` controller in ACP to the `wcf` application

### DIFF
--- a/wcfsetup/install/files/lib/system/request/LinkHandler.class.php
+++ b/wcfsetup/install/files/lib/system/request/LinkHandler.class.php
@@ -170,6 +170,9 @@ class LinkHandler extends SingletonFactory
         if ($controller === null) {
             if ($isACP) {
                 $controller = 'Index';
+                if ($abbreviation !== 'wcf') {
+                    throw new \InvalidArgumentException("A 'controller' must be specified for non-'wcf' links in ACP.");
+                }
             } else {
                 if (!empty($parameters['application']) && $abbreviation !== 'wcf') {
                     $application = ApplicationHandler::getInstance()->getApplication($abbreviation);

--- a/wcfsetup/install/files/lib/system/request/RequestHandler.class.php
+++ b/wcfsetup/install/files/lib/system/request/RequestHandler.class.php
@@ -127,6 +127,10 @@ final class RequestHandler extends SingletonFactory
             if ($this->isACPRequest()) {
                 if (empty($routeData['controller'])) {
                     $routeData['controller'] = 'index';
+
+                    if ($application !== 'wcf') {
+                        $this->redirect($routeData, 'wcf', 'index');
+                    }
                 }
             } else {
                 // handle landing page for frontend requests

--- a/wcfsetup/install/files/lib/system/request/RequestHandler.class.php
+++ b/wcfsetup/install/files/lib/system/request/RequestHandler.class.php
@@ -160,20 +160,6 @@ final class RequestHandler extends SingletonFactory
             } else {
                 $controller = $routeData['controller'];
 
-                if (
-                    $this->isACPRequest()
-                    && ($controller === 'login' || $controller === 'index')
-                    && $application !== 'wcf'
-                ) {
-                    HeaderUtil::redirect(
-                        LinkHandler::getInstance()->getLink(\ucfirst($controller)),
-                        true,
-                        false
-                    );
-
-                    exit;
-                }
-
                 $classApplication = $application;
                 if (
                     !empty($routeData['isDefaultController'])


### PR DESCRIPTION
It is not clear why this was added in d49006fac289699c925a6d5644f102b7ebfc972c,
but it does not appear to still be required. The login check in WCFACP
correctly redirects to the `wcf` app even if an application controller is
requested.
