### PR TITLE
Stop adding `rel="noreferrer"` to external URLs

### DIFF
--- a/wcfsetup/install/files/acp/templates/header.tpl
+++ b/wcfsetup/install/files/acp/templates/header.tpl
@@ -211,7 +211,6 @@
 				if (link.classList.contains('externalURL')) {
 					var rel = (link.rel === '') ? [] : link.rel.split(' ');
 					if (rel.indexOf('noopener') === -1) rel.push('noopener');
-					if (rel.indexOf('noreferrer') === -1) rel.push('noreferrer');
 					
 					link.rel = rel.join(' ');
 				}

--- a/wcfsetup/install/files/lib/system/html/output/node/HtmlOutputNodeA.class.php
+++ b/wcfsetup/install/files/lib/system/html/output/node/HtmlOutputNodeA.class.php
@@ -77,7 +77,7 @@ class HtmlOutputNodeA extends AbstractHtmlOutputNode
 
         $rel = 'nofollow';
         if (EXTERNAL_LINK_TARGET_BLANK) {
-            $rel .= ' noopener noreferrer';
+            $rel .= ' noopener';
 
             $element->setAttribute('target', '_blank');
         }

--- a/wcfsetup/install/files/lib/system/template/plugin/AnchorAttributesFunctionTemplatePlugin.class.php
+++ b/wcfsetup/install/files/lib/system/template/plugin/AnchorAttributesFunctionTemplatePlugin.class.php
@@ -59,7 +59,7 @@ class AnchorAttributesFunctionTemplatePlugin implements IFunctionTemplatePlugin
 
             $rel = 'nofollow';
             if (EXTERNAL_LINK_TARGET_BLANK) {
-                $rel .= ' noopener noreferrer';
+                $rel .= ' noopener';
                 $attributes .= ' target="_blank"';
             }
             if ($isUgc) {

--- a/wcfsetup/install/files/lib/util/StringUtil.class.php
+++ b/wcfsetup/install/files/lib/util/StringUtil.class.php
@@ -763,7 +763,7 @@ final class StringUtil
             $attributes .= ' class="externalURL"';
             $rel = 'nofollow';
             if (EXTERNAL_LINK_TARGET_BLANK) {
-                $rel .= ' noopener noreferrer';
+                $rel .= ' noopener';
                 $attributes .= 'target="_blank"';
             }
             if ($isUgc) {


### PR DESCRIPTION
This property was added together with `noopener` to protect users with older web
browsers that do not yet support `noopener`. The latter now is well-supported since
several years and in fact even is the default value in modern web browsers.

This allows us to drop the `noreferrer` from those links safely. Stripping the
`referer` header can be more reliably achieved with the `referrer-policy`
header that also gives the administrator more fine-grained control.
