### PR TITLE
Move ban checking from WCF boot to middleware

### DIFF
--- a/wcfsetup/install/files/lib/http/Helper.class.php
+++ b/wcfsetup/install/files/lib/http/Helper.class.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace wcf\http;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Provides various helper methods for PSR-7/PSR-15 request processing.
+ *
+ * @author  Tim Duesterhus
+ * @copyright   2001-2022 WoltLab GmbH
+ * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @package WoltLabSuite\Core\Http
+ * @since   6.0
+ */
+final class Helper
+{
+    /**
+     * Returns whether the request's 'x-requested-with' header is equal
+     * to 'XMLHttpRequest'.
+     */
+    public static function isAjaxRequest(ServerRequestInterface $request): bool
+    {
+        return $request->getHeaderLine('x-requested-with') === 'XMLHttpRequest';
+    }
+
+    /**
+     * Forbid creation of Helper objects.
+     */
+    private function __construct()
+    {
+        // does nothing
+    }
+}

--- a/wcfsetup/install/files/lib/http/middleware/CheckForOfflineMode.class.php
+++ b/wcfsetup/install/files/lib/http/middleware/CheckForOfflineMode.class.php
@@ -7,6 +7,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use wcf\http\Helper;
 use wcf\system\box\BoxHandler;
 use wcf\system\exception\AJAXException;
 use wcf\system\notice\NoticeHandler;
