### PR TITLE
Permit the use of the native `<button>` element

### DIFF
--- a/com.woltlab.wcf/templates/__buttonFormField.tpl
+++ b/com.woltlab.wcf/templates/__buttonFormField.tpl
@@ -3,6 +3,6 @@
 	*}id="{@$field->getPrefixedId()}" {*
 	*}name="{@$field->getPrefixedId()}" {*
 	*}value="{$field->getValue()}"{*
-	*}{if !$field->getFieldClasses()|empty} class="{implode from=$field->getFieldClasses() item='class' glue=' '}{$class}{/implode}"{/if}{*
+	*}{if !$field->getFieldClasses()|empty} class="button {implode from=$field->getFieldClasses() item='class' glue=' '}{$class}{/implode}"{/if}{*
 	*}{foreach from=$field->getFieldAttributes() key='attributeName' item='attributeValue'} {$attributeName}="{$attributeValue}"{/foreach}{*
 *}>{$field->getButtonLabel()}</button>

--- a/com.woltlab.wcf/templates/__formButton.tpl
+++ b/com.woltlab.wcf/templates/__formButton.tpl
@@ -8,7 +8,7 @@
 		*}>
 {else}
 	<button id="{@$button->getPrefixedId()}"{*
-		*}{if !$button->getClasses()|empty} class="{implode from=$button->getClasses() item='class' glue=' '}{$class}{/implode}"{/if}{*
+		*}{if !$button->getClasses()|empty} class="button {implode from=$button->getClasses() item='class' glue=' '}{$class}{/implode}"{/if}{*
 		*}{foreach from=$button->getAttributes() key='attributeName' item='attributeValue'} {$attributeName}="{$attributeValue}"{/foreach}{*
 		*}{if $button->getAccessKey()} accesskey="{$button->getAccessKey()}"{/if}{*
 	*}>{$button->getLabel()}</button>

--- a/com.woltlab.wcf/templates/__mediaSetCategoryDialog.tpl
+++ b/com.woltlab.wcf/templates/__mediaSetCategoryDialog.tpl
@@ -24,5 +24,5 @@
 </div>
 
 <div class="formSubmit">
-	<button data-type="submit" class="buttonPrimary">{lang}wcf.global.button.submit{/lang}</button>
+	<button data-type="submit" class="button buttonPrimary">{lang}wcf.global.button.submit{/lang}</button>
 </div>

--- a/com.woltlab.wcf/templates/__multifactorTotpDeviceNoDeleteButton.tpl
+++ b/com.woltlab.wcf/templates/__multifactorTotpDeviceNoDeleteButton.tpl
@@ -1,4 +1,4 @@
-<button type="button" id="{@$button->getPrefixedId()}" class="jsStaticDialog" data-dialog-id="{@$button->getPrefixedId()}DeletionInfo">{$button->getLabel()}</button>
+<button type="button" id="{@$button->getPrefixedId()}" class="button jsStaticDialog" data-dialog-id="{@$button->getPrefixedId()}DeletionInfo">{$button->getLabel()}</button>
 <div style="display: none;" id="{@$button->getPrefixedId()}DeletionInfo" data-title="{lang}wcf.user.security.multifactor.totp.lastDevice.title{/lang}">
 	{lang deviceName=$device[deviceName]}wcf.user.security.multifactor.totp.lastDevice{/lang}
 </div>

--- a/com.woltlab.wcf/templates/__wysiwygPreviewFormButton.tpl
+++ b/com.woltlab.wcf/templates/__wysiwygPreviewFormButton.tpl
@@ -1,5 +1,5 @@
 <button id="{@$button->getPrefixedId()}"{*
-	*}{if !$button->getClasses()|empty} class="{implode from=$button->getClasses() item='class' glue=' '}{$class}{/implode}"{/if}{*
+	*}{if !$button->getClasses()|empty} class="button {implode from=$button->getClasses() item='class' glue=' '}{$class}{/implode}"{/if}{*
 	*}{foreach from=$button->getAttributes() key='attributeName' item='attributeValue'} {$attributeName}="{$attributeValue}"{/foreach}{*
 	*}{if $button->getAccessKey()} accesskey="{$button->getAccessKey()}"{/if}{*
 *}>{$button->getLabel()}</button>

--- a/com.woltlab.wcf/templates/accountSecurity.tpl
+++ b/com.woltlab.wcf/templates/accountSecurity.tpl
@@ -89,7 +89,7 @@
 					
 					{if !$session->isCurrentSession()}
 						<div class="accountSecurityButtons">
-							<button class="small sessionDeleteButton" data-session-id="{$session->getSessionID()}">{lang}wcf.user.security.deleteSession{/lang}</button>
+							<button class="button small sessionDeleteButton" data-session-id="{$session->getSessionID()}">{lang}wcf.user.security.deleteSession{/lang}</button>
 						</div>
 					{/if}
 				</div>

--- a/com.woltlab.wcf/templates/articleAdd.tpl
+++ b/com.woltlab.wcf/templates/articleAdd.tpl
@@ -560,7 +560,7 @@
 	
 	<div class="formSubmit">
 		<input type="submit" value="{lang}wcf.global.button.submit{/lang}" accesskey="s">
-		<button id="buttonMessagePreview" class="jsOnly">{lang}wcf.global.button.preview{/lang}</button>
+		<button id="buttonMessagePreview" class="button jsOnly">{lang}wcf.global.button.preview{/lang}</button>
 		<input type="hidden" name="isMultilingual" value="{@$isMultilingual}">
 		<input type="hidden" name="timeNowReference" value="{@TIME_NOW}">
 		{csrfToken}

--- a/com.woltlab.wcf/templates/articleAddDialog.tpl
+++ b/com.woltlab.wcf/templates/articleAddDialog.tpl
@@ -11,7 +11,7 @@
 		</dl>
 		
 		<div class="formSubmit">
-			<button class="buttonPrimary">{lang}wcf.global.button.next{/lang}</button>
+			<button class="button buttonPrimary">{lang}wcf.global.button.next{/lang}</button>
 		</div>
 	</div>
 </div>

--- a/com.woltlab.wcf/templates/commentAddGuestDialog.tpl
+++ b/com.woltlab.wcf/templates/commentAddGuestDialog.tpl
@@ -22,5 +22,5 @@
 
 <div class="formSubmit">
 	<input type="submit" value="{lang}wcf.global.button.submit{/lang}" accesskey="s">
-	<button data-type="cancel">{lang}wcf.global.button.cancel{/lang}</button>
+	<button clas="button" data-type="cancel">{lang}wcf.global.button.cancel{/lang}</button>
 </div>

--- a/com.woltlab.wcf/templates/commentEditor.tpl
+++ b/com.woltlab.wcf/templates/commentEditor.tpl
@@ -6,11 +6,11 @@
 {include file='messageFormTabsInline'}
 
 <div class="formSubmit">
-	<button class="buttonPrimary" data-type="save" accesskey="s">{lang}wcf.global.button.submit{/lang}</button>
+	<button class="button buttonPrimary" data-type="save" accesskey="s">{lang}wcf.global.button.submit{/lang}</button>
 	
 	{include file='messageFormPreviewButton' previewMessageFieldID=$wysiwygSelector previewButtonID=$wysiwygSelector|concat:'_PreviewButton' previewMessageObjectType='com.woltlab.wcf.comment' previewMessageObjectID=$comment->commentID}
 	
-	<button data-type="cancel">{lang}wcf.global.button.cancel{/lang}</button>
+	<button class="button" data-type="cancel">{lang}wcf.global.button.cancel{/lang}</button>
 </div>
 
 {include file='wysiwyg'}

--- a/com.woltlab.wcf/templates/commentListAddComment.tpl
+++ b/com.woltlab.wcf/templates/commentListAddComment.tpl
@@ -18,7 +18,7 @@
 			{include file='wysiwyg'}
 			
 			<div class="formSubmit">
-				<button class="buttonPrimary" data-type="save" accesskey="s">{lang}wcf.global.button.submit{/lang}</button>
+				<button class="button buttonPrimary" data-type="save" accesskey="s">{lang}wcf.global.button.submit{/lang}</button>
 				
 				{include file='messageFormPreviewButton' previewMessageFieldID=$wysiwygSelector previewButtonID=$wysiwygSelector|concat:'_PreviewButton' previewMessageObjectType='com.woltlab.wcf.comment' previewMessageObjectID=0}
 			</div>
@@ -49,7 +49,7 @@
 				{include file='wysiwyg' wysiwygSelector=$_commentResponseWysiwygSelector}
 				
 				<div class="formSubmit">
-					<button class="buttonPrimary" data-type="save" accesskey="s">{lang}wcf.global.button.submit{/lang}</button>
+					<button class="button buttonPrimary" data-type="save" accesskey="s">{lang}wcf.global.button.submit{/lang}</button>
 					
 					{include file='messageFormPreviewButton' previewMessageFieldID=$_commentResponseWysiwygSelector previewButtonID=$_commentResponseWysiwygSelector|concat:'_PreviewButton' previewMessageObjectType='com.woltlab.wcf.comment.response' previewMessageObjectID=0}
 				</div>

--- a/com.woltlab.wcf/templates/commentResponseEditor.tpl
+++ b/com.woltlab.wcf/templates/commentResponseEditor.tpl
@@ -6,11 +6,11 @@
 {include file='messageFormTabsInline'}
 
 <div class="formSubmit">
-	<button class="buttonPrimary" data-type="save" accesskey="s">{lang}wcf.global.button.submit{/lang}</button>
+	<button class="button buttonPrimary" data-type="save" accesskey="s">{lang}wcf.global.button.submit{/lang}</button>
 	
 	{include file='messageFormPreviewButton' previewMessageFieldID=$wysiwygSelector previewButtonID=$wysiwygSelector|concat:'_PreviewButton' previewMessageObjectType='com.woltlab.wcf.comment.response' previewMessageObjectID=$response->responseID}
 	
-	<button data-type="cancel">{lang}wcf.global.button.cancel{/lang}</button>
+	<button class="button" data-type="cancel">{lang}wcf.global.button.cancel{/lang}</button>
 </div>
 
 {include file='wysiwyg'}

--- a/com.woltlab.wcf/templates/manageSubscription.tpl
+++ b/com.woltlab.wcf/templates/manageSubscription.tpl
@@ -16,5 +16,5 @@
 </div>
 
 <div class="formSubmit">
-	<button class="jsButtonSave buttonPrimary">{lang}wcf.global.button.save{/lang}</button>
+	<button class="button jsButtonSave buttonPrimary">{lang}wcf.global.button.save{/lang}</button>
 </div>

--- a/com.woltlab.wcf/templates/mediaEditor.tpl
+++ b/com.woltlab.wcf/templates/mediaEditor.tpl
@@ -134,5 +134,5 @@
 {include file='aclSimple'}
 
 <div class="formSubmit">
-	<button data-type="submit" class="buttonPrimary">{lang}wcf.global.button.submit{/lang}</button>
+	<button data-type="submit" class="button buttonPrimary">{lang}wcf.global.button.submit{/lang}</button>
 </div>

--- a/com.woltlab.wcf/templates/membersList.tpl
+++ b/com.woltlab.wcf/templates/membersList.tpl
@@ -72,7 +72,7 @@
 			{/hascontent}
 			
 			<div class="containerListFilterOptions jsOnly">
-				<button class="small jsStaticDialog" data-dialog-id="membersListSortFilter"><span class="icon icon16 fa-filter"></span> {lang}wcf.global.filter{/lang}</button>
+				<button class="button small jsStaticDialog" data-dialog-id="membersListSortFilter"><span class="icon icon16 fa-filter"></span> {lang}wcf.global.filter{/lang}</button>
 			</div>
 		</div>
 		<ol class="containerList userList">

--- a/com.woltlab.wcf/templates/messageFormPreviewButton.tpl
+++ b/com.woltlab.wcf/templates/messageFormPreviewButton.tpl
@@ -3,7 +3,7 @@
 {if !$previewMessageObjectType|isset}{assign var=previewMessageObjectType value=''}{/if}
 {if !$previewMessageObjectID|isset}{assign var=previewMessageObjectID value=0}{/if}
 
