### PR TITLE
Show WCF_N in ACP's index.tpl only when not 1

### DIFF
--- a/wcfsetup/install/files/acp/templates/index.tpl
+++ b/wcfsetup/install/files/acp/templates/index.tpl
@@ -89,15 +89,17 @@
 			
 			<dl>
 				<dt>{lang}wcf.acp.index.system.software.version{/lang}</dt>
-				<dd>{@WCF_VERSION}</dd>
+				<dd>{WCF_VERSION}</dd>
 			</dl>
 			
 			{event name='softwareFields'}
 			
-			<dl>
-				<dt>{lang}wcf.acp.index.system.software.databaseNumber{/lang}</dt>
-				<dd>{@WCF_N}</dd>
-			</dl>
+			{if WCF_N != 1}
+				<dl>
+					<dt>{lang}wcf.acp.index.system.software.databaseNumber{/lang}</dt>
+					<dd>{WCF_N}</dd>
+				</dl>
+			{/if}
 		</section>
 		
 		{if !ENABLE_ENTERPRISE_MODE || $__wcf->getUser()->hasOwnerAccess()}


### PR DESCRIPTION
Since e3fd38fd7ef7e3bb1dbb871fdd6786c7009aa36d it is no longer possible to
configure WCF_N to anything other than `1`. Only updated installations might
still have a value that is not `1` and even then it should be rare.

Do not show the number, unless it is non-standard to not confuse the reader
with information that are not relevant.
