### PR TITLE
Make AbstractAjaxAction actually abstract

### DIFF
--- a/wcfsetup/install/files/lib/action/AbstractAjaxAction.class.php
+++ b/wcfsetup/install/files/lib/action/AbstractAjaxAction.class.php
@@ -7,7 +7,7 @@ use wcf\util\JSON;
 /**
  * @deprecated 5.5 Use PSR-7 responses (e.g. Laminas' JsonResponse).
  */
-class AbstractAjaxAction extends AbstractAction
+abstract class AbstractAjaxAction extends AbstractAction
 {
     /**
      * Sends a JSON-encoded response.


### PR DESCRIPTION
Without a controller that inherits from it, the AbstractAjaxAction will do
absolutely nothing useful:

- It fires events that cannot usefully be handled in a generic way.
- It sends an empty HTML response (i.e. a white page).
