### PR TITLE
Fix Database::getInsertID() return type PHPDoc

### DIFF
--- a/wcfsetup/install/files/lib/system/database/Database.class.php
+++ b/wcfsetup/install/files/lib/system/database/Database.class.php
@@ -142,7 +142,7 @@ abstract class Database {
 	 * 
 	 * @param	string		$table
 	 * @param	string		$field
-	 * @return	integer
+	 * @return	string
 	 * @throws	DatabaseException
 	 */
 	public function getInsertID($table, $field) {


### PR DESCRIPTION
The PHPDoc claimed that PDO::lastInsertId() returns an integer, while the actual return type is false|string.

Apart from developer confusion, wrong types mainly is an issue for static analysis and other automated code tools. With PHP return type annotations this could mislead a developer too and produce exceptions in 3rd party code explicitly stating PHP return types.

(Alternatively, this could be fixed by casting the string to an int. That solution may have other issues though.)