### PR TITLE
Clean up the package system further

### DIFF
--- a/wcfsetup/install/files/lib/acp/form/PackageStartInstallForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/PackageStartInstallForm.class.php
@@ -2,16 +2,15 @@
 
 namespace wcf\acp\form;
 
+use wcf\acp\page\PackageInstallationConfirmPage;
 use wcf\data\package\installation\queue\PackageInstallationQueue;
 use wcf\data\package\installation\queue\PackageInstallationQueueEditor;
 use wcf\data\package\Package;
 use wcf\form\AbstractForm;
-use wcf\system\database\util\PreparedStatementConditionBuilder;
 use wcf\system\exception\IllegalLinkException;
 use wcf\system\exception\PermissionDeniedException;
 use wcf\system\exception\UserInputException;
 use wcf\system\package\PackageArchive;
-use wcf\system\package\PackageInstallationDispatcher;
 use wcf\system\package\validation\PackageValidationException;
 use wcf\system\package\validation\PackageValidationManager;
 use wcf\system\request\LinkHandler;
@@ -228,37 +227,14 @@ class PackageStartInstallForm extends AbstractForm
 
         $this->saved();
 
-        $conditions = new PreparedStatementConditionBuilder();
-        $conditions->add("userID = ?", [WCF::getUser()->userID]);
-        $conditions->add("parentQueueID = ?", [0]);
-        if ($processNo != 0) {
-            $conditions->add("processNo = ?", [$processNo]);
-        }
-        $conditions->add("done = ?", [0]);
+        HeaderUtil::redirect(LinkHandler::getInstance()->getControllerLink(
+            PackageInstallationConfirmPage::class,
+            [
+                'queueID' => $this->queue->queueID,
+            ]
+        ));
 
-        $sql = "SELECT      *
-                FROM        wcf1_package_installation_queue
-                {$conditions}
-                ORDER BY    queueID ASC";
-        $statement = WCF::getDB()->prepare($sql);
-        $statement->execute($conditions->getParameters());
-        $packageInstallation = $statement->fetchArray();
-
-        if (!isset($packageInstallation['queueID'])) {
-            $url = LinkHandler::getInstance()->getLink('PackageList');
-            HeaderUtil::redirect($url);
-
-            exit;
-        } else {
-            $url = LinkHandler::getInstance()->getLink(
-                'PackageInstallationConfirm',
-                [],
-                'queueID=' . $packageInstallation['queueID']
-            );
-            HeaderUtil::redirect($url);
-
-            exit;
-        }
+        exit;
     }
 
     /**

--- a/wcfsetup/install/files/lib/acp/page/IndexPage.class.php
+++ b/wcfsetup/install/files/lib/acp/page/IndexPage.class.php
@@ -3,13 +3,13 @@
 namespace wcf\acp\page;
 
 use wcf\data\devtools\missing\language\item\DevtoolsMissingLanguageItemList;
+use wcf\data\package\installation\queue\PackageInstallationQueue;
 use wcf\data\user\User;
 use wcf\page\AbstractPage;
 use wcf\system\application\ApplicationHandler;
 use wcf\system\cache\builder\OptionCacheBuilder;
 use wcf\system\database\util\PreparedStatementConditionBuilder;
 use wcf\system\Environment;
-use wcf\system\package\PackageInstallationDispatcher;
 use wcf\system\registry\RegistryHandler;
 use wcf\system\request\LinkHandler;
 use wcf\system\WCF;
@@ -195,24 +195,16 @@ class IndexPage extends AbstractPage
     {
         // check package installation queue
         if (!\PACKAGE_ID && $this->action == 'WCFSetup') {
-            $sql = "SELECT      queueID
-                    FROM        wcf1_package_installation_queue
-                    WHERE       userID = ?
-                            AND parentQueueID = 0
-                            AND done = 0
-                    ORDER BY    queueID ASC";
-            $statement = WCF::getDB()->prepare($sql);
-            $statement->execute([WCF::getUser()->userID]);
-            $queueID = $statement->fetchSingleColumn();
+            $queue = new PackageInstallationQueue(1);
 
-            if ($queueID) {
-                WCF::getTPL()->assign(['queueID' => $queueID]);
-                WCF::getTPL()->display('packageInstallationSetup');
+            \assert($queue->queueID === 1);
+            \assert($queue->parentQueueID === 0);
+            \assert($queue->package === 'com.woltlab.wcf');
 
-                exit;
-            } else {
-                throw new \LogicException('Unreachable');
-            }
+            WCF::getTPL()->assign(['queueID' => $queue->queueID]);
+            WCF::getTPL()->display('packageInstallationSetup');
+
+            exit;
         }
 
         // show page

--- a/wcfsetup/install/files/lib/data/package/installation/queue/PackageInstallationQueueAction.class.php
+++ b/wcfsetup/install/files/lib/data/package/installation/queue/PackageInstallationQueueAction.class.php
@@ -43,51 +43,7 @@ class PackageInstallationQueueAction extends AbstractDatabaseObjectAction
     /**
      * @inheritDoc
      */
