### PR TITLE
Remove obsolete option "profile_mail_use_captcha"

### DIFF
--- a/com.woltlab.wcf/option.xml
+++ b/com.woltlab.wcf/option.xml
@@ -735,7 +735,7 @@ block:wcf.acp.option.blacklist_sfs_action.block]]></selectoptions>
 				<categoryname>security.antispam.captcha</categoryname>
 				<optiontype>captchaSelect</optiontype>
 				<defaultvalue>com.woltlab.wcf.recaptcha</defaultvalue>
-				<enableoptions>:!register_use_captcha,!lost_password_use_captcha,!profile_mail_use_captcha,!search_use_captcha</enableoptions>
+				<enableoptions>:!register_use_captcha,!lost_password_use_captcha,!search_use_captcha</enableoptions>
 				<allowemptyvalue>1</allowemptyvalue>
 			</option>
 			<option name="register_use_captcha">
@@ -744,11 +744,6 @@ block:wcf.acp.option.blacklist_sfs_action.block]]></selectoptions>
 				<defaultvalue>1</defaultvalue>
 			</option>
 			<option name="lost_password_use_captcha">
-				<categoryname>security.antispam.captcha</categoryname>
-				<optiontype>boolean</optiontype>
-				<defaultvalue>1</defaultvalue>
-			</option>
-			<option name="profile_mail_use_captcha">
 				<categoryname>security.antispam.captcha</categoryname>
 				<optiontype>boolean</optiontype>
 				<defaultvalue>1</defaultvalue>
@@ -1712,6 +1707,7 @@ DESC:wcf.global.sortOrder.descending</selectoptions>
 		</options>
 	</import>
 	<delete>
+        <option name="profile_mail_use_captcha"/>
 		<option name="http_enable_gzip"/>
 		<option name="meta_keywords"/>
 		<option name="register_admin_notification"/>

--- a/constants.php
+++ b/constants.php
@@ -76,7 +76,6 @@
 \define('CAPTCHA_TYPE', 'com.woltlab.wcf.recaptcha');
 \define('REGISTER_USE_CAPTCHA', 1);
 \define('LOST_PASSWORD_USE_CAPTCHA', 1);
-\define('PROFILE_MAIL_USE_CAPTCHA', 1);
 \define('SEARCH_USE_CAPTCHA', 1);
 \define('RECAPTCHA_PUBLICKEY', '');
 \define('RECAPTCHA_PRIVATEKEY', '');

--- a/wcfsetup/install/lang/de.xml
+++ b/wcfsetup/install/lang/de.xml
@@ -1613,7 +1613,6 @@ Bitte {if LANGUAGE_USE_INFORMAL_VARIANT}befolge{else}befolgen Sie{/if} die Anlei
 		<item name="wcf.acp.option.captcha_type"><![CDATA[Captcha-Art]]></item>
 		<item name="wcf.acp.option.register_use_captcha"><![CDATA[Captcha in Registrierung aktivieren]]></item>
 		<item name="wcf.acp.option.lost_password_use_captcha"><![CDATA[Captcha in „Kennwort vergessen“ aktivieren]]></item>
-		<item name="wcf.acp.option.profile_mail_use_captcha"><![CDATA[Captcha in „E-Mail an Benutzer schicken“ aktivieren]]></item>
 		<item name="wcf.acp.option.search_use_captcha"><![CDATA[Captcha in Suchfunktion aktivieren]]></item>
 		<item name="wcf.acp.option.category.security.antispam.captcha"><![CDATA[Captchas]]></item>
 		<item name="wcf.acp.option.category.security.general.authentication"><![CDATA[Benutzer-Authentifikation]]></item>

--- a/wcfsetup/install/lang/en.xml
+++ b/wcfsetup/install/lang/en.xml
@@ -1598,7 +1598,6 @@ Please follow the instructions described in <a href="https://www.woltlab.com/art
 		<item name="wcf.acp.option.captcha_type"><![CDATA[Captcha Type]]></item>
 		<item name="wcf.acp.option.register_use_captcha"><![CDATA[Enable Captcha protection during registration]]></item>
 		<item name="wcf.acp.option.lost_password_use_captcha"><![CDATA[Enable Captcha protection for lost password]]></item>
-		<item name="wcf.acp.option.profile_mail_use_captcha"><![CDATA[Enable Captcha protection for send email to user]]></item>
 		<item name="wcf.acp.option.search_use_captcha"><![CDATA[Enable Captcha protection for search]]></item>
 		<item name="wcf.acp.option.category.security.antispam.captcha"><![CDATA[Captchas]]></item>
 		<item name="wcf.acp.option.category.security.general.authentication"><![CDATA[User Authentication]]></item>


### PR DESCRIPTION
For some reason, the option that was already removed in #4399 is fully back in the code. This PR aims to remove it again.