### PR TITLE
Store SHA-256 hashes in `wcf1_package_installation_file_log`

### DIFF
--- a/wcfsetup/install/files/acp/database/update_com.woltlab.wcf_5.6.php
+++ b/wcfsetup/install/files/acp/database/update_com.woltlab.wcf_5.6.php
@@ -9,8 +9,10 @@
  * @package WoltLabSuite\Core
  */
 
+use wcf\system\database\table\column\BigintDatabaseTableColumn;
 use wcf\system\database\table\column\NotNullInt10DatabaseTableColumn;
 use wcf\system\database\table\column\TinyintDatabaseTableColumn;
+use wcf\system\database\table\column\VarbinaryDatabaseTableColumn;
 use wcf\system\database\table\PartialDatabaseTable;
 
 return [
@@ -25,6 +27,12 @@ return [
     PartialDatabaseTable::create('wcf1_package_installation_file_log')
         ->columns([
             NotNullInt10DatabaseTableColumn::create('packageID'),
+            VarbinaryDatabaseTableColumn::create('sha256')
+                ->length(32)
+                ->defaultValue(null),
+            BigintDatabaseTableColumn::create('lastUpdated')
+                ->length(20)
+                ->defaultValue(null),
         ]),
     PartialDatabaseTable::create('wcf1_package_installation_plugin')
         ->columns([

--- a/wcfsetup/install/files/lib/system/package/plugin/FilePackageInstallationPlugin.class.php
+++ b/wcfsetup/install/files/lib/system/package/plugin/FilePackageInstallationPlugin.class.php
@@ -69,19 +69,21 @@ class FilePackageInstallationPlugin extends AbstractPackageInstallationPlugin im
 
             // log files
             $sql = "INSERT INTO wcf" . WCF_N . "_package_installation_file_log
-                                (packageID, filename, application)
-                    VALUES      (?, ?, ?)";
+                                (packageID, filename, application, sha256, lastUpdated)
+                    VALUES      (?, ?, ?, ?, ?)";
             $statement = WCF::getDB()->prepareStatement($sql);
-            $statement->execute([
-                $this->installation->getPackageID(),
-                'config.inc.php',
-                Package::getAbbreviation($this->installation->getPackage()->package),
-            ]);
-            $statement->execute([
-                $this->installation->getPackageID(),
+            foreach ([
                 PackageInstallationDispatcher::CONFIG_FILE,
-                Package::getAbbreviation($this->installation->getPackage()->package),
-            ]);
+                'config.inc.php',
+            ] as $filename) {
+                $statement->execute([
+                    $this->installation->getPackageID(),
+                    $filename,
+                    Package::getAbbreviation($this->installation->getPackage()->package),
+                    \hash_file('sha256', $packageDir . $filename, true),
+                    \TIME_NOW,
+                ]);
+            }
 
             // load application
             WCF::loadRuntimeApplication($this->installation->getPackageID());

--- a/wcfsetup/setup/db/install.sql
+++ b/wcfsetup/setup/db/install.sql
@@ -956,6 +956,8 @@ CREATE TABLE wcf1_package_installation_file_log (
 	packageID INT(10) NOT NULL,
 	filename VARBINARY(765) NOT NULL, -- VARBINARY(765) roughly equals VARCHAR(255)
 	application VARCHAR(20) NOT NULL,
+	sha256 VARBINARY(32) DEFAULT NULL,
+	lastUpdated BIGINT(20) DEFAULT NULL,
 	UNIQUE KEY applicationFile (application, filename)
 );
 


### PR DESCRIPTION
It is not planned to actively check them anywhere, but having something is
often better than needing them. They might ease manual verification of the
installation's consistency.
