### PR TITLE
Mark various action controllers as final

### DIFF
--- a/wcfsetup/install/files/lib/acp/action/AJAXFileDeleteAction.class.php
+++ b/wcfsetup/install/files/lib/acp/action/AJAXFileDeleteAction.class.php
@@ -11,6 +11,6 @@ namespace wcf\acp\action;
  * @package WoltLabSuite\Core\Acp\Action
  * @since   5.2
  */
-class AJAXFileDeleteAction extends \wcf\action\AJAXFileDeleteAction
+final class AJAXFileDeleteAction extends \wcf\action\AJAXFileDeleteAction
 {
 }

--- a/wcfsetup/install/files/lib/acp/action/AJAXFileUploadAction.class.php
+++ b/wcfsetup/install/files/lib/acp/action/AJAXFileUploadAction.class.php
@@ -11,6 +11,6 @@ namespace wcf\acp\action;
  * @package WoltLabSuite\Core\Acp\Action
  * @since   5.2
  */
-class AJAXFileUploadAction extends \wcf\action\AJAXFileUploadAction
+final class AJAXFileUploadAction extends \wcf\action\AJAXFileUploadAction
 {
 }

--- a/wcfsetup/install/files/lib/acp/action/AJAXInvokeAction.class.php
+++ b/wcfsetup/install/files/lib/acp/action/AJAXInvokeAction.class.php
@@ -10,6 +10,6 @@ namespace wcf\acp\action;
  * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
  * @package WoltLabSuite\Core\Acp\Action
  */
-class AJAXInvokeAction extends \wcf\action\AJAXInvokeAction
+final class AJAXInvokeAction extends \wcf\action\AJAXInvokeAction
 {
 }

--- a/wcfsetup/install/files/lib/acp/action/AJAXProxyAction.class.php
+++ b/wcfsetup/install/files/lib/acp/action/AJAXProxyAction.class.php
@@ -10,6 +10,6 @@ namespace wcf\acp\action;
  * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
  * @package WoltLabSuite\Core\Acp\Action
  */
-class AJAXProxyAction extends \wcf\action\AJAXProxyAction
+final class AJAXProxyAction extends \wcf\action\AJAXProxyAction
 {
 }

--- a/wcfsetup/install/files/lib/acp/action/AJAXUploadAction.class.php
+++ b/wcfsetup/install/files/lib/acp/action/AJAXUploadAction.class.php
@@ -10,6 +10,6 @@ namespace wcf\acp\action;
  * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
  * @package WoltLabSuite\Core\Acp\Action
  */
-class AJAXUploadAction extends \wcf\action\AJAXUploadAction
+final class AJAXUploadAction extends \wcf\action\AJAXUploadAction
 {
 }

--- a/wcfsetup/install/files/lib/acp/action/CacheClearAction.class.php
+++ b/wcfsetup/install/files/lib/acp/action/CacheClearAction.class.php
@@ -17,7 +17,7 @@ use wcf\system\request\LinkHandler;
  * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
  * @package WoltLabSuite\Core\Acp\Action
  */
