### PR TITLE
Partial Data Binding for the Main Menu

### DIFF
--- a/ts/WoltLabSuite/Core/Acp/Ui/Page/Menu/Main/Backend.ts
+++ b/ts/WoltLabSuite/Core/Acp/Ui/Page/Menu/Main/Backend.ts
@@ -20,7 +20,7 @@ function getSubMenuItems(subMenu: HTMLElement, menuItem: string): MenuItem[] {
       children,
       counter: 0,
       depth: 1,
-      identifier: false,
+      identifier: null,
       title,
     };
   });
@@ -40,7 +40,7 @@ function getMenuItems(category: HTMLOListElement): MenuItem[] {
       children,
       counter: 0,
       depth: 2,
-      identifier: false,
+      identifier: null,
       link: link.href,
       title: link.textContent!,
     };
@@ -59,7 +59,7 @@ function getMenuItemActions(link: HTMLAnchorElement): MenuItem[] {
       children: [],
       counter: 0,
       depth: 2,
-      identifier: false,
+      identifier: null,
       link: action.href,
       title: action.dataset.tooltip || action.title,
     };
@@ -82,7 +82,7 @@ export class AcpUiPageMenuMainBackend implements PageMenuMainProvider {
           children,
           counter: 0,
           depth: 0,
-          identifier: false,
+          identifier: null,
           title,
         };
       },

--- a/ts/WoltLabSuite/Core/Acp/Ui/Page/Menu/Main/Backend.ts
+++ b/ts/WoltLabSuite/Core/Acp/Ui/Page/Menu/Main/Backend.ts
@@ -20,6 +20,7 @@ function getSubMenuItems(subMenu: HTMLElement, menuItem: string): MenuItem[] {
       children,
       counter: 0,
       depth: 1,
+      identifier: false,
       title,
     };
   });
@@ -39,6 +40,7 @@ function getMenuItems(category: HTMLOListElement): MenuItem[] {
       children,
       counter: 0,
       depth: 2,
+      identifier: false,
       link: link.href,
       title: link.textContent!,
     };
@@ -57,6 +59,7 @@ function getMenuItemActions(link: HTMLAnchorElement): MenuItem[] {
       children: [],
       counter: 0,
       depth: 2,
+      identifier: false,
       link: action.href,
       title: action.dataset.tooltip || action.title,
     };
@@ -79,6 +82,7 @@ export class AcpUiPageMenuMainBackend implements PageMenuMainProvider {
           children,
           counter: 0,
           depth: 0,
+          identifier: false,
           title,
         };
       },

