### PR TITLE
Use \SensitiveParameterValue as the replacement value in exception handling

### DIFF
--- a/wcfsetup/install/files/lib/core.functions.php
+++ b/wcfsetup/install/files/lib/core.functions.php
@@ -736,8 +736,12 @@ EXPLANATION;
 							$isSensitive = true;
 						}
 
-						if ($isSensitive && isset($item['args'][$i])) {
-							$item['args'][$i] = '[redacted]';
+						if (
+							$isSensitive
+							&& isset($item['args'][$i])
+							&& !($item['args'][$i] instanceof \SensitiveParameterValue)
+						) {
+							$item['args'][$i] = new \SensitiveParameterValue($item['args'][$i]);
 						}
 						$i++;
 					}
@@ -748,8 +752,12 @@ EXPLANATION;
 						|| $item['class'] === 'PDO'
 					) {
 						if ($item['function'] === '__construct') {
-							$item['args'] = array_map(function () {
-								return '[redacted]';
+							$item['args'] = array_map(function ($value) {
+								if (!($value instanceof \SensitiveParameterValue)) {
+									$value = new \SensitiveParameterValue($value);
+								}
+
+								return $value;
 							}, $item['args']);
 						}
 					}


### PR DESCRIPTION
Use the standard PHP 8.2 replacement value, instead of the `[redacted]` string
for consistency. This works as expected, because `SensitiveParameterValue` is
polyfilled.
