### PR TITLE
Explicitly handle a `null` value in UserOptionOutput

### DIFF
--- a/wcfsetup/install/files/lib/system/option/user/MessageUserOptionOutput.class.php
+++ b/wcfsetup/install/files/lib/system/option/user/MessageUserOptionOutput.class.php
@@ -25,8 +25,13 @@ class MessageUserOptionOutput implements IUserOptionOutput
      */
     public function getOutput(User $user, UserOption $option, $value)
     {
+        if ($value === null) {
+            return '';
+        }
+
         $value = StringUtil::trim($value);
-        if (empty($value)) {
+
+        if ($value === '') {
             return '';
         }
 

--- a/wcfsetup/install/files/lib/system/option/user/NewlineToBreakUserOptionOutput.class.php
+++ b/wcfsetup/install/files/lib/system/option/user/NewlineToBreakUserOptionOutput.class.php
@@ -21,6 +21,10 @@ class NewlineToBreakUserOptionOutput implements IUserOptionOutput
      */
     public function getOutput(User $user, UserOption $option, $value)
     {
+        if ($value === null) {
+            return '';
+        }
+
         return \nl2br(StringUtil::encodeHTML($value), false);
     }
 }

--- a/wcfsetup/install/files/lib/system/option/user/SelectOptionsUserOptionOutput.class.php
+++ b/wcfsetup/install/files/lib/system/option/user/SelectOptionsUserOptionOutput.class.php
@@ -23,9 +23,12 @@ class SelectOptionsUserOptionOutput implements IUserOptionOutput
     public function getOutput(User $user, UserOption $option, $value)
     {
         $result = self::getResult($option, $value);
+
         if ($result === null) {
             return '';
-        } elseif (\is_array($result)) {
+        }
+
+        if (\is_array($result)) {
             $output = '';
             foreach ($result as $resultValue) {
                 if (!empty($output)) {
@@ -49,6 +52,10 @@ class SelectOptionsUserOptionOutput implements IUserOptionOutput
      */
     protected static function getResult(UserOption $option, $value)
     {
+        if ($value === null) {
+            return null;
+        }
+
         $options = OptionUtil::parseSelectOptions($option->selectOptions);
 
         // multiselect
@@ -67,7 +74,7 @@ class SelectOptionsUserOptionOutput implements IUserOptionOutput
                 return $options[$value];
             }
 
-            return;
+            return null;
         }
     }
 }


### PR DESCRIPTION
userOptions are commonly nullable, because no default value can be defined for
the `TEXT` column type family.

`null` needs to be handled explicitly, because PHP 8.1 deprecated passing
`null` to non-nullable string parameters of native functions. As an example
without this change, `null` could be passed to `StringUtil::trim()` in
`MessageUserOptioNOutput` which in turn passes it to `preg_replace()`.
