### PR TITLE
Capture longer strings in exception stack traces

### DIFF
--- a/wcfsetup/install/files/lib/core.functions.php
+++ b/wcfsetup/install/files/lib/core.functions.php
@@ -15,6 +15,7 @@ namespace {
 
 	if (PHP_VERSION_ID >= 80200) {
 		@ini_set('zend.exception_ignore_args', 0);
+		@ini_set('zend.exception_string_param_max_len', 25);
 	}
 	@ini_set('assert.exception', 1);
 


### PR DESCRIPTION
The default is 15 characters which is very short and easily ambiguous, due to
common prefixes. Conservatively increase this to 25.

see 316dbefaa34eace0ff8db4cadcb0c52b5cae673c
