### PR TITLE
Create the `com.woltlab.wcf` package early during WCFSetup

### DIFF
--- a/wcfsetup/install/files/acp/database/update_com.woltlab.wcf_5.6.php
+++ b/wcfsetup/install/files/acp/database/update_com.woltlab.wcf_5.6.php
@@ -9,13 +9,38 @@
  * @package WoltLabSuite\Core
  */
 
+use wcf\system\database\table\column\NotNullInt10DatabaseTableColumn;
 use wcf\system\database\table\column\TinyintDatabaseTableColumn;
 use wcf\system\database\table\PartialDatabaseTable;
 
 return [
+    PartialDatabaseTable::create('wcf1_acp_template')
+        ->columns([
+            NotNullInt10DatabaseTableColumn::create('packageID'),
+        ]),
+    PartialDatabaseTable::create('wcf1_language_item')
+        ->columns([
+            NotNullInt10DatabaseTableColumn::create('packageID'),
+        ]),
+    PartialDatabaseTable::create('wcf1_package_installation_file_log')
+        ->columns([
+            NotNullInt10DatabaseTableColumn::create('packageID'),
+        ]),
+    PartialDatabaseTable::create('wcf1_package_installation_plugin')
+        ->columns([
+            NotNullInt10DatabaseTableColumn::create('packageID'),
+        ]),
+    PartialDatabaseTable::create('wcf1_package_installation_sql_log')
+        ->columns([
+            NotNullInt10DatabaseTableColumn::create('packageID'),
+        ]),
     PartialDatabaseTable::create('wcf1_page')
         ->columns([
             TinyintDatabaseTableColumn::create('isLandingPage')
                 ->drop(),
+        ]),
+    PartialDatabaseTable::create('wcf1_user_group_option')
+        ->columns([
+            NotNullInt10DatabaseTableColumn::create('packageID'),
         ]),
 ];

--- a/wcfsetup/install/files/acp/install.php
+++ b/wcfsetup/install/files/acp/install.php
@@ -20,41 +20,6 @@ $statement->execute([1]);
 // Clear any outdated cached data from WCFSetup.
 UserStorageHandler::getInstance()->clear();
 