--- a/ts/WoltLabSuite/Core/Ui/Page/Menu/Main.ts
+++ b/ts/WoltLabSuite/Core/Ui/Page/Menu/Main.ts
@@ -19,6 +19,7 @@ export class PageMenuMain implements PageMenuProvider {
   private readonly callbackOpen: CallbackOpen;
   private readonly container: PageMenuContainer;
   private readonly mainMenu: HTMLElement;
+  private readonly menuItemBadges = new Map<string, HTMLElement>();
   private readonly menuItemProvider: PageMenuMainProvider;
   private readonly observer: MutationObserver;
 
@@ -220,6 +221,10 @@ export class PageMenuMain implements PageMenuProvider {
         counter.setAttribute("aria-hidden", "true");
         counter.textContent = menuItem.counter.toString();
 
+        if (menuItem.identifier !== false) {
+          this.menuItemBadges.set(menuItem.identifier, counter);
+        }
+
         link.append(counter);
       }
 
@@ -314,6 +319,28 @@ export class PageMenuMain implements PageMenuProvider {
     } else {
       this.mainMenu.classList.remove("pageMenuMobileButtonHasContent");
     }
+
+    const menuItems = this.menuItemProvider.getMenuItems(this.mainMenu);
+    menuItems.forEach((menuItem) => this.refreshUnreadBage(menuItem));
+  }
+
+  private refreshUnreadBage(menuItem: MenuItem): void {
+    if (menuItem.identifier !== false) {
+      const counter = this.menuItemBadges.get(menuItem.identifier);
+      if (counter) {
+        if (menuItem.counter === 0) {
+          counter.remove();
+          this.menuItemBadges.delete(menuItem.identifier);
+        } else {
+          const value = parseInt(counter.textContent!, 10);
+          if (value !== menuItem.counter) {
+            counter.textContent = menuItem.counter.toString();
+          }
+        }
+      }
+    }
+
+    menuItem.children.forEach((child) => this.refreshUnreadBage(child));
   }
 
   private updateOverflowIndicator(container: HTMLElement): void {

--- a/ts/WoltLabSuite/Core/Ui/Page/Menu/Main.ts
+++ b/ts/WoltLabSuite/Core/Ui/Page/Menu/Main.ts
@@ -221,7 +221,7 @@ export class PageMenuMain implements PageMenuProvider {
         counter.setAttribute("aria-hidden", "true");
         counter.textContent = menuItem.counter.toString();
 
-        if (menuItem.identifier !== false) {
+        if (menuItem.identifier !== null) {
           this.menuItemBadges.set(menuItem.identifier, counter);
         }
 
@@ -325,7 +325,7 @@ export class PageMenuMain implements PageMenuProvider {
   }
 
   private refreshUnreadBage(menuItem: MenuItem): void {
-    if (menuItem.identifier !== false) {
+    if (menuItem.identifier !== null) {
       const counter = this.menuItemBadges.get(menuItem.identifier);
       if (counter) {
         if (menuItem.counter === 0) {

--- a/ts/WoltLabSuite/Core/Ui/Page/Menu/Main/Frontend.ts
+++ b/ts/WoltLabSuite/Core/Ui/Page/Menu/Main/Frontend.ts
@@ -41,11 +41,14 @@ function normalizeMenuItem(menuItem: HTMLElement, depth: MenuItemDepth): MenuIte
 
   const active = menuItem.classList.contains("active");
 
+  const identifier = anchor.parentElement!.dataset.identifier!;
+
   return {
     active,
     children,
     counter,
     depth,
+    identifier,
     link,
     title,
   };

--- a/ts/WoltLabSuite/Core/Ui/Page/Menu/Main/Provider.ts
+++ b/ts/WoltLabSuite/Core/Ui/Page/Menu/Main/Provider.ts
@@ -16,6 +16,7 @@ export type MenuItem = {
   children: MenuItem[];
   counter: number;
   depth: MenuItemDepth;
+  identifier: string | false;
   link?: string;
   title: string;
 };

--- a/ts/WoltLabSuite/Core/Ui/Page/Menu/Main/Provider.ts
+++ b/ts/WoltLabSuite/Core/Ui/Page/Menu/Main/Provider.ts
@@ -16,7 +16,7 @@ export type MenuItem = {
   children: MenuItem[];
   counter: number;
   depth: MenuItemDepth;
-  identifier: string | false;
+  identifier: string | null;
   link?: string;
   title: string;
 };

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Acp/Ui/Page/Menu/Main/Backend.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Acp/Ui/Page/Menu/Main/Backend.js
@@ -20,6 +20,7 @@ define(["require", "exports"], function (require, exports) {
                 children,
                 counter: 0,
                 depth: 1,
+                identifier: false,
                 title,
             };
         });
@@ -36,6 +37,7 @@ define(["require", "exports"], function (require, exports) {
                 children,
                 counter: 0,
                 depth: 2,
+                identifier: false,
                 link: link.href,
                 title: link.textContent,
             };
@@ -52,6 +54,7 @@ define(["require", "exports"], function (require, exports) {
                 children: [],
                 counter: 0,
                 depth: 2,
+                identifier: false,
                 link: action.href,
                 title: action.dataset.tooltip || action.title,
             };
@@ -70,6 +73,7 @@ define(["require", "exports"], function (require, exports) {
                     children,
                     counter: 0,
                     depth: 0,
+                    identifier: false,
                     title,
                 };
             });

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Acp/Ui/Page/Menu/Main/Backend.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Acp/Ui/Page/Menu/Main/Backend.js
@@ -20,7 +20,7 @@ define(["require", "exports"], function (require, exports) {
                 children,
                 counter: 0,
                 depth: 1,
-                identifier: false,
+                identifier: null,
                 title,
             };
         });
@@ -37,7 +37,7 @@ define(["require", "exports"], function (require, exports) {
                 children,
                 counter: 0,
                 depth: 2,
-                identifier: false,
+                identifier: null,
                 link: link.href,
                 title: link.textContent,
             };
@@ -54,7 +54,7 @@ define(["require", "exports"], function (require, exports) {
                 children: [],
                 counter: 0,
                 depth: 2,
-                identifier: false,
+                identifier: null,
                 link: action.href,
                 title: action.dataset.tooltip || action.title,
             };
@@ -73,7 +73,7 @@ define(["require", "exports"], function (require, exports) {
                     children,
                     counter: 0,
                     depth: 0,
-                    identifier: false,
+                    identifier: null,
                     title,
                 };
             });

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Page/Menu/Main.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Page/Menu/Main.js
@@ -15,6 +15,7 @@ define(["require", "exports", "tslib", "./Container", "../../../Language", "../.
     Util_1 = tslib_1.__importDefault(Util_1);
     class PageMenuMain {
         constructor(menuItemProvider) {
+            this.menuItemBadges = new Map();
             this.mainMenu = document.querySelector(".mainMenu");
             this.menuItemProvider = menuItemProvider;
             this.container = new Container_1.default(this);
@@ -167,6 +168,9 @@ define(["require", "exports", "tslib", "./Container", "../../../Language", "../.
                     counter.classList.add("pageMenuMainItemCounter", "badge", "badgeUpdate");
                     counter.setAttribute("aria-hidden", "true");
                     counter.textContent = menuItem.counter.toString();
+                    if (menuItem.identifier !== false) {
+                        this.menuItemBadges.set(menuItem.identifier, counter);
+                    }
                     link.append(counter);
                 }
                 listItem.append(link);
@@ -245,6 +249,26 @@ define(["require", "exports", "tslib", "./Container", "../../../Language", "../.
             else {
                 this.mainMenu.classList.remove("pageMenuMobileButtonHasContent");
             }
+            const menuItems = this.menuItemProvider.getMenuItems(this.mainMenu);
+            menuItems.forEach((menuItem) => this.refreshUnreadBage(menuItem));
+        }
+        refreshUnreadBage(menuItem) {
+            if (menuItem.identifier !== false) {
+                const counter = this.menuItemBadges.get(menuItem.identifier);
+                if (counter) {
+                    if (menuItem.counter === 0) {
+                        counter.remove();
+                        this.menuItemBadges.delete(menuItem.identifier);
+                    }
+                    else {
+                        const value = parseInt(counter.textContent, 10);
+                        if (value !== menuItem.counter) {
+                            counter.textContent = menuItem.counter.toString();
+                        }
+                    }
+                }
+            }
+            menuItem.children.forEach((child) => this.refreshUnreadBage(child));
         }
         updateOverflowIndicator(container) {
             const hasOverflow = container.clientHeight < container.scrollHeight;

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Page/Menu/Main.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Page/Menu/Main.js
@@ -168,7 +168,7 @@ define(["require", "exports", "tslib", "./Container", "../../../Language", "../.
                     counter.classList.add("pageMenuMainItemCounter", "badge", "badgeUpdate");
                     counter.setAttribute("aria-hidden", "true");
                     counter.textContent = menuItem.counter.toString();
-                    if (menuItem.identifier !== false) {
+                    if (menuItem.identifier !== null) {
                         this.menuItemBadges.set(menuItem.identifier, counter);
                     }
                     link.append(counter);
@@ -253,7 +253,7 @@ define(["require", "exports", "tslib", "./Container", "../../../Language", "../.
             menuItems.forEach((menuItem) => this.refreshUnreadBage(menuItem));
         }
         refreshUnreadBage(menuItem) {
-            if (menuItem.identifier !== false) {
+            if (menuItem.identifier !== null) {
                 const counter = this.menuItemBadges.get(menuItem.identifier);
                 if (counter) {
                     if (menuItem.counter === 0) {

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Page/Menu/Main/Frontend.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Page/Menu/Main/Frontend.js
@@ -36,11 +36,13 @@ define(["require", "exports"], function (require, exports) {
             link = anchor.href;
         }
         const active = menuItem.classList.contains("active");
+        const identifier = anchor.parentElement.dataset.identifier;
         return {
             active,
             children,
             counter,
             depth,
+            identifier,
             link,
             title,
         };


### PR DESCRIPTION
Synchronizes the mobile menu with the changes to the main menu, in particular keeps the unread counter in sync.

See https://www.woltlab.com/community/thread/296147-alle-als-gelesen-markieren-entfernt-counter-badges-nicht-mehr/