### PR TITLE
Disable `zend.exception_ignore_args` for PHP 8.2 once WCF's exception handler is bound

### DIFF
--- a/wcfsetup/install/files/lib/core.functions.php
+++ b/wcfsetup/install/files/lib/core.functions.php
@@ -12,6 +12,11 @@ namespace {
 	set_exception_handler([WCF::class, 'handleException']);
 	// set php error handler
 	set_error_handler([WCF::class, 'handleError'], E_ALL);
+
+	if (PHP_VERSION_ID >= 80200) {
+		@ini_set('zend.exception_ignore_args', 0);
+	}
+
 	// set shutdown function
 	register_shutdown_function([WCF::class, 'destruct']);
 	// set autoload function


### PR DESCRIPTION
With the introduction of the `\SensitiveParameter` attribute in PHP sensitive
values in stack traces should be sanitized and administrators already have the
capability of disabling the public printing of the stack trace.

Force enable the collection of stack frame arguments for exceptions to ease
debugging.
