### PR TITLE
Lazy loader for modules

### DIFF
--- a/ts/WoltLabSuite/Core/Dom/Observer.ts
+++ b/ts/WoltLabSuite/Core/Dom/Observer.ts
@@ -1,0 +1,58 @@
+let observer: MutationObserver;
+
+type CallbackMatch = (element: HTMLElement) => void;
+
+const selectors = new Map<string, CallbackMatch[]>();
+
+function findElements(node: HTMLElement): void {
+  for (const [selector, callbacks] of selectors.entries()) {
+    if (node.matches(selector)) {
+      notifyCallbacks(node, callbacks);
+    }
+
+    const matches = node.querySelectorAll<HTMLElement>(selector);
+    for (const element of matches) {
+      notifyCallbacks(element, callbacks);
+    }
+  }
+}
+
+function notifyCallbacks(element: HTMLElement, callbacks: CallbackMatch[]): void {
+  for (const callback of callbacks) {
+    callback(element);
+  }
+}
+
+export function wheneverSeen(selector: string, callback: CallbackMatch): void {
+  if (!selectors.has(selector)) {
+    selectors.set(selector, []);
+  }
+  selectors.get(selector)!.push(callback);
+
+  findElements(document.body);
+
+  if (observer === undefined) {
+    observer = new MutationObserver((mutations) => {
+      for (const mutation of mutations) {
+        for (const node of mutation.addedNodes) {
+          if (node instanceof HTMLElement) {
+            findElements(node);
+          }
+        }
+      }
+    });
+    observer.observe(document, { subtree: true, childList: true });
+  }
+}
+
+export function findUniqueElements(selector: string, callback: CallbackMatch) {
+  const knownElements = new WeakSet();
+
+  wheneverSeen(selector, (element) => {
+    if (!knownElements.has(element)) {
+      knownElements.add(element);
+
+      callback(element);
+    }
+  });
+}

--- a/ts/WoltLabSuite/Core/Dom/Observer.ts
+++ b/ts/WoltLabSuite/Core/Dom/Observer.ts
@@ -1,3 +1,12 @@
+/**
+ * Provides functions to watch for elements being added to the document.
+ *
+ * @author Alexander Ebert
+ * @copyright 2001-2022 WoltLab GmbH
+ * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @module WoltLabSuite/Core/Dom/Observer
+ */
+
 let observer: MutationObserver;
 
 type CallbackMatch = (element: HTMLElement) => void;
@@ -23,6 +32,11 @@ function notifyCallbacks(element: HTMLElement, callbacks: CallbackMatch[]): void
   }
 }
 
