### PR TITLE
Fix Facebook media provider

### DIFF
--- a/com.woltlab.wcf/mediaProvider.xml
+++ b/com.woltlab.wcf/mediaProvider.xml
@@ -72,8 +72,8 @@ https?://www.twitch.tv/[a-zA-Z0-9]+/v/(?<VIDEO>[0-9]+)]]></regex>
 		</provider>
 		<provider name="facebook-video">
 			<title>Facebook Video</title>
-			<regex><![CDATA[(?<HREF>https?://(www\.)?facebook\.com/watch/\?v=(?<ID>[0-9]+))
-(?<HREF>https?://(www\.)?facebook\.com/[a-zA-Z0-9_-]+/videos/(?<ID>[0-9]+)/)
+			<regex><![CDATA[(?<HREF>https?://(www\.)?facebook\.com/watch/?\?v=(?<ID>[0-9]+))
+(?<HREF>https?://(www\.)?facebook\.com/[a-zA-Z0-9_\.-]+/videos/(?<ID>[0-9]+))
 (?<HREF>https?://fb\.watch/(?<ID>[a-zA-Z0-9_-]+)/)]]></regex>
 			<html><![CDATA[<div class="fb-video" data-href="{$HREF}" data-allowfullscreen="true">{$HREF}</div>
 <script>require(['WoltLabSuite/Core/Wrapper/FacebookSdk'],function(FB){FB.XFBML.parse()})</script>]]></html>


### PR DESCRIPTION
In Facebook video urls, usernames CAN contain periods, but they're currently not supported. There's also no need for a trailing slash (after `watch` and/or after the whole url).

Example: https://www.facebook.com/RaiPlay.it/videos/1059491774481091