### PR TITLE
Increase limit in LikeRebuildDataWorker

### DIFF
--- a/wcfsetup/install/files/lib/system/worker/LikeRebuildDataWorker.class.php
+++ b/wcfsetup/install/files/lib/system/worker/LikeRebuildDataWorker.class.php
@@ -27,7 +27,7 @@ class LikeRebuildDataWorker extends AbstractRebuildDataWorker
     /**
      * @inheritDoc
      */
-    protected $limit = 1000;
+    protected $limit = 10000;
 
     /**
      * @inheritDoc


### PR DESCRIPTION
The query to retrieve the `Like` DBOs is not particularly efficient and
effectively boils down to a full table scan without real optimization
opportunities due to how the worker needs to merge the like data:

Like Data is merged based ob objectTypeID and objectID, thus it makes sense to
retrieve related likes in-order to avoid needing to reload the existing data
for a large number of objects.

Unfortunately the likes for a single object are placed all over the wcf1_like
table, as the clustered index is based on the `likeID`, making this retrieval
expensive.

By increasing the per-iteration limit, the number of costly like retrievals can
be reduced, ultimately increasing performance of the worker.

A test with a limit of 25000 on the CLI showed a peak memory usage of 40 MB.
The per-iteration time looked acceptable (i.e. unlikely to a hit the
max_execution_time via HTTP) as well. The new limit of 10000 is a conservative
choice to be safe on older systems.
