### PR TITLE
Fix consideration of the search query when generating message excerpts in search results

### DIFF
--- a/wcfsetup/install/files/lib/data/search/SearchAction.class.php
+++ b/wcfsetup/install/files/lib/data/search/SearchAction.class.php
@@ -10,6 +10,7 @@ use wcf\system\flood\FloodControl;
 use wcf\system\search\SearchEngine;
 use wcf\system\search\SearchHandler;
 use wcf\system\search\SearchResultHandler;
+use wcf\system\search\SearchResultTextParser;
 use wcf\system\WCF;
 
 /**
@@ -120,6 +121,7 @@ class SearchAction extends AbstractDatabaseObjectAction
         $resultHandler = new SearchResultHandler($search, $startIndex);
         $resultHandler->loadSearchResults();
         $templateName = $resultHandler->getTemplateName();
+        SearchResultTextParser::getInstance()->setSearchQuery($resultHandler->getQuery());
 
         WCF::getTPL()->assign([
             'objects' => $resultHandler->getSearchResults(),
@@ -166,6 +168,7 @@ class SearchAction extends AbstractDatabaseObjectAction
         $resultHandler = new SearchResultHandler($search, SEARCH_RESULTS_PER_PAGE * ($this->parameters['pageNo'] - 1));
         $resultHandler->loadSearchResults();
         $templateName = $resultHandler->getTemplateName();
+        SearchResultTextParser::getInstance()->setSearchQuery($resultHandler->getQuery());
 
         WCF::getTPL()->assign([
             'objects' => $resultHandler->getSearchResults(),

--- a/wcfsetup/install/files/lib/system/search/SearchResultTextParser.class.php
+++ b/wcfsetup/install/files/lib/system/search/SearchResultTextParser.class.php
@@ -218,4 +218,12 @@ class SearchResultTextParser extends SingletonFactory
         // do highlighting
         return KeywordHighlighter::getInstance()->doHighlight($text);
     }
+
+    /**
+     * @since 5.5
+     */
+    public function setSearchQuery(string $searchQuery): void
+    {
+        $this->searchQuery = $searchQuery;
+    }
 }


### PR DESCRIPTION
Since the rebuild of the search function the results are loaded via AJAX. This accidentally broke the generation of the message excerpt, since the highlight parameter is no longer present at this point.