+/**
+ * Invokes a callback whenever a selector matches an element added
+ * to the DOM. Elements being removed and then added again will be
+ * reported again.
+ */
 export function wheneverSeen(selector: string, callback: CallbackMatch): void {
   if (!selectors.has(selector)) {
     selectors.set(selector, []);
@@ -45,6 +59,12 @@ export function wheneverSeen(selector: string, callback: CallbackMatch): void {
   }
 }
 
+/**
+ * Works identical to `wheneverSeen` wite the difference that all
+ * previously matched elements are tracked and will not be reported
+ * again. Useful for applying event listeners or transformations
+ * that should be applied just once.
+ */
 export function findUniqueElements(selector: string, callback: CallbackMatch) {
   const knownElements = new WeakSet();
 

--- a/ts/WoltLabSuite/Core/LazyLoader.ts
+++ b/ts/WoltLabSuite/Core/LazyLoader.ts
@@ -1,0 +1,77 @@
+/**
+ * Efficient lazy loader that executes a callback once a selector matches
+ * for the first time and the document has finished loading.
+ *
+ * Designed for actions that do not require eager execution, such as
+ * binding specific event listeners on runtime. It should not be used for
+ * components that alter the visible UI to prevent layout shifts.
+ *
+ * Based on the work of GitHub‘s Catalyst library (MIT license).
+ * See https://github.com/github/catalyst/blob/c7983581adffd88f059e3c70674350b4fea4ee47/src/lazy-define.ts
+ *
+ * @author Alexander Ebert
+ * @copyright 2001-2022 WoltLab GmbH
+ * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @module WoltLabSuite/Core/LazyLoader
+ */
+
+type CallbackWhenSeen = () => void;
+
+let observer: MutationObserver;
+const selectors = new Map<string, CallbackWhenSeen[]>();
+const timers = new Map<HTMLElement, number>();
+
+const documentReady = new Promise<void>((resolve) => {
+  if (document.readyState === "loading") {
+    document.addEventListener("readystatechange", () => resolve(), { once: true });
+  } else {
+    resolve();
+  }
+});
+
+function testElement(element: HTMLElement): void {
+  if (timers.get(element) !== undefined) {
+    window.cancelAnimationFrame(timers.get(element)!);
+  }
+
+  timers.set(
+    element,
+    window.requestAnimationFrame(() => {
+      for (const selector of selectors.keys()) {
+        if (element.matches(selector) || element.querySelector(selector) !== null) {
+          for (const callback of selectors.get(selector)!) {
+            void documentReady.then(() => callback());
+          }
+
+          selectors.delete(selector);
+          timers.delete(element);
+        }
+      }
+    }),
+  );
+}
+
+export function whenSeen(selector: string, callback: CallbackWhenSeen): void {
+  if (!selectors.has(selector)) {
+    selectors.set(selector, []);
+  }
+  selectors.get(selector)!.push(callback);
+
+  testElement(document.body);
+
+  if (observer === undefined) {
+    observer = new MutationObserver((mutations) => {
+      if (selectors.size === 0) {
+        return;
+      }
+
+      for (const mutation of mutations) {
+        for (const node of mutation.addedNodes) {
+          if (node instanceof HTMLElement) {
+            testElement(node);
+          }
+        }
+      }
+    });
+  }
+}

--- a/ts/WoltLabSuite/Core/LazyLoader.ts
+++ b/ts/WoltLabSuite/Core/LazyLoader.ts
@@ -44,9 +44,10 @@ function testElement(element: HTMLElement): void {
           }
 
           selectors.delete(selector);
-          timers.delete(element);
         }
       }
+
+      timers.delete(element);
     }),
   );
 }

--- a/ts/WoltLabSuite/Core/LazyLoader.ts
+++ b/ts/WoltLabSuite/Core/LazyLoader.ts
@@ -51,7 +51,7 @@ function testElement(element: HTMLElement): void {
   );
 }
 
-export function whenSeen(selector: string, callback: CallbackWhenSeen): void {
+export function whenFirstSeen(selector: string, callback: CallbackWhenSeen): void {
   if (!selectors.has(selector)) {
     selectors.set(selector, []);
   }
@@ -74,4 +74,5 @@ export function whenSeen(selector: string, callback: CallbackWhenSeen): void {
       }
     });
   }