-    protected $requireACP = ['cancelInstallation', 'prepareQueue'];
-
-    /**
-     * Validates the 'prepareQueue' action:
-     */
-    public function validatePrepareQueue()
-    {
-        $this->readInteger('packageID');
-
-        $this->package = new Package($this->parameters['packageID']);
-        if (!$this->package->packageID) {
-            throw new UserInputException('packageID');
-        }
-
-        if (
-            !isset($this->parameters['action'])
-            || !\in_array($this->parameters['action'], ['install', 'update', 'uninstall', 'rollback'])
-        ) {
-            throw new UserInputException('action');
-        }
-    }
-
-    /**
-     * Prepares a new package installation queue.
-     *
-     * @return  int[]
-     */
-    public function prepareQueue()
-    {
-        $processNo = PackageInstallationQueue::getNewProcessNo();
-
-        $queue = PackageInstallationQueueEditor::create([
-            'processNo' => $processNo,
-            'userID' => WCF::getUser()->userID,
-            'package' => $this->package->package,
-            'packageName' => $this->package->packageName,
-            'packageID' => $this->package->packageID,
-            'action' => $this->parameters['action'],
-            'installationType' => 'other',
-        ]);
-
-        return [
-            'queueID' => $queue->queueID,
-        ];
-    }
+    protected $requireACP = ['cancelInstallation'];
 
     /**
      * Validates the 'cancelInstallation' action.

--- a/wcfsetup/install/files/lib/system/WCFSetup.class.php
+++ b/wcfsetup/install/files/lib/system/WCFSetup.class.php
@@ -1215,6 +1215,7 @@ final class WCFSetup extends WCF
 
         // register essential wcf package
         $queue = PackageInstallationQueueEditor::create([
+            'queueID' => 1,
             'processNo' => $processNo,
             'userID' => $admin->userID,
             'package' => 'com.woltlab.wcf',
@@ -1222,6 +1223,9 @@ final class WCFSetup extends WCF
             'archive' => $to,
             'isApplication' => 1,
         ]);
+        if ($queue->queueID !== 1) {
+            throw new \LogicException("Failed to register queue for 'com.woltlab.wcf'.");
+        }
 
         // register all other delivered packages
         \asort($otherPackages);

--- a/wcfsetup/install/files/lib/system/package/PackageInstallationNodeBuilder.class.php
+++ b/wcfsetup/install/files/lib/system/package/PackageInstallationNodeBuilder.class.php
@@ -352,34 +352,6 @@ class PackageInstallationNodeBuilder
     }
 
     /**
-     * Inserts a node before given target node. Will shift all target
-     * nodes to provide to be descendants of the new node. If you intend
-     * to insert more than a single node, you should prefer shiftNodes().
-     *
-     * @param string $beforeNode
-     * @param callable $callback
-     */
-    public function insertNode($beforeNode, callable $callback)
-    {
-        $newNode = $this->getToken();
-
-        // update descendants
-        $sql = "UPDATE  wcf1_package_installation_node
-                SET     parentNode = ?
-                WHERE   parentNode = ?
-                    AND processNo = ?";
-        $statement = WCF::getDB()->prepare($sql);
-        $statement->execute([
-            $newNode,
-            $beforeNode,
-            $this->installation->queue->processNo,
-        ]);
-
-        // execute callback
-        $callback($beforeNode, $newNode);
-    }
-
-    /**
      * Shifts nodes to allow dynamic inserts at runtime.
      *
      * @param string $oldParentNode

--- a/wcfsetup/install/files/lib/system/package/PackageInstallationNodeBuilder.class.php
+++ b/wcfsetup/install/files/lib/system/package/PackageInstallationNodeBuilder.class.php
@@ -292,16 +292,7 @@ class PackageInstallationNodeBuilder
         $newNode = $this->getToken();
 
         // update descendants
-        $sql = "UPDATE  wcf1_package_installation_node
-                SET     parentNode = ?
-                WHERE   parentNode = ?
-                    AND processNo = ?";
-        $statement = WCF::getDB()->prepare($sql);
-        $statement->execute([
-            $newNode,
-            $node,
-            $this->installation->queue->processNo,
-        ]);
+        $this->shiftNodes($node, $newNode);
 
         // create a copy of current node (prevents empty nodes)
         $sql = "SELECT  nodeType, nodeData, done

--- a/wcfsetup/install/files/lib/system/package/PackageInstallationNodeBuilder.class.php
+++ b/wcfsetup/install/files/lib/system/package/PackageInstallationNodeBuilder.class.php
@@ -315,7 +315,7 @@ class PackageInstallationNodeBuilder
         $statement->execute([
             $this->installation->queue->queueID,
             $this->installation->queue->processNo,
-            0,
+            $sequenceNo,
             $newNode,
             $node,
             $row['nodeType'],
@@ -326,8 +326,7 @@ class PackageInstallationNodeBuilder
         // move other child-nodes greater than $sequenceNo into new node
         $sql = "UPDATE  wcf1_package_installation_node
                 SET     parentNode = ?,
-                        node = ?,
-                        sequenceNo = (sequenceNo - ?)
+                        node = ?
                 WHERE   node = ?
                     AND processNo = ?
                     AND sequenceNo > ?";
@@ -335,7 +334,6 @@ class PackageInstallationNodeBuilder
         $statement->execute([
             $node,
             $newNode,
-            $sequenceNo,
             $node,
             $this->installation->queue->processNo,
             $sequenceNo,

--- a/wcfsetup/install/files/lib/system/package/PackageUpdateDispatcher.class.php
+++ b/wcfsetup/install/files/lib/system/package/PackageUpdateDispatcher.class.php
@@ -852,17 +852,6 @@ class PackageUpdateDispatcher extends SingletonFactory
     }
 
     /**
-     * Creates a new package installation scheduler.
-     *
-     * @param array $selectedPackages
-     * @return  PackageInstallationScheduler
-     */
-    public function prepareInstallation(array $selectedPackages)
-    {
-        return new PackageInstallationScheduler($selectedPackages);
-    }
-
-    /**
      * Returns package update versions of the specified package.
      *
      * @param string $package package identifier


### PR DESCRIPTION
- Simplify redirect in PackageStartInstallForm
- Remove PackageInstallationNodeBuilder::insertNode()
- Make use of `shiftNodes()` in PackageInstallationNodeBuilder::cloneNode()
- Preserve the sequence numbers when cloning a package node
- Simplify the package queue retrieval for completing WCFSetup in IndexPage
- Remove PackageInstallationQueueAction::prepareQueue()
- Remove PackageUpdateDispatcher::prepareInstallation()
