### PR TITLE
Add basic check for the runtime environment

### DIFF
--- a/wcfsetup/install/files/acp/templates/index.tpl
+++ b/wcfsetup/install/files/acp/templates/index.tpl
@@ -4,6 +4,10 @@
 	<h1 class="contentTitle">{lang}wcf.global.acp{/lang}</h1>
 </header>
 
+{if !(50500 <= PHP_VERSION_ID && PHP_VERSION_ID <= 70499)}
+	<div class="error">{lang}wcf.global.incompatiblePhpVersion{/lang}</div>
+{/if}
+
 {if TIME_NOW < 1641038400}
 	<div class="warning">{lang}wcf.acp.package.upgradeRequired.expiring{/lang}</div>
 {elseif TIME_NOW < 1656676800}

--- a/wcfsetup/install/files/acp/templates/packageList.tpl
+++ b/wcfsetup/install/files/acp/templates/packageList.tpl
@@ -58,6 +58,10 @@
 	{/hascontent}
 </header>
 
+{if !(50500 <= PHP_VERSION_ID && PHP_VERSION_ID <= 70499)}
+	<div class="error">{lang}wcf.global.incompatiblePhpVersion{/lang}</div>
+{/if}
+
 {if TIME_NOW < 1641038400}
 	<div class="warning">{lang}wcf.acp.package.upgradeRequired.expiring{/lang}</div>
 {elseif TIME_NOW < 1656676800}

--- a/wcfsetup/install/files/lib/system/request/RequestHandler.class.php
+++ b/wcfsetup/install/files/lib/system/request/RequestHandler.class.php
@@ -67,6 +67,8 @@ class RequestHandler extends SingletonFactory {
 					throw new IllegalLinkException();
 				}
 			}
+
+			$this->checkSystemEnvironment();
 			
 			// build request
 			$this->buildRequest($application);
@@ -98,6 +100,19 @@ class RequestHandler extends SingletonFactory {
 		catch (NamedUserException $e) {
 			$e->show();
 			exit;
+		}
+	}
+
+	private function checkSystemEnvironment()
+	{
+		if ($this->isACPRequest()) {
+			return;
+		}
+
+		if (!(50500 <= PHP_VERSION_ID && PHP_VERSION_ID <= 70499)) {
+			\header('HTTP/1.1 500 Internal Server Error');
+
+			throw new NamedUserException(WCF::getLanguage()->get('wcf.global.incompatiblePhpVersion'));
 		}
 	}
 	

--- a/wcfsetup/install/lang/de.xml
+++ b/wcfsetup/install/lang/de.xml
@@ -3010,6 +3010,7 @@ E-Mail-Adresse: {@$emailAddress} {* this line ends with a space *}
 		<item name="wcf.global.button.showNavigation"><![CDATA[Navigation anzeigen]]></item>
 		<item name="wcf.global.button.hideSidebar"><![CDATA[Sidebar verbergen]]></item>
 		<item name="wcf.global.button.showSidebar"><![CDATA[Sidebar anzeigen]]></item>
+		<item name="wcf.global.incompatiblePhpVersion"><![CDATA[Fehlerhafte Server-Konfiguration: Die eingesetzte Version von „PHP” ist nicht kompatibel, ein Betrieb ist nicht möglich. Es wird mindestens PHP in Version 5.5 benötigt, unterstützt werden die Versionen bis PHP 7.4. Für den Einsatz höherer PHP-Versionen muss die Software auf eine aktuelle Version umgestellt werden.]]></item>
 	</category>
 	
 	<category name="wcf.global.form">

--- a/wcfsetup/install/lang/en.xml
+++ b/wcfsetup/install/lang/en.xml
@@ -2960,6 +2960,7 @@ Email: {@$emailAddress} {* this line ends with a space *}
 		<item name="wcf.global.button.showNavigation"><![CDATA[Show Navigation]]></item>
 		<item name="wcf.global.button.hideSidebar"><![CDATA[Hide Sidebar]]></item>
 		<item name="wcf.global.button.showSidebar"><![CDATA[Show Sidebar]]></item>
+		<item name="wcf.global.incompatiblePhpVersion"><![CDATA[Bad server configuration: The configured version of “PHP” is not compatible, operation is not possible. At least PHP in version 5.5 is required, versions up to PHP 7.4 are supported. For the use of higher PHP versions the software must be updated to a current version.]]></item>
 	</category>
 	
 	<category name="wcf.global.form">


### PR DESCRIPTION
Running WoltLab Suite in an unsupported environment might work for the
majority of requests, some requests might fail very visibly. But there
also is a third type: A request that *appear* to execute properly, but
that subtly behaves incorrectly, due to a change in PHP's behavior.

The latter type is dangerous, as those requests might introduce errors
into the dataset that are very hard to impossible to correct after the
fact because the necessary information to fix up the data is no longer
available.

Prevent this situation from occuring by performing a basic test of the
runtime environment and halting processing early if this test fails to
ensure that it processed as little as possible.