-<button id="{$previewButtonID}" class="jsOnly">{lang}wcf.global.button.preview{/lang}</button>
+<button id="{$previewButtonID}" class="button jsOnly">{lang}wcf.global.button.preview{/lang}</button>
 
 <script data-relocate="true">
 	$(function() {

--- a/com.woltlab.wcf/templates/messageUserConsent.tpl
+++ b/com.woltlab.wcf/templates/messageUserConsent.tpl
@@ -5,7 +5,7 @@
 	</div>
 	<div class="messageUserConsentDescription">{lang}wcf.message.user.consent.description{/lang}</div>
 	<div class="messageUserConsentButtonContainer">
-		<button class="small jsButtonMessageUserConsentEnable">{lang}wcf.message.user.consent.button.enable{/lang}</button>
+		<button class="button small jsButtonMessageUserConsentEnable">{lang}wcf.message.user.consent.button.enable{/lang}</button>
 	</div>
 	<div class="messageUserConsentNotice">{lang}wcf.message.user.consent.notice{/lang}</div>
 </div>

--- a/com.woltlab.wcf/templates/moderationList.tpl
+++ b/com.woltlab.wcf/templates/moderationList.tpl
@@ -81,7 +81,7 @@
 						</li>
 					{/hascontent}
 					<li class="columnApplyFilter jsOnly">
-						<button class="small jsStaticDialog" data-dialog-id="moderationListSortFilter"><span class="icon icon16 fa-filter"></span> {lang}wcf.global.filter{/lang}</button>
+						<button class="button small jsStaticDialog" data-dialog-id="moderationListSortFilter"><span class="icon icon16 fa-filter"></span> {lang}wcf.global.filter{/lang}</button>
 					</li>
 				</ol>
 			</li>

--- a/com.woltlab.wcf/templates/moderationQueueAssignUser.tpl
+++ b/com.woltlab.wcf/templates/moderationQueueAssignUser.tpl
@@ -28,7 +28,7 @@
 	</dl>
 	
 	<div class="formSubmit">
-		<button data-type="submit">{lang}wcf.global.button.submit{/lang}</button>
+		<button class="button" data-type="submit">{lang}wcf.global.button.submit{/lang}</button>
 	</div>
 </div>
 

--- a/com.woltlab.wcf/templates/moderationReportDialog.tpl
+++ b/com.woltlab.wcf/templates/moderationReportDialog.tpl
@@ -17,6 +17,6 @@
 	{event name='sections'}
 	
 	<div class="formSubmit">
-		<button class="jsSubmitReport buttonPrimary" accesskey="s">{lang}wcf.global.button.submit{/lang}</button>
+		<button class="button jsSubmitReport buttonPrimary" accesskey="s">{lang}wcf.global.button.submit{/lang}</button>
 	</div>
 {/if}

--- a/com.woltlab.wcf/templates/poll.tpl
+++ b/com.woltlab.wcf/templates/poll.tpl
@@ -54,12 +54,12 @@
 		<div class="formSubmit jsOnly"{if !$poll->canVote() && $__pollView === 'result' && !$poll->canSeeResult()} style="display: none"{/if}>
 			{content}
 				{if $__wcf->getUser()->userID}
-					<button class="small votePollButton"{if $poll->canVote() && $__pollView === 'vote'} disabled{else} hidden{/if}>{lang}wcf.poll.button.vote{/lang}</button>
-					<button class="small showVoteFormButton"{if $__pollView === 'vote' || !$poll->canVote()} hidden{/if}>{lang}wcf.poll.button.showVote{/lang}</button>
-					<button class="small showResultsButton"{if $__pollView === 'result' || !$poll->canSeeResult()} hidden{/if}>{lang}wcf.poll.button.showResult{/lang}</button>
+					<button class="button small votePollButton"{if $poll->canVote() && $__pollView === 'vote'} disabled{else} hidden{/if}>{lang}wcf.poll.button.vote{/lang}</button>
+					<button class="button small showVoteFormButton"{if $__pollView === 'vote' || !$poll->canVote()} hidden{/if}>{lang}wcf.poll.button.showVote{/lang}</button>
+					<button class="button small showResultsButton"{if $__pollView === 'result' || !$poll->canSeeResult()} hidden{/if}>{lang}wcf.poll.button.showResult{/lang}</button>
 				{/if}
 				{if $poll->canViewParticipants() || ($poll->canVote() && $poll->isPublic)}
-					<button class="small showPollParticipantsButton"{if $__pollView === 'vote' || !$poll->canSeeResult()} hidden{/if}>{lang}wcf.poll.button.showParticipants{/lang}</button>
+					<button class="button small showPollParticipantsButton"{if $__pollView === 'vote' || !$poll->canSeeResult()} hidden{/if}>{lang}wcf.poll.button.showParticipants{/lang}</button>
 				{/if}
 
 				{event name='pollButtons'}

--- a/com.woltlab.wcf/templates/signatureEdit.tpl
+++ b/com.woltlab.wcf/templates/signatureEdit.tpl
@@ -60,7 +60,7 @@
 	{if !$__wcf->user->disableSignature}
 		<div class="formSubmit">
 			<input type="submit" value="{lang}wcf.global.button.submit{/lang}" accesskey="s">
-			<button id="previewButton" class="jsOnly" accesskey="p">{lang}wcf.global.button.preview{/lang}</button>
+			<button id="previewButton" class="button jsOnly" accesskey="p">{lang}wcf.global.button.preview{/lang}</button>
 			{csrfToken}
 		</div>
 	{/if}

--- a/com.woltlab.wcf/templates/userProfileAboutEditable.tpl
+++ b/com.woltlab.wcf/templates/userProfileAboutEditable.tpl
@@ -24,8 +24,8 @@
 {/foreach}
 
 <div class="formSubmit">
-	<button class="buttonPrimary" accesskey="s" data-type="save">{lang}wcf.global.button.save{/lang}</button>
-	<button data-type="restore">{lang}wcf.global.button.cancel{/lang}</button>
+	<button class="button buttonPrimary" accesskey="s" data-type="save">{lang}wcf.global.button.save{/lang}</button>
+	<button class="button" data-type="restore">{lang}wcf.global.button.cancel{/lang}</button>
 </div>
 
 <script data-relocate="true">

--- a/ts/WoltLabSuite/Core/Acp/Ui/DataImport/Manager.ts
+++ b/ts/WoltLabSuite/Core/Acp/Ui/DataImport/Manager.ts
@@ -63,7 +63,7 @@ export class AcpUiDataImportManager implements AjaxCallbackObject {
 
     const formSubmit = document.createElement("div");
     formSubmit.className = "formSubmit";
-    formSubmit.innerHTML = `<button class="buttonPrimary">${Language.get("wcf.global.button.next")}</button>`;
+    formSubmit.innerHTML = `<button class="button buttonPrimary">${Language.get("wcf.global.button.next")}</button>`;
 
     content.appendChild(formSubmit);
     UiDialog.rebuild(this);

--- a/ts/WoltLabSuite/Core/Acp/Ui/Template/Group/Copy.ts
+++ b/ts/WoltLabSuite/Core/Acp/Ui/Template/Group/Copy.ts
@@ -98,7 +98,7 @@ class AcpUiTemplateGroupCopy implements AjaxCallbackObject, DialogCallbackObject
   </dd>
 </dl>
 <div class="formSubmit">
-  <button class="buttonPrimary" data-type="submit">${Language.get("wcf.global.button.submit")}</button>
+  <button class="button buttonPrimary" data-type="submit">${Language.get("wcf.global.button.submit")}</button>
 </div>`,
     };
   }

--- a/ts/WoltLabSuite/Core/Acp/Ui/User/Action/Handler/Ban/Dialog.ts
+++ b/ts/WoltLabSuite/Core/Acp/Ui/User/Action/Handler/Ban/Dialog.ts
@@ -141,7 +141,9 @@ export class BanDialog {
    </dl>
  </div>
  <div class="formSubmit dialogFormSubmit">
-   <button class="buttonPrimary formSubmitButton" accesskey="s">${Language.get("wcf.global.button.submit")}</button>
+   <button class="button buttonPrimary formSubmitButton" accesskey="s">${Language.get(
+     "wcf.global.button.submit",
+   )}</button>
  </div>`,
     };
   }

--- a/ts/WoltLabSuite/Core/Acp/Ui/Worker.ts
+++ b/ts/WoltLabSuite/Core/Acp/Ui/Worker.ts
@@ -113,7 +113,8 @@ class AcpUiWorker implements AjaxCallbackObject, DialogCallbackObject {
 
       const formSubmit = document.createElement("div");
       formSubmit.className = "formSubmit";
-      formSubmit.innerHTML = '<button class="buttonPrimary">' + Language.get("wcf.global.button.next") + "</button>";
+      formSubmit.innerHTML =
+        '<button class="button buttonPrimary">' + Language.get("wcf.global.button.next") + "</button>";
 
       content.appendChild(formSubmit);
       UiDialog.rebuild(this);

--- a/ts/WoltLabSuite/Core/Bbcode/Code.ts
+++ b/ts/WoltLabSuite/Core/Bbcode/Code.ts
@@ -60,9 +60,7 @@ class Code {
       return;
     }
 
-    const button = document.createElement("span");
-    button.tabIndex = 0;
-    button.setAttribute("role", "button");
+    const button = document.createElement("button");
     button.className = "icon icon24 fa-files-o pointer jsTooltip";
     button.setAttribute("title", Language.get("wcf.message.bbcode.code.copy"));
 
@@ -71,15 +69,8 @@ class Code {
 
       UiNotification.show(Language.get("wcf.message.bbcode.code.copy.success"));
     };
-    button.addEventListener("click", clickCallback);
-    button.addEventListener("keydown", (event) => {
-      if (event.key === "Enter" || event.key === " ") {
-        event.preventDefault();
-
-        void clickCallback();
-      }
-    });
-
+    button.addEventListener("click", () => clickCallback());
+    
     header.appendChild(button);
   }
 

--- a/ts/WoltLabSuite/Core/Date/Picker.ts
+++ b/ts/WoltLabSuite/Core/Date/Picker.ts
@@ -31,8 +31,8 @@ let _dateGrid: HTMLUListElement;
 let _dateHour: HTMLSelectElement;
 let _dateMinute: HTMLSelectElement;
 let _dateMonth: HTMLSelectElement;
-let _dateMonthNext: HTMLAnchorElement;
-let _dateMonthPrevious: HTMLAnchorElement;
+let _dateMonthNext: HTMLButtonElement;
+let _dateMonthPrevious: HTMLButtonElement;
 let _dateTime: HTMLElement;
 let _dateYear: HTMLSelectElement;
 let _datePicker: HTMLElement | null = null;
@@ -54,15 +54,12 @@ function createPicker() {
   const header = document.createElement("header");
   _datePicker.appendChild(header);
 
-  _dateMonthPrevious = document.createElement("a");
+  _dateMonthPrevious = document.createElement("button");
   _dateMonthPrevious.className = "previous jsTooltip";
-  _dateMonthPrevious.href = "#";
-  _dateMonthPrevious.setAttribute("role", "button");
-  _dateMonthPrevious.tabIndex = 0;
   _dateMonthPrevious.title = Language.get("wcf.date.datePicker.previousMonth");
   _dateMonthPrevious.setAttribute("aria-label", Language.get("wcf.date.datePicker.previousMonth"));
   _dateMonthPrevious.innerHTML = '<span class="icon icon16 fa-arrow-left"></span>';
-  _dateMonthPrevious.addEventListener("click", (ev) => DatePicker.previousMonth(ev));
+  _dateMonthPrevious.addEventListener("click", () => DatePicker.previousMonth());
   header.appendChild(_dateMonthPrevious);
 
   const monthYearContainer = document.createElement("span");
@@ -89,15 +86,12 @@ function createPicker() {
   _dateYear.addEventListener("change", changeYear);
   monthYearContainer.appendChild(_dateYear);
 
-  _dateMonthNext = document.createElement("a");
+  _dateMonthNext = document.createElement("button");
   _dateMonthNext.className = "next jsTooltip";
-  _dateMonthNext.href = "#";
-  _dateMonthNext.setAttribute("role", "button");
-  _dateMonthNext.tabIndex = 0;
   _dateMonthNext.title = Language.get("wcf.date.datePicker.nextMonth");
   _dateMonthNext.setAttribute("aria-label", Language.get("wcf.date.datePicker.nextMonth"));
   _dateMonthNext.innerHTML = '<span class="icon icon16 fa-arrow-right"></span>';
-  _dateMonthNext.addEventListener("click", (ev) => DatePicker.nextMonth(ev));
+  _dateMonthNext.addEventListener("click", () => DatePicker.nextMonth());
   header.appendChild(_dateMonthNext);
 
   _dateGrid = document.createElement("ul");
@@ -252,9 +246,6 @@ function getDateValue(attributeName: string): Date {
  * Opens the date picker.
  */
 function open(event: MouseEvent): void {
-  event.preventDefault();
-  event.stopPropagation();
-
   createPicker();
 
   const target = event.currentTarget as HTMLInputElement;
@@ -763,11 +754,8 @@ const DatePicker = {
         const container = document.createElement("div");
         container.className = "inputAddon";
 
-        const openButton = document.createElement("a");
+        const openButton = document.createElement("button");
         openButton.className = "inputSuffix button jsTooltip";
-        openButton.href = "#";
-        openButton.setAttribute("role", "button");
-        openButton.tabIndex = 0;
         openButton.title = Language.get("wcf.date.datePicker");
         openButton.setAttribute("aria-label", Language.get("wcf.date.datePicker"));
         openButton.setAttribute("aria-haspopup", "true");
@@ -857,9 +845,7 @@ const DatePicker = {
   /**
    * Shows the previous month.
    */
-  previousMonth(event: MouseEvent): void {
-    event.preventDefault();
-
+  previousMonth(): void {
     if (_dateMonth.value === "0") {
       _dateMonth.value = "11";
       _dateYear.value = (+_dateYear.value - 1).toString();
@@ -873,9 +859,7 @@ const DatePicker = {
   /**
    * Shows the next month.
    */
-  nextMonth(event: MouseEvent): void {
-    event.preventDefault();
-
+  nextMonth(): void {
     if (_dateMonth.value === "11") {
       _dateMonth.value = "0";
       _dateYear.value = (+_dateYear.value + 1).toString();

--- a/ts/WoltLabSuite/Core/Media/Manager/Editor.ts
+++ b/ts/WoltLabSuite/Core/Media/Manager/Editor.ts
@@ -120,7 +120,7 @@ class MediaManagerEditor extends MediaManager<MediaManagerEditorOptions> {
         </dl>
       </div>
       <div class="formSubmit">
-        <button class="buttonPrimary">${Language.get("wcf.global.button.insert")}</button>
+        <button class="button buttonPrimary">${Language.get("wcf.global.button.insert")}</button>
       </div>`;
 
     UiDialog.open({

--- a/ts/WoltLabSuite/Core/Ui/Confirmation.ts
+++ b/ts/WoltLabSuite/Core/Ui/Confirmation.ts
@@ -43,11 +43,12 @@ class UiConfirmation implements DialogCallbackObject {
 
     this.confirmButton = document.createElement("button");
     this.confirmButton.dataset.type = "submit";
-    this.confirmButton.classList.add("buttonPrimary");
+    this.confirmButton.classList.add("button", "buttonPrimary");
     this.confirmButton.textContent = Language.get("wcf.global.confirmation.confirm");
     formSubmit.appendChild(this.confirmButton);
 
     const cancelButton = document.createElement("button");
+    cancelButton.classList.add("button");
     cancelButton.textContent = Language.get("wcf.global.confirmation.cancel");
     cancelButton.addEventListener("click", () => {
       UiDialog.close(this);

--- a/ts/WoltLabSuite/Core/Ui/Dialog.ts
+++ b/ts/WoltLabSuite/Core/Ui/Dialog.ts
@@ -388,14 +388,11 @@ const UiDialog = {
     header.appendChild(title);
 
     if (options.closable) {
-      const closeButton = document.createElement("a");
+      const closeButton = document.createElement("button");
       closeButton.className = "dialogCloseButton jsTooltip";
-      closeButton.href = "#";
-      closeButton.setAttribute("role", "button");
-      closeButton.tabIndex = 0;
       closeButton.title = options.closeButtonLabel;
       closeButton.setAttribute("aria-label", options.closeButtonLabel);
-      closeButton.addEventListener("click", (ev) => this._close(ev));
+      closeButton.addEventListener("click", () => this._close());
       header.appendChild(closeButton);
 
       const span = document.createElement("span");
@@ -724,9 +721,7 @@ const UiDialog = {
   /**
    * Handles clicks on the close button or the backdrop if enabled.
    */
-  _close(event: MouseEvent): boolean {
-    event.preventDefault();
-
+  _close(): boolean {
     const data = _dialogs.get(_activeDialog!);
     if (data === undefined) {
       // Closing the dialog while it is already being closed
@@ -760,7 +755,9 @@ const UiDialog = {
     }
 
     if (Core.stringToBool(_container.getAttribute("close-on-click"))) {
-      this._close(event);
+      event.preventDefault();
+
+      this._close();
     } else {
       event.preventDefault();
     }

--- a/ts/WoltLabSuite/Core/Ui/Message/Share/Dialog.ts
+++ b/ts/WoltLabSuite/Core/Ui/Message/Share/Dialog.ts
@@ -150,7 +150,7 @@ function openDialog(event: MouseEvent): void {
         <dl>
           <dt></dt>
           <dd>
-              <button class="shareDialogNativeButton" data-url="${StringUtil.escapeHTML(
+              <button class="button shareDialogNativeButton" data-url="${StringUtil.escapeHTML(
                 target.href,
               )}" data-title="${StringUtil.escapeHTML(target.dataset.linkTitle || "")}">${Language.get(
         "wcf.message.share.nativeShare",

--- a/ts/WoltLabSuite/Core/Ui/Moderation/Clipboard/AssignUser.ts
+++ b/ts/WoltLabSuite/Core/Ui/Moderation/Clipboard/AssignUser.ts
@@ -142,7 +142,7 @@ class UiModerationClipboardAssignUser implements AjaxCallbackObject, DialogCallb
   </dl>
 </div>
 <div class="formSubmit">
-  <button class="buttonPrimary" data-type="submit">${Language.get("wcf.global.button.save")}</button>
+  <button class="button buttonPrimary" data-type="submit">${Language.get("wcf.global.button.save")}</button>
 </div>`,
     };
   }

--- a/ts/WoltLabSuite/Core/Ui/Page/Header/Menu.ts
+++ b/ts/WoltLabSuite/Core/Ui/Page/Header/Menu.ts
@@ -185,8 +185,6 @@ function setupA11y(): void {
 
     const showMenuButton = document.createElement("button");
     showMenuButton.className = "visuallyHidden";
-    showMenuButton.tabIndex = 0;
-    showMenuButton.setAttribute("role", "button");
     showMenuButton.setAttribute("aria-label", Language.get("wcf.global.button.showMenu"));
     element.insertBefore(showMenuButton, link.nextSibling);
 

--- a/ts/WoltLabSuite/Core/Ui/Page/JumpTo.ts
+++ b/ts/WoltLabSuite/Core/Ui/Page/JumpTo.ts
@@ -97,7 +97,7 @@ class UiPageJumpTo implements DialogCallbackObject {
         </dd>
       </dl>
       <div class="formSubmit">
-        <button class="buttonPrimary">${Language.get("wcf.global.button.submit")}</button>
+        <button class="button buttonPrimary">${Language.get("wcf.global.button.submit")}</button>
       </div>`;
 
     return {

--- a/ts/WoltLabSuite/Core/Ui/Page/Menu/Main.ts
+++ b/ts/WoltLabSuite/Core/Ui/Page/Menu/Main.ts
@@ -221,10 +221,8 @@ export class PageMenuMain implements PageMenuProvider {
 
       const menuId = DomUtil.getUniqueId();
 
-      const button = document.createElement("a");
+      const button = document.createElement("button");
       button.classList.add("pageMenuMainItemToggle");
-      button.tabIndex = 0;
-      button.setAttribute("role", "button");
       button.setAttribute("aria-expanded", "false");
       button.setAttribute("aria-controls", menuId);
       button.innerHTML = '<span class="icon icon24 fa-angle-down" aria-hidden="true"></span>';
@@ -239,17 +237,8 @@ export class PageMenuMain implements PageMenuProvider {
       list.id = menuId;
       list.hidden = true;
 
-      button.addEventListener("click", (event) => {
-        event.preventDefault();
-
+      button.addEventListener("click", () => {
         this.toggleList(button, list);
-      });
-      button.addEventListener("keydown", (event) => {
-        if (event.key === "Enter" || event.key === " ") {
-          event.preventDefault();
-
-          button.click();
-        }
       });
 
       list.addEventListener("keydown", (event) => {
@@ -267,7 +256,7 @@ export class PageMenuMain implements PageMenuProvider {
     return listItem;
   }
 
-  private toggleList(button: HTMLAnchorElement, list: HTMLUListElement): void {
+  private toggleList(button: HTMLButtonElement, list: HTMLUListElement): void {
     if (list.hidden) {
       button.setAttribute("aria-expanded", "true");
       list.hidden = false;

--- a/ts/WoltLabSuite/Core/Ui/Password.ts
+++ b/ts/WoltLabSuite/Core/Ui/Password.ts
@@ -35,11 +35,9 @@ function initElement(input: HTMLInputElement): void {
   input.insertAdjacentElement("beforebegin", inputAddon);
   inputAddon.appendChild(input);
 
-  const button = document.createElement("span");
+  const button = document.createElement("button");
   button.title = Language.get("wcf.global.form.password.button.show");
   button.classList.add("button", "inputSuffix", "jsTooltip");
-  button.setAttribute("role", "button");
-  button.tabIndex = 0;
   button.setAttribute("aria-hidden", "true");
   inputAddon.appendChild(button);
 
@@ -49,12 +47,6 @@ function initElement(input: HTMLInputElement): void {
 
   button.addEventListener("click", () => {
     toggle(input, button, icon);
-  });
-  button.addEventListener("keydown", (event) => {
-    if (event.key === "Enter" || event.key === " ") {
-      event.preventDefault();
-      toggle(input, button, icon);
-    }
   });
 
   // Hide the password when the form is being submitted to prevent

--- a/ts/WoltLabSuite/Core/Ui/Poll/Editor.ts
+++ b/ts/WoltLabSuite/Core/Ui/Poll/Editor.ts
@@ -157,20 +157,16 @@ class UiPollEditor {
     pollOptionInput.appendChild(sortHandle);
 
     // buttons
-    const addButton = document.createElement("a");
-    listItem.setAttribute("role", "button");
-    listItem.setAttribute("href", "#");
+    const addButton = document.createElement("button");
     addButton.classList.add("icon", "icon16", "fa-plus", "jsTooltip", "jsAddOption", "pointer");
     addButton.setAttribute("title", Language.get("wcf.poll.button.addOption"));
     addButton.addEventListener("click", () => this.createOption());
     pollOptionInput.appendChild(addButton);
 
-    const deleteButton = document.createElement("a");
-    deleteButton.setAttribute("role", "button");
-    deleteButton.setAttribute("href", "#");
+    const deleteButton = document.createElement("button");
     deleteButton.classList.add("icon", "icon16", "fa-times", "jsTooltip", "jsDeleteOption", "pointer");
     deleteButton.setAttribute("title", Language.get("wcf.poll.button.removeOption"));
-    deleteButton.addEventListener("click", (ev) => this.removeOption(ev));
+    deleteButton.addEventListener("click", () => this.removeOption(deleteButton));
     pollOptionInput.appendChild(deleteButton);
 
     // input field
@@ -253,10 +249,7 @@ class UiPollEditor {
   /**
    * Removes a poll option after clicking on its deletion button.
    */
-  private removeOption(event: Event): void {
-    event.preventDefault();
-
-    const button = event.currentTarget as HTMLSpanElement;
+  private removeOption(button: HTMLButtonElement): void {
     button.closest("li")!.remove();
 
     this.optionCount--;

--- a/ts/WoltLabSuite/Core/Ui/Reaction/Handler.ts
+++ b/ts/WoltLabSuite/Core/Ui/Reaction/Handler.ts
@@ -174,7 +174,7 @@ class UiReactionHandler {
       this._toggleReactPopover(elementData.objectId, elementData.reactButton!, ev);
     });
     elementData.reactButton.addEventListener("keydown", (event) => {
-      if (event.key === "Enter") {
+      if (event.key === "Enter" || event.key === " ") {
         event.preventDefault();
 
         this._toggleReactPopover(elementData.objectId, elementData.reactButton!, null);

--- a/ts/WoltLabSuite/Core/Ui/Reaction/Profile/Loader.ts
+++ b/ts/WoltLabSuite/Core/Ui/Reaction/Profile/Loader.ts
@@ -59,7 +59,7 @@ class UiReactionProfileLoader {
     loadButtonList.appendChild(this._noMoreEntries);
 
     this._loadButton = document.createElement("button");
-    this._loadButton.className = "small";
+    this._loadButton.classList.add("button", "small");
     this._loadButton.innerHTML = Language.get("wcf.like.reaction.more");
     this._loadButton.addEventListener("click", () => this._loadReactions());
     this._loadButton.style.display = "none";

--- a/ts/WoltLabSuite/Core/Ui/Redactor/Code.ts
+++ b/ts/WoltLabSuite/Core/Ui/Redactor/Code.ts
@@ -255,10 +255,10 @@ class UiRedactorCode implements DialogCallbackObject {
           </dl>
         </div>
         <div class="formSubmit">
-          <button id="${idButtonSave}" class="buttonPrimary" data-type="submit">${Language.get(
+          <button id="${idButtonSave}" class="button buttonPrimary" data-type="submit">${Language.get(
         "wcf.global.button.save",
       )}</button>
-          <button id="${idButtonDelete}">${Language.get("wcf.global.button.delete")}</button>
+          <button id="${idButtonDelete}" class="button">${Language.get("wcf.global.button.delete")}</button>
         </div>`,
     };
   }

--- a/ts/WoltLabSuite/Core/Ui/Redactor/Link.ts
+++ b/ts/WoltLabSuite/Core/Ui/Redactor/Link.ts
@@ -95,7 +95,7 @@ class UiRedactorLink implements DialogCallbackObject {
           </dd>
         </dl>
         <div class="formSubmit">
-          <button id="redactor-modal-button-action" class="buttonPrimary"></button>
+          <button id="redactor-modal-button-action" class="button buttonPrimary"></button>
         </div>`,
     };
   }

--- a/ts/WoltLabSuite/Core/Ui/Redactor/Quote.ts
+++ b/ts/WoltLabSuite/Core/Ui/Redactor/Quote.ts
@@ -293,10 +293,10 @@ class UiRedactorQuote {
           </dl>
         </div>
         <div class="formSubmit">
-          <button id="${idButtonSave}" class="buttonPrimary" data-type="submit">${Language.get(
+          <button id="${idButtonSave}" class="button buttonPrimary" data-type="submit">${Language.get(
         "wcf.global.button.save",
       )}</button>
-          <button id="${idButtonDelete}">${Language.get("wcf.global.button.delete")}</button>
+          <button id="${idButtonDelete}" class="button">${Language.get("wcf.global.button.delete")}</button>
         </div>`,
     };
   }

--- a/ts/WoltLabSuite/Core/Ui/Redactor/Spoiler.ts
+++ b/ts/WoltLabSuite/Core/Ui/Redactor/Spoiler.ts
@@ -188,10 +188,10 @@ class UiRedactorSpoiler implements DialogCallbackObject {
           </dl>
         </div>
         <div class="formSubmit">
-          <button id="${idButtonSave}" class="buttonPrimary" data-type="submit">${Language.get(
+          <button id="${idButtonSave}" class="button buttonPrimary" data-type="submit">${Language.get(
         "wcf.global.button.save",
       )}</button>
-          <button id="${idButtonDelete}">${Language.get("wcf.global.button.delete")}</button>
+          <button id="${idButtonDelete}" class="button">${Language.get("wcf.global.button.delete")}</button>
         </div>`,
     };
   }

--- a/ts/WoltLabSuite/Core/Ui/Redactor/Table.ts
+++ b/ts/WoltLabSuite/Core/Ui/Redactor/Table.ts
@@ -71,7 +71,7 @@ class UiRedactorTable implements DialogCallbackObject {
           </dd>
         </dl>
         <div class="formSubmit">
-          <button id="redactor-modal-button-action" class="buttonPrimary" data-type="submit">${Language.get(
+          <button id="redactor-modal-button-action" class="button buttonPrimary" data-type="submit">${Language.get(
             "wcf.global.button.insert",
           )}</button>
         </div>`,

--- a/ts/WoltLabSuite/Core/Ui/User/Activity/Recent.ts
+++ b/ts/WoltLabSuite/Core/Ui/User/Activity/Recent.ts
@@ -29,7 +29,8 @@ class UiUserActivityRecent implements AjaxCallbackObject {
     const showMoreItem = document.createElement("li");
     showMoreItem.className = "showMore";
     if (this.list.childElementCount) {
-      showMoreItem.innerHTML = '<button class="small">' + Language.get("wcf.user.recentActivity.more") + "</button>";
+      showMoreItem.innerHTML =
+        '<button class="button small">' + Language.get("wcf.user.recentActivity.more") + "</button>";
 
       const button = showMoreItem.children[0] as HTMLButtonElement;
       button.addEventListener("click", (ev) => this.showMore(ev));

--- a/ts/WoltLabSuite/Core/Ui/User/Editor.ts
+++ b/ts/WoltLabSuite/Core/Ui/User/Editor.ts
@@ -250,7 +250,7 @@ class UserEditor implements AjaxCallbackObject, DialogCallbackObject {
         </dl>
       </div>
       <div class="formSubmit">
-        <button class="buttonPrimary">${Language.get("wcf.global.button.submit")}</button>
+        <button class="button buttonPrimary">${Language.get("wcf.global.button.submit")}</button>
       </div>`,
     };
   }

--- a/ts/WoltLabSuite/Core/Ui/User/Menu/View.ts
+++ b/ts/WoltLabSuite/Core/Ui/User/Menu/View.ts
@@ -165,9 +165,9 @@ export class UserMenuView {
       </div>
       <div class="userMenuItemMeta"></div>
       <div class="userMenuItemUnread">
-        <a href="#" class="userMenuItemMarkAsRead" role="button">
+        <button class="userMenuItemMarkAsRead">
           <span class="icon icon24 fa-check jsTooltip" title="${Language.get("wcf.global.button.markAsRead")}"></span>
-        </a>
+        </button>
       </div>
     `;
 
@@ -175,9 +175,7 @@ export class UserMenuView {
     element.querySelector(".userMenuItemMeta")!.append(time);
 
     const markAsRead = element.querySelector(".userMenuItemMarkAsRead")!;
-    markAsRead.addEventListener("click", async (event) => {
-      event.preventDefault();
-
+    markAsRead.addEventListener("click", async () => {
       await this.provider.markAsRead(itemData.objectId);
 
       this.markAsRead(element);

--- a/wcfsetup/install/files/acp/js/WCF.ACP.js
+++ b/wcfsetup/install/files/acp/js/WCF.ACP.js
@@ -278,7 +278,7 @@ WCF.ACP.Package.Installation = Class.extend({
 		if (this._dialog !== null) {
 			this._purgeTemplateContent($.proxy(function() {
 				var $form = $('<div class="formSubmit" />').appendTo($('#packageInstallationInnerContent'));
-				$('<button class="buttonPrimary">' + WCF.Language.get('wcf.acp.package.installation.rollback') + '</button>').appendTo($form).click($.proxy(this._rollback, this));
+				$('<button class="button buttonPrimary">' + WCF.Language.get('wcf.acp.package.installation.rollback') + '</button>').appendTo($form).click($.proxy(this._rollback, this));
 				
 				$('#packageInstallationInnerContentContainer').show();
 				
@@ -390,7 +390,7 @@ WCF.ACP.Package.Installation = Class.extend({
 			
 			this._purgeTemplateContent($.proxy(function() {
 				var $form = $('<div class="formSubmit" />').appendTo($('#packageInstallationInnerContent'));
-				var $button = $('<button class="buttonPrimary">' + WCF.Language.get('wcf.global.button.next') + '</button>').appendTo($form).click(function() {
+				var $button = $('<button class="button buttonPrimary">' + WCF.Language.get('wcf.global.button.next') + '</button>').appendTo($form).click(function() {
 					$(this).disable();
 					window.location = data.redirectLocation;
 				});
@@ -424,7 +424,7 @@ WCF.ACP.Package.Installation = Class.extend({
 				this._setIcon('question');
 				
 				var $form = $('<div class="formSubmit" />').appendTo($('#packageInstallationInnerContent'));
-				$('<button class="buttonPrimary">' + WCF.Language.get('wcf.global.button.next') + '</button>').appendTo($form).click($.proxy(function(event) {
+				$('<button class="button buttonPrimary">' + WCF.Language.get('wcf.global.button.next') + '</button>').appendTo($form).click($.proxy(function(event) {
 					$(event.currentTarget).disable();
 					
 					this._submit(data);
@@ -1325,7 +1325,7 @@ WCF.ACP.User.BanHandler = {
 			// create dialog
 			this._dialog = $('<div />').hide().appendTo(document.body);
 			this._dialog.append($('<div class="section"><dl><dt><label for="userBanReason">' + WCF.Language.get('wcf.acp.user.banReason') + '</label></dt><dd><textarea id="userBanReason" cols="40" rows="3" /><small>' + WCF.Language.get('wcf.acp.user.banReason.description') + '</small></dd></dl><dl><dt></dt><dd><label for="userBanNeverExpires"><input type="checkbox" name="userBanNeverExpires" id="userBanNeverExpires" checked> ' + WCF.Language.get('wcf.acp.user.ban.neverExpires') + '</label></dd></dl><dl id="userBanExpiresSettings" style="display: none;"><dt><label for="userBanExpires">' + WCF.Language.get('wcf.acp.user.ban.expires') + '</label></dt><dd><input type="date" name="userBanExpires" id="userBanExpires" class="medium" min="' + new Date(TIME_NOW * 1000).toISOString() + '" data-ignore-timezone="true" /><small>' + WCF.Language.get('wcf.acp.user.ban.expires.description') + '</small></dd></dl></div>'));
-			this._dialog.append($('<div class="formSubmit"><button class="buttonPrimary" accesskey="s">' + WCF.Language.get('wcf.global.button.submit') + '</button></div>'));
+			this._dialog.append($('<div class="formSubmit"><button class="button buttonPrimary" accesskey="s">' + WCF.Language.get('wcf.global.button.submit') + '</button></div>'));
 			
 			this._dialog.find('#userBanNeverExpires').change(function() {
 				$('#userBanExpiresSettings').toggle();

--- a/wcfsetup/install/files/acp/templates/__buttonFormField.tpl
+++ b/wcfsetup/install/files/acp/templates/__buttonFormField.tpl
@@ -3,6 +3,6 @@
 	*}id="{@$field->getPrefixedId()}" {*
 	*}name="{@$field->getPrefixedId()}" {*
 	*}value="{$field->getValue()}"{*
-	*}{if !$field->getFieldClasses()|empty} class="{implode from=$field->getFieldClasses() item='class' glue=' '}{$class}{/implode}"{/if}{*
+	*}{if !$field->getFieldClasses()|empty} class="button {implode from=$field->getFieldClasses() item='class' glue=' '}{$class}{/implode}"{/if}{*
 	*}{foreach from=$field->getFieldAttributes() key='attributeName' item='attributeValue'} {$attributeName}="{$attributeValue}"{/foreach}{*
 *}>{$field->getButtonLabel()}</button>

--- a/wcfsetup/install/files/acp/templates/__devtoolsProjectInstructionsFormField.tpl
+++ b/wcfsetup/install/files/acp/templates/__devtoolsProjectInstructionsFormField.tpl
@@ -113,7 +113,7 @@
 			</div>
 			
 			<div class="formSubmit">
-				<button data-type="submit" class="buttonPrimary">{lang}wcf.global.button.submit{/lang}</button>
+				<button data-type="submit" class="button buttonPrimary">{lang}wcf.global.button.submit{/lang}</button>
 			</div>
 		{/capture}
 		
@@ -161,7 +161,7 @@
 			</div>
 			
 			<div class="formSubmit">
-				<button data-type="submit" class="buttonPrimary">{lang}wcf.global.button.submit{/lang}</button>
+				<button data-type="submit" class="button buttonPrimary">{lang}wcf.global.button.submit{/lang}</button>
 			</div>
 		{/capture}
 		

--- a/wcfsetup/install/files/acp/templates/__formButton.tpl
+++ b/wcfsetup/install/files/acp/templates/__formButton.tpl
@@ -8,7 +8,7 @@
 		*}>
 {else}
 	<button id="{@$button->getPrefixedId()}"{*
-		*}{if !$button->getClasses()|empty} class="{implode from=$button->getClasses() item='class' glue=' '}{$class}{/implode}"{/if}{*
+		*}{if !$button->getClasses()|empty} class="button {implode from=$button->getClasses() item='class' glue=' '}{$class}{/implode}"{/if}{*
 		*}{foreach from=$button->getAttributes() key='attributeName' item='attributeValue'} {$attributeName}="{$attributeValue}"{/foreach}{*
 		*}{if $button->getAccessKey()} accesskey="{$button->getAccessKey()}"{/if}{*
 	*}>{$button->getLabel()}</button>

--- a/wcfsetup/install/files/acp/templates/__mediaSetCategoryDialog.tpl
+++ b/wcfsetup/install/files/acp/templates/__mediaSetCategoryDialog.tpl
@@ -24,5 +24,5 @@
 </div>
 
 <div class="formSubmit">
-	<button data-type="submit" class="buttonPrimary">{lang}wcf.global.button.submit{/lang}</button>
+	<button data-type="submit" class="button buttonPrimary">{lang}wcf.global.button.submit{/lang}</button>
 </div>

--- a/wcfsetup/install/files/acp/templates/__optionRewriteTest.tpl
+++ b/wcfsetup/install/files/acp/templates/__optionRewriteTest.tpl
@@ -20,7 +20,7 @@
 		</div>
 		
 		<div class="formSubmit">
-			<button id="rewriteTestStart" class="buttonPrimary">{lang}wcf.acp.option.url_omit_index_php.button.runTestAgain{/lang}</button>
+			<button id="rewriteTestStart" class="button buttonPrimary">{lang}wcf.acp.option.url_omit_index_php.button.runTestAgain{/lang}</button>
 		</div>
 	</div>
 	<script data-relocate="true">

--- a/wcfsetup/install/files/acp/templates/__wysiwygPreviewFormButton.tpl
+++ b/wcfsetup/install/files/acp/templates/__wysiwygPreviewFormButton.tpl
@@ -1,5 +1,5 @@
 <button id="{@$button->getPrefixedId()}"{*
-	*}{if !$button->getClasses()|empty} class="{implode from=$button->getClasses() item='class' glue=' '}{$class}{/implode}"{/if}{*
+	*}{if !$button->getClasses()|empty} class="button {implode from=$button->getClasses() item='class' glue=' '}{$class}{/implode}"{/if}{*
 	*}{foreach from=$button->getAttributes() key='attributeName' item='attributeValue'} {$attributeName}="{$attributeValue}"{/foreach}{*
 	*}{if $button->getAccessKey()} accesskey="{$button->getAccessKey()}"{/if}{*
 *}>{$button->getLabel()}</button>

--- a/wcfsetup/install/files/acp/templates/articleAdd.tpl
+++ b/wcfsetup/install/files/acp/templates/articleAdd.tpl
@@ -553,7 +553,7 @@
 	
 	<div class="formSubmit">
 		<input type="submit" value="{lang}wcf.global.button.submit{/lang}" accesskey="s">
-		<button id="buttonMessagePreview" class="jsOnly">{lang}wcf.global.button.preview{/lang}</button>
+		<button id="buttonMessagePreview" class="button jsOnly">{lang}wcf.global.button.preview{/lang}</button>
 		<input type="hidden" name="isMultilingual" value="{@$isMultilingual}">
 		<input type="hidden" name="timeNowReference" value="{@TIME_NOW}">
 		{csrfToken}

--- a/wcfsetup/install/files/acp/templates/articleAddDialog.tpl
+++ b/wcfsetup/install/files/acp/templates/articleAddDialog.tpl
@@ -11,7 +11,7 @@
 		</dl>
 		
 		<div class="formSubmit">
-			<button class="buttonPrimary">{lang}wcf.global.button.next{/lang}</button>
+			<button class="button buttonPrimary">{lang}wcf.global.button.next{/lang}</button>
 		</div>
 	</div>
 </div>

--- a/wcfsetup/install/files/acp/templates/articleCategoryDialog.tpl
+++ b/wcfsetup/install/files/acp/templates/articleCategoryDialog.tpl
@@ -14,5 +14,5 @@
 </div>
 
 <div class="formSubmit">
-	<button data-type="submit">{lang}wcf.global.button.submit{/lang}</button>
+	<button class="button" data-type="submit">{lang}wcf.global.button.submit{/lang}</button>
 </div>

--- a/wcfsetup/install/files/acp/templates/boxAddDialog.tpl
+++ b/wcfsetup/install/files/acp/templates/boxAddDialog.tpl
@@ -27,7 +27,7 @@
 		{/if}
 		
 		<div class="formSubmit">
-			<button class="buttonPrimary">{lang}wcf.global.button.next{/lang}</button>
+			<button class="button buttonPrimary">{lang}wcf.global.button.next{/lang}</button>
 		</div>
 	</div>
 </div>

--- a/wcfsetup/install/files/acp/templates/devtoolsNotificationTest.tpl
+++ b/wcfsetup/install/files/acp/templates/devtoolsNotificationTest.tpl
@@ -22,7 +22,7 @@
 			{foreach from=$eventList item=event}
 				<dt>{lang}wcf.user.notification.{$event->objectType}.{$event->eventName}{/lang}</dt>
 				<dd>
-					<button class="small jsTestEventButton" data-event-id="{$event->eventID}" data-title="{lang}wcf.user.notification.{$event->objectType}.{$event->eventName}{/lang}">{lang}wcf.acp.devtools.notificationTest.button.test{/lang}</button>
+					<button class="button small jsTestEventButton" data-event-id="{$event->eventID}" data-title="{lang}wcf.user.notification.{$event->objectType}.{$event->eventName}{/lang}">{lang}wcf.acp.devtools.notificationTest.button.test{/lang}</button>
 				</dd>
 			{/foreach}
 		</dl>

--- a/wcfsetup/install/files/acp/templates/devtoolsNotificationTestDialog.tpl
+++ b/wcfsetup/install/files/acp/templates/devtoolsNotificationTestDialog.tpl
@@ -132,7 +132,7 @@
 {/if}
 
 <div class="formSubmit">
-	<button class="small buttonPrimary" id="notificationTestAllSectionButton">{lang}wcf.acp.devtools.notificationTest.button.showAll{/lang}</button>
+	<button class="small button buttonPrimary" id="notificationTestAllSectionButton">{lang}wcf.acp.devtools.notificationTest.button.showAll{/lang}</button>
 	<button class="small button" id="notificationTestTitleSectionButton">{lang}wcf.acp.devtools.notificationTest.titles{/lang}</button>
 	<button class="small button" id="notificationTestMessageSectionButton">{lang}wcf.acp.devtools.notificationTest.messages{/lang}</button>
 	<button class="small button" id="notificationTestLinkSectionButton">{lang}wcf.acp.devtools.notificationTest.links{/lang}</button>

--- a/wcfsetup/install/files/acp/templates/devtoolsProjectList.tpl
+++ b/wcfsetup/install/files/acp/templates/devtoolsProjectList.tpl
@@ -83,7 +83,7 @@
 	</dl>
 	
 	<div class="formSubmit">
-		<button id="projectQuickSetupSubmit" class="buttonPrimary">{lang}wcf.global.button.submit{/lang}</button>
+		<button id="projectQuickSetupSubmit" class="button buttonPrimary">{lang}wcf.global.button.submit{/lang}</button>
 	</div>
 </div>
 

--- a/wcfsetup/install/files/acp/templates/devtoolsProjectSync.tpl
+++ b/wcfsetup/install/files/acp/templates/devtoolsProjectSync.tpl
@@ -65,7 +65,7 @@
 						</td>
 						{if $_isSupported}
 							{if $_targetCount}
-								<td class="columnIcon"><button class="small jsInvokePip" data-target="{$_targets[0]}">{$_targets[0]}</button></td>
+								<td class="columnIcon"><button class="button small jsInvokePip" data-target="{$_targets[0]}">{$_targets[0]}</button></td>
 								<td class="columnText"><small class="jsInvokePipResult" data-target="{$_targets[0]}">{lang}wcf.acp.devtools.sync.status.idle{/lang}</small></td>
 							{else}
 								<td class="columnText" colspan="2">
@@ -85,7 +85,7 @@
 									class="jsHasPipTargets jsSkipTargetDetection"
 								{/if}
 							>
-								<td class="columnIcon"><button class="small jsInvokePip" data-target="{$_targets[$i]}">{$_targets[$i]}</button></td>
+								<td class="columnIcon"><button class="button small jsInvokePip" data-target="{$_targets[$i]}">{$_targets[$i]}</button></td>
 								<td class="columnText"><small class="jsInvokePipResult" data-target="{$_targets[$i]}">{lang}wcf.acp.devtools.sync.status.idle{/lang}</small></td>
 							</tr>
 						{/section}

--- a/wcfsetup/install/files/acp/templates/languageItemEditDialog.tpl
+++ b/wcfsetup/install/files/acp/templates/languageItemEditDialog.tpl
@@ -46,9 +46,9 @@
 <input type="hidden" name="languageItemID" id="overlayLanguageItemID" value="{@$item->languageItemID}">
 
 <div class="formSubmit">
-	<button class="jsSubmitLanguageItem buttonPrimary" accesskey="s">{lang}wcf.global.button.submit{/lang}</button>
+	<button class="button buttonPrimary jsSubmitLanguageItem" accesskey="s">{lang}wcf.global.button.submit{/lang}</button>
 	
 	{if $item->isCustomLanguageItem}
-		<button class="jsDeleteLanguageItem">{lang}wcf.global.button.delete{/lang}</button>
+		<button class="button jsDeleteLanguageItem">{lang}wcf.global.button.delete{/lang}</button>
 	{/if}
 </div>

--- a/wcfsetup/install/files/acp/templates/mediaEditor.tpl
+++ b/wcfsetup/install/files/acp/templates/mediaEditor.tpl
@@ -134,5 +134,5 @@
 {include file='aclSimple'}
 
 <div class="formSubmit">
-	<button data-type="submit" class="buttonPrimary">{lang}wcf.global.button.submit{/lang}</button>
+	<button data-type="submit" class="button buttonPrimary">{lang}wcf.global.button.submit{/lang}</button>
 </div>

--- a/wcfsetup/install/files/acp/templates/package.tpl
+++ b/wcfsetup/install/files/acp/templates/package.tpl
@@ -20,7 +20,7 @@
 			<ul>
 				{content}
 					{if $package->canUninstall()}
-						<li><button class="jsUninstallButton" data-object-id="{@$package->packageID}" data-confirm-message="{lang __encode=true}wcf.acp.package.uninstallation.confirm{/lang}" data-is-required="{if $package->isRequired()}true{else}false{/if}" data-is-application="{if $package->isApplication}true{else}false{/if}"><span class="icon icon16 fa-times"></span> <span>{lang}wcf.acp.package.button.uninstall{/lang}</span></button></li>
+						<li><button class="button jsUninstallButton" data-object-id="{@$package->packageID}" data-confirm-message="{lang __encode=true}wcf.acp.package.uninstallation.confirm{/lang}" data-is-required="{if $package->isRequired()}true{else}false{/if}" data-is-application="{if $package->isApplication}true{else}false{/if}"><span class="icon icon16 fa-times"></span> <span>{lang}wcf.acp.package.button.uninstall{/lang}</span></button></li>
 					{/if}
 
 					{event name='contentHeaderNavigation'}

--- a/wcfsetup/install/files/acp/templates/packageUpdate.tpl
+++ b/wcfsetup/install/files/acp/templates/packageUpdate.tpl
@@ -35,7 +35,7 @@
 </div>
 
 <div class="formSubmit">
-	<button class="buttonPrimary" id="packageUpdateSubmitButton">{lang}wcf.global.button.submit{/lang}</button>
+	<button class="button buttonPrimary" id="packageUpdateSubmitButton">{lang}wcf.global.button.submit{/lang}</button>
 </div>
 
 <script data-relocate="true">

--- a/wcfsetup/install/files/acp/templates/packageUpdateUnauthorized.tpl
+++ b/wcfsetup/install/files/acp/templates/packageUpdateUnauthorized.tpl
@@ -51,5 +51,5 @@
 </section>
 
 <div class="formSubmit">
-	<button class="buttonPrimary" data-type="submit" data-package-update-server-id="{@$updateServer->packageUpdateServerID}">{lang}wcf.global.button.submit{/lang}</button>
+	<button class="button buttonPrimary" data-type="submit" data-package-update-server-id="{@$updateServer->packageUpdateServerID}">{lang}wcf.global.button.submit{/lang}</button>
 </div>

--- a/wcfsetup/install/files/acp/templates/pageAddDialog.tpl
+++ b/wcfsetup/install/files/acp/templates/pageAddDialog.tpl
@@ -25,7 +25,7 @@
 		{/if}
 		
 		<div class="formSubmit">
-			<button class="buttonPrimary">{lang}wcf.global.button.next{/lang}</button>
+			<button class="button buttonPrimary">{lang}wcf.global.button.next{/lang}</button>
 		</div>
 	</div>
 </div>

--- a/wcfsetup/install/files/acp/templates/pageHeaderSearch.tpl
+++ b/wcfsetup/install/files/acp/templates/pageHeaderSearch.tpl
@@ -18,7 +18,7 @@
 		
 		<input type="search" name="q" id="pageHeaderSearchInput" class="pageHeaderSearchInput" placeholder="{lang}wcf.global.search.enterSearchTerm{/lang}" autocomplete="off" required value="" data-toggle="search">
 		
-		<button class="pageHeaderSearchInputButton" type="submit">
+		<button class="button pageHeaderSearchInputButton" type="submit">
 			<span class="icon icon16 pointer fa-search" title="{lang}wcf.global.search{/lang}"></span>
 		</button>
 	</div>

--- a/wcfsetup/install/files/acp/templates/pluginStoreAuthorization.tpl
+++ b/wcfsetup/install/files/acp/templates/pluginStoreAuthorization.tpl
@@ -20,5 +20,5 @@
 </section>
 
 <div class="formSubmit">
-	<button>{lang}wcf.global.button.submit{/lang}</button>
+	<button class="button buttonPrimary">{lang}wcf.global.button.submit{/lang}</button>
 </div>

--- a/wcfsetup/install/files/acp/templates/sitemapList.tpl
+++ b/wcfsetup/install/files/acp/templates/sitemapList.tpl
@@ -7,7 +7,7 @@
 
 	<nav class="contentHeaderNavigation">
 		<ul>
-			<li><button id="sitemapRebuildButton"><span class="icon icon16 fa-refresh"></span> <span>{lang}wcf.acp.rebuildData.com.woltlab.wcf.sitemap{/lang}</span></button></li>
+			<li><button class="button" id="sitemapRebuildButton"><span class="icon icon16 fa-refresh"></span> <span>{lang}wcf.acp.rebuildData.com.woltlab.wcf.sitemap{/lang}</span></button></li>
 
 			{event name='contentHeaderNavigation'}
 		</ul>

--- a/wcfsetup/install/files/acp/templates/stat.tpl
+++ b/wcfsetup/install/files/acp/templates/stat.tpl
@@ -72,7 +72,7 @@
 </section>
 
 <div class="formSubmit">
-	<button class="buttonPrimary" id="statRefreshButton">{lang}wcf.global.button.refresh{/lang}</button>
+	<button class="button buttonPrimary" id="statRefreshButton">{lang}wcf.global.button.refresh{/lang}</button>
 </div>
 
 <div id="chartTooltip" class="balloonTooltip active" style="display: none"></div>

--- a/wcfsetup/install/files/acp/templates/styleAdd.tpl
+++ b/wcfsetup/install/files/acp/templates/styleAdd.tpl
@@ -1174,7 +1174,7 @@
 	</dl>
 	
 	<div class="formSubmit">
-		<button id="styleDisableProtectionSubmit" class="buttonPrimary" disabled>{lang}wcf.global.button.submit{/lang}</button>
+		<button id="styleDisableProtectionSubmit" class="button buttonPrimary" disabled>{lang}wcf.global.button.submit{/lang}</button>
 	</div>
 </div>
 

--- a/wcfsetup/install/files/acp/templates/tagSetAsSynonyms.tpl
+++ b/wcfsetup/install/files/acp/templates/tagSetAsSynonyms.tpl
@@ -9,5 +9,5 @@
 </ul>
 
 <div class="formSubmit">
-	<button data-type="submit">{lang}wcf.global.button.submit{/lang}</button>
+	<button class="button" data-type="submit">{lang}wcf.global.button.submit{/lang}</button>
 </div>

--- a/wcfsetup/install/files/acp/templates/trophyAdd.tpl
+++ b/wcfsetup/install/files/acp/templates/trophyAdd.tpl
@@ -283,7 +283,7 @@
 	</div>
 
 	<div class="formSubmit">
-		<button class="buttonPrimary">{lang}wcf.global.button.save{/lang}</button>
+		<button class="button buttonPrimary">{lang}wcf.global.button.save{/lang}</button>
 	</div>
 </div>
 

--- a/wcfsetup/install/files/js/3rdParty/redactor2/plugins/WoltLabImage.js
+++ b/wcfsetup/install/files/js/3rdParty/redactor2/plugins/WoltLabImage.js
@@ -107,8 +107,8 @@ $.Redactor.prototype.WoltLabImage = function() {
 					+ '<input id="redactor-image-title" style="display: none">' /* dummy because redactor expects it to be present */
 					+ '<input id="redactor-image-caption" style="display: none">' /* dummy because redactor expects it to be present */
 					+ '<div class="formSubmit">'
-						+ '<button id="redactor-modal-button-action" class="buttonPrimary">Insert</button>'
-						+ '<button id="redactor-modal-button-delete" class="redactor-modal-button-offset">Delete</button>'
+						+ '<button id="redactor-modal-button-action" class="button buttonPrimary">Insert</button>'
+						+ '<button id="redactor-modal-button-delete" class="button redactor-modal-button-offset">Delete</button>'
 					+ '</div>'
 				+ '</div>';
 		},

--- a/wcfsetup/install/files/js/3rdParty/redactor2/redactor.js
+++ b/wcfsetup/install/files/js/3rdParty/redactor2/redactor.js
@@ -7392,8 +7392,8 @@
 						'link': String() + '<div class="redactor-modal-tab" data-title="General">' + '<section>' + '<label>URL</label>' + '<input type="url" id="redactor-link-url" aria-label="URL" />' + '</section>' + '<section>' + '<label>' + this.lang.get(
 							'text') + '</label>' + '<input type="text" id="redactor-link-url-text" aria-label="' + this.lang.get(
 							'text') + '" />' + '</section>' + '<section>' + '<label class="checkbox"><input type="checkbox" id="redactor-link-blank"> ' + this.lang.get(
-							'link-in-new-tab') + '</label>' + '</section>' + '<section>' + '<button id="redactor-modal-button-action">' + this.lang.get(
-							'insert') + '</button>' + '<button id="redactor-modal-button-cancel">' + this.lang.get(
+							'link-in-new-tab') + '</label>' + '</section>' + '<section>' + '<button class="button" id="redactor-modal-button-action">' + this.lang.get(
+							'insert') + '</button>' + '<button class="button" id="redactor-modal-button-cancel">' + this.lang.get(
 							'cancel') + '</button>' + '</section>' + '</div>'
 					};
 					
@@ -7441,7 +7441,7 @@
 					this.$modal = $('<div id="redactor-modal" role="dialog" />');
 					this.$modalHeader = $('<div id="redactor-modal-header" />');
 					this.$modalClose = $(
-						'<button type="button" id="redactor-modal-close" aria-label="' + this.lang.get(
+						'<button class="button" type="button" id="redactor-modal-close" aria-label="' + this.lang.get(
 						'close') + '" />').html('&times;');
 					this.$modalBody = $('<div id="redactor-modal-body" />');
 					

--- a/wcfsetup/install/files/js/WCF.Comment.js
+++ b/wcfsetup/install/files/js/WCF.Comment.js
@@ -265,7 +265,7 @@ WCF.Comment.Handler = Class.extend({
 	_handleLoadNextComments: function() {
 		if (this._displayedComments < this._container.data('comments')) {
 			if (this._loadNextComments === null) {
-				this._loadNextComments = $('<li class="commentLoadNext showMore"><button class="small">' + WCF.Language.get('wcf.comment.more') + '</button></li>').appendTo(this._container);
+				this._loadNextComments = $('<li class="commentLoadNext showMore"><button class="button small">' + WCF.Language.get('wcf.comment.more') + '</button></li>').appendTo(this._container);
 				this._loadNextComments.children('button').click($.proxy(this._loadComments, this));
 			}
 			

--- a/wcfsetup/install/files/js/WCF.Message.js
+++ b/wcfsetup/install/files/js/WCF.Message.js
@@ -1376,8 +1376,8 @@ if (COMPILER_TARGET_DEFAULT) {
 			
 			// add 'insert' and 'delete' buttons
 			var $formSubmit = $('<div class="formSubmit" />').appendTo(this._dialog);
-			if (this._supportPaste) this._buttons.insert = $('<button class="buttonPrimary">' + WCF.Language.get('wcf.message.quote.insertAllQuotes') + '</button>').click($.proxy(this._insertSelected, this)).appendTo($formSubmit);
-			this._buttons.remove = $('<button>' + WCF.Language.get('wcf.message.quote.removeAllQuotes') + '</button>').click($.proxy(this._removeSelected, this)).appendTo($formSubmit);
+			if (this._supportPaste) this._buttons.insert = $('<button class="button buttonPrimary">' + WCF.Language.get('wcf.message.quote.insertAllQuotes') + '</button>').click($.proxy(this._insertSelected, this)).appendTo($formSubmit);
+			this._buttons.remove = $('<button class="button">' + WCF.Language.get('wcf.message.quote.removeAllQuotes') + '</button>').click($.proxy(this._removeSelected, this)).appendTo($formSubmit);
 			
 			// show dialog
 			this._dialog.wcfDialog({

--- a/wcfsetup/install/files/js/WCF.User.js
+++ b/wcfsetup/install/files/js/WCF.User.js
@@ -1609,7 +1609,7 @@ WCF.User.RecentActivityLoader = Class.extend({
 		});
 		
 		if (this._container.children('li').length) {
-			this._loadButton = $('<li class="showMore"><button class="small">' + WCF.Language.get('wcf.user.recentActivity.more') + '</button></li>').appendTo(this._container);
+			this._loadButton = $('<li class="showMore"><button class="button small">' + WCF.Language.get('wcf.user.recentActivity.more') + '</button></li>').appendTo(this._container);
 			this._loadButton = this._loadButton.children('button').click($.proxy(this._click, this));
 		}
 		else {
@@ -1757,7 +1757,7 @@ WCF.User.LikeLoader = Class.extend({
 			success: $.proxy(this._success, this)
 		});
 		
-		var $container = $('<li class="likeListMore showMore"><button class="small">' + WCF.Language.get('wcf.like.likes.more') + '</button><small>' + WCF.Language.get('wcf.like.likes.noMoreEntries') + '</small></li>').appendTo(this._container);
+		var $container = $('<li class="likeListMore showMore"><button class="button small">' + WCF.Language.get('wcf.like.likes.more') + '</button><small>' + WCF.Language.get('wcf.like.likes.noMoreEntries') + '</small></li>').appendTo(this._container);
 		this._loadButton = $container.children('button').click($.proxy(this._click, this));
 		this._noMoreEntries = $container.children('small').hide();
 		

--- a/wcfsetup/install/files/js/WCF.js
+++ b/wcfsetup/install/files/js/WCF.js
@@ -5463,7 +5463,7 @@ if (COMPILER_TARGET_DEFAULT) {
 				
 				// display continue button
 				var $formSubmit = $('<div class="formSubmit" />').appendTo(this._dialog);
-				$('<button class="buttonPrimary">' + WCF.Language.get('wcf.global.button.next') + '</button>').appendTo(
+				$('<button class="button buttonPrimary">' + WCF.Language.get('wcf.global.button.next') + '</button>').appendTo(
 					$formSubmit).focus().click(function () {
 					if (data.returnValues.redirectURL) {
 						window.location = data.returnValues.redirectURL;

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Acp/Ui/CodeMirror/Media.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Acp/Ui/CodeMirror/Media.js
@@ -14,7 +14,7 @@ define(["require", "exports", "tslib", "../../../Media/Manager/Editor", "../../.
         }
         insert(mediaList, insertType, thumbnailSize) {
             switch (insertType) {
-                case "separate" /* Separate */: {
+                case "separate" /* MediaInsertType.Separate */: {
                     let sizeArgument = "";
                     if (thumbnailSize) {
                         sizeArgument = ` size="${thumbnailSize}"`;

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Acp/Ui/DataImport/Manager.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Acp/Ui/DataImport/Manager.js
@@ -47,7 +47,7 @@ define(["require", "exports", "tslib", "../../../Ajax", "../../../Core", "../../
             spinner.classList.add("fa-check", "green");
             const formSubmit = document.createElement("div");
             formSubmit.className = "formSubmit";
-            formSubmit.innerHTML = `<button class="buttonPrimary">${Language.get("wcf.global.button.next")}</button>`;
+            formSubmit.innerHTML = `<button class="button buttonPrimary">${Language.get("wcf.global.button.next")}</button>`;
             content.appendChild(formSubmit);
             Dialog_1.default.rebuild(this);
             const button = formSubmit.children[0];

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Acp/Ui/Package/Update/Manager.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Acp/Ui/Package/Update/Manager.js
@@ -71,13 +71,13 @@ define(["require", "exports", "tslib", "../../../../Ajax", "../../../../Language
                 this.submitButton.disabled = false;
             }
             switch (response.type) {
-                case "authorizationRequired" /* AuthorizationRequired */:
+                case "authorizationRequired" /* ResponseType.AuthorizationRequired */:
                     this.promptCredentials(response.template);
                     break;
-                case "conflict" /* Conflict */:
+                case "conflict" /* ResponseType.Conflict */:
                     this.showConflict(response.template);
                     break;
-                case "queue" /* Queue */:
+                case "queue" /* ResponseType.Queue */:
                     this.startInstallation(response.queueID);
                     break;
                 default:

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Acp/Ui/Template/Group/Copy.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Acp/Ui/Template/Group/Copy.js
@@ -76,7 +76,7 @@ define(["require", "exports", "tslib", "../../../../Ajax", "../../../../Language
   </dd>
 </dl>
 <div class="formSubmit">
-  <button class="buttonPrimary" data-type="submit">${Language.get("wcf.global.button.submit")}</button>
+  <button class="button buttonPrimary" data-type="submit">${Language.get("wcf.global.button.submit")}</button>
 </div>`,
             };
         }

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Acp/Ui/User/Action/Handler/Ban/Dialog.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Acp/Ui/User/Action/Handler/Ban/Dialog.js
@@ -119,7 +119,7 @@ define(["require", "exports", "tslib", "../../../../../../Ui/Dialog", "../../../
    </dl>
  </div>
  <div class="formSubmit dialogFormSubmit">
-   <button class="buttonPrimary formSubmitButton" accesskey="s">${Language.get("wcf.global.button.submit")}</button>
+   <button class="button buttonPrimary formSubmitButton" accesskey="s">${Language.get("wcf.global.button.submit")}</button>
  </div>`,
             };
         }

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Acp/Ui/Worker.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Acp/Ui/Worker.js
@@ -67,7 +67,8 @@ define(["require", "exports", "tslib", "../../Ajax", "../../Core", "../../Langua
                 spinner.classList.add("fa-check", "green");
                 const formSubmit = document.createElement("div");
                 formSubmit.className = "formSubmit";
-                formSubmit.innerHTML = '<button class="buttonPrimary">' + Language.get("wcf.global.button.next") + "</button>";
+                formSubmit.innerHTML =
+                    '<button class="button buttonPrimary">' + Language.get("wcf.global.button.next") + "</button>";
                 content.appendChild(formSubmit);
                 Dialog_1.default.rebuild(this);
                 const button = formSubmit.children[0];

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Bbcode/Code.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Bbcode/Code.js
@@ -46,22 +46,14 @@ define(["require", "exports", "tslib", "../Language", "../Clipboard", "../Ui/Not
             if (!header) {
                 return;
             }
-            const button = document.createElement("span");
-            button.tabIndex = 0;
-            button.setAttribute("role", "button");
+            const button = document.createElement("button");
             button.className = "icon icon24 fa-files-o pointer jsTooltip";
             button.setAttribute("title", Language.get("wcf.message.bbcode.code.copy"));
             const clickCallback = async () => {
                 await Clipboard.copyElementTextToClipboard(this.codeContainer);
                 UiNotification.show(Language.get("wcf.message.bbcode.code.copy.success"));
             };
-            button.addEventListener("click", clickCallback);
-            button.addEventListener("keydown", (event) => {
-                if (event.key === "Enter" || event.key === " ") {
-                    event.preventDefault();
-                    void clickCallback();
-                }
-            });
+            button.addEventListener("click", () => clickCallback());
             header.appendChild(button);
         }
         async highlight() {

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Controller/Popover.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Controller/Popover.js
@@ -115,7 +115,7 @@ define(["require", "exports", "tslib", "../Ajax", "../Dom/Change/Listener", "../
                 if (element.closest(".popover") !== null) {
                     this.cache.set(id, {
                         content: null,
-                        state: 0 /* None */,
+                        state: 0 /* State.None */,
                     });
                     return;
                 }
@@ -138,7 +138,7 @@ define(["require", "exports", "tslib", "../Ajax", "../Dom/Change/Listener", "../
                 if (!this.cache.has(cacheId)) {
                     this.cache.set(cacheId, {
                         content: null,
-                        state: 0 /* None */,
+                        state: 0 /* State.None */,
                     });
                 }
             });
@@ -157,7 +157,7 @@ define(["require", "exports", "tslib", "../Ajax", "../Dom/Change/Listener", "../
                 fragment = Util_1.default.createFragmentFromHtml("<p>" + content + "</p>");
             }
             data.content = fragment;
-            data.state = 2 /* Ready */;
+            data.state = 2 /* State.Ready */;
             if (this.activeId) {
                 const activeElement = this.elements.get(this.activeId).element;
                 if (activeElement.dataset.cacheId === cacheId) {
@@ -187,7 +187,7 @@ define(["require", "exports", "tslib", "../Ajax", "../Dom/Change/Listener", "../
                 if (this.hoverId === id) {
                     this.show();
                 }
-            }, 800 /* Show */);
+            }, 800 /* Delay.Show */);
         }
         /**
          * Handles the mouse leaving the popover-enabled element or the popover itself.
@@ -197,7 +197,7 @@ define(["require", "exports", "tslib", "../Ajax", "../Dom/Change/Listener", "../
             if (this.timerLeave) {
                 return;
             }
-            this.timerLeave = window.setTimeout(() => this.hidePopover(), 500 /* Hide */);
+            this.timerLeave = window.setTimeout(() => this.hidePopover(), 500 /* Delay.Hide */);
         }
         /**
          * Handles the mouse start hovering the popover element.
@@ -243,13 +243,13 @@ define(["require", "exports", "tslib", "../Ajax", "../Dom/Change/Listener", "../
             const cacheId = elementData.element.dataset.cacheId;
             const data = this.cache.get(cacheId);
             switch (data.state) {
-                case 2 /* Ready */: {
+                case 2 /* State.Ready */: {
                     this.popoverContent.appendChild(data.content);
                     this.rebuild();
                     break;
                 }
-                case 0 /* None */: {
-                    data.state = 1 /* Loading */;
+                case 0 /* State.None */: {
+                    data.state = 1 /* State.Loading */;
                     const handler = this.handlers.get(elementData.identifier);
                     if (handler.loadCallback) {
                         handler.loadCallback(elementData.objectId, this, elementData.element);
@@ -268,7 +268,7 @@ define(["require", "exports", "tslib", "../Ajax", "../Dom/Change/Listener", "../
                     }
                     break;
                 }
-                case 1 /* Loading */: {
+                case 1 /* State.Loading */: {
                     // Do not interrupt inflight requests.
                     break;
                 }

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Date/Picker.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Date/Picker.js
@@ -47,15 +47,12 @@ define(["require", "exports", "tslib", "../Core", "./Util", "../Dom/Change/Liste
         });
         const header = document.createElement("header");
         _datePicker.appendChild(header);
-        _dateMonthPrevious = document.createElement("a");
+        _dateMonthPrevious = document.createElement("button");
         _dateMonthPrevious.className = "previous jsTooltip";
-        _dateMonthPrevious.href = "#";
-        _dateMonthPrevious.setAttribute("role", "button");
-        _dateMonthPrevious.tabIndex = 0;
         _dateMonthPrevious.title = Language.get("wcf.date.datePicker.previousMonth");
         _dateMonthPrevious.setAttribute("aria-label", Language.get("wcf.date.datePicker.previousMonth"));
         _dateMonthPrevious.innerHTML = '<span class="icon icon16 fa-arrow-left"></span>';
-        _dateMonthPrevious.addEventListener("click", (ev) => DatePicker.previousMonth(ev));
+        _dateMonthPrevious.addEventListener("click", () => DatePicker.previousMonth());
         header.appendChild(_dateMonthPrevious);
         const monthYearContainer = document.createElement("span");
         header.appendChild(monthYearContainer);
@@ -77,15 +74,12 @@ define(["require", "exports", "tslib", "../Core", "./Util", "../Dom/Change/Liste
         _dateYear.setAttribute("aria-label", Language.get("wcf.date.datePicker.year"));
         _dateYear.addEventListener("change", changeYear);
         monthYearContainer.appendChild(_dateYear);
-        _dateMonthNext = document.createElement("a");
+        _dateMonthNext = document.createElement("button");
         _dateMonthNext.className = "next jsTooltip";
-        _dateMonthNext.href = "#";
-        _dateMonthNext.setAttribute("role", "button");
-        _dateMonthNext.tabIndex = 0;
         _dateMonthNext.title = Language.get("wcf.date.datePicker.nextMonth");
         _dateMonthNext.setAttribute("aria-label", Language.get("wcf.date.datePicker.nextMonth"));
         _dateMonthNext.innerHTML = '<span class="icon icon16 fa-arrow-right"></span>';
-        _dateMonthNext.addEventListener("click", (ev) => DatePicker.nextMonth(ev));
+        _dateMonthNext.addEventListener("click", () => DatePicker.nextMonth());
         header.appendChild(_dateMonthNext);
         _dateGrid = document.createElement("ul");
         _datePicker.appendChild(_dateGrid);
@@ -213,8 +207,6 @@ define(["require", "exports", "tslib", "../Core", "./Util", "../Dom/Change/Liste
      * Opens the date picker.
      */
     function open(event) {
-        event.preventDefault();
-        event.stopPropagation();
         createPicker();
         const target = event.currentTarget;
         const input = target.nodeName === "INPUT" ? target : target.previousElementSibling;
@@ -632,11 +624,8 @@ define(["require", "exports", "tslib", "../Core", "./Util", "../Dom/Change/Liste
                 // create input addon
                 const container = document.createElement("div");
                 container.className = "inputAddon";
-                const openButton = document.createElement("a");
+                const openButton = document.createElement("button");
                 openButton.className = "inputSuffix button jsTooltip";
-                openButton.href = "#";
-                openButton.setAttribute("role", "button");
-                openButton.tabIndex = 0;
                 openButton.title = Language.get("wcf.date.datePicker");
                 openButton.setAttribute("aria-label", Language.get("wcf.date.datePicker"));
                 openButton.setAttribute("aria-haspopup", "true");
@@ -713,8 +702,7 @@ define(["require", "exports", "tslib", "../Core", "./Util", "../Dom/Change/Liste
         /**
          * Shows the previous month.
          */
-        previousMonth(event) {
-            event.preventDefault();
+        previousMonth() {
             if (_dateMonth.value === "0") {
                 _dateMonth.value = "11";
                 _dateYear.value = (+_dateYear.value - 1).toString();
@@ -727,8 +715,7 @@ define(["require", "exports", "tslib", "../Core", "./Util", "../Dom/Change/Liste
         /**
          * Shows the next month.
          */
-        nextMonth(event) {
-            event.preventDefault();
+        nextMonth() {
             if (_dateMonth.value === "11") {
                 _dateMonth.value = "0";
                 _dateYear.value = (+_dateYear.value + 1).toString();

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Dom/Traverse.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Dom/Traverse.js
@@ -12,10 +12,10 @@ define(["require", "exports"], function (require, exports) {
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.prevByTag = exports.prevByClass = exports.prevBySel = exports.prev = exports.nextByTag = exports.nextByClass = exports.nextBySel = exports.next = exports.parentByTag = exports.parentByClass = exports.parentBySel = exports.childrenByTag = exports.childrenByClass = exports.childrenBySel = exports.childByTag = exports.childByClass = exports.childBySel = void 0;
     const _test = new Map([
-        [0 /* None */, () => true],
-        [1 /* Selector */, (element, selector) => element.matches(selector)],
-        [2 /* ClassName */, (element, className) => element.classList.contains(className)],
-        [3 /* TagName */, (element, tagName) => element.nodeName === tagName],
+        [0 /* Type.None */, () => true],
+        [1 /* Type.Selector */, (element, selector) => element.matches(selector)],
+        [2 /* Type.ClassName */, (element, className) => element.classList.contains(className)],
+        [3 /* Type.TagName */, (element, tagName) => element.nodeName === tagName],
     ]);
     function _getChildren(element, type, value) {
         if (!(element instanceof Element)) {
@@ -60,57 +60,57 @@ define(["require", "exports"], function (require, exports) {
      * Examines child elements and returns the first child matching the given selector.
      */
     function childBySel(element, selector) {
-        return _getChildren(element, 1 /* Selector */, selector)[0] || null;
+        return _getChildren(element, 1 /* Type.Selector */, selector)[0] || null;
     }
     exports.childBySel = childBySel;
     /**
      * Examines child elements and returns the first child that has the given CSS class set.
      */
     function childByClass(element, className) {
-        return _getChildren(element, 2 /* ClassName */, className)[0] || null;
+        return _getChildren(element, 2 /* Type.ClassName */, className)[0] || null;
     }
     exports.childByClass = childByClass;
     function childByTag(element, tagName) {
-        return _getChildren(element, 3 /* TagName */, tagName)[0] || null;
+        return _getChildren(element, 3 /* Type.TagName */, tagName)[0] || null;
     }
     exports.childByTag = childByTag;
     /**
      * Examines child elements and returns all children matching the given selector.
      */
     function childrenBySel(element, selector) {
-        return _getChildren(element, 1 /* Selector */, selector);
+        return _getChildren(element, 1 /* Type.Selector */, selector);
     }
     exports.childrenBySel = childrenBySel;
     /**
      * Examines child elements and returns all children that have the given CSS class set.
      */
     function childrenByClass(element, className) {
-        return _getChildren(element, 2 /* ClassName */, className);
+        return _getChildren(element, 2 /* Type.ClassName */, className);
     }
     exports.childrenByClass = childrenByClass;
     function childrenByTag(element, tagName) {
-        return _getChildren(element, 3 /* TagName */, tagName);
+        return _getChildren(element, 3 /* Type.TagName */, tagName);
     }
     exports.childrenByTag = childrenByTag;
     /**
      * Examines parent nodes and returns the first parent that matches the given selector.
      */
     function parentBySel(element, selector, untilElement) {
-        return _getParent(element, 1 /* Selector */, selector, untilElement);
+        return _getParent(element, 1 /* Type.Selector */, selector, untilElement);
     }
     exports.parentBySel = parentBySel;
     /**
      * Examines parent nodes and returns the first parent that has the given CSS class set.
      */
     function parentByClass(element, className, untilElement) {
-        return _getParent(element, 2 /* ClassName */, className, untilElement);
+        return _getParent(element, 2 /* Type.ClassName */, className, untilElement);
     }
     exports.parentByClass = parentByClass;
     /**
      * Examines parent nodes and returns the first parent which equals the given tag.
      */
     function parentByTag(element, tagName, untilElement) {
-        return _getParent(element, 3 /* TagName */, tagName, untilElement);
+        return _getParent(element, 3 /* Type.TagName */, tagName, untilElement);
     }
     exports.parentByTag = parentByTag;
     /**
@@ -119,28 +119,28 @@ define(["require", "exports"], function (require, exports) {
      * @deprecated 5.4 Use `element.nextElementSibling` instead.
      */
     function next(element) {
-        return _getSibling(element, "nextElementSibling", 0 /* None */, "");
+        return _getSibling(element, "nextElementSibling", 0 /* Type.None */, "");
     }
     exports.next = next;
     /**
      * Returns the next element sibling that matches the given selector.
      */
     function nextBySel(element, selector) {
-        return _getSibling(element, "nextElementSibling", 1 /* Selector */, selector);
+        return _getSibling(element, "nextElementSibling", 1 /* Type.Selector */, selector);
     }
     exports.nextBySel = nextBySel;
     /**
      * Returns the next element sibling with given CSS class.
      */
     function nextByClass(element, className) {
-        return _getSibling(element, "nextElementSibling", 2 /* ClassName */, className);
+        return _getSibling(element, "nextElementSibling", 2 /* Type.ClassName */, className);
     }
     exports.nextByClass = nextByClass;
     /**
      * Returns the next element sibling with given CSS class.
      */
     function nextByTag(element, tagName) {
-        return _getSibling(element, "nextElementSibling", 3 /* TagName */, tagName);
+        return _getSibling(element, "nextElementSibling", 3 /* Type.TagName */, tagName);
     }
     exports.nextByTag = nextByTag;
     /**
@@ -149,28 +149,28 @@ define(["require", "exports"], function (require, exports) {
      * @deprecated 5.4 Use `element.previousElementSibling` instead.
      */
     function prev(element) {
-        return _getSibling(element, "previousElementSibling", 0 /* None */, "");
+        return _getSibling(element, "previousElementSibling", 0 /* Type.None */, "");
     }
     exports.prev = prev;
     /**
      * Returns the previous element sibling that matches the given selector.
      */
     function prevBySel(element, selector) {
-        return _getSibling(element, "previousElementSibling", 1 /* Selector */, selector);
+        return _getSibling(element, "previousElementSibling", 1 /* Type.Selector */, selector);
     }
     exports.prevBySel = prevBySel;
     /**
      * Returns the previous element sibling with given CSS class.
      */
     function prevByClass(element, className) {
-        return _getSibling(element, "previousElementSibling", 2 /* ClassName */, className);
+        return _getSibling(element, "previousElementSibling", 2 /* Type.ClassName */, className);
     }
     exports.prevByClass = prevByClass;
     /**
      * Returns the previous element sibling with given CSS class.
      */
     function prevByTag(element, tagName) {
-        return _getSibling(element, "previousElementSibling", 3 /* TagName */, tagName);
+        return _getSibling(element, "previousElementSibling", 3 /* Type.TagName */, tagName);
     }
     exports.prevByTag = prevByTag;
 });

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/I18n/Plural.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/I18n/Plural.js
@@ -13,46 +13,46 @@ define(["require", "exports", "tslib", "../StringUtil"], function (require, expo
         // Afrikaans
         af(n) {
             if (n == 1) {
-                return "one" /* One */;
+                return "one" /* Category.One */;
             }
         },
         // Amharic
         am(n) {
             const i = Math.floor(Math.abs(n));
             if (n == 1 || i === 0) {
-                return "one" /* One */;
+                return "one" /* Category.One */;
             }
         },
         // Arabic
         ar(n) {
             if (n == 0) {
-                return "zero" /* Zero */;
+                return "zero" /* Category.Zero */;
             }
             if (n == 1) {
-                return "one" /* One */;
+                return "one" /* Category.One */;
             }
             if (n == 2) {
-                return "two" /* Two */;
+                return "two" /* Category.Two */;
             }
             const mod100 = n % 100;
             if (mod100 >= 3 && mod100 <= 10) {
-                return "few" /* Few */;
+                return "few" /* Category.Few */;
             }
             if (mod100 >= 11 && mod100 <= 99) {
-                return "many" /* Many */;
+                return "many" /* Category.Many */;
             }
         },
         // Assamese
         as(n) {
             const i = Math.floor(Math.abs(n));
             if (n == 1 || i === 0) {
-                return "one" /* One */;
+                return "one" /* Category.One */;
             }
         },
         // Azerbaijani
         az(n) {
             if (n == 1) {
-                return "one" /* One */;
+                return "one" /* Category.One */;
             }
         },
         // Belarusian
@@ -60,26 +60,26 @@ define(["require", "exports", "tslib", "../StringUtil"], function (require, expo
             const mod10 = n % 10;
             const mod100 = n % 100;
             if (mod10 == 1 && mod100 != 11) {
-                return "one" /* One */;
+                return "one" /* Category.One */;
             }
             if (mod10 >= 2 && mod10 <= 4 && !(mod100 >= 12 && mod100 <= 14)) {
-                return "few" /* Few */;
+                return "few" /* Category.Few */;
             }
             if (mod10 == 0 || (mod10 >= 5 && mod10 <= 9) || (mod100 >= 11 && mod100 <= 14)) {
-                return "many" /* Many */;
+                return "many" /* Category.Many */;
             }
         },
         // Bulgarian
         bg(n) {
             if (n == 1) {
-                return "one" /* One */;
+                return "one" /* Category.One */;
             }
         },
         // Bengali
         bn(n) {
             const i = Math.floor(Math.abs(n));
             if (n == 1 || i === 0) {
-                return "one" /* One */;
+                return "one" /* Category.One */;
             }
         },
         // Tibetan
@@ -95,54 +95,54 @@ define(["require", "exports", "tslib", "../StringUtil"], function (require, expo
             const fMod10 = f % 10;
             const fMod100 = f % 100;
             if ((v == 0 && mod10 == 1 && mod100 != 11) || (fMod10 == 1 && fMod100 != 11)) {
-                return "one" /* One */;
+                return "one" /* Category.One */;
             }
             if ((v == 0 && mod10 >= 2 && mod10 <= 4 && mod100 >= 12 && mod100 <= 14) ||
                 (fMod10 >= 2 && fMod10 <= 4 && fMod100 >= 12 && fMod100 <= 14)) {
-                return "few" /* Few */;
+                return "few" /* Category.Few */;
             }
         },
         // Czech
         cs(n) {
             const v = Plural.getV(n);
             if (n == 1 && v === 0) {
-                return "one" /* One */;
+                return "one" /* Category.One */;
             }
             if (n >= 2 && n <= 4 && v === 0) {
-                return "few" /* Few */;
+                return "few" /* Category.Few */;
             }
             if (v === 0) {
-                return "many" /* Many */;
+                return "many" /* Category.Many */;
             }
         },
         // Welsh
         cy(n) {
             if (n == 0) {
-                return "zero" /* Zero */;
+                return "zero" /* Category.Zero */;
             }
             if (n == 1) {
-                return "one" /* One */;
+                return "one" /* Category.One */;
             }
             if (n == 2) {
-                return "two" /* Two */;
+                return "two" /* Category.Two */;
             }
             if (n == 3) {
-                return "few" /* Few */;
+                return "few" /* Category.Few */;
             }
             if (n == 6) {
-                return "many" /* Many */;
+                return "many" /* Category.Many */;
             }
         },
         // Danish
         da(n) {
             if (n > 0 && n < 2) {
-                return "one" /* One */;
+                return "one" /* Category.One */;
             }
         },
         // Greek
         el(n) {
             if (n == 1) {
-                return "one" /* One */;
+                return "one" /* Category.One */;
             }
         },
         // Catalan (ca)
@@ -157,71 +157,71 @@ define(["require", "exports", "tslib", "../StringUtil"], function (require, expo
         // Urdu (ur)
         en(n) {
             if (n == 1 && Plural.getV(n) === 0) {
-                return "one" /* One */;
+                return "one" /* Category.One */;
             }
         },
         // Spanish
         es(n) {
             if (n == 1) {
-                return "one" /* One */;
+                return "one" /* Category.One */;
             }
         },
         // Basque
         eu(n) {
             if (n == 1) {
-                return "one" /* One */;
+                return "one" /* Category.One */;
             }
         },
         // Persian
         fa(n) {
             if (n >= 0 && n <= 1) {
-                return "one" /* One */;
+                return "one" /* Category.One */;
             }
         },
         // French
         fr(n) {
             if (n >= 0 && n < 2) {
-                return "one" /* One */;
+                return "one" /* Category.One */;
             }
         },
         // Irish
         ga(n) {
             if (n == 1) {
-                return "one" /* One */;
+                return "one" /* Category.One */;
             }
             if (n == 2) {
-                return "two" /* Two */;
+                return "two" /* Category.Two */;
             }
             if (n == 3 || n == 4 || n == 5 || n == 6) {
-                return "few" /* Few */;
+                return "few" /* Category.Few */;
             }
             if (n == 7 || n == 8 || n == 9 || n == 10) {
-                return "many" /* Many */;
+                return "many" /* Category.Many */;
             }
         },
         // Gujarati
         gu(n) {
             if (n >= 0 && n <= 1) {
-                return "one" /* One */;
+                return "one" /* Category.One */;
             }
         },
         // Hebrew
         he(n) {
             const v = Plural.getV(n);
             if (n == 1 && v === 0) {
-                return "one" /* One */;
+                return "one" /* Category.One */;
             }
             if (n == 2 && v === 0) {
-                return "two" /* Two */;
+                return "two" /* Category.Two */;
             }
             if (n > 10 && v === 0 && n % 10 == 0) {
-                return "many" /* Many */;
+                return "many" /* Category.Many */;
             }
         },
         // Hindi
         hi(n) {
             if (n >= 0 && n <= 1) {
-                return "one" /* One */;
+                return "one" /* Category.One */;
             }
         },
         // Croatian
@@ -232,13 +232,13 @@ define(["require", "exports", "tslib", "../StringUtil"], function (require, expo
         // Hungarian
         hu(n) {
             if (n == 1) {
-                return "one" /* One */;
+                return "one" /* Category.One */;
             }
         },
         // Armenian
         hy(n) {
             if (n >= 0 && n < 2) {
-                return "one" /* One */;
+                return "one" /* Category.One */;
             }
         },
         // Indonesian
@@ -249,7 +249,7 @@ define(["require", "exports", "tslib", "../StringUtil"], function (require, expo
         is(n) {
             const f = Plural.getF(n);
             if ((f === 0 && n % 10 === 1 && !(n % 100 === 11)) || !(f === 0)) {
-                return "one" /* One */;
+                return "one" /* Category.One */;
             }
         },
         // Japanese
@@ -263,13 +263,13 @@ define(["require", "exports", "tslib", "../StringUtil"], function (require, expo
         // Georgian
         ka(n) {
             if (n == 1) {
-                return "one" /* One */;
+                return "one" /* Category.One */;
             }
         },
         // Kazakh
         kk(n) {
             if (n == 1) {
-                return "one" /* One */;
+                return "one" /* Category.One */;
             }
         },
         // Khmer
@@ -279,7 +279,7 @@ define(["require", "exports", "tslib", "../StringUtil"], function (require, expo
         // Kannada
         kn(n) {
             if (n >= 0 && n <= 1) {
-                return "one" /* One */;
+                return "one" /* Category.One */;
             }
         },
         // Korean
@@ -289,19 +289,19 @@ define(["require", "exports", "tslib", "../StringUtil"], function (require, expo
         // Kurdish
         ku(n) {
             if (n == 1) {
-                return "one" /* One */;
+                return "one" /* Category.One */;
             }
         },
         // Kyrgyz
         ky(n) {
             if (n == 1) {
-                return "one" /* One */;
+                return "one" /* Category.One */;
             }
         },
         // Luxembourgish
         lb(n) {
             if (n == 1) {
-                return "one" /* One */;
+                return "one" /* Category.One */;
             }
         },
         // Lao
@@ -313,13 +313,13 @@ define(["require", "exports", "tslib", "../StringUtil"], function (require, expo
             const mod10 = n % 10;
             const mod100 = n % 100;
             if (mod10 == 1 && !(mod100 >= 11 && mod100 <= 19)) {
-                return "one" /* One */;
+                return "one" /* Category.One */;
             }
             if (mod10 >= 2 && mod10 <= 9 && !(mod100 >= 11 && mod100 <= 19)) {
-                return "few" /* Few */;
+                return "few" /* Category.Few */;
             }
             if (Plural.getF(n) != 0) {
-                return "many" /* Many */;
+                return "many" /* Category.Many */;
             }
         },
         // Latvian
@@ -331,10 +331,10 @@ define(["require", "exports", "tslib", "../StringUtil"], function (require, expo
             const fMod10 = f % 10;
             const fMod100 = f % 100;
             if (mod10 == 0 || (mod100 >= 11 && mod100 <= 19) || (v == 2 && fMod100 >= 11 && fMod100 <= 19)) {
-                return "zero" /* Zero */;
+                return "zero" /* Category.Zero */;
             }
             if ((mod10 == 1 && mod100 != 11) || (v == 2 && fMod10 == 1 && fMod100 != 11) || (v != 2 && fMod10 == 1)) {
-                return "one" /* One */;
+                return "one" /* Category.One */;
             }
         },
         // Macedonian
@@ -344,19 +344,19 @@ define(["require", "exports", "tslib", "../StringUtil"], function (require, expo
         // Malayalam
         ml(n) {
             if (n == 1) {
-                return "one" /* One */;
+                return "one" /* Category.One */;
             }
         },
         // Mongolian
         mn(n) {
             if (n == 1) {
-                return "one" /* One */;
+                return "one" /* Category.One */;
             }
         },
         // Marathi
         mr(n) {
             if (n == 1) {
-                return "one" /* One */;
+                return "one" /* Category.One */;
             }
         },
         // Malay
@@ -367,13 +367,13 @@ define(["require", "exports", "tslib", "../StringUtil"], function (require, expo
         mt(n) {
             const mod100 = n % 100;
             if (n == 1) {
-                return "one" /* One */;
+                return "one" /* Category.One */;
             }
             if (n == 0 || (mod100 >= 2 && mod100 <= 10)) {
-                return "few" /* Few */;
+                return "few" /* Category.Few */;
             }
             if (mod100 >= 11 && mod100 <= 19) {
-                return "many" /* Many */;
+                return "many" /* Category.Many */;
             }
         },
         // Burmese
@@ -383,25 +383,25 @@ define(["require", "exports", "tslib", "../StringUtil"], function (require, expo
         // Norwegian
         no(n) {
             if (n == 1) {
-                return "one" /* One */;
+                return "one" /* Category.One */;
             }
         },
         // Nepali
         ne(n) {
             if (n == 1) {
-                return "one" /* One */;
+                return "one" /* Category.One */;
             }
         },
         // Odia
         or(n) {
             if (n == 1) {
-                return "one" /* One */;
+                return "one" /* Category.One */;
             }
         },
         // Punjabi
         pa(n) {
             if (n == 1 || n == 0) {
-                return "one" /* One */;
+                return "one" /* Category.One */;
             }
         },
         // Polish
@@ -410,26 +410,26 @@ define(["require", "exports", "tslib", "../StringUtil"], function (require, expo
             const mod10 = n % 10;
             const mod100 = n % 100;
             if (n == 1 && v == 0) {
-                return "one" /* One */;
+                return "one" /* Category.One */;
             }
             if (v == 0 && mod10 >= 2 && mod10 <= 4 && !(mod100 >= 12 && mod100 <= 14)) {
-                return "few" /* Few */;
+                return "few" /* Category.Few */;
             }
             if (v == 0 &&
                 ((n != 1 && mod10 >= 0 && mod10 <= 1) || (mod10 >= 5 && mod10 <= 9) || (mod100 >= 12 && mod100 <= 14))) {
-                return "many" /* Many */;
+                return "many" /* Category.Many */;
             }
         },
         // Pashto
         ps(n) {
             if (n == 1) {
-                return "one" /* One */;
+                return "one" /* Category.One */;
             }
         },
         // Portuguese
         pt(n) {
             if (n >= 0 && n < 2) {
-                return "one" /* One */;
+                return "one" /* Category.One */;
             }
         },
         // Romanian
@@ -437,10 +437,10 @@ define(["require", "exports", "tslib", "../StringUtil"], function (require, expo
             const v = Plural.getV(n);
             const mod100 = n % 100;
             if (n == 1 && v === 0) {
-                return "one" /* One */;
+                return "one" /* Category.One */;
             }
             if (v != 0 || n == 0 || (mod100 >= 2 && mod100 <= 19)) {
-                return "few" /* Few */;
+                return "few" /* Category.Few */;
             }
         },
         // Russian
@@ -449,26 +449,26 @@ define(["require", "exports", "tslib", "../StringUtil"], function (require, expo
             const mod100 = n % 100;
             if (Plural.getV(n) == 0) {
                 if (mod10 == 1 && mod100 != 11) {
-                    return "one" /* One */;
+                    return "one" /* Category.One */;
                 }
                 if (mod10 >= 2 && mod10 <= 4 && !(mod100 >= 12 && mod100 <= 14)) {
-                    return "few" /* Few */;
+                    return "few" /* Category.Few */;
                 }
                 if (mod10 == 0 || (mod10 >= 5 && mod10 <= 9) || (mod100 >= 11 && mod100 <= 14)) {
-                    return "many" /* Many */;
+                    return "many" /* Category.Many */;
                 }
             }
         },
         // Sindhi
         sd(n) {
             if (n == 1) {
-                return "one" /* One */;
+                return "one" /* Category.One */;
             }
         },
         // Sinhala
         si(n) {
             if (n == 0 || n == 1 || (Math.floor(n) == 0 && Plural.getF(n) == 1)) {
-                return "one" /* One */;
+                return "one" /* Category.One */;
             }
         },
         // Slovak
@@ -481,19 +481,19 @@ define(["require", "exports", "tslib", "../StringUtil"], function (require, expo
             const v = Plural.getV(n);
             const mod100 = n % 100;
             if (v == 0 && mod100 == 1) {
-                return "one" /* One */;
+                return "one" /* Category.One */;
             }
             if (v == 0 && mod100 == 2) {
-                return "two" /* Two */;
+                return "two" /* Category.Two */;
             }
             if ((v == 0 && (mod100 == 3 || mod100 == 4)) || v != 0) {
-                return "few" /* Few */;
+                return "few" /* Category.Few */;
             }
         },
         // Albanian
         sq(n) {
             if (n == 1) {
-                return "one" /* One */;
+                return "one" /* Category.One */;
             }
         },
         // Serbian
@@ -504,13 +504,13 @@ define(["require", "exports", "tslib", "../StringUtil"], function (require, expo
         // Tamil
         ta(n) {
             if (n == 1) {
-                return "one" /* One */;
+                return "one" /* Category.One */;
             }
         },
         // Telugu
         te(n) {
             if (n == 1) {
-                return "one" /* One */;
+                return "one" /* Category.One */;
             }
         },
         // Tajik
@@ -524,19 +524,19 @@ define(["require", "exports", "tslib", "../StringUtil"], function (require, expo
         // Turkmen
         tk(n) {
             if (n == 1) {
-                return "one" /* One */;
+                return "one" /* Category.One */;
             }
         },
         // Turkish
         tr(n) {
             if (n == 1) {
-                return "one" /* One */;
+                return "one" /* Category.One */;
             }
         },
         // Uyghur
         ug(n) {
             if (n == 1) {
-                return "one" /* One */;
+                return "one" /* Category.One */;
             }
         },
         // Ukrainian
@@ -547,7 +547,7 @@ define(["require", "exports", "tslib", "../StringUtil"], function (require, expo
         // Uzbek
         uz(n) {
             if (n == 1) {
-                return "one" /* One */;
+                return "one" /* Category.One */;
             }
         },
         // Vietnamese
@@ -575,7 +575,7 @@ define(["require", "exports", "tslib", "../StringUtil"], function (require, expo
             if (category) {
                 return category;
             }
-            return "other" /* Other */;
+            return "other" /* Category.Other */;
         },
         /**
          * Returns the value for a `plural` element used in the template.
@@ -602,7 +602,7 @@ define(["require", "exports", "tslib", "../StringUtil"], function (require, expo
             }
             let category = Plural.getCategory(value);
             if (!parameters[category]) {
-                category = "other" /* Other */;
+                category = "other" /* Category.Other */;
             }
             const string = parameters[category];
             if (string.indexOf("#") !== -1) {

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Media/Manager/Editor.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Media/Manager/Editor.js
@@ -84,7 +84,7 @@ define(["require", "exports", "tslib", "./Base", "../../Core", "../../Event/Hand
         </dl>
       </div>
       <div class="formSubmit">
-        <button class="buttonPrimary">${Language.get("wcf.global.button.insert")}</button>
+        <button class="button buttonPrimary">${Language.get("wcf.global.button.insert")}</button>
       </div>`;
             UiDialog.open({
                 _dialogSetup: () => {

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Media/Manager/Editor.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Media/Manager/Editor.js
@@ -166,7 +166,7 @@ define(["require", "exports", "tslib", "./Base", "../../Core", "../../Event/Hand
                 thumbnailSize = thumbnailSizeSelect.value;
             }
             if (this._options.callbackInsert !== null) {
-                this._options.callbackInsert(this._mediaToInsert, "separate" /* Separate */, thumbnailSize);
+                this._options.callbackInsert(this._mediaToInsert, "separate" /* MediaInsertType.Separate */, thumbnailSize);
             }
             else {
                 this._options.editor.buffer.set();

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Alignment.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Alignment.js
@@ -236,8 +236,8 @@ define(["require", "exports", "tslib", "../Core", "../Dom/Traverse", "../Dom/Uti
             }
         }
         else if (options.pointerClassNames.length === 2) {
-            element.classList[top === "auto" ? "add" : "remove"](options.pointerClassNames[0 /* Bottom */]);
-            element.classList[left === "auto" ? "add" : "remove"](options.pointerClassNames[1 /* Right */]);
+            element.classList[top === "auto" ? "add" : "remove"](options.pointerClassNames[0 /* PointerClass.Bottom */]);
+            element.classList[left === "auto" ? "add" : "remove"](options.pointerClassNames[1 /* PointerClass.Right */]);
         }
         Util_1.default.setStyles(element, {
             bottom: bottom === "auto" ? bottom : Math.round(bottom).toString() + "px",

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Color/Picker.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Color/Picker.js
@@ -106,19 +106,19 @@ define(["require", "exports", "tslib", "../../Core", "../Dialog", "../../Dom/Uti
 </div>`,
                 options: {
                     onSetup: (content) => {
-                        this.channels.set("r" /* R */, content.querySelector('input[data-channel="r"]'));
-                        this.channels.set("g" /* G */, content.querySelector('input[data-channel="g"]'));
-                        this.channels.set("b" /* B */, content.querySelector('input[data-channel="b"]'));
-                        this.channels.set("a" /* A */, content.querySelector('input[data-channel="a"]'));
+                        this.channels.set("r" /* Channel.R */, content.querySelector('input[data-channel="r"]'));
+                        this.channels.set("g" /* Channel.G */, content.querySelector('input[data-channel="g"]'));
+                        this.channels.set("b" /* Channel.B */, content.querySelector('input[data-channel="b"]'));
+                        this.channels.set("a" /* Channel.A */, content.querySelector('input[data-channel="a"]'));
                         this.channels.forEach((input) => {
-                            input.addEventListener("input", () => this.updateColor("rgba" /* RGBA */));
+                            input.addEventListener("input", () => this.updateColor("rgba" /* ColorSource.RGBA */));
                         });
                         this.hslContainer = content.querySelector(".colorPickerHsvContainer");
-                        this.hsl.set("hue" /* Hue */, content.querySelector('input[data-coordinate="hue"]'));
-                        this.hsl.set("saturation" /* Saturation */, content.querySelector('input[data-coordinate="saturation"]'));
-                        this.hsl.set("lightness" /* Lightness */, content.querySelector('input[data-coordinate="lightness"]'));
+                        this.hsl.set("hue" /* HSL.Hue */, content.querySelector('input[data-coordinate="hue"]'));
+                        this.hsl.set("saturation" /* HSL.Saturation */, content.querySelector('input[data-coordinate="saturation"]'));
+                        this.hsl.set("lightness" /* HSL.Lightness */, content.querySelector('input[data-coordinate="lightness"]'));
                         this.hsl.forEach((input) => {
-                            input.addEventListener("input", () => this.updateColor("hsl" /* HSL */));
+                            input.addEventListener("input", () => this.updateColor("hsl" /* ColorSource.HSL */));
                         });
                         this.newColor = content.querySelector(".colorPickerColorNew > span");
                         this.oldColor = content.querySelector(".colorPickerColorOld > span");
@@ -178,7 +178,7 @@ define(["require", "exports", "tslib", "../../Core", "../Dialog", "../../Dom/Uti
                     return;
                 }
             }
-            this.setColor(color, "hex" /* HEX */);
+            this.setColor(color, "hex" /* ColorSource.HEX */);
         }
         /**
          * Returns the current RGBA color set via the color and alpha input.
@@ -186,18 +186,18 @@ define(["require", "exports", "tslib", "../../Core", "../Dialog", "../../Dom/Uti
          * @since 5.5
          */
         getColor(source) {
-            const a = parseFloat(this.channels.get("a" /* A */).value);
-            if (source === "hsl" /* HSL */) {
-                const rgb = ColorUtil.hslToRgb(parseInt(this.hsl.get("hue" /* Hue */).value, 10), parseInt(this.hsl.get("saturation" /* Saturation */).value, 10), parseInt(this.hsl.get("lightness" /* Lightness */).value, 10));
+            const a = parseFloat(this.channels.get("a" /* Channel.A */).value);
+            if (source === "hsl" /* ColorSource.HSL */) {
+                const rgb = ColorUtil.hslToRgb(parseInt(this.hsl.get("hue" /* HSL.Hue */).value, 10), parseInt(this.hsl.get("saturation" /* HSL.Saturation */).value, 10), parseInt(this.hsl.get("lightness" /* HSL.Lightness */).value, 10));
                 return {
                     ...rgb,
                     a,
                 };
             }
             return {
-                r: parseInt(this.channels.get("r" /* R */).value, 10),
-                g: parseInt(this.channels.get("g" /* G */).value, 10),
-                b: parseInt(this.channels.get("b" /* B */).value, 10),
+                r: parseInt(this.channels.get("r" /* Channel.R */).value, 10),
+                g: parseInt(this.channels.get("g" /* Channel.G */).value, 10),
+                b: parseInt(this.channels.get("b" /* Channel.B */).value, 10),
                 a,
             };
         }
@@ -220,22 +220,22 @@ define(["require", "exports", "tslib", "../../Core", "../Dialog", "../../Dom/Uti
             }
             const { r, g, b, a } = color;
             const { h, s, l } = ColorUtil.rgbToHsl(r, g, b);
-            if (source !== "hsl" /* HSL */) {
-                this.hsl.get("hue" /* Hue */).value = h.toString();
-                this.hsl.get("saturation" /* Saturation */).value = s.toString();
-                this.hsl.get("lightness" /* Lightness */).value = l.toString();
+            if (source !== "hsl" /* ColorSource.HSL */) {
+                this.hsl.get("hue" /* HSL.Hue */).value = h.toString();
+                this.hsl.get("saturation" /* HSL.Saturation */).value = s.toString();
+                this.hsl.get("lightness" /* HSL.Lightness */).value = l.toString();
             }
-            this.hslContainer.style.setProperty(`--${"hue" /* Hue */}`, `${h}`);
-            this.hslContainer.style.setProperty(`--${"saturation" /* Saturation */}`, `${s}%`);
-            this.hslContainer.style.setProperty(`--${"lightness" /* Lightness */}`, `${l}%`);
-            if (source !== "rgba" /* RGBA */) {
-                this.channels.get("r" /* R */).value = r.toString();
-                this.channels.get("g" /* G */).value = g.toString();
-                this.channels.get("b" /* B */).value = b.toString();
-                this.channels.get("a" /* A */).value = a.toString();
+            this.hslContainer.style.setProperty(`--${"hue" /* HSL.Hue */}`, `${h}`);
+            this.hslContainer.style.setProperty(`--${"saturation" /* HSL.Saturation */}`, `${s}%`);
+            this.hslContainer.style.setProperty(`--${"lightness" /* HSL.Lightness */}`, `${l}%`);
+            if (source !== "rgba" /* ColorSource.RGBA */) {
+                this.channels.get("r" /* Channel.R */).value = r.toString();
+                this.channels.get("g" /* Channel.G */).value = g.toString();
+                this.channels.get("b" /* Channel.B */).value = b.toString();
+                this.channels.get("a" /* Channel.A */).value = a.toString();
             }
             this.newColor.style.backgroundColor = ColorUtil.rgbaToString(color);
-            if (source !== "hex" /* HEX */) {
+            if (source !== "hex" /* ColorSource.HEX */) {
                 this.colorTextInput.value = ColorUtil.rgbaToHex(color);
             }
         }
@@ -248,7 +248,7 @@ define(["require", "exports", "tslib", "../../Core", "../Dialog", "../../Dom/Uti
             if (typeof color === "string") {
                 color = ColorUtil.stringToRgba(color);
             }
-            this.setColor(color, "setup" /* Setup */);
+            this.setColor(color, "setup" /* ColorSource.Setup */);
             this.oldColor.style.backgroundColor = ColorUtil.rgbaToString(color);
         }
         /**
@@ -257,7 +257,7 @@ define(["require", "exports", "tslib", "../../Core", "../Dialog", "../../Dom/Uti
          * @since 5.5
          */
         submitDialog() {
-            const color = this.getColor("rgba" /* RGBA */);
+            const color = this.getColor("rgba" /* ColorSource.RGBA */);
             const colorString = ColorUtil.rgbaToString(color);
             this.oldColor.style.backgroundColor = colorString;
             this.input.value = colorString;

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Confirmation.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Confirmation.js
@@ -30,10 +30,11 @@ define(["require", "exports", "tslib", "../Core", "../Language", "./Dialog"], fu
             this.dialog.appendChild(formSubmit);
             this.confirmButton = document.createElement("button");
             this.confirmButton.dataset.type = "submit";
-            this.confirmButton.classList.add("buttonPrimary");
+            this.confirmButton.classList.add("button", "buttonPrimary");
             this.confirmButton.textContent = Language.get("wcf.global.confirmation.confirm");
             formSubmit.appendChild(this.confirmButton);
             const cancelButton = document.createElement("button");
+            cancelButton.classList.add("button");
             cancelButton.textContent = Language.get("wcf.global.confirmation.cancel");
             cancelButton.addEventListener("click", () => {
                 Dialog_1.default.close(this);

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Dialog.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Dialog.js
@@ -318,14 +318,11 @@ define(["require", "exports", "tslib", "../Core", "../Dom/Change/Listener", "./S
             title.id = titleId;
             header.appendChild(title);
             if (options.closable) {
-                const closeButton = document.createElement("a");
+                const closeButton = document.createElement("button");
                 closeButton.className = "dialogCloseButton jsTooltip";
-                closeButton.href = "#";
-                closeButton.setAttribute("role", "button");
-                closeButton.tabIndex = 0;
                 closeButton.title = options.closeButtonLabel;
                 closeButton.setAttribute("aria-label", options.closeButtonLabel);
-                closeButton.addEventListener("click", (ev) => this._close(ev));
+                closeButton.addEventListener("click", () => this._close());
                 header.appendChild(closeButton);
                 const span = document.createElement("span");
                 span.className = "icon icon24 fa-times";
@@ -596,8 +593,7 @@ define(["require", "exports", "tslib", "../Core", "../Dom/Change/Listener", "./S
         /**
          * Handles clicks on the close button or the backdrop if enabled.
          */
-        _close(event) {
-            event.preventDefault();
+        _close() {
             const data = _dialogs.get(_activeDialog);
             if (data === undefined) {
                 // Closing the dialog while it is already being closed
@@ -624,7 +620,8 @@ define(["require", "exports", "tslib", "../Core", "../Dom/Change/Listener", "./S
                 return;
             }
             if (Core.stringToBool(_container.getAttribute("close-on-click"))) {
-                this._close(event);
+                event.preventDefault();
+                this._close();
             }
             else {
                 event.preventDefault();

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Message/Share/Dialog.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Message/Share/Dialog.js
@@ -122,7 +122,7 @@ define(["require", "exports", "tslib", "../../Dialog", "../../../Dom/Util", "../
         <dl>
           <dt></dt>
           <dd>
-              <button class="shareDialogNativeButton" data-url="${StringUtil.escapeHTML(target.href)}" data-title="${StringUtil.escapeHTML(target.dataset.linkTitle || "")}">${Language.get("wcf.message.share.nativeShare")}</button>
+              <button class="button shareDialogNativeButton" data-url="${StringUtil.escapeHTML(target.href)}" data-title="${StringUtil.escapeHTML(target.dataset.linkTitle || "")}">${Language.get("wcf.message.share.nativeShare")}</button>
           </dd>
         </dl>
       `;

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Moderation/Clipboard/AssignUser.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Moderation/Clipboard/AssignUser.js
@@ -118,7 +118,7 @@ define(["require", "exports", "tslib", "../../../Event/Handler", "../../Notifica
   </dl>
 </div>
 <div class="formSubmit">
-  <button class="buttonPrimary" data-type="submit">${Language.get("wcf.global.button.save")}</button>
+  <button class="button buttonPrimary" data-type="submit">${Language.get("wcf.global.button.save")}</button>
 </div>`,
             };
         }

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Page/Header/Menu.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Page/Header/Menu.js
@@ -159,8 +159,6 @@ define(["require", "exports", "tslib", "../../../Environment", "../../../Languag
             link.setAttribute("aria-expanded", "false");
             const showMenuButton = document.createElement("button");
             showMenuButton.className = "visuallyHidden";
-            showMenuButton.tabIndex = 0;
-            showMenuButton.setAttribute("role", "button");
             showMenuButton.setAttribute("aria-label", Language.get("wcf.global.button.showMenu"));
             element.insertBefore(showMenuButton, link.nextSibling);
             let showMenu = false;

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Page/JumpTo.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Page/JumpTo.js
@@ -86,7 +86,7 @@ define(["require", "exports", "tslib", "../../Language", "../Dialog"], function 
         </dd>
       </dl>
       <div class="formSubmit">
-        <button class="buttonPrimary">${Language.get("wcf.global.button.submit")}</button>
+        <button class="button buttonPrimary">${Language.get("wcf.global.button.submit")}</button>
       </div>`;
             return {
                 id: "paginationOverlay",

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Page/Menu/Main.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Page/Menu/Main.js
@@ -169,10 +169,8 @@ define(["require", "exports", "tslib", "./Container", "../../../Language", "../.
             if (menuItem.children.length) {
                 listItem.classList.add("pageMenuMainItemExpandable");
                 const menuId = Util_1.default.getUniqueId();
-                const button = document.createElement("a");
+                const button = document.createElement("button");
                 button.classList.add("pageMenuMainItemToggle");
-                button.tabIndex = 0;
-                button.setAttribute("role", "button");
                 button.setAttribute("aria-expanded", "false");
                 button.setAttribute("aria-controls", menuId);
                 button.innerHTML = '<span class="icon icon24 fa-angle-down" aria-hidden="true"></span>';
@@ -184,15 +182,8 @@ define(["require", "exports", "tslib", "./Container", "../../../Language", "../.
                 const list = this.buildMenuItemList(menuItem.children);
                 list.id = menuId;
                 list.hidden = true;
-                button.addEventListener("click", (event) => {
-                    event.preventDefault();
+                button.addEventListener("click", () => {
                     this.toggleList(button, list);
-                });
-                button.addEventListener("keydown", (event) => {
-                    if (event.key === "Enter" || event.key === " ") {
-                        event.preventDefault();
-                        button.click();
-                    }
                 });
                 list.addEventListener("keydown", (event) => {
                     if (event.key === "Escape") {

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Password.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Password.js
@@ -33,11 +33,9 @@ define(["require", "exports", "tslib", "../Dom/Change/Listener", "../Language"],
         inputAddon.classList.add("inputAddon");
         input.insertAdjacentElement("beforebegin", inputAddon);
         inputAddon.appendChild(input);
-        const button = document.createElement("span");
+        const button = document.createElement("button");
         button.title = Language.get("wcf.global.form.password.button.show");
         button.classList.add("button", "inputSuffix", "jsTooltip");
-        button.setAttribute("role", "button");
-        button.tabIndex = 0;
         button.setAttribute("aria-hidden", "true");
         inputAddon.appendChild(button);
         const icon = document.createElement("span");
@@ -45,12 +43,6 @@ define(["require", "exports", "tslib", "../Dom/Change/Listener", "../Language"],
         button.appendChild(icon);
         button.addEventListener("click", () => {
             toggle(input, button, icon);
-        });
-        button.addEventListener("keydown", (event) => {
-            if (event.key === "Enter" || event.key === " ") {
-                event.preventDefault();
-                toggle(input, button, icon);
-            }
         });
         // Hide the password when the form is being submitted to prevent
         // it from being stored within the web browser's autocomplete list.

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Poll/Editor.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Poll/Editor.js
@@ -88,19 +88,15 @@ define(["require", "exports", "tslib", "../../Core", "../../Language", "../Sorta
             sortHandle.classList.add("icon", "icon16", "fa-arrows", "sortableNodeHandle");
             pollOptionInput.appendChild(sortHandle);
             // buttons
-            const addButton = document.createElement("a");
-            listItem.setAttribute("role", "button");
-            listItem.setAttribute("href", "#");
+            const addButton = document.createElement("button");
             addButton.classList.add("icon", "icon16", "fa-plus", "jsTooltip", "jsAddOption", "pointer");
             addButton.setAttribute("title", Language.get("wcf.poll.button.addOption"));
             addButton.addEventListener("click", () => this.createOption());
             pollOptionInput.appendChild(addButton);
-            const deleteButton = document.createElement("a");
-            deleteButton.setAttribute("role", "button");
-            deleteButton.setAttribute("href", "#");
+            const deleteButton = document.createElement("button");
             deleteButton.classList.add("icon", "icon16", "fa-times", "jsTooltip", "jsDeleteOption", "pointer");
             deleteButton.setAttribute("title", Language.get("wcf.poll.button.removeOption"));
-            deleteButton.addEventListener("click", (ev) => this.removeOption(ev));
+            deleteButton.addEventListener("click", () => this.removeOption(deleteButton));
             pollOptionInput.appendChild(deleteButton);
             // input field
             const optionInput = document.createElement("input");
@@ -170,9 +166,7 @@ define(["require", "exports", "tslib", "../../Core", "../../Language", "../Sorta
         /**
          * Removes a poll option after clicking on its deletion button.
          */
-        removeOption(event) {
-            event.preventDefault();
-            const button = event.currentTarget;
+        removeOption(button) {
             button.closest("li").remove();
             this.optionCount--;
             if (this.optionList.childElementCount === 0) {

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Reaction/Handler.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Reaction/Handler.js
@@ -107,7 +107,7 @@ define(["require", "exports", "tslib", "../../Ajax", "../../Core", "../../Dom/Ch
                 this._toggleReactPopover(elementData.objectId, elementData.reactButton, ev);
             });
             elementData.reactButton.addEventListener("keydown", (event) => {
-                if (event.key === "Enter") {
+                if (event.key === "Enter" || event.key === " ") {
                     event.preventDefault();
                     this._toggleReactPopover(elementData.objectId, elementData.reactButton, null);
                 }

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Reaction/Profile/Loader.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Reaction/Profile/Loader.js
@@ -36,7 +36,7 @@ define(["require", "exports", "tslib", "../../../Ajax", "../../../Core", "../../
             this._noMoreEntries.style.display = "none";
             loadButtonList.appendChild(this._noMoreEntries);
             this._loadButton = document.createElement("button");
-            this._loadButton.className = "small";
+            this._loadButton.classList.add("button", "small");
             this._loadButton.innerHTML = Language.get("wcf.like.reaction.more");
             this._loadButton.addEventListener("click", () => this._loadReactions());
             this._loadButton.style.display = "none";

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Redactor/Code.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Redactor/Code.js
@@ -204,8 +204,8 @@ define(["require", "exports", "tslib", "../../Core", "../../Dom/Util", "../../Ev
           </dl>
         </div>
         <div class="formSubmit">
-          <button id="${idButtonSave}" class="buttonPrimary" data-type="submit">${Language.get("wcf.global.button.save")}</button>
-          <button id="${idButtonDelete}">${Language.get("wcf.global.button.delete")}</button>
+          <button id="${idButtonSave}" class="button buttonPrimary" data-type="submit">${Language.get("wcf.global.button.save")}</button>
+          <button id="${idButtonDelete}" class="button">${Language.get("wcf.global.button.delete")}</button>
         </div>`,
             };
         }

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Redactor/Link.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Redactor/Link.js
@@ -79,7 +79,7 @@ define(["require", "exports", "tslib", "../../Core", "../../Dom/Util", "../../La
           </dd>
         </dl>
         <div class="formSubmit">
-          <button id="redactor-modal-button-action" class="buttonPrimary"></button>
+          <button id="redactor-modal-button-action" class="button buttonPrimary"></button>
         </div>`,
             };
         }

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Redactor/Quote.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Redactor/Quote.js
@@ -232,8 +232,8 @@ define(["require", "exports", "tslib", "../../Core", "../../Dom/Util", "../../Ev
           </dl>
         </div>
         <div class="formSubmit">
-          <button id="${idButtonSave}" class="buttonPrimary" data-type="submit">${Language.get("wcf.global.button.save")}</button>
-          <button id="${idButtonDelete}">${Language.get("wcf.global.button.delete")}</button>
+          <button id="${idButtonSave}" class="button buttonPrimary" data-type="submit">${Language.get("wcf.global.button.save")}</button>
+          <button id="${idButtonDelete}" class="button">${Language.get("wcf.global.button.delete")}</button>
         </div>`,
             };
         }

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Redactor/Spoiler.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Redactor/Spoiler.js
@@ -150,8 +150,8 @@ define(["require", "exports", "tslib", "../../Core", "../../Dom/Util", "../../Ev
           </dl>
         </div>
         <div class="formSubmit">
-          <button id="${idButtonSave}" class="buttonPrimary" data-type="submit">${Language.get("wcf.global.button.save")}</button>
-          <button id="${idButtonDelete}">${Language.get("wcf.global.button.delete")}</button>
+          <button id="${idButtonSave}" class="button buttonPrimary" data-type="submit">${Language.get("wcf.global.button.save")}</button>
+          <button id="${idButtonDelete}" class="button">${Language.get("wcf.global.button.delete")}</button>
         </div>`,
             };
         }

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Redactor/Table.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Redactor/Table.js
@@ -56,7 +56,7 @@ define(["require", "exports", "tslib", "../../Language", "../Dialog"], function 
           </dd>
         </dl>
         <div class="formSubmit">
-          <button id="redactor-modal-button-action" class="buttonPrimary" data-type="submit">${Language.get("wcf.global.button.insert")}</button>
+          <button id="redactor-modal-button-action" class="button buttonPrimary" data-type="submit">${Language.get("wcf.global.button.insert")}</button>
         </div>`,
             };
         }

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Search/Extended.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Search/Extended.js
@@ -37,7 +37,7 @@ define(["require", "exports", "tslib", "../../Ajax", "../../Date/Picker", "../..
             this.form.addEventListener("submit", (event) => {
                 event.preventDefault();
                 this.activePage = 1;
-                void this.search(0 /* Modify */);
+                void this.search(0 /* SearchAction.Modify */);
             });
             this.typeInput.addEventListener("change", () => this.changeType());
             window.addEventListener("popstate", () => {
@@ -95,7 +95,7 @@ define(["require", "exports", "tslib", "../../Ajax", "../../Date/Picker", "../..
         updateQueryString(searchAction) {
             const url = new URL(this.form.action);
             url.search += url.search !== "" ? "&" : "?";
-            if (searchAction !== 1 /* Navigation */) {
+            if (searchAction !== 1 /* SearchAction.Navigation */) {
                 this.searchParameters = [];
                 new FormData(this.form).forEach((value, key) => {
                     if (value.toString().trim()) {
@@ -108,7 +108,7 @@ define(["require", "exports", "tslib", "../../Ajax", "../../Date/Picker", "../..
                 parameters.push(["pageNo", this.activePage.toString()]);
             }
             url.search += new URLSearchParams(parameters);
-            if (searchAction === 2 /* Init */) {
+            if (searchAction === 2 /* SearchAction.Init */) {
                 window.history.replaceState({}, document.title, url.toString());
             }
             else {
@@ -178,7 +178,7 @@ define(["require", "exports", "tslib", "../../Ajax", "../../Date/Picker", "../..
                 }
             });
             this.typeInput.dispatchEvent(new Event("change"));
-            void this.search(2 /* Init */);
+            void this.search(2 /* SearchAction.Init */);
         }
         initPagination(position) {
             const wrapperDiv = document.createElement("div");
@@ -210,7 +210,7 @@ define(["require", "exports", "tslib", "../../Ajax", "../../Date/Picker", "../..
             this.activePage = pageNo;
             this.removeSearchResults();
             this.showSearchResults(template);
-            this.updateQueryString(1 /* Navigation */);
+            this.updateQueryString(1 /* SearchAction.Navigation */);
         }
         removeSearchResults() {
             while (this.form.nextSibling !== null && this.form.nextSibling !== this.delimiter) {

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/User/Activity/Recent.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/User/Activity/Recent.js
@@ -15,7 +15,8 @@ define(["require", "exports", "tslib", "../../../Ajax", "../../../Core", "../../
             const showMoreItem = document.createElement("li");
             showMoreItem.className = "showMore";
             if (this.list.childElementCount) {
-                showMoreItem.innerHTML = '<button class="small">' + Language.get("wcf.user.recentActivity.more") + "</button>";
+                showMoreItem.innerHTML =
+                    '<button class="button small">' + Language.get("wcf.user.recentActivity.more") + "</button>";
                 const button = showMoreItem.children[0];
                 button.addEventListener("click", (ev) => this.showMore(ev));
             }

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/User/Editor.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/User/Editor.js
@@ -210,7 +210,7 @@ define(["require", "exports", "tslib", "../../Ajax", "../../Core", "../../Dom/Ut
         </dl>
       </div>
       <div class="formSubmit">
-        <button class="buttonPrimary">${Language.get("wcf.global.button.submit")}</button>
+        <button class="button buttonPrimary">${Language.get("wcf.global.button.submit")}</button>
       </div>`,
             };
         }

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/User/Menu/View.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/User/Menu/View.js
@@ -132,16 +132,15 @@ define(["require", "exports", "tslib", "../../../Date/Util", "../../../StringUti
       </div>
       <div class="userMenuItemMeta"></div>
       <div class="userMenuItemUnread">
-        <a href="#" class="userMenuItemMarkAsRead" role="button">
+        <button class="userMenuItemMarkAsRead">
           <span class="icon icon24 fa-check jsTooltip" title="${Language.get("wcf.global.button.markAsRead")}"></span>
-        </a>
+        </button>
       </div>
     `;
             const time = (0, Util_1.getTimeElement)(new Date(itemData.time * 1000));
             element.querySelector(".userMenuItemMeta").append(time);
             const markAsRead = element.querySelector(".userMenuItemMarkAsRead");
-            markAsRead.addEventListener("click", async (event) => {
-                event.preventDefault();
+            markAsRead.addEventListener("click", async () => {
                 await this.provider.markAsRead(itemData.objectId);
                 this.markAsRead(element);
             });

--- a/wcfsetup/install/files/style/layout/form.scss
+++ b/wcfsetup/install/files/style/layout/form.scss
@@ -117,7 +117,6 @@ select {
 	   into the next row, also requires some changes to `.dialogFormSubmit`! */
 	margin-bottom: -10px;
 
-	> button,
 	> input[type="button"],
 	> input[type="reset"],
 	> input[type="submit"],

--- a/wcfsetup/install/files/style/ui/button.scss
+++ b/wcfsetup/install/files/style/ui/button.scss
@@ -1,3 +1,11 @@
+button {
+	all: unset;
+
+	&.focus-visible:focus {
+		outline: 5px auto -webkit-focus-ring-color;
+	}
+}
+
 input[type="button"],
 input[type="reset"],
 input[type="submit"],

--- a/wcfsetup/install/files/style/ui/button.scss
+++ b/wcfsetup/install/files/style/ui/button.scss
@@ -1,4 +1,3 @@
-button,
 input[type="button"],
 input[type="reset"],
 input[type="submit"],
@@ -47,7 +46,6 @@ a.button {
 	}
 }
 
-button.buttonPrimary,
 input[type="button"].buttonPrimary,
 input[type="submit"],
 .button.buttonPrimary,
@@ -64,7 +62,6 @@ a.button.buttonPrimary {
 
 /* hover states are only applied to non-touch devices to avoid "leftover" hover states after taps */
 html:not(.touch) {
-	button,
 	input[type="button"],
 	input[type="reset"],
 	input[type="submit"],
@@ -77,7 +74,6 @@ html:not(.touch) {
 		}
 	}
 
-	button.buttonPrimary,
 	input[type="button"].buttonPrimary,
 	input[type="submit"],
 	.button.buttonPrimary,
@@ -91,7 +87,6 @@ html:not(.touch) {
 }
 
 /* disabled state */
-button,
 input[type="button"],
 input[type="reset"],
 input[type="submit"],
@@ -108,7 +103,6 @@ a.button {
 
 /* force active state for buttons toggling a dropdown */
 .dropdownOpen {
-	> button,
 	> input[type="button"],
 	> input[type="reset"],
 	> input[type="submit"],
@@ -118,7 +112,6 @@ a.button {
 		color: $wcfButtonTextActive;
 	}
 
-	> button.buttonPrimary,
 	> input[type="button"].buttonPrimary,
 	> input[type="submit"],
 	> .button.buttonPrimary,

--- a/wcfsetup/install/files/style/ui/comment.scss
+++ b/wcfsetup/install/files/style/ui/comment.scss
@@ -67,7 +67,7 @@
 		padding: 10px 20px 0 20px;
 	}
 
-	textarea + button {
+	textarea + .button {
 		margin-top: 2px;
 	}
 


### PR DESCRIPTION
Strip all styling and allow it to be used in places where `a[role="button"]` and similar workarounds had to be used.