### PR TITLE
Update mediaProvider Regex to support YouTube Clips

### DIFF
--- a/com.woltlab.wcf/mediaProvider.xml
+++ b/com.woltlab.wcf/mediaProvider.xml
@@ -4,7 +4,7 @@
 		<provider name="youtube">
 			<title>YouTube</title>
 			<regex><![CDATA[https?://(?:.+?\.)?youtu(?:\.be/|be\.com/(?:#/)?watch\?(?:.*?&)?v=)(?P<ID>[a-zA-Z0-9_-]+)
-https?://(?:.+?\.)?youtube.com/shorts/(?P<ID>[a-zA-Z0-9_-]+)]]></regex>
+https?://(?:.+?\.)?youtube.com/(?:shorts|clip)/(?P<ID>[a-zA-Z0-9_-]+)]]></regex>
 			<className>wcf\system\bbcode\media\provider\YouTubeBBCodeMediaProvider</className>
 		</provider>
 		<provider name="youtube-playlist">


### PR DESCRIPTION
The proposed change should allow YouTube Clips also to be parsed by `YouTubeBBCodeMediaProvider`