-class CacheClearAction extends AbstractAction
+final class CacheClearAction extends AbstractAction
 {
     /**
      * @inheritDoc

--- a/wcfsetup/install/files/lib/acp/action/DevtoolsInstallPackageAction.class.php
+++ b/wcfsetup/install/files/lib/acp/action/DevtoolsInstallPackageAction.class.php
@@ -19,7 +19,7 @@ use wcf\util\StringUtil;
  * @package WoltLabSuite\Core\Acp\Action
  * @since   5.2
  */
-class DevtoolsInstallPackageAction extends InstallPackageAction
+final class DevtoolsInstallPackageAction extends InstallPackageAction
 {
     /**
      * project whose source is installed as a package

--- a/wcfsetup/install/files/lib/acp/action/FullLogoutAction.class.php
+++ b/wcfsetup/install/files/lib/acp/action/FullLogoutAction.class.php
@@ -15,7 +15,7 @@ use wcf\system\WCF;
  * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
  * @package WoltLabSuite\Core\Acp\Action
  */
-class FullLogoutAction extends LogoutAction
+final class FullLogoutAction extends LogoutAction
 {
     /**
      * @inheritDoc

--- a/wcfsetup/install/files/lib/acp/action/UserExportGdprAction.class.php
+++ b/wcfsetup/install/files/lib/acp/action/UserExportGdprAction.class.php
@@ -31,7 +31,7 @@ use wcf\util\UserUtil;
  * @license     GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
  * @package     WoltLabSuite\Core\Acp\Action
  */
-class UserExportGdprAction extends AbstractAction
+final class UserExportGdprAction extends AbstractAction
 {
     /**
      * export data

--- a/wcfsetup/install/files/lib/acp/action/UserQuickSearchAction.class.php
+++ b/wcfsetup/install/files/lib/acp/action/UserQuickSearchAction.class.php
@@ -20,7 +20,7 @@ use wcf\system\WCF;
  * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
  * @package WoltLabSuite\Core\Acp\Action
  */
-class UserQuickSearchAction extends AbstractAction
+final class UserQuickSearchAction extends AbstractAction
 {
     /**
      * @inheritDoc

--- a/wcfsetup/install/files/lib/acp/action/WorkerProxyAction.class.php
+++ b/wcfsetup/install/files/lib/acp/action/WorkerProxyAction.class.php
@@ -18,7 +18,7 @@ use wcf\util\JSON;
  * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
  * @package WoltLabSuite\Core\Acp\Action
  */
-class WorkerProxyAction extends AJAXInvokeAction
+final class WorkerProxyAction extends AJAXInvokeAction
 {
     /**
      * @inheritDoc

--- a/wcfsetup/install/files/lib/action/BackgroundQueuePerformAction.class.php
+++ b/wcfsetup/install/files/lib/action/BackgroundQueuePerformAction.class.php
@@ -15,7 +15,7 @@ use wcf\system\WCF;
  * @package WoltLabSuite\Core\Action
  * @since   3.0
  */
-class BackgroundQueuePerformAction extends AbstractAction
+final class BackgroundQueuePerformAction extends AbstractAction
 {
     /**
      * number of jobs that will be processed per invocation

--- a/wcfsetup/install/files/lib/action/CoreRewriteTestAction.class.php
+++ b/wcfsetup/install/files/lib/action/CoreRewriteTestAction.class.php
@@ -14,7 +14,7 @@ use wcf\system\exception\IllegalLinkException;
  * @package WoltLabSuite\Core\Action
  * @since       3.1
  */
-class CoreRewriteTestAction extends AbstractAction
+final class CoreRewriteTestAction extends AbstractAction
 {
     const AVAILABLE_DURING_OFFLINE_MODE = true;
 

--- a/wcfsetup/install/files/lib/action/DeleteSessionAction.class.php
+++ b/wcfsetup/install/files/lib/action/DeleteSessionAction.class.php
@@ -17,7 +17,7 @@ use wcf\util\StringUtil;
  * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
  * @package WoltLabSuite\Core\Action
  */
-class DeleteSessionAction extends AbstractSecureAction
+final class DeleteSessionAction extends AbstractSecureAction
 {
     use TAJAXException;
 

--- a/wcfsetup/install/files/lib/action/ImageProxyAction.class.php
+++ b/wcfsetup/install/files/lib/action/ImageProxyAction.class.php
@@ -28,7 +28,7 @@ use wcf\util\Url;
  * @package WoltLabSuite\Core\Action
  * @since   3.0
  */
-class ImageProxyAction extends AbstractAction
+final class ImageProxyAction extends AbstractAction
 {
     /**
      * @inheritDoc

--- a/wcfsetup/install/files/lib/action/MessageQuoteAction.class.php
+++ b/wcfsetup/install/files/lib/action/MessageQuoteAction.class.php
@@ -19,7 +19,7 @@ use wcf\util\StringUtil;
  * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
  * @package WoltLabSuite\Core\Action
  */
-class MessageQuoteAction extends AJAXProxyAction
+final class MessageQuoteAction extends AJAXProxyAction
 {
     /**
      * indicates if the WCF.Message.Quote.Manager object requesting data has any

--- a/wcfsetup/install/files/lib/action/NotificationConfirmAction.class.php
+++ b/wcfsetup/install/files/lib/action/NotificationConfirmAction.class.php
@@ -24,7 +24,7 @@ use wcf\system\WCF;
  * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
  * @package WoltLabSuite\Core\Action
  */
-class NotificationConfirmAction extends AbstractAction
+final class NotificationConfirmAction extends AbstractAction
 {
     /**
      * @inheritDoc

--- a/wcfsetup/install/files/lib/action/NotificationDisableAction.class.php
+++ b/wcfsetup/install/files/lib/action/NotificationDisableAction.class.php
@@ -16,7 +16,7 @@ use wcf\util\StringUtil;
  * @package WoltLabSuite\Core\Action
  * @deprecated  5.3 Replaced by NotificationUnsubscribeForm
  */
-class NotificationDisableAction extends AbstractAction
+final class NotificationDisableAction extends AbstractAction
 {
     /**
      * event id

--- a/wcfsetup/install/files/lib/action/PaypalCallbackAction.class.php
+++ b/wcfsetup/install/files/lib/action/PaypalCallbackAction.class.php
@@ -18,7 +18,7 @@ use wcf\system\payment\type\IPaymentType;
  * @package WoltLabSuite\Core\Action
  * @see https://developer.paypal.com/docs/api-basics/notifications/ipn/IPNImplementation/
  */
-class PaypalCallbackAction extends AbstractAction
+final class PaypalCallbackAction extends AbstractAction
 {
     /**
      * @inheritDoc


### PR DESCRIPTION
There is no good reason to inherit from a controller and possible child classes
are not taken into account during refactoring anyway. Mark these as `final` to
prevent inheritance in the first place.