@@ -47,7 +48,7 @@ final class CheckForOfflineMode implements MiddlewareInterface
 
     private function getOfflineResponse(ServerRequestInterface $request): ResponseInterface
     {
-        if ($this->isAjaxRequest($request)) {
+        if (Helper::isAjaxRequest($request)) {
             throw new AJAXException(
                 WCF::getLanguage()->getDynamicVariable('wcf.ajax.error.permissionDenied'),
                 AJAXException::INSUFFICIENT_PERMISSIONS
@@ -78,10 +79,5 @@ final class CheckForOfflineMode implements MiddlewareInterface
     private function userCanBypassOfflineMode(): bool
     {
         return WCF::getSession()->getPermission('admin.general.canViewPageDuringOfflineMode');
-    }
-
-    private function isAjaxRequest(ServerRequestInterface $request): bool
-    {
-        return $request->getHeaderLine('x-requested-with') === 'XMLHttpRequest';
     }
 }

--- a/wcfsetup/install/files/lib/http/middleware/CheckUserBan.class.php
+++ b/wcfsetup/install/files/lib/http/middleware/CheckUserBan.class.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace wcf\http\middleware;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use wcf\data\user\User;
+use wcf\system\exception\AJAXException;
+use wcf\system\exception\NamedUserException;
+use wcf\system\WCF;
+
+/**
+ * Checks whether the user is banned and deletes their sessions.
+ *
+ * @author  Tim Duesterhus
+ * @copyright   2001-2022 WoltLab GmbH
+ * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @package WoltLabSuite\Core\Http\Middleware
+ * @since   6.0
+ */
+final class CheckUserBan implements MiddlewareInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $user = WCF::getUser();
+
+        if ($this->isBanned($user)) {
+            if ($this->isAjaxRequest($request)) {
+                throw new AJAXException(
+                    WCF::getLanguage()->getDynamicVariable('wcf.user.error.isBanned'),
+                    AJAXException::INSUFFICIENT_PERMISSIONS
+                );
+            } else {
+                // Delete sessions only for non-AJAX requests to ensure
+                // that the user was able to see the message properly
+                WCF::getSession()->deleteUserSessionsExcept($user);
+
+                throw new NamedUserException(WCF::getLanguage()->getDynamicVariable('wcf.user.error.isBanned'));
+            }
+        }
+
+        return $handler->handle($request);
+    }
+
+    private function isBanned(User $user): bool
+    {
+        if (!$user->userID) {
+            return false;
+        }
+
+        if ($user->hasOwnerAccess()) {
+            return false;
+        }
+
+        return !!$user->banned;
+    }
+
+    private function isAjaxRequest(ServerRequestInterface $request): bool
+    {
+        return $request->getHeaderLine('x-requested-with') === 'XMLHttpRequest';
+    }
+}

--- a/wcfsetup/install/files/lib/http/middleware/CheckUserBan.class.php
+++ b/wcfsetup/install/files/lib/http/middleware/CheckUserBan.class.php
@@ -7,6 +7,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use wcf\data\user\User;
+use wcf\http\Helper;
 use wcf\system\exception\AJAXException;
 use wcf\system\exception\NamedUserException;
 use wcf\system\WCF;
@@ -30,7 +31,7 @@ final class CheckUserBan implements MiddlewareInterface
         $user = WCF::getUser();
 
         if ($this->isBanned($user)) {
-            if ($this->isAjaxRequest($request)) {
+            if (Helper::isAjaxRequest($request)) {
                 throw new AJAXException(
                     WCF::getLanguage()->getDynamicVariable('wcf.user.error.isBanned'),
                     AJAXException::INSUFFICIENT_PERMISSIONS
@@ -58,10 +59,5 @@ final class CheckUserBan implements MiddlewareInterface
         }
 
         return !!$user->banned;
-    }
-
-    private function isAjaxRequest(ServerRequestInterface $request): bool
-    {
-        return $request->getHeaderLine('x-requested-with') === 'XMLHttpRequest';
     }
 }

--- a/wcfsetup/install/files/lib/system/WCF.class.php
+++ b/wcfsetup/install/files/lib/system/WCF.class.php
@@ -18,10 +18,8 @@ use wcf\system\cache\builder\PackageUpdateCacheBuilder;
 use wcf\system\cronjob\CronjobScheduler;
 use wcf\system\database\MySQLDatabase;
 use wcf\system\event\EventHandler;
-use wcf\system\exception\AJAXException;
 use wcf\system\exception\ErrorException;
 use wcf\system\exception\IPrintableException;
-use wcf\system\exception\NamedUserException;
 use wcf\system\exception\ParentClassException;
 use wcf\system\exception\SystemException;
 use wcf\system\language\LanguageFactory;
@@ -177,7 +175,6 @@ class WCF
         $this->initCronjobs();
         $this->initCoreObjects();
         $this->initApplications();
-        $this->initBlacklist();
 
         EventHandler::getInstance()->fireAction($this, 'initialized');
     }
@@ -559,28 +556,6 @@ class WCF
 
         $styleHandler = StyleHandler::getInstance();
         $styleHandler->changeStyle($styleID);
-    }
-
-    /**
-     * Executes the blacklist.
-     */
-    protected function initBlacklist()
-    {
-        $isAjax = isset($_SERVER['HTTP_X_REQUESTED_WITH']) && ($_SERVER['HTTP_X_REQUESTED_WITH'] == 'XMLHttpRequest');
-
-        // handle banned users
-        if (self::getUser()->userID && self::getUser()->banned && !self::getUser()->hasOwnerAccess()) {
-            if ($isAjax) {
-                throw new AJAXException(
-                    self::getLanguage()->getDynamicVariable('wcf.user.error.isBanned'),
-                    AJAXException::INSUFFICIENT_PERMISSIONS
-                );
-            } else {
-                self::getSession()->delete();
-
-                throw new NamedUserException(self::getLanguage()->getDynamicVariable('wcf.user.error.isBanned'));
-            }
-        }
     }
 
     /**

--- a/wcfsetup/install/files/lib/system/WCFACP.class.php
+++ b/wcfsetup/install/files/lib/system/WCFACP.class.php
@@ -69,7 +69,6 @@ class WCFACP extends WCF
             $this->initApplications();
         }
 
-        $this->initBlacklist();
         $this->initAuth();
 
         EventHandler::getInstance()->fireAction($this, 'initialized');

--- a/wcfsetup/install/files/lib/system/request/RequestHandler.class.php
+++ b/wcfsetup/install/files/lib/system/request/RequestHandler.class.php
@@ -14,6 +14,7 @@ use wcf\http\middleware\CheckForEnterpriseNonOwnerAccess;
 use wcf\http\middleware\CheckForExpiredAppEvaluation;
 use wcf\http\middleware\CheckForOfflineMode;
 use wcf\http\middleware\CheckSystemEnvironment;
+use wcf\http\middleware\CheckUserBan;
 use wcf\http\middleware\EnforceCacheControlPrivate;
 use wcf\http\middleware\EnforceFrameOptions;
 use wcf\http\Pipeline;
@@ -95,6 +96,7 @@ final class RequestHandler extends SingletonFactory
                     new EnforceCacheControlPrivate(),
                     new EnforceFrameOptions(),
                     new CheckSystemEnvironment(),
+                    new CheckUserBan(),
                     new CheckForEnterpriseNonOwnerAccess(),
                     new CheckForExpiredAppEvaluation(),
                     new CheckForOfflineMode(),


### PR DESCRIPTION
The previous location in WCF made sense back when `initBlacklist()` also
checked the IP address, User-Agent, or hostname blocklist to prevent processing
the request as much as possible. As all these checks are gone now, the only
thing that remains is the inexpensive ban check.

Move it into a middleware, it does not really belong into WCF which should just
be responsible for booting the framework independently of the request in
question.
