### PR TITLE
Update the Unread Counter Using the Server-side Counter

### DIFF
--- a/ts/WoltLabSuite/Core/Ui/User/Menu/Data/ModerationQueue.ts
+++ b/ts/WoltLabSuite/Core/Ui/User/Menu/Data/ModerationQueue.ts
@@ -22,6 +22,11 @@ type Options = {
   title: string;
 };
 
+type ResponseGetData = {
+  items: UserMenuData[];
+  totalCount: number;
+};
+
 type ResponseMarkAsRead = {
   markAsRead: number;
   totalCount: number;
@@ -65,14 +70,13 @@ class UserMenuDataModerationQueue implements UserMenuProvider {
   async getData(): Promise<UserMenuData[]> {
     const data = (await dboAction("getModerationQueueData", "wcf\\data\\moderation\\queue\\ModerationQueueAction")
       .disableLoadingIndicator()
-      .dispatch()) as UserMenuData[];
+      .dispatch()) as ResponseGetData;
 
-    const counter = data.filter((item) => item.isUnread).length;
-    this.updateCounter(counter);
+    this.updateCounter(data.totalCount);
 
     this.stale = false;
 
-    return data;
+    return data.items;
   }
 
   getFooter(): UserMenuFooter | null {

--- a/ts/WoltLabSuite/Core/Ui/User/Menu/Data/Notification.ts
+++ b/ts/WoltLabSuite/Core/Ui/User/Menu/Data/Notification.ts
@@ -123,6 +123,11 @@ type Options = {
   title: string;
 };
 
+type ResponseGetData = {
+  items: UserMenuData[];
+  totalCount: number;
+};
+
 type ResponseMarkAsRead = {
   markAsRead: number;
   totalCount: number;
@@ -179,14 +184,13 @@ class UserMenuDataNotification implements DesktopNotifications, UserMenuProvider
   async getData(): Promise<UserMenuData[]> {
     const data = (await dboAction("getNotificationData", "wcf\\data\\user\\notification\\UserNotificationAction")
       .disableLoadingIndicator()
-      .dispatch()) as UserMenuData[];
+      .dispatch()) as ResponseGetData;
 
-    const counter = data.filter((item) => item.isUnread).length;
-    this.updateCounter(counter);
+    this.updateCounter(data.totalCount);
 
     this.stale = false;
 
-    return data;
+    return data.items;
   }
 
   getFooter(): UserMenuFooter | null {

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/User/Menu/Data/ModerationQueue.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/User/Menu/Data/ModerationQueue.js
@@ -44,10 +44,9 @@ define(["require", "exports", "tslib", "../../../../Ajax", "../View", "../Manage
             const data = (await (0, Ajax_1.dboAction)("getModerationQueueData", "wcf\\data\\moderation\\queue\\ModerationQueueAction")
                 .disableLoadingIndicator()
                 .dispatch());
-            const counter = data.filter((item) => item.isUnread).length;
-            this.updateCounter(counter);
+            this.updateCounter(data.totalCount);
             this.stale = false;
-            return data;
+            return data.items;
         }
         getFooter() {
             return {

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/User/Menu/Data/Notification.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/User/Menu/Data/Notification.js
@@ -135,10 +135,9 @@ define(["require", "exports", "tslib", "../../../../Ajax", "../View", "../Manage
             const data = (await (0, Ajax_1.dboAction)("getNotificationData", "wcf\\data\\user\\notification\\UserNotificationAction")
                 .disableLoadingIndicator()
                 .dispatch());
-            const counter = data.filter((item) => item.isUnread).length;
-            this.updateCounter(counter);
+            this.updateCounter(data.totalCount);
             this.stale = false;
-            return data;
+            return data.items;
         }
         getFooter() {
             return {

--- a/wcfsetup/install/files/lib/data/moderation/queue/ModerationQueueAction.class.php
+++ b/wcfsetup/install/files/lib/data/moderation/queue/ModerationQueueAction.class.php
@@ -143,10 +143,8 @@ class ModerationQueueAction extends AbstractDatabaseObjectAction
     {
         ['queues' => $queues, 'totalCount' => $totalCount] = $this->getModerationQueues();
 
-        $data = [];
-        /** @var ViewableModerationQueue $queue */
-        foreach ($queues as $queue) {
-            $data[] = [
+        $items = \array_map(static function (ViewableModerationQueue $queue) {
+            return [
                 'content' => $queue->getAffectedObject()->getTitle(),
                 'image' => '<span class="icon icon48 ' . $queue->getIconName() . '"></span>',
                 'isUnread' => $queue->isNew(),
@@ -155,9 +153,12 @@ class ModerationQueueAction extends AbstractDatabaseObjectAction
                 'time' => $queue->lastChangeTime,
                 'usernames' => [],
             ];
-        }
+        }, $queues);
 
-        return $data;
+        return [
+            'items' => $items,
+            'totalCount' => $totalCount,
+        ];
     }
 
     /**

--- a/wcfsetup/install/files/lib/data/user/notification/UserNotificationAction.class.php
+++ b/wcfsetup/install/files/lib/data/user/notification/UserNotificationAction.class.php
@@ -265,7 +265,10 @@ class UserNotificationAction extends AbstractDatabaseObjectAction
             ];
         }
 
-        return $notifications;
+        return [
+            'items' => $notifications,
+            'totalCount' => $data['notificationCount'],
+        ];
     }
 
     /**


### PR DESCRIPTION
The previous implementation relied on the number of unread items currently visible in the user menu. This caused an incorrect number shown for >10 unread items.

Notice: This is a last-minute API change to report the correct number from the server-side.

Fixes [#4877](https://github.com/WoltLab/WCF/issues/4877)