### PR TITLE
Mark PHP 8.2 as supported

### DIFF
--- a/wcfsetup/install/files/acp/templates/index.tpl
+++ b/wcfsetup/install/files/acp/templates/index.tpl
@@ -4,7 +4,7 @@
 	<h1 class="contentTitle">{lang}wcf.global.acp{/lang}</h1>
 </header>
 
-{if !(80100 <= PHP_VERSION_ID && PHP_VERSION_ID <= 80199)}
+{if !(80100 <= PHP_VERSION_ID && PHP_VERSION_ID <= 80299)}
 	<div class="error">{lang}wcf.global.incompatiblePhpVersion{/lang}</div>
 {/if}
 {foreach from=$evaluationExpired item=$expiredApp}

--- a/wcfsetup/install/files/acp/templates/packageList.tpl
+++ b/wcfsetup/install/files/acp/templates/packageList.tpl
@@ -50,7 +50,7 @@
 	{/hascontent}
 </header>
 
-{if !(80100 <= PHP_VERSION_ID && PHP_VERSION_ID <= 80199)}
+{if !(80100 <= PHP_VERSION_ID && PHP_VERSION_ID <= 80299)}
 	<div class="error">{lang}wcf.global.incompatiblePhpVersion{/lang}</div>
 {/if}
 {foreach from=$taintedApplications item=$taintedApplication}

--- a/wcfsetup/install/files/lib/acp/page/SystemCheckPage.class.php
+++ b/wcfsetup/install/files/lib/acp/page/SystemCheckPage.class.php
@@ -83,7 +83,7 @@ class SystemCheckPage extends AbstractPage
         'minimum' => '8.1.2',
         'deprecated' => [],
         'sufficient' => [],
-        'recommended' => ['8.1'],
+        'recommended' => ['8.1', '8.2'],
     ];
 
     public $foreignKeys = [

--- a/wcfsetup/install/lang/de.xml
+++ b/wcfsetup/install/lang/de.xml
@@ -3979,7 +3979,7 @@ Dateianhänge:
 		<item name="wcf.global.rss.accessToken.info"><![CDATA[Der Link zum anonymen RSS-Feed enthält nur Inhalte, auf die Gäste Zugriff haben. Der Link zum personalisierten RSS-Feed enthält alle Inhalte, auf die {if LANGUAGE_USE_INFORMAL_VARIANT}du{else}Sie{/if} Zugriff {if LANGUAGE_USE_INFORMAL_VARIANT}hast{else}haben{/if}.]]></item>
 		<item name="wcf.global.rss.withAccessToken"><![CDATA[Personalisierter RSS-Feed]]></item>
 		<item name="wcf.global.rss.withoutAccessToken"><![CDATA[Anonymer RSS-Feed]]></item>
-		<item name="wcf.global.incompatiblePhpVersion"><![CDATA[Fehlerhafte Server-Konfiguration: Die eingesetzte Version von „PHP” ist nicht kompatibel, ein Betrieb ist nicht möglich. Es wird mindestens PHP in Version 8.1 benötigt, unterstützt werden die Versionen bis PHP 8.1. Für den Einsatz höherer PHP-Versionen muss die Software auf eine aktuelle Version umgestellt werden.]]></item>
+		<item name="wcf.global.incompatiblePhpVersion"><![CDATA[Fehlerhafte Server-Konfiguration: Die eingesetzte Version von „PHP” ist nicht kompatibel, ein Betrieb ist nicht möglich. Es wird mindestens PHP in Version 8.1 benötigt, unterstützt werden die Versionen bis PHP 8.2. Für den Einsatz höherer PHP-Versionen muss die Software auf eine aktuelle Version umgestellt werden.]]></item>
 	</category>
 	<category name="wcf.global.form">
 		<item name="wcf.global.form.boolean.no"><![CDATA[Nein]]></item>


### PR DESCRIPTION
With the update of HTMLPurifier to 4.16.0 the last known incompatibility with
PHP 8.2 is fixed.

see 91bf9126edc2343511f7b54043f1cc203ea3ce4e
