### PR TITLE
Allow @-sign in username

### DIFF
--- a/wcfsetup/install/files/lib/util/UserUtil.class.php
+++ b/wcfsetup/install/files/lib/util/UserUtil.class.php
@@ -40,7 +40,7 @@ final class UserUtil
             }
         }
         // username must not be a valid e-mail
-        if (self::isValidEmail($name)) {
+        if (self::isValidEmail($name) && \strpos($name, '.') !== false) {
             return false;
         }
 


### PR DESCRIPTION
Currently, the check for email addresses as username is too strict, as an email address in user@host format is valid. However, this results in usernames no longer being allowed to contain an @ character, otherwise they will be recognized as a valid email address.

See https://www.woltlab.com/community/thread/296653-benutzernamen-mit-im-namen-bei-5-5-nicht-mehr-m%C3%B6glich