### PR TITLE
Fix sending credentials when updating packages

### DIFF
--- a/wcfsetup/install/files/lib/data/package/update/PackageUpdateAction.class.php
+++ b/wcfsetup/install/files/lib/data/package/update/PackageUpdateAction.class.php
@@ -662,6 +662,7 @@ class PackageUpdateAction extends AbstractDatabaseObjectAction
             $this->readString('password', false, 'authData');
             $this->readString('username', false, 'authData');
             $this->readBoolean('saveCredentials', true, 'authData');
+            $this->parameters['authData']['isStoreCode'] = false;
         }
     }
 


### PR DESCRIPTION
Previously the `isStoreCode` array key would not be defined when updating,
resulting in the code erroring out in PackageUpdateAction::createQueue() due to
accessing an undefined array key.

see eb1f573e7ddf8ac96baa80132284e1efc7c9659d
