### PR TITLE
Add cache for page objects in menus

### DIFF
--- a/wcfsetup/install/files/lib/data/menu/item/MenuItem.class.php
+++ b/wcfsetup/install/files/lib/data/menu/item/MenuItem.class.php
@@ -191,4 +191,11 @@ class MenuItem extends DatabaseObject implements ITitledObject
 
         return $this->handler;
     }
+
+    public function cachePageObject(): void
+    {
+        if ($this->pageObjectID && $this->getMenuPageHandler() !== null) {
+            $this->getMenuPageHandler()->cacheObject($this->pageObjectID);
+        }
+    }
 }

--- a/wcfsetup/install/files/lib/data/menu/item/MenuItemNodeTree.class.php
+++ b/wcfsetup/install/files/lib/data/menu/item/MenuItemNodeTree.class.php
@@ -93,6 +93,8 @@ class MenuItemNodeTree
 
         // build menu structure
         foreach ($menuItemList as $menuItem) {
+            $menuItem->cachePageObject();
+            
             $this->menuItems[$menuItem->itemID] = $menuItem;
 
             if (!isset($this->menuItemStructure[$menuItem->parentItemID])) {

--- a/wcfsetup/install/files/lib/system/page/handler/AbstractMenuPageHandler.class.php
+++ b/wcfsetup/install/files/lib/system/page/handler/AbstractMenuPageHandler.class.php
@@ -31,4 +31,11 @@ abstract class AbstractMenuPageHandler implements IMenuPageHandler
     {
         return true;
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function cacheObject(int $objectID): void
+    {
+    }
 }

--- a/wcfsetup/install/files/lib/system/page/handler/ArticlePageHandler.class.php
+++ b/wcfsetup/install/files/lib/system/page/handler/ArticlePageHandler.class.php
@@ -119,4 +119,12 @@ class ArticlePageHandler extends AbstractLookupPageHandler implements IOnlineLoc
             ViewableArticleContentRuntimeCache::getInstance()->cacheObjectID($user->pageObjectID);
         }
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function cacheObject(int $objectID): void
+    {
+        ViewableArticleRuntimeCache::getInstance()->cacheObjectID($objectID);
+    }
 }

--- a/wcfsetup/install/files/lib/system/page/handler/IMenuPageHandler.class.php
+++ b/wcfsetup/install/files/lib/system/page/handler/IMenuPageHandler.class.php
@@ -30,4 +30,11 @@ interface IMenuPageHandler
      * @return  bool        false if the page should be hidden from menus
      */
     public function isVisible($objectID = null);
+
+    /**
+     * Caches the given object id to save SQL queries if multiple objects of the same type are queried in the menu.
+     * 
+     * @since 6.0
+     */
+    public function cacheObject(int $objectID): void;
 }


### PR DESCRIPTION
If several articles were linked in the menu, this led to a lot of SQL queries.

see https://www.woltlab.com/community/thread/296798-articlepagehandler-optimieren/