-// update acp templates
-$sql = "UPDATE  wcf" . WCF_N . "_acp_template
-        SET     packageID = ?";
-$statement = WCF::getDB()->prepareStatement($sql);
-$statement->execute([1]);
-
-// update language
-$sql = "UPDATE  wcf" . WCF_N . "_language_item
-        SET     packageID = ?";
-$statement = WCF::getDB()->prepareStatement($sql);
-$statement->execute([1]);
-
-// update installation logs
-$sql = "UPDATE  wcf" . WCF_N . "_package_installation_file_log
-        SET     packageID = ?";
-$statement = WCF::getDB()->prepareStatement($sql);
-$statement->execute([1]);
-
-$sql = "UPDATE  wcf" . WCF_N . "_package_installation_sql_log
-        SET     packageID = ?";
-$statement = WCF::getDB()->prepareStatement($sql);
-$statement->execute([1]);
-
-// update pips
-$sql = "UPDATE  wcf" . WCF_N . "_package_installation_plugin
-        SET     packageID = ?";
-$statement = WCF::getDB()->prepareStatement($sql);
-$statement->execute([1]);
-
-// group options
-$sql = "UPDATE  wcf" . WCF_N . "_user_group_option
-        SET     packageID = ?";
-$statement = WCF::getDB()->prepareStatement($sql);
-$statement->execute([1]);
-
 // get server timezone
 if ($timezone = @\date_default_timezone_get()) {
     if ($timezone != 'Europe/London' && \in_array($timezone, DateUtil::getAvailableTimezones())) {

--- a/wcfsetup/install/files/lib/system/WCFSetup.class.php
+++ b/wcfsetup/install/files/lib/system/WCFSetup.class.php
@@ -891,11 +891,11 @@ final class WCFSetup extends WCF
 
         if (!empty($matches[1])) {
             $sql = "INSERT INTO wcf" . WCF_N . "_package_installation_sql_log
-                                (sqlTable)
-                    VALUES      (?)";
+                                (packageID, sqlTable)
+                    VALUES      (?, ?)";
             $statement = self::getDB()->prepareStatement($sql);
             foreach ($matches[1] as $tableName) {
-                $statement->execute([$tableName]);
+                $statement->execute([1, $tableName]);
             }
         }
 
@@ -913,10 +913,11 @@ final class WCFSetup extends WCF
             * in different behaviour in MySQL and MSSQL. You SHOULD NOT move this into install.sql!
             */
             $sql = "INSERT INTO wcf" . WCF_N . "_package_installation_plugin
-                                (pluginName, priority, className)
-                    VALUES      (?, ?, ?)";
+                                (packageID, pluginName, priority, className)
+                    VALUES      (?, ?, ?, ?)";
             $statement = self::getDB()->prepareStatement($sql);
             $statement->execute([
+                1,
                 'packageInstallationPlugin',
                 1,
                 'wcf\system\package\plugin\PIPPackageInstallationPlugin',
@@ -949,13 +950,13 @@ final class WCFSetup extends WCF
         // save acp template log
         if (!empty($acpTemplateInserts)) {
             $sql = "INSERT INTO wcf" . WCF_N . "_acp_template
-                                (templateName, application)
-                    VALUES      (?, ?)";
+                                (packageID, templateName, application)
+                    VALUES      (?, ?, ?)";
             $statement = self::getDB()->prepareStatement($sql);
 
             self::getDB()->beginTransaction();
             foreach ($acpTemplateInserts as $acpTemplate) {
-                $statement->execute([$acpTemplate, 'wcf']);
+                $statement->execute([1, $acpTemplate, 'wcf']);
             }
             self::getDB()->commitTransaction();
         }
@@ -963,13 +964,13 @@ final class WCFSetup extends WCF
         // save file log
         if (!empty($fileInserts)) {
             $sql = "INSERT INTO wcf" . WCF_N . "_package_installation_file_log
-                                (filename, application)
-                    VALUES      (?, ?)";
+                                (packageID, filename, application)
+                    VALUES      (?, ?, ?)";
             $statement = self::getDB()->prepareStatement($sql);
 
             self::getDB()->beginTransaction();
             foreach ($fileInserts as $file) {
-                $statement->execute([$file, 'wcf']);
+                $statement->execute([1, $file, 'wcf']);
             }
             self::getDB()->commitTransaction();
         }
@@ -1017,7 +1018,7 @@ final class WCFSetup extends WCF
             $xml->load($filename);
 
             // import xml
-            LanguageEditor::importFromXML($xml, 0);
+            LanguageEditor::importFromXML($xml, 1);
         }
 
         // set default language

--- a/wcfsetup/install/files/lib/system/package/PackageInstallationDispatcher.class.php
+++ b/wcfsetup/install/files/lib/system/package/PackageInstallationDispatcher.class.php
@@ -630,6 +630,13 @@ class PackageInstallationDispatcher
      */
     protected function createPackage(array $packageData)
     {
+        if (!PACKAGE_ID && $packageData['package'] === 'com.woltlab.wcf') {
+            $packageEditor = new PackageEditor(new Package(1));
+            $packageEditor->update($packageData);
+
+            return new Package(1);
+        }
+
         return PackageEditor::create($packageData);
     }
 

--- a/wcfsetup/setup/db/install.sql
+++ b/wcfsetup/setup/db/install.sql
@@ -5,7 +5,7 @@
 */
 DROP TABLE IF EXISTS wcf1_package_installation_sql_log;
 CREATE TABLE wcf1_package_installation_sql_log (
-	packageID INT(10),
+	packageID INT(10) NOT NULL,
 	sqlTable VARCHAR(100) NOT NULL DEFAULT '',
 	sqlColumn VARCHAR(100) NOT NULL DEFAULT '',
 	sqlIndex VARCHAR(100) NOT NULL DEFAULT '',
@@ -120,7 +120,7 @@ CREATE TABLE wcf1_acp_session_log (
 DROP TABLE IF EXISTS wcf1_acp_template;
 CREATE TABLE wcf1_acp_template (
 	templateID INT(10) NOT NULL AUTO_INCREMENT PRIMARY KEY,
-	packageID INT(10),
+	packageID INT(10) NOT NULL,
 	templateName VARCHAR(191) NOT NULL,
 	application VARCHAR(20) NOT NULL,
 	UNIQUE KEY applicationTemplate (application, templateName)
@@ -670,7 +670,7 @@ CREATE TABLE wcf1_language_item (
 	languageUseCustomValue TINYINT(1) NOT NULL DEFAULT 0,
 	languageItemOriginIsSystem TINYINT(1) NOT NULL DEFAULT 1,
 	languageCategoryID INT(10) NOT NULL,
-	packageID INT(10),
+	packageID INT(10) NOT NULL,
 	languageItemOldValue MEDIUMTEXT,
 	languageCustomItemDisableTime INT(10),
 	isCustomLanguageItem TINYINT(1) NOT NULL DEFAULT 0,
@@ -953,7 +953,7 @@ CREATE TABLE wcf1_package_exclusion (
 
 DROP TABLE IF EXISTS wcf1_package_installation_file_log;
 CREATE TABLE wcf1_package_installation_file_log (
-	packageID INT(10),
+	packageID INT(10) NOT NULL,
 	filename VARBINARY(765) NOT NULL, -- VARBINARY(765) roughly equals VARCHAR(255)
 	application VARCHAR(20) NOT NULL,
 	UNIQUE KEY applicationFile (application, filename)
@@ -982,7 +982,7 @@ CREATE TABLE wcf1_package_installation_node (
 DROP TABLE IF EXISTS wcf1_package_installation_plugin;
 CREATE TABLE wcf1_package_installation_plugin (
 	pluginName VARCHAR(191) NOT NULL PRIMARY KEY,
-	packageID INT(10),
+	packageID INT(10) NOT NULL,
 	priority TINYINT(1) NOT NULL DEFAULT 0,
 	className VARCHAR(255) NOT NULL
 );
@@ -1636,7 +1636,7 @@ CREATE TABLE wcf1_user_group_assignment (
 DROP TABLE IF EXISTS wcf1_user_group_option;
 CREATE TABLE wcf1_user_group_option (
 	optionID INT(10) NOT NULL AUTO_INCREMENT PRIMARY KEY,
-	packageID INT(10),
+	packageID INT(10) NOT NULL,
 	optionName VARCHAR(191) NOT NULL DEFAULT '',
 	categoryName VARCHAR(191) NOT NULL DEFAULT '',
 	optionType VARCHAR(255) NOT NULL DEFAULT '',
@@ -1948,6 +1948,9 @@ CREATE TABLE wcf1_user_to_language (
 	languageID INT(10) NOT NULL,
 	UNIQUE KEY userID (userID, languageID)
 );
+
+-- Create the package early. This is required for the FOREIGN KEYs.
+INSERT INTO wcf1_package (packageID, package) VALUES (1, 'com.woltlab.wcf');
 
 /* SQL_PARSER_OFFSET */
 
@@ -2334,9 +2337,9 @@ INSERT INTO wcf1_user_group (groupID, groupName, groupDescription, groupType) VA
 INSERT INTO wcf1_user_group (groupID, groupName, groupDescription, groupType) VALUES (5, 'wcf.acp.group.group5', '', 4); -- Moderators
 
 -- default user group options
-INSERT INTO wcf1_user_group_option (optionID, optionName, categoryName, optionType, defaultValue, showOrder, usersOnly) VALUES (1, 'admin.general.canUseAcp', 'admin.general', 'boolean', '0', 1, 1);
-INSERT INTO wcf1_user_group_option (optionID, optionName, categoryName, optionType, defaultValue, showOrder, usersOnly) VALUES (2, 'admin.configuration.package.canInstallPackage', 'admin.configuration.package', 'boolean', '0', 1, 1);
-INSERT INTO wcf1_user_group_option (optionID, optionName, categoryName, optionType, defaultValue, showOrder, usersOnly) VALUES (3, 'admin.user.canEditGroup', 'admin.user.group', 'boolean', '0', 1, 1);
+INSERT INTO wcf1_user_group_option (packageID, optionID, optionName, categoryName, optionType, defaultValue, showOrder, usersOnly) VALUES (1, 1, 'admin.general.canUseAcp', 'admin.general', 'boolean', '0', 1, 1);
+INSERT INTO wcf1_user_group_option (packageID, optionID, optionName, categoryName, optionType, defaultValue, showOrder, usersOnly) VALUES (1, 2, 'admin.configuration.package.canInstallPackage', 'admin.configuration.package', 'boolean', '0', 1, 1);
+INSERT INTO wcf1_user_group_option (packageID, optionID, optionName, categoryName, optionType, defaultValue, showOrder, usersOnly) VALUES (1, 3, 'admin.user.canEditGroup', 'admin.user.group', 'boolean', '0', 1, 1);
 
 -- default user group option values
 INSERT INTO wcf1_user_group_option_value (groupID, optionID, optionValue) VALUES (1, 1, '0');	-- Everyone


### PR DESCRIPTION
This allows us to properly specify FOREIGN KEYs for `packageID` columns.
