### PR TITLE
Explicitly convert float to int

### DIFF
--- a/wcfsetup/install/files/lib/system/image/adapter/GDImageAdapter.class.php
+++ b/wcfsetup/install/files/lib/system/image/adapter/GDImageAdapter.class.php
@@ -261,7 +261,7 @@ class GDImageAdapter implements IImageAdapter, IWebpImageAdapter
             $this->colorData['red'],
             $this->colorData['green'],
             $this->colorData['blue'],
-            (1 - $opacity) * 127
+            (int) (1 - $opacity) * 127
         );
 
         // draw text


### PR DESCRIPTION
Implicit conversion from float to int is deprecated in PHP 8.1.