### PR TITLE
Remove scss.inc.php compatiblity include

### DIFF
--- a/wcfsetup/install/files/lib/system/style/scssphp/scss.inc.php
+++ b/wcfsetup/install/files/lib/system/style/scssphp/scss.inc.php
@@ -1,7 +1,0 @@
-<?php
-
-/**
- * @deprecated 5.3 The SCSS compiler is a composer package as of 5.2.
- */
-
-require(WCF_DIR . 'lib/system/api/scssphp/scssphp/scss.inc.php');


### PR DESCRIPTION
This is longish-deprecated and the fix is trivial: Just remove the include, the
classes are implicitly available by composer's autoloader.
