### PR TITLE
Gracefully ignore Thumbnail generation failures in DefaultUploadFileSaveStrategy

### DIFF
--- a/wcfsetup/install/files/lib/system/upload/DefaultUploadFileSaveStrategy.class.php
+++ b/wcfsetup/install/files/lib/system/upload/DefaultUploadFileSaveStrategy.class.php
@@ -310,7 +310,13 @@ class DefaultUploadFileSaveStrategy implements IUploadFileSaveStrategy
             return;
         }
 
-        $adapter->loadFile($file->getLocation());
+        try {
+            $adapter->loadFile($file->getLocation());
+        } catch (\Exception $e) {
+            \wcf\functions\exception\logThrowable($e);
+
+            return;
+        }
 
         $updateData = [];
         foreach ($this->options['thumbnailSizes'] as $type => $sizeData) {
@@ -331,11 +337,18 @@ class DefaultUploadFileSaveStrategy implements IUploadFileSaveStrategy
             }
 
             if ($file->width > $sizeData['width'] || $file->height > $sizeData['height']) {
-                $thumbnail = $adapter->createThumbnail(
-                    $sizeData['width'],
-                    $sizeData['height'],
-                    $sizeData['retainDimensions'] ?? true
-                );
+                try {
+                    $thumbnail = $adapter->createThumbnail(
+                        $sizeData['width'],
+                        $sizeData['height'],
+                        $sizeData['retainDimensions'] ?? true
+                    );
+                } catch (\Exception $e) {
+                    \wcf\functions\exception\logThrowable($e);
+
+                    continue;
+                }
+
                 $adapter->writeImage($thumbnail, $thumbnailLocation);
                 // Clear thumbnail as soon as possible to free up the memory for the next size.
                 $thumbnail = null;


### PR DESCRIPTION
`->generateThumbnails()` might already not do anything if the memory limit is
likely going to be exceeded, causing image upload to be thumbnail-less. Extend
this to all cases of thumbnail generation failure by catching exceptions thrown
when loading the image or when performing the resizing operation.
