### PR TITLE
Remove RoutingCacheBuilder::handleLandingPageWithOverriddenApplication()

### DIFF
--- a/wcfsetup/install/files/lib/system/cache/builder/RoutingCacheBuilder.class.php
+++ b/wcfsetup/install/files/lib/system/cache/builder/RoutingCacheBuilder.class.php
@@ -41,12 +41,12 @@ class RoutingCacheBuilder extends AbstractCacheBuilder
         $data = [
             'ciControllers' => $this->getCaseInsensitiveControllers(),
             'landingPages' => $this->getLandingPages(),
+            'customUrls' => $this->getCustomUrls(),
         ];
 
-        $data['customUrls'] = $this->getCustomUrls();
         $data['applicationOverrides'] = $this->getApplicationOverrides($data['customUrls']);
 
-        return $this->handleLandingPageWithOverriddenApplication($data);
+        return $data;
     }
 
     /**
@@ -344,40 +344,6 @@ class RoutingCacheBuilder extends AbstractCacheBuilder
             }
 
             $data[ApplicationHandler::getInstance()->getAbbreviation($application->packageID)] = $controller;
-        }
-
-        return $data;
-    }
-
-    protected function handleLandingPageWithOverriddenApplication(array $data): array
-    {
-        if (!PACKAGE_ID) {
-            return $data;
-        }
-
-        $landingPageController = $data['landingPages']['wcf']['controller'];
-        $controllers = [$landingPageController];
-
-        // The controller may be the custom url of a CMS page.
-        if (\str_starts_with($landingPageController, '__WCF_CMS__')) {
-            $controllers = \array_filter(
-                $data['customUrls']['reverse']['wcf'],
-                static function ($controller) use ($landingPageController) {
-                    return \str_starts_with($controller, "{$landingPageController}-");
-                },
-                \ARRAY_FILTER_USE_KEY
-            );
-        }
-
-        foreach ($controllers as $controller) {
-            if (isset($data['applicationOverrides']['reverse']['wcf'][$controller])) {
-                $overriddenApplication = $data['applicationOverrides']['reverse']['wcf'][$controller];
-
-                // The original landing page of the target app has been implicitly overridden, thus we need to
-                // replace the data of the affected app. This is necessary in order to avoid the original landing
-                // page to be conflicting with the global landing page, eventually overshadowing it.
-                $data['landingPages'][$overriddenApplication] = $data['landingPages']['wcf'];
-            }
         }
 
         return $data;


### PR DESCRIPTION
This logic was introduced in 000c0c8a26491708b2af995bdd6f0e627cc75161 which
intended to (and actually did) fix #2905.

However the commit makes more changes than are actually necessary to fix the
issue:

The change in ControllerMap caused the branch condition to become impossible.
This change might have been required to fix the issue, but the logic was
unneccessarily complex, because of the dead branch. It was subsequently removed
in commit 416dafddb18a3e82750c6e8ca089d4f9132b39dc.

Likewise the change to RoutingCacheBuilder does not have any effect on the bug
reported in #2905. After reverting the change within RoutingCacheBuilder the
bug is not reproducible. It is reproducible however when reverting the change
in RequestHandler, indicating that this change is the only relevant in that
commit.

This commit reverts the change to RoutingCacheBuilder, because it is not
neccessary and because it actually introduced intransparent behavior into the
routing system:

If the landing page of `wcf` (i.e. the page that previously was considered to
be the global landing page before removing the distinction in
64a1be56f2ef06f8b4b2bea0cccc7c8b8374588a) is a page that is assigned to
`packageID = 1` (i.e. to `wcf`), but virtually relocated into an application
(e.g. `wbb`), then the application's configured landing page will be ignored
and wcf's landing page will be used instead.

This implicit override is not exposed to the administrator and it is also not
necessary. It works perfectly fine to move wcf's landing page into a different
app where it is not considered to be the landing page: The URLs generated by
the link handler will simply include the controller name and the redirect
performed by the URL canonicalization feature will go to the right place.
