### PR TITLE
Stop dynamically creating the `packageDir` field on the Template DBO

### DIFF
--- a/wcfsetup/install/files/lib/data/template/Template.class.php
+++ b/wcfsetup/install/files/lib/data/template/Template.class.php
@@ -6,7 +6,6 @@ use wcf\data\DatabaseObject;
 use wcf\data\package\PackageCache;
 use wcf\system\application\ApplicationHandler;
 use wcf\system\WCF;
-use wcf\util\FileUtil;
 
 /**
  * Represents a template.
@@ -51,16 +50,7 @@ class Template extends DatabaseObject
             $statement->execute([$id]);
             $row = $statement->fetchArray();
 
-            if ($row !== false) {
-                // get relative directory of the template the application
-                // belongs to
-                if ($row['application'] != 'wcf') {
-                    $application = ApplicationHandler::getInstance()->getApplication($row['application']);
-                } else {
-                    $application = ApplicationHandler::getInstance()->getWCF();
-                }
-                $row['packageDir'] = PackageCache::getInstance()->getPackage($application->packageID)->packageDir;
-            } else {
+            if ($row === false) {
                 $row = [];
             }
         } elseif ($object !== null) {
@@ -77,8 +67,21 @@ class Template extends DatabaseObject
      */
     public function getPath()
     {
-        /** @noinspection PhpUndefinedFieldInspection */
-        return FileUtil::getRealPath(WCF_DIR . $this->packageDir) . 'templates/' . $this->templateGroupFolderName . $this->templateName . '.tpl';
+        return $this->getPackageDir() . '/templates/' . $this->templateGroupFolderName . $this->templateName . '.tpl';
+    }
+
+    /**
+     * @since 6.0
+     */
+    private function getPackageDir(): string
+    {
+        if ($this->application != 'wcf') {
+            $application = ApplicationHandler::getInstance()->getApplication($this->application);
+        } else {
+            $application = ApplicationHandler::getInstance()->getWCF();
+        }
+
+        return \realpath(WCF_DIR . PackageCache::getInstance()->getPackage($application->packageID)->packageDir);
     }
 
     /**

--- a/wcfsetup/install/files/lib/data/template/TemplateList.class.php
+++ b/wcfsetup/install/files/lib/data/template/TemplateList.class.php
@@ -3,8 +3,6 @@
 namespace wcf\data\template;
 
 use wcf\data\DatabaseObjectList;
-use wcf\data\package\PackageCache;
-use wcf\system\application\ApplicationHandler;
 
 /**
  * Represents a list of templates.
@@ -40,26 +38,5 @@ class TemplateList extends DatabaseObjectList
             ON          package.packageID = template.packageID
             LEFT JOIN   wcf" . WCF_N . "_template_group template_group
             ON          template_group.templateGroupID = template.templateGroupID";
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function readObjects()
-    {
-        parent::readObjects();
-
-        foreach ($this->objects as $template) {
-            if ($template->application != 'wcf') {
-                $application = ApplicationHandler::getInstance()->getApplication($template->application);
-            } else {
-                $application = ApplicationHandler::getInstance()->getWCF();
-            }
-            $package = PackageCache::getInstance()->getPackage($application->packageID);
-
-            // set directory of the application package the template
-            // belongs to
-            $template->packageDir = $package->packageDir;
-        }
     }
 }


### PR DESCRIPTION
TemplateList throws a deprecation in PHP 8.2:

> Message: Creation of dynamic property wcf\data\template\Template::$packageDir is deprecated

Fix this by creating a proper method to retrieve the packageDir, instead of
dynamically creating a property when loading the DBO. It appears the property
is not used outside of the Template class and it arguably isn't useful outside
of it either, thus the new method is `private`.
