### PR TITLE
Remove __wcfVersion template variable

### DIFF
--- a/wcfsetup/install/files/lib/system/WCF.class.php
+++ b/wcfsetup/install/files/lib/system/WCF.class.php
@@ -789,7 +789,6 @@ class WCF
         self::getTPL()->registerPrefilter(['event', 'hascontent', 'lang', 'jslang', 'csrfToken']);
         self::getTPL()->assign([
             '__wcf' => $wcf,
-            '__wcfVersion' => LAST_UPDATE_TIME, // @deprecated 2.1, use LAST_UPDATE_TIME directly
         ]);
 
         $isAjax = isset($_SERVER['HTTP_X_REQUESTED_WITH']) && ($_SERVER['HTTP_X_REQUESTED_WITH'] == 'XMLHttpRequest');


### PR DESCRIPTION
This one is long-deprecated, breaks very obviously and is trivially replaced.
