### PR TITLE
Rerun the .DS_Store deletion script

### DIFF
--- a/com.woltlab.wcf/package.xml
+++ b/com.woltlab.wcf/package.xml
@@ -103,6 +103,7 @@ tar cvf com.woltlab.wcf/files_pre_check.tar -C wcfsetup/install/files/ \
 		<instruction type="templateDelete" />
 		<instruction type="script" run="standalone">acp/update_com.woltlab.wcf_5.5_clearPackageDeprecations.php</instruction>
 		<instruction type="script" run="standalone">acp/update_com.woltlab.wcf_5.5_cleanupPackageExclusion.php</instruction>
+		<instruction type="script" run="standalone">acp/update_com.woltlab.wcf_5.5_deleteDsStore.php</instruction>
 
 		<!-- Misc. Update Scripts. -->
 		<instruction type="script" run="standalone">acp/update_com.woltlab.wcf_5.5_randomize_cronjobs.php</instruction>
@@ -112,7 +113,10 @@ tar cvf com.woltlab.wcf/files_pre_check.tar -C wcfsetup/install/files/ \
 		<instruction type="script" run="standalone">acp/update_com.woltlab.wcf_5.5_starttls.php</instruction>
 	</instructions>
 
-	<instructions type="update" fromversion="5.5.1">
+	<instructions type="update" fromversion="5.5.2">
 		<instruction type="file">files_update.tar</instruction>
+
+		<!-- Tentative update instructions from 5.5.2. -->
+		<instruction type="script">acp/update_com.woltlab.wcf_5.5_deleteDsStore.php</instruction>
 	</instructions>
 </package>

--- a/wcfsetup/install/files/acp/update_com.woltlab.wcf_5.5_deleteDsStore.php
+++ b/wcfsetup/install/files/acp/update_com.woltlab.wcf_5.5_deleteDsStore.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * Deletes .DS_Store and ._.DS_Store files.
+ *
+ * @author  Tim Duesterhus
+ * @copyright   2001-2022 WoltLab GmbH
+ * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @package WoltLabSuite\Core
+ */
+
+use wcf\data\application\Application;
+use wcf\system\WCF;
+
+$sql = "SELECT  *
+        FROM    wcf1_package_installation_file_log
+        WHERE   filename LIKE ?
+            OR  filename LIKE ?";
+$selectStatement = WCF::getDB()->prepare($sql);
+$selectStatement->execute([
+    '%/.DS_Store',
+    '%/._.DS_Store',
+]);
+
+$sql = "DELETE FROM wcf1_package_installation_file_log
+        WHERE       packageID = ?
+                AND filename = ?
+                AND application = ?";
+$deleteStatement = WCF::getDB()->prepare($sql);
+
+while (($row = $selectStatement->fetchArray())) {
+    $packageDir = Application::getDirectory($row['application']);
+    $fullPath = $packageDir . $row['filename'];
+
+    if (!\file_exists($fullPath) || !\is_file($fullPath)) {
+        continue;
+    }
+
+    if (
+        \basename($fullPath) !== '.DS_Store'
+        && \basename($fullPath) !== '._.DS_Store'
+    ) {
+        continue;
+    }
+
+    \unlink($fullPath);
+    $deleteStatement->execute([
+        $row['packageID'],
+        $row['filename'],
+        $row['application'],
+    ]);
+}


### PR DESCRIPTION
The files.tar of 5.5.0 RC 3 contained them, the files_update.tar did not. Thus
instances upgrading from 5.4 straight to 5.5.0 RC 3 are affected by this issue,
whereas instances coming from RC 2 are not necessarily.

Add this script to the update instructions from 5.4 to clean all instances
coming from 5.4.x. Add it also to the update instructions from 5.5.1 to clean all
instances coming from 5.5.x.

see https://www.woltlab.com/community/thread/296244-ds-store-dateien-erneut-in-der-installation/
see #4699
