### PR TITLE
Explicitly trust `x-forwarded-proto` for Diactoros' ServerRequest

### DIFF
--- a/wcfsetup/install/files/lib/system/request/RequestHandler.class.php
+++ b/wcfsetup/install/files/lib/system/request/RequestHandler.class.php
@@ -4,6 +4,7 @@ namespace wcf\system\request;
 
 use Laminas\Diactoros\Response\RedirectResponse;
 use Laminas\Diactoros\ServerRequestFactory;
+use Laminas\Diactoros\ServerRequestFilter\FilterUsingXForwardedHeaders;
 use Laminas\HttpHandlerRunner\Emitter\SapiEmitter;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -72,7 +73,12 @@ final class RequestHandler extends SingletonFactory
                 }
             }
 
-            $psrRequest = ServerRequestFactory::fromGlobals();
+            $psrRequest = ServerRequestFactory::fromGlobals(
+                requestFilter: FilterUsingXForwardedHeaders::trustProxies(
+                    ['*'],
+                    [FilterUsingXForwardedHeaders::HEADER_PROTO]
+                )
+            );
 
             $builtRequest = $this->buildRequest($psrRequest, $application);
 

--- a/wcfsetup/install/files/lib/system/request/RequestHandler.class.php
+++ b/wcfsetup/install/files/lib/system/request/RequestHandler.class.php
@@ -74,7 +74,12 @@ final class RequestHandler extends SingletonFactory
             }
 
             $psrRequest = ServerRequestFactory::fromGlobals(
-                requestFilter: FilterUsingXForwardedHeaders::trustProxies(
+                $_SERVER,
+                $_GET,
+                $_POST,
+                $_COOKIE,
+                $_FILES,
+                FilterUsingXForwardedHeaders::trustProxies(
                     ['*'],
                     [FilterUsingXForwardedHeaders::HEADER_PROTO]
                 )

--- a/wcfsetup/install/files/lib/system/request/RequestHandler.class.php
+++ b/wcfsetup/install/files/lib/system/request/RequestHandler.class.php
@@ -74,11 +74,11 @@ final class RequestHandler extends SingletonFactory
             }
 
             $psrRequest = ServerRequestFactory::fromGlobals(
-                $_SERVER,
-                $_GET,
-                $_POST,
-                $_COOKIE,
-                $_FILES,
+                null, // $_SERVER
+                null, // $_GET
+                null, // $_POST
+                null, // $_COOKIE
+                null, // $_FILES
                 FilterUsingXForwardedHeaders::trustProxies(
                     ['*'],
                     [FilterUsingXForwardedHeaders::HEADER_PROTO]


### PR DESCRIPTION
This is required to future-proof the Diactoros configuration to be consistent
with RouteHandler::secureConnection().

see https://github.com/laminas/laminas-diactoros/blob/c272a93fc716456599d26bf7cc3281ccb708dabf/docs/book/v2/forward-migration.md