+  observer.observe(document, { subtree: true, childList: true });
 }

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Dom/Observer.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Dom/Observer.js
@@ -1,3 +1,11 @@
+/**
+ * Provides functions to watch for elements being added to the document.
+ *
+ * @author Alexander Ebert
+ * @copyright 2001-2022 WoltLab GmbH
+ * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @module WoltLabSuite/Core/Dom/Observer
+ */
 define(["require", "exports"], function (require, exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
@@ -20,6 +28,11 @@ define(["require", "exports"], function (require, exports) {
             callback(element);
         }
     }
+    /**
+     * Invokes a callback whenever a selector matches an element added
+     * to the DOM. Elements being removed and then added again will be
+     * reported again.
+     */
     function wheneverSeen(selector, callback) {
         if (!selectors.has(selector)) {
             selectors.set(selector, []);
@@ -40,6 +53,12 @@ define(["require", "exports"], function (require, exports) {
         }
     }
     exports.wheneverSeen = wheneverSeen;
+    /**
+     * Works identical to `wheneverSeen` wite the difference that all
+     * previously matched elements are tracked and will not be reported
+     * again. Useful for applying event listeners or transformations
+     * that should be applied just once.
+     */
     function findUniqueElements(selector, callback) {
         const knownElements = new WeakSet();
         wheneverSeen(selector, (element) => {

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Dom/Observer.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Dom/Observer.js
@@ -1,0 +1,53 @@
+define(["require", "exports"], function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.findUniqueElements = exports.wheneverSeen = void 0;
+    let observer;
+    const selectors = new Map();
+    function findElements(node) {
+        for (const [selector, callbacks] of selectors.entries()) {
+            if (node.matches(selector)) {
+                notifyCallbacks(node, callbacks);
+            }
+            const matches = node.querySelectorAll(selector);
+            for (const element of matches) {
+                notifyCallbacks(element, callbacks);
+            }
+        }
+    }
+    function notifyCallbacks(element, callbacks) {
+        for (const callback of callbacks) {
+            callback(element);
+        }
+    }
+    function wheneverSeen(selector, callback) {
+        if (!selectors.has(selector)) {
+            selectors.set(selector, []);
+        }
+        selectors.get(selector).push(callback);
+        findElements(document.body);
+        if (observer === undefined) {
+            observer = new MutationObserver((mutations) => {
+                for (const mutation of mutations) {
+                    for (const node of mutation.addedNodes) {
+                        if (node instanceof HTMLElement) {
+                            findElements(node);
+                        }
+                    }
+                }
+            });
+            observer.observe(document, { subtree: true, childList: true });
+        }
+    }
+    exports.wheneverSeen = wheneverSeen;
+    function findUniqueElements(selector, callback) {
+        const knownElements = new WeakSet();
+        wheneverSeen(selector, (element) => {
+            if (!knownElements.has(element)) {
+                knownElements.add(element);
+                callback(element);
+            }
+        });
+    }
+    exports.findUniqueElements = findUniqueElements;
+});

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/LazyLoader.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/LazyLoader.js
@@ -40,9 +40,9 @@ define(["require", "exports"], function (require, exports) {
                         void documentReady.then(() => callback());
                     }
                     selectors.delete(selector);
-                    timers.delete(element);
                 }
             }
+            timers.delete(element);
         }));
     }
     function whenFirstSeen(selector, callback) {

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/LazyLoader.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/LazyLoader.js
@@ -30,13 +30,18 @@ define(["require", "exports"], function (require, exports) {
         }
     });
     function testElement(element) {
+        // Debounce the checks against the same target.
         if (timers.get(element) !== undefined) {
             window.cancelAnimationFrame(timers.get(element));
         }
         timers.set(element, window.requestAnimationFrame(() => {
             for (const selector of selectors.keys()) {
+                // Check if the element itself or any of its descendants
+                // matches the provided selector.
                 if (element.matches(selector) || element.querySelector(selector) !== null) {
                     for (const callback of selectors.get(selector)) {
+                        // Wait for the document to fully load before notifying
+                        // the callbacks to avoid layout shifts during page load.
                         void documentReady.then(() => callback());
                     }
                     selectors.delete(selector);
@@ -50,14 +55,18 @@ define(["require", "exports"], function (require, exports) {
             selectors.set(selector, []);
         }
         selectors.get(selector).push(callback);
+        // Immediately schedule a check to find matching elements
+        // that already exist in the document at call time.
         testElement(document.body);
         if (observer === undefined) {
+            // Check for elements added to the document on runtime.
             observer = new MutationObserver((mutations) => {
                 if (selectors.size === 0) {
                     return;
                 }
                 for (const mutation of mutations) {
                     for (const node of mutation.addedNodes) {
+                        // Skip changes to SVG elements or text nodes.
                         if (node instanceof HTMLElement) {
                             testElement(node);
                         }

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/LazyLoader.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/LazyLoader.js
@@ -17,7 +17,7 @@
 define(["require", "exports"], function (require, exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
-    exports.whenSeen = void 0;
+    exports.whenFirstSeen = void 0;
     let observer;
     const selectors = new Map();
     const timers = new Map();
@@ -45,7 +45,7 @@ define(["require", "exports"], function (require, exports) {
             }
         }));
     }
-    function whenSeen(selector, callback) {
+    function whenFirstSeen(selector, callback) {
         if (!selectors.has(selector)) {
             selectors.set(selector, []);
         }
@@ -65,6 +65,7 @@ define(["require", "exports"], function (require, exports) {
                 }
             });
         }
+        observer.observe(document, { subtree: true, childList: true });
     }
-    exports.whenSeen = whenSeen;
+    exports.whenFirstSeen = whenFirstSeen;
 });

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/LazyLoader.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/LazyLoader.js
@@ -1,0 +1,70 @@
+/**
+ * Efficient lazy loader that executes a callback once a selector matches
+ * for the first time and the document has finished loading.
+ *
+ * Designed for actions that do not require eager execution, such as
+ * binding specific event listeners on runtime. It should not be used for
+ * components that alter the visible UI to prevent layout shifts.
+ *
+ * Based on the work of GitHub‘s Catalyst library (MIT license).
+ * See https://github.com/github/catalyst/blob/c7983581adffd88f059e3c70674350b4fea4ee47/src/lazy-define.ts
+ *
+ * @author Alexander Ebert
+ * @copyright 2001-2022 WoltLab GmbH
+ * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @module WoltLabSuite/Core/LazyLoader
+ */
+define(["require", "exports"], function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.whenSeen = void 0;
+    let observer;
+    const selectors = new Map();
+    const timers = new Map();
+    const documentReady = new Promise((resolve) => {
+        if (document.readyState === "loading") {
+            document.addEventListener("readystatechange", () => resolve(), { once: true });
+        }
+        else {
+            resolve();
+        }
+    });
+    function testElement(element) {
+        if (timers.get(element) !== undefined) {
+            window.cancelAnimationFrame(timers.get(element));
+        }
+        timers.set(element, window.requestAnimationFrame(() => {
+            for (const selector of selectors.keys()) {
+                if (element.matches(selector) || element.querySelector(selector) !== null) {
+                    for (const callback of selectors.get(selector)) {
+                        void documentReady.then(() => callback());
+                    }
+                    selectors.delete(selector);
+                    timers.delete(element);
+                }
+            }
+        }));
+    }
+    function whenSeen(selector, callback) {
+        if (!selectors.has(selector)) {
+            selectors.set(selector, []);
+        }
+        selectors.get(selector).push(callback);
+        testElement(document.body);
+        if (observer === undefined) {
+            observer = new MutationObserver((mutations) => {
+                if (selectors.size === 0) {
+                    return;
+                }
+                for (const mutation of mutations) {
+                    for (const node of mutation.addedNodes) {
+                        if (node instanceof HTMLElement) {
+                            testElement(node);
+                        }
+                    }
+                }
+            });
+        }
+    }
+    exports.whenSeen = whenSeen;
+});


### PR DESCRIPTION
A lot of times entire modules have to be loaded ahead of time, because certain elements might be present on the page. This can be solved by introducing a lazy loader that will take a selector to look for and notifies a callback whenever this selector matches for the first time.

For performance reasons the lazy loader will wait for the page to fully load before notifying any callbacks. This should not be used for components that alter the visual representation of the page, eventually causing layout shifts.

```ts
whenFirstSeen(".myFancyClass", () => {
  void import("./Foo").then(({ bar }) => bar());
});
```

Another helpful feature is the ability to register a callback that is invoked whenever a matching element is added to the document. Removing and adding the identical element to the document will trigger the callback again.

```ts
wheneverSeen(".myFancyClass", (element: HTMLElement) => {
  /* … */
});
```

The additional function `findUniqueElement()` tracks all previously seen elements and will report them only once. This is especially useful for functions that want to perform certain actions, such as binding event listeners, only once.

```ts
findUniqueElements(".myFancyClass", (element: HTMLElement) => {
  /* … */
});
```