### PR TITLE
Configure dynamic options in post_install.php

### DIFF
--- a/wcfsetup/install/files/acp/post_install.php
+++ b/wcfsetup/install/files/acp/post_install.php
@@ -5,7 +5,9 @@ use wcf\data\object\type\ObjectTypeCache;
 use wcf\data\package\PackageCache;
 use wcf\data\user\UserEditor;
 use wcf\data\user\UserProfileAction;
+use wcf\system\image\adapter\ImagickImageAdapter;
 use wcf\system\WCF;
+use wcf\util\StringUtil;
 
 // set default landing page
 $sql = "UPDATE  wcf1_application
@@ -79,4 +81,40 @@ $statement->execute([
 
     $this->installation->getPackageID(),
     'com.woltlab.wcf.refreshSearchRobots',
+]);
+
+// Configure dynamic option values
+
+$sql = "UPDATE  wcf1_option
+        SET     optionValue = ?
+        WHERE   optionName = ?";
+$statement = WCF::getDB()->prepare($sql);
+$statement->execute([
+    StringUtil::getUUID(),
+    'wcf_uuid',
+]);
+
+if (
+    ImagickImageAdapter::isSupported()
+    && ImagickImageAdapter::supportsAnimatedGIFs(ImagickImageAdapter::getVersion())
+    && ImagickImageAdapter::supportsWebp()
+) {
+    $statement->execute([
+        'imagick',
+        'image_adapter_type',
+    ]);
+}
+
+$user = WCF::getUser();
+$statement->execute([
+    $user->username,
+    'mail_from_name',
+]);
+$statement->execute([
+    $user->email,
+    'mail_from_address',
+]);
+$statement->execute([
+    $user->email,
+    'mail_admin_address',
 ]);

--- a/wcfsetup/install/files/lib/system/WCFSetup.class.php
+++ b/wcfsetup/install/files/lib/system/WCFSetup.class.php
@@ -1306,14 +1306,9 @@ final class WCFSetup extends WCF
         $factory = new ACPSessionFactory();
         $factory->load();
 
-        $useImagick = ImagickImageAdapter::isSupported()
-            && ImagickImageAdapter::supportsAnimatedGIFs(ImagickImageAdapter::getVersion())
-            && ImagickImageAdapter::supportsWebp();
-
         SessionHandler::getInstance()->changeUser($admin);
         SessionHandler::getInstance()->register('__wcfSetup_developerMode', self::$developerMode);
         SessionHandler::getInstance()->register('__wcfSetup_directories', self::$directories);
-        SessionHandler::getInstance()->register('__wcfSetup_imagick', $useImagick);
         SessionHandler::getInstance()->registerReauthentication();
         SessionHandler::getInstance()->update();
 

--- a/wcfsetup/install/files/lib/system/package/PackageInstallationDispatcher.class.php
+++ b/wcfsetup/install/files/lib/system/package/PackageInstallationDispatcher.class.php
@@ -44,7 +44,6 @@ use wcf\util\CryptoUtil;
 use wcf\util\FileUtil;
 use wcf\util\HeaderUtil;
 use wcf\util\JSON;
-use wcf\util\StringUtil;
 
 /**
  * PackageInstallationDispatcher handles the whole installation process.
@@ -213,11 +212,6 @@ class PackageInstallationDispatcher
                             WHERE   optionName = ?";
                     $statement = WCF::getDB()->prepareStatement($sql);
 
-                    $statement->execute([
-                        StringUtil::getUUID(),
-                        'wcf_uuid',
-                    ]);
-
                     if (\file_exists(WCF_DIR . 'cookiePrefix.txt')) {
                         $statement->execute([
                             COOKIE_PREFIX,
@@ -226,20 +220,6 @@ class PackageInstallationDispatcher
 
                         @\unlink(WCF_DIR . 'cookiePrefix.txt');
                     }
-
-                    $user = new User(1);
-                    $statement->execute([
-                        $user->username,
-                        'mail_from_name',
-                    ]);
-                    $statement->execute([
-                        $user->email,
-                        'mail_from_address',
-                    ]);
-                    $statement->execute([
-                        $user->email,
-                        'mail_admin_address',
-                    ]);
 
                     $statement->execute([
                         // We do not use the cache-timing safe class Hex, because we run the
@@ -264,13 +244,6 @@ class PackageInstallationDispatcher
 
                     if (WCF::getSession()->getVar('__wcfSetup_developerMode')) {
                         $this->setupDeveloperMode();
-                    }
-
-                    if (WCF::getSession()->getVar('__wcfSetup_imagick')) {
-                        $statement->execute([
-                            'imagick',
-                            'image_adapter_type',
-                        ]);
                     }
 
                     // update options.inc.php


### PR DESCRIPTION
This simplifies WCFSetup and more importantly PackageInstallationDispatcher. It
also removes the useless session variable for the Imagick default status.
