### PR TITLE
Remove SID_ARG_2ND from JavaScript

### DIFF
--- a/com.woltlab.wcf/templates/headIncludeJavaScript.tpl
+++ b/com.woltlab.wcf/templates/headIncludeJavaScript.tpl
@@ -3,7 +3,6 @@
 *}
 
 <script>
-	var SID_ARG_2ND	= '';
 	var WCF_PATH = '{@$__wcf->getPath()}';
 	var WSC_API_URL = '{@$__wcf->getPath()}';
 	{* The SECURITY_TOKEN is defined in wcf.globalHelper.js *}

--- a/wcfsetup/install/files/acp/templates/header.tpl
+++ b/wcfsetup/install/files/acp/templates/header.tpl
@@ -29,7 +29,6 @@
 	{/if}
 	
 	<script>
-		var SID_ARG_2ND = '';
 		var WCF_PATH = '{@$__wcf->getPath()}';
 		var WSC_API_URL = '{@$__wcf->getPath()}acp/';
 		{* The SECURITY_TOKEN is defined in wcf.globalHelper.js *}


### PR DESCRIPTION
These were removed from PHP in 8a35fd6de81f1138456fb777eb57d4b3907c0c66.
