### PR TITLE
Use explicit casts instead of function invocation

### DIFF
--- a/wcfsetup/install/files/acp/update_com.woltlab.wcf_5.5_starttls.php
+++ b/wcfsetup/install/files/acp/update_com.woltlab.wcf_5.5_starttls.php
@@ -35,7 +35,7 @@ if (\str_starts_with(MAIL_SMTP_HOST, 'ssl://')) {
             $data = $connection->gets();
             if (\preg_match('/^(\d{3})([- ])(.*)$/', $data, $matches)) {
                 if ($code === null) {
-                    $code = \intval($matches[1]);
+                    $code = (int)$matches[1];
                 }
 
                 if ($code == $matches[1]) {

--- a/wcfsetup/install/files/images/favicon/corsProxy.php
+++ b/wcfsetup/install/files/images/favicon/corsProxy.php
@@ -17,7 +17,7 @@ $types = [
 if (!empty($_GET['type']) || !isset($types[$_GET['type']])) {
     // get parameters
     $type = $_GET['type'];
-    $styleID = (!empty($_GET['styleID'])) ? \intval($_GET['styleID']) : 'default';
+    $styleID = (!empty($_GET['styleID'])) ? (int)$_GET['styleID'] : 'default';
     if ($styleID === 'default' || $styleID > 0) {
         if ($styleID === 'default') {
             $filename = 'default.' . $types[$type]['filename'];

--- a/wcfsetup/install/files/lib/acp/action/DevtoolsInstallPackageAction.class.php
+++ b/wcfsetup/install/files/lib/acp/action/DevtoolsInstallPackageAction.class.php
@@ -50,7 +50,7 @@ class DevtoolsInstallPackageAction extends InstallPackageAction
         AbstractDialogAction::readParameters();
 
         if (isset($_POST['projectID'])) {
-            $this->projectID = \intval($_POST['projectID']);
+            $this->projectID = (int)$_POST['projectID'];
         }
         $this->project = new DevtoolsProject($this->projectID);
         if (!$this->project->projectID) {
@@ -62,7 +62,7 @@ class DevtoolsInstallPackageAction extends InstallPackageAction
         }
 
         if (isset($_POST['queueID'])) {
-            $this->queueID = \intval($_POST['queueID']);
+            $this->queueID = (int)$_POST['queueID'];
         }
         $this->queue = new PackageInstallationQueue($this->queueID);
         if (!$this->queue->queueID) {

--- a/wcfsetup/install/files/lib/acp/action/InstallPackageAction.class.php
+++ b/wcfsetup/install/files/lib/acp/action/InstallPackageAction.class.php
@@ -63,7 +63,7 @@ class InstallPackageAction extends AbstractDialogAction
             $this->node = StringUtil::trim($_POST['node']);
         }
         if (isset($_POST['queueID'])) {
-            $this->queueID = \intval($_POST['queueID']);
+            $this->queueID = (int)$_POST['queueID'];
         }
         $this->queue = new PackageInstallationQueue($this->queueID);
 

--- a/wcfsetup/install/files/lib/acp/action/UninstallPackageAction.class.php
+++ b/wcfsetup/install/files/lib/acp/action/UninstallPackageAction.class.php
@@ -46,10 +46,10 @@ class UninstallPackageAction extends InstallPackageAction
         }
 
         if (isset($_POST['packageID'])) {
-            $this->packageID = \intval($_POST['packageID']);
+            $this->packageID = (int)$_POST['packageID'];
         } else {
             if (isset($_POST['queueID'])) {
-                $this->queueID = \intval($_POST['queueID']);
+                $this->queueID = (int)$_POST['queueID'];
             }
             $this->queue = new PackageInstallationQueue($this->queueID);
 

--- a/wcfsetup/install/files/lib/acp/action/UserExportGdprAction.class.php
+++ b/wcfsetup/install/files/lib/acp/action/UserExportGdprAction.class.php
@@ -134,7 +134,7 @@ class UserExportGdprAction extends AbstractAction
         parent::readParameters();
 
         if (isset($_GET['id'])) {
-            $this->userID = \intval($_GET['id']);
+            $this->userID = (int)$_GET['id'];
         }
 
         $this->user = UserProfileRuntimeCache::getInstance()->getObject($this->userID);

--- a/wcfsetup/install/files/lib/acp/action/WorkerProxyAction.class.php
+++ b/wcfsetup/install/files/lib/acp/action/WorkerProxyAction.class.php
@@ -56,7 +56,7 @@ class WorkerProxyAction extends AJAXInvokeAction
             $this->className = $_POST['className'];
         }
         if (isset($_POST['loopCount'])) {
-            $this->loopCount = \intval($_POST['loopCount']);
+            $this->loopCount = (int)$_POST['loopCount'];
         }
         if (isset($_POST['parameters']) && \is_array($_POST['parameters'])) {
             $this->parameters = $_POST['parameters'];

--- a/wcfsetup/install/files/lib/acp/form/AbstractCategoryAddForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/AbstractCategoryAddForm.class.php
@@ -242,10 +242,10 @@ abstract class AbstractCategoryAddForm extends AbstractForm
             $this->descriptionUseHtml = 1;
         }
         if (isset($_POST['parentCategoryID'])) {
-            $this->parentCategoryID = \intval($_POST['parentCategoryID']);
+            $this->parentCategoryID = (int)$_POST['parentCategoryID'];
         }
         if (isset($_POST['showOrder'])) {
-            $this->showOrder = \intval($_POST['showOrder']);
+            $this->showOrder = (int)$_POST['showOrder'];
         }
     }
 

--- a/wcfsetup/install/files/lib/acp/form/AbstractCategoryEditForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/AbstractCategoryEditForm.class.php
@@ -95,7 +95,7 @@ abstract class AbstractCategoryEditForm extends AbstractCategoryAddForm
         parent::readParameters();
 
         if (isset($_REQUEST['id'])) {
-            $this->categoryID = \intval($_REQUEST['id']);
+            $this->categoryID = (int)$_REQUEST['id'];
         }
         $this->category = new Category($this->categoryID);
         if (!$this->category->categoryID) {

--- a/wcfsetup/install/files/lib/acp/form/AbstractCustomOptionForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/AbstractCustomOptionForm.class.php
@@ -146,7 +146,7 @@ abstract class AbstractCustomOptionForm extends AbstractAcpForm
 
         if ($this->action === 'edit') {
             if (isset($_REQUEST['id'])) {
-                $this->optionID = \intval($_REQUEST['id']);
+                $this->optionID = (int)$_REQUEST['id'];
             }
             $this->option = new $this->baseClass($this->optionID);
             if (!$this->option->getObjectID()) {
@@ -181,24 +181,24 @@ abstract class AbstractCustomOptionForm extends AbstractAcpForm
             $this->selectOptions = $_POST['selectOptions'];
         }
         if (isset($_POST['required'])) {
-            $this->required = \intval($_POST['required']);
+            $this->required = (int)$_POST['required'];
         }
         if (isset($_POST['showOrder'])) {
-            $this->showOrder = \intval($_POST['showOrder']);
+            $this->showOrder = (int)$_POST['showOrder'];
         }
         if (isset($_POST['isDisabled'])) {
             $this->isDisabled = 1;
         }
 
         if ($this->optionType == 'boolean' || $this->optionType == 'integer') {
-            $this->defaultValue = \intval($this->defaultValue);
+            $this->defaultValue = (int)$this->defaultValue;
 
             if ($this->optionType == 'boolean') {
                 $this->validationPattern = '';
             }
         }
         if ($this->optionType == 'float') {
-            $this->defaultValue = \floatval($this->defaultValue);
+            $this->defaultValue = (float)$this->defaultValue;
         }
     }
 

--- a/wcfsetup/install/files/lib/acp/form/AdAddForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/AdAddForm.class.php
@@ -169,10 +169,10 @@ class AdAddForm extends AbstractForm
             $this->isDisabled = 1;
         }
         if (isset($_POST['objectTypeID'])) {
-            $this->objectTypeID = \intval($_POST['objectTypeID']);
+            $this->objectTypeID = (int)$_POST['objectTypeID'];
         }
         if (isset($_POST['showOrder'])) {
-            $this->showOrder = \intval($_POST['showOrder']);
+            $this->showOrder = (int)$_POST['showOrder'];
         }
 
         foreach ($this->groupedConditionObjectTypes as $groupedObjectTypes) {

--- a/wcfsetup/install/files/lib/acp/form/AdEditForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/AdEditForm.class.php
@@ -99,7 +99,7 @@ class AdEditForm extends AdAddForm
         parent::readParameters();
 
         if (isset($_REQUEST['id'])) {
-            $this->adID = \intval($_REQUEST['id']);
+            $this->adID = (int)$_REQUEST['id'];
         }
         $this->adObject = new Ad($this->adID);
         if (!$this->adObject->adID) {

--- a/wcfsetup/install/files/lib/acp/form/ApplicationEditForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/ApplicationEditForm.class.php
@@ -98,7 +98,7 @@ class ApplicationEditForm extends AbstractForm
         }
 
         if (isset($_REQUEST['id'])) {
-            $this->packageID = \intval($_REQUEST['id']);
+            $this->packageID = (int)$_REQUEST['id'];
         }
         $this->application = new ViewableApplication(new Application($this->packageID));
         if (!$this->application->packageID) {
@@ -125,7 +125,7 @@ class ApplicationEditForm extends AbstractForm
             $this->domainPath = StringUtil::trim($_POST['domainPath']);
         }
         if (isset($_POST['landingPageID'])) {
-            $this->landingPageID = \intval($_POST['landingPageID']);
+            $this->landingPageID = (int)$_POST['landingPageID'];
         }
     }
 

--- a/wcfsetup/install/files/lib/acp/form/ArticleAddForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/ArticleAddForm.class.php
@@ -211,7 +211,7 @@ class ArticleAddForm extends AbstractForm
         parent::readParameters();
 
         if (isset($_REQUEST['categoryID'])) {
-            $this->categoryID = \intval($_REQUEST['categoryID']);
+            $this->categoryID = (int)$_REQUEST['categoryID'];
         }
 
         // get available languages
@@ -268,7 +268,7 @@ class ArticleAddForm extends AbstractForm
 
         if (WCF::getSession()->getPermission('admin.content.article.canManageArticle') || WCF::getSession()->getPermission('admin.content.article.canManageOwnArticles')) {
             if (isset($_POST['publicationStatus'])) {
-                $this->publicationStatus = \intval($_POST['publicationStatus']);
+                $this->publicationStatus = (int)$_POST['publicationStatus'];
             }
         } else {
             $this->publicationStatus = Article::UNPUBLISHED;

--- a/wcfsetup/install/files/lib/acp/form/ArticleEditForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/ArticleEditForm.class.php
@@ -55,7 +55,7 @@ class ArticleEditForm extends ArticleAddForm
         parent::readParameters();
 
         if (isset($_REQUEST['id'])) {
-            $this->articleID = \intval($_REQUEST['id']);
+            $this->articleID = (int)$_REQUEST['id'];
         }
         $this->article = new Article($this->articleID);
         if (!$this->article->articleID) {

--- a/wcfsetup/install/files/lib/acp/form/BBCodeEditForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/BBCodeEditForm.class.php
@@ -73,7 +73,7 @@ class BBCodeEditForm extends BBCodeAddForm
         AbstractForm::readParameters();
 
         if (isset($_REQUEST['id'])) {
-            $this->bbcodeID = \intval($_REQUEST['id']);
+            $this->bbcodeID = (int)$_REQUEST['id'];
         }
         $this->bbcode = new BBCode($this->bbcodeID);
         if (!$this->bbcode->bbcodeID) {

--- a/wcfsetup/install/files/lib/acp/form/BBCodeMediaProviderEditForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/BBCodeMediaProviderEditForm.class.php
@@ -48,7 +48,7 @@ class BBCodeMediaProviderEditForm extends BBCodeMediaProviderAddForm
         parent::readParameters();
 
         if (isset($_REQUEST['id'])) {
-            $this->providerID = \intval($_REQUEST['id']);
+            $this->providerID = (int)$_REQUEST['id'];
         }
         $this->mediaProvider = new BBCodeMediaProvider($this->providerID);
         if (!$this->mediaProvider->providerID) {

--- a/wcfsetup/install/files/lib/acp/form/BoxAddForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/BoxAddForm.class.php
@@ -237,7 +237,7 @@ class BoxAddForm extends AbstractForm
         parent::readParameters();
 
         if (isset($_GET['presetBoxID'])) {
-            $this->presetBoxID = \intval($_GET['presetBoxID']);
+            $this->presetBoxID = (int)$_GET['presetBoxID'];
         }
         if ($this->presetBoxID) {
             $this->presetBox = new Box($this->presetBoxID);
@@ -336,16 +336,16 @@ class BoxAddForm extends AbstractForm
             $this->position = $_POST['position'];
         }
         if (isset($_POST['showOrder'])) {
-            $this->showOrder = \intval($_POST['showOrder']);
+            $this->showOrder = (int)$_POST['showOrder'];
         }
         if (isset($_POST['visibleEverywhere'])) {
-            $this->visibleEverywhere = \intval($_POST['visibleEverywhere']);
+            $this->visibleEverywhere = (int)$_POST['visibleEverywhere'];
         }
         if (isset($_POST['cssClassName'])) {
             $this->cssClassName = StringUtil::trim($_POST['cssClassName']);
         }
         if (isset($_POST['showHeader'])) {
-            $this->showHeader = \intval($_POST['showHeader']);
+            $this->showHeader = (int)$_POST['showHeader'];
         }
         if (isset($_POST['isDisabled'])) {
             $this->isDisabled = 1;
@@ -357,10 +357,10 @@ class BoxAddForm extends AbstractForm
             $this->linkType = $_POST['linkType'];
         }
         if (!empty($_POST['linkPageID'])) {
-            $this->linkPageID = \intval($_POST['linkPageID']);
+            $this->linkPageID = (int)$_POST['linkPageID'];
         }
         if (!empty($_POST['linkPageObjectID'])) {
-            $this->linkPageObjectID = \intval($_POST['linkPageObjectID']);
+            $this->linkPageObjectID = (int)$_POST['linkPageObjectID'];
         }
         if (isset($_POST['externalURL'])) {
             $this->externalURL = StringUtil::trim($_POST['externalURL']);
@@ -372,7 +372,7 @@ class BoxAddForm extends AbstractForm
             $this->content = ArrayUtil::trim($_POST['content']);
         }
         if (isset($_POST['boxControllerID'])) {
-            $this->boxControllerID = \intval($_POST['boxControllerID']);
+            $this->boxControllerID = (int)$_POST['boxControllerID'];
         }
         if (isset($_POST['aclValues']) && \is_array($_POST['aclValues'])) {
             $this->aclValues = $_POST['aclValues'];

--- a/wcfsetup/install/files/lib/acp/form/BoxEditForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/BoxEditForm.class.php
@@ -50,7 +50,7 @@ class BoxEditForm extends BoxAddForm
         parent::readParameters();
 
         if (isset($_REQUEST['id'])) {
-            $this->boxID = \intval($_REQUEST['id']);
+            $this->boxID = (int)$_REQUEST['id'];
         }
         $this->box = new Box($this->boxID);
         if (!$this->box->boxID) {

--- a/wcfsetup/install/files/lib/acp/form/CaptchaQuestionEditForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/CaptchaQuestionEditForm.class.php
@@ -84,7 +84,7 @@ class CaptchaQuestionEditForm extends CaptchaQuestionAddForm
         parent::readParameters();
 
         if (isset($_REQUEST['id'])) {
-            $this->captchaQuestionID = \intval($_REQUEST['id']);
+            $this->captchaQuestionID = (int)$_REQUEST['id'];
         }
         $this->captchaQuestion = new CaptchaQuestion($this->captchaQuestionID);
         if (!$this->captchaQuestion->questionID) {

--- a/wcfsetup/install/files/lib/acp/form/ContactRecipientAddForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/ContactRecipientAddForm.class.php
@@ -89,10 +89,10 @@ class ContactRecipientAddForm extends AbstractForm
         }
 
         if (isset($_POST['isDisabled'])) {
-            $this->isDisabled = \intval($_POST['isDisabled']);
+            $this->isDisabled = (int)$_POST['isDisabled'];
         }
         if (isset($_POST['showOrder'])) {
-            $this->showOrder = \intval($_POST['showOrder']);
+            $this->showOrder = (int)$_POST['showOrder'];
         }
     }
 

--- a/wcfsetup/install/files/lib/acp/form/ContactRecipientEditForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/ContactRecipientEditForm.class.php
@@ -52,7 +52,7 @@ class ContactRecipientEditForm extends ContactRecipientAddForm
         parent::readParameters();
 
         if (isset($_REQUEST['id'])) {
-            $this->recipientID = \intval($_REQUEST['id']);
+            $this->recipientID = (int)$_REQUEST['id'];
         }
         $this->recipient = new ContactRecipient($this->recipientID);
         if (!$this->recipient->recipientID) {

--- a/wcfsetup/install/files/lib/acp/form/CronjobEditForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/CronjobEditForm.class.php
@@ -44,7 +44,7 @@ class CronjobEditForm extends CronjobAddForm
         parent::readParameters();
 
         if (isset($_REQUEST['id'])) {
-            $this->cronjobID = \intval($_REQUEST['id']);
+            $this->cronjobID = (int)$_REQUEST['id'];
         }
         $this->cronjob = new Cronjob($this->cronjobID);
         if (!$this->cronjob->cronjobID) {

--- a/wcfsetup/install/files/lib/acp/form/DataImportForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/DataImportForm.class.php
@@ -203,7 +203,7 @@ class DataImportForm extends AbstractForm
             $this->fileSystemPath = StringUtil::trim($_POST['fileSystemPath']);
         }
         if (isset($_POST['userMergeMode'])) {
-            $this->userMergeMode = \intval($_POST['userMergeMode']);
+            $this->userMergeMode = (int)$_POST['userMergeMode'];
         }
         if (isset($_POST['additionalData'])) {
             $this->additionalData = ArrayUtil::trim($_POST['additionalData']);

--- a/wcfsetup/install/files/lib/acp/form/DevtoolsProjectPipEntryAddForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/DevtoolsProjectPipEntryAddForm.class.php
@@ -77,7 +77,7 @@ class DevtoolsProjectPipEntryAddForm extends AbstractFormBuilderForm
         parent::readParameters();
 
         if (isset($_REQUEST['id'])) {
-            $this->projectID = \intval($_REQUEST['id']);
+            $this->projectID = (int)$_REQUEST['id'];
         }
         $this->project = new DevtoolsProject($this->projectID);
         if (!$this->project->projectID) {

--- a/wcfsetup/install/files/lib/acp/form/LabelAddForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/LabelAddForm.class.php
@@ -118,10 +118,10 @@ class LabelAddForm extends AbstractForm
             $this->customCssClassName = StringUtil::trim($_POST['customCssClassName']);
         }
         if (isset($_POST['groupID'])) {
-            $this->groupID = \intval($_POST['groupID']);
+            $this->groupID = (int)$_POST['groupID'];
         }
         if (isset($_POST['showOrder'])) {
-            $this->showOrder = \intval($_POST['showOrder']);
+            $this->showOrder = (int)$_POST['showOrder'];
         }
     }
 

--- a/wcfsetup/install/files/lib/acp/form/LabelEditForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/LabelEditForm.class.php
@@ -50,7 +50,7 @@ class LabelEditForm extends LabelAddForm
         parent::readParameters();
 
         if (isset($_REQUEST['id'])) {
-            $this->labelID = \intval($_REQUEST['id']);
+            $this->labelID = (int)$_REQUEST['id'];
         }
         $this->labelObj = new Label($this->labelID);
         if (!$this->labelObj->labelID) {

--- a/wcfsetup/install/files/lib/acp/form/LabelGroupAddForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/LabelGroupAddForm.class.php
@@ -118,7 +118,7 @@ class LabelGroupAddForm extends AbstractForm
             $this->objectTypes = $_POST['objectTypes'];
         }
         if (isset($_POST['showOrder'])) {
-            $this->showOrder = \intval($_POST['showOrder']);
+            $this->showOrder = (int)$_POST['showOrder'];
         }
     }
 

--- a/wcfsetup/install/files/lib/acp/form/LabelGroupEditForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/LabelGroupEditForm.class.php
@@ -50,7 +50,7 @@ class LabelGroupEditForm extends LabelGroupAddForm
         parent::readParameters();
 
         if (isset($_REQUEST['id'])) {
-            $this->groupID = \intval($_REQUEST['id']);
+            $this->groupID = (int)$_REQUEST['id'];
         }
         $this->group = new LabelGroup($this->groupID);
         if (!$this->group->groupID) {

--- a/wcfsetup/install/files/lib/acp/form/LanguageAddForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/LanguageAddForm.class.php
@@ -90,7 +90,7 @@ class LanguageAddForm extends AbstractForm
             $this->languageCode = StringUtil::trim($_POST['languageCode']);
         }
         if (isset($_POST['sourceLanguageID'])) {
-            $this->sourceLanguageID = \intval($_POST['sourceLanguageID']);
+            $this->sourceLanguageID = (int)$_POST['sourceLanguageID'];
         }
     }
 

--- a/wcfsetup/install/files/lib/acp/form/LanguageEditForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/LanguageEditForm.class.php
@@ -33,7 +33,7 @@ class LanguageEditForm extends LanguageAddForm
         parent::readParameters();
 
         if (isset($_REQUEST['id'])) {
-            $this->languageID = \intval($_REQUEST['id']);
+            $this->languageID = (int)$_REQUEST['id'];
         }
         $this->language = new Language($this->languageID);
         if (!$this->language->languageID) {

--- a/wcfsetup/install/files/lib/acp/form/LanguageExportForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/LanguageExportForm.class.php
@@ -75,7 +75,7 @@ class LanguageExportForm extends AbstractForm
         parent::readParameters();
 
         if (isset($_REQUEST['id'])) {
-            $this->languageID = \intval($_REQUEST['id']);
+            $this->languageID = (int)$_REQUEST['id'];
         }
     }
 
@@ -95,10 +95,10 @@ class LanguageExportForm extends AbstractForm
         }
 
         if (isset($_POST['exportCustomValues'])) {
-            $this->exportCustomValues = \intval($_POST['exportCustomValues']);
+            $this->exportCustomValues = (int)$_POST['exportCustomValues'];
         }
         if (isset($_POST['languageID'])) {
-            $this->languageID = \intval($_POST['languageID']);
+            $this->languageID = (int)$_POST['languageID'];
         }
     }
 

--- a/wcfsetup/install/files/lib/acp/form/LanguageImportForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/LanguageImportForm.class.php
@@ -90,10 +90,10 @@ class LanguageImportForm extends AbstractForm
             $this->filename = $_FILES['languageUpload']['tmp_name'];
         }
         if (isset($_POST['sourceLanguageID'])) {
-            $this->sourceLanguageID = \intval($_POST['sourceLanguageID']);
+            $this->sourceLanguageID = (int)$_POST['sourceLanguageID'];
         }
         if (isset($_POST['packageID'])) {
-            $this->packageID = \intval($_POST['packageID']);
+            $this->packageID = (int)$_POST['packageID'];
         }
     }
 

--- a/wcfsetup/install/files/lib/acp/form/LanguageMultilingualismForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/LanguageMultilingualismForm.class.php
@@ -72,7 +72,7 @@ class LanguageMultilingualismForm extends AbstractForm
         parent::readFormParameters();
 
         if (isset($_POST['enable'])) {
-            $this->enable = \intval($_POST['enable']);
+            $this->enable = (int)$_POST['enable'];
         }
         if (isset($_POST['languageIDs']) && \is_array($_POST['languageIDs'])) {
             $this->languageIDs = ArrayUtil::toIntegerArray($_POST['languageIDs']);

--- a/wcfsetup/install/files/lib/acp/form/MenuAddForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/MenuAddForm.class.php
@@ -114,16 +114,16 @@ class MenuAddForm extends AbstractForm
             $this->position = $_POST['position'];
         }
         if (isset($_POST['showOrder'])) {
-            $this->showOrder = \intval($_POST['showOrder']);
+            $this->showOrder = (int)$_POST['showOrder'];
         }
         if (isset($_POST['visibleEverywhere'])) {
-            $this->visibleEverywhere = \intval($_POST['visibleEverywhere']);
+            $this->visibleEverywhere = (int)$_POST['visibleEverywhere'];
         }
         if (isset($_POST['cssClassName'])) {
             $this->cssClassName = StringUtil::trim($_POST['cssClassName']);
         }
         if (isset($_POST['showHeader'])) {
-            $this->showHeader = \intval($_POST['showHeader']);
+            $this->showHeader = (int)$_POST['showHeader'];
         }
         if (isset($_POST['pageIDs']) && \is_array($_POST['pageIDs'])) {
             $this->pageIDs = ArrayUtil::toIntegerArray($_POST['pageIDs']);

--- a/wcfsetup/install/files/lib/acp/form/MenuEditForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/MenuEditForm.class.php
@@ -48,7 +48,7 @@ class MenuEditForm extends MenuAddForm
         parent::readParameters();
 
         if (isset($_REQUEST['id'])) {
-            $this->menuID = \intval($_REQUEST['id']);
+            $this->menuID = (int)$_REQUEST['id'];
         }
         $this->menu = new Menu($this->menuID);
         if (!$this->menu->menuID) {

--- a/wcfsetup/install/files/lib/acp/form/MenuItemAddForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/MenuItemAddForm.class.php
@@ -125,7 +125,7 @@ class MenuItemAddForm extends AbstractForm
         parent::readParameters();
 
         if (isset($_REQUEST['menuID'])) {
-            $this->menuID = \intval($_REQUEST['menuID']);
+            $this->menuID = (int)$_REQUEST['menuID'];
         }
         $this->menu = new Menu($this->menuID);
         if (!$this->menu->menuID) {
@@ -171,16 +171,16 @@ class MenuItemAddForm extends AbstractForm
             $this->isInternalLink = (bool)$_POST['isInternalLink'];
         }
         if (!empty($_POST['pageID'])) {
-            $this->pageID = \intval($_POST['pageID']);
+            $this->pageID = (int)$_POST['pageID'];
         }
         if (!empty($_POST['pageObjectID'])) {
-            $this->pageObjectID = \intval($_POST['pageObjectID']);
+            $this->pageObjectID = (int)$_POST['pageObjectID'];
         }
         if (!empty($_POST['parentItemID'])) {
-            $this->parentItemID = \intval($_POST['parentItemID']);
+            $this->parentItemID = (int)$_POST['parentItemID'];
         }
         if (isset($_POST['showOrder'])) {
-            $this->showOrder = \intval($_POST['showOrder']);
+            $this->showOrder = (int)$_POST['showOrder'];
         }
     }
 

--- a/wcfsetup/install/files/lib/acp/form/MenuItemEditForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/MenuItemEditForm.class.php
@@ -44,7 +44,7 @@ class MenuItemEditForm extends MenuItemAddForm
         AbstractForm::readParameters();
 
         if (isset($_REQUEST['id'])) {
-            $this->itemID = \intval($_REQUEST['id']);
+            $this->itemID = (int)$_REQUEST['id'];
         }
         $this->menuItem = new MenuItem($this->itemID);
         if (!$this->menuItem->itemID) {

--- a/wcfsetup/install/files/lib/acp/form/NoticeAddForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/NoticeAddForm.class.php
@@ -176,7 +176,7 @@ class NoticeAddForm extends AbstractForm
             $this->noticeUseHtml = 1;
         }
         if (isset($_POST['showOrder'])) {
-            $this->showOrder = \intval($_POST['showOrder']);
+            $this->showOrder = (int)$_POST['showOrder'];
         }
 
         foreach ($this->groupedConditionObjectTypes as $groupedObjectTypes) {

--- a/wcfsetup/install/files/lib/acp/form/NoticeEditForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/NoticeEditForm.class.php
@@ -124,7 +124,7 @@ class NoticeEditForm extends NoticeAddForm
         parent::readParameters();
 
         if (isset($_REQUEST['id'])) {
-            $this->noticeID = \intval($_REQUEST['id']);
+            $this->noticeID = (int)$_REQUEST['id'];
         }
         $this->notice = new Notice($this->noticeID);
         if (!$this->notice->noticeID) {

--- a/wcfsetup/install/files/lib/acp/form/NotificationPresetSettingsForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/NotificationPresetSettingsForm.class.php
@@ -77,7 +77,7 @@ class NotificationPresetSettingsForm extends AbstractForm
             $this->settings = $_POST['settings'];
         }
         if (isset($_POST['applyChangesToExistingUsers'])) {
-            $this->applyChangesToExistingUsers = \intval($_POST['applyChangesToExistingUsers']);
+            $this->applyChangesToExistingUsers = (int)$_POST['applyChangesToExistingUsers'];
         }
     }
 

--- a/wcfsetup/install/files/lib/acp/form/OptionForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/OptionForm.class.php
@@ -49,7 +49,7 @@ class OptionForm extends AbstractOptionListForm
     public function readParameters()
     {
         if (isset($_REQUEST['id'])) {
-            $this->categoryID = \intval($_REQUEST['id']);
+            $this->categoryID = (int)$_REQUEST['id'];
         }
         $this->category = new OptionCategory($this->categoryID);
         if (!$this->category->categoryID) {

--- a/wcfsetup/install/files/lib/acp/form/PackageUpdateServerEditForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/PackageUpdateServerEditForm.class.php
@@ -43,7 +43,7 @@ class PackageUpdateServerEditForm extends PackageUpdateServerAddForm
         parent::readParameters();
 
         if (isset($_REQUEST['id'])) {
-            $this->packageUpdateServerID = \intval($_REQUEST['id']);
+            $this->packageUpdateServerID = (int)$_REQUEST['id'];
         }
         $this->updateServer = new PackageUpdateServer($this->packageUpdateServerID);
         if (!$this->updateServer->packageUpdateServerID) {

--- a/wcfsetup/install/files/lib/acp/form/PageAddForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/PageAddForm.class.php
@@ -236,7 +236,7 @@ class PageAddForm extends AbstractForm
         $this->availableBoxes = $boxList->getObjects();
 
         if (isset($_GET['presetPageID'])) {
-            $this->presetPageID = \intval($_GET['presetPageID']);
+            $this->presetPageID = (int)$_GET['presetPageID'];
         }
         if ($this->presetPageID) {
             $this->presetPage = new Page($this->presetPageID);
@@ -292,7 +292,7 @@ class PageAddForm extends AbstractForm
 
         $this->allowSpidersToIndex = 0;
         if (isset($_POST['parentPageID'])) {
-            $this->parentPageID = \intval($_POST['parentPageID']);
+            $this->parentPageID = (int)$_POST['parentPageID'];
         }
         if (isset($_POST['name'])) {
             $this->name = StringUtil::trim($_POST['name']);
@@ -316,10 +316,10 @@ class PageAddForm extends AbstractForm
             $this->addPageToMainMenu = 1;
         }
         if (isset($_POST['applicationPackageID'])) {
-            $this->applicationPackageID = \intval($_POST['applicationPackageID']);
+            $this->applicationPackageID = (int)$_POST['applicationPackageID'];
         }
         if (!empty($_POST['parentMenuItemID'])) {
-            $this->parentMenuItemID = \intval($_POST['parentMenuItemID']);
+            $this->parentMenuItemID = (int)$_POST['parentMenuItemID'];
         }
         if (isset($_POST['enableShareButtons'])) {
             $this->enableShareButtons = 1;

--- a/wcfsetup/install/files/lib/acp/form/PageEditForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/PageEditForm.class.php
@@ -57,7 +57,7 @@ class PageEditForm extends PageAddForm
         parent::readParameters();
 
         if (isset($_REQUEST['id'])) {
-            $this->pageID = \intval($_REQUEST['id']);
+            $this->pageID = (int)$_REQUEST['id'];
         }
         $this->page = new Page($this->pageID);
         if (!$this->page->pageID) {
@@ -84,7 +84,7 @@ class PageEditForm extends PageAddForm
         parent::readFormParameters();
 
         if (isset($_POST['overrideApplicationPackageID'])) {
-            $this->overrideApplicationPackageID = \intval($_POST['overrideApplicationPackageID']);
+            $this->overrideApplicationPackageID = (int)$_POST['overrideApplicationPackageID'];
         }
 
         $this->pageType = $this->page->pageType;

--- a/wcfsetup/install/files/lib/acp/form/PaidSubscriptionAddForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/PaidSubscriptionAddForm.class.php
@@ -200,10 +200,10 @@ class PaidSubscriptionAddForm extends AbstractForm
             $this->isDisabled = 1;
         }
         if (isset($_POST['showOrder'])) {
-            $this->showOrder = \intval($_POST['showOrder']);
+            $this->showOrder = (int)$_POST['showOrder'];
         }
         if (isset($_POST['cost'])) {
-            $this->cost = \floatval($_POST['cost']);
+            $this->cost = (float)$_POST['cost'];
         }
         if (isset($_POST['currency'])) {
             $this->currency = $_POST['currency'];
@@ -213,7 +213,7 @@ class PaidSubscriptionAddForm extends AbstractForm
         }
         if (!$this->subscriptionLengthPermanent) {
             if (isset($_POST['subscriptionLength'])) {
-                $this->subscriptionLength = \intval($_POST['subscriptionLength']);
+                $this->subscriptionLength = (int)$_POST['subscriptionLength'];
             }
             if (isset($_POST['subscriptionLengthUnit'])) {
                 $this->subscriptionLengthUnit = $_POST['subscriptionLengthUnit'];

--- a/wcfsetup/install/files/lib/acp/form/PaidSubscriptionEditForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/PaidSubscriptionEditForm.class.php
@@ -43,7 +43,7 @@ class PaidSubscriptionEditForm extends PaidSubscriptionAddForm
     public function readParameters()
     {
         if (isset($_REQUEST['id'])) {
-            $this->subscriptionID = \intval($_REQUEST['id']);
+            $this->subscriptionID = (int)$_REQUEST['id'];
         }
         $this->subscription = new PaidSubscription($this->subscriptionID);
         if (!$this->subscription->subscriptionID) {

--- a/wcfsetup/install/files/lib/acp/form/PaidSubscriptionUserAddForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/PaidSubscriptionUserAddForm.class.php
@@ -82,7 +82,7 @@ class PaidSubscriptionUserAddForm extends AbstractForm
         parent::readParameters();
 
         if (isset($_REQUEST['id'])) {
-            $this->subscriptionID = \intval($_REQUEST['id']);
+            $this->subscriptionID = (int)$_REQUEST['id'];
         }
         $this->subscription = new PaidSubscription($this->subscriptionID);
         if (!$this->subscription->subscriptionID) {

--- a/wcfsetup/install/files/lib/acp/form/PaidSubscriptionUserEditForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/PaidSubscriptionUserEditForm.class.php
@@ -52,7 +52,7 @@ class PaidSubscriptionUserEditForm extends PaidSubscriptionUserAddForm
         AbstractForm::readParameters();
 
         if (isset($_REQUEST['id'])) {
-            $this->subscriptionUserID = \intval($_REQUEST['id']);
+            $this->subscriptionUserID = (int)$_REQUEST['id'];
         }
         $this->subscriptionUser = new PaidSubscriptionUser($this->subscriptionUserID);
         if (!$this->subscriptionUser->subscriptionUserID || !$this->subscriptionUser->endDate || !$this->subscriptionUser->isActive) {

--- a/wcfsetup/install/files/lib/acp/form/SitemapEditForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/SitemapEditForm.class.php
@@ -152,13 +152,13 @@ class SitemapEditForm extends AbstractForm
         parent::readFormParameters();
 
         if (isset($_POST['priority'])) {
-            $this->priority = \round(\floatval($_POST['priority']), 1);
+            $this->priority = \round((float)$_POST['priority'], 1);
         }
         if (isset($_POST['changeFreq'])) {
             $this->changeFreq = $_POST['changeFreq'];
         }
         if (isset($_POST['rebuildTime'])) {
-            $this->rebuildTime = \intval($_POST['rebuildTime']);
+            $this->rebuildTime = (int)$_POST['rebuildTime'];
         }
         $this->isDisabled = (isset($_POST['isDisabled'])) ? 1 : 0;
     }

--- a/wcfsetup/install/files/lib/acp/form/SmileyAddForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/SmileyAddForm.class.php
@@ -176,10 +176,10 @@ class SmileyAddForm extends AbstractForm
         }
 
         if (isset($_POST['showOrder'])) {
-            $this->showOrder = \intval($_POST['showOrder']);
+            $this->showOrder = (int)$_POST['showOrder'];
         }
         if (isset($_POST['categoryID'])) {
-            $this->categoryID = \intval($_POST['categoryID']);
+            $this->categoryID = (int)$_POST['categoryID'];
         }
         if (isset($_POST['smileyCode'])) {
             $this->smileyCode = StringUtil::trim($_POST['smileyCode']);

--- a/wcfsetup/install/files/lib/acp/form/SmileyEditForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/SmileyEditForm.class.php
@@ -49,7 +49,7 @@ class SmileyEditForm extends SmileyAddForm
         parent::readParameters();
 
         if (isset($_REQUEST['id'])) {
-            $this->smileyID = \intval($_REQUEST['id']);
+            $this->smileyID = (int)$_REQUEST['id'];
         }
         $this->smiley = new Smiley($this->smileyID);
         if (!$this->smiley->smileyID) {

--- a/wcfsetup/install/files/lib/acp/form/StyleAddForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/StyleAddForm.class.php
@@ -397,7 +397,7 @@ class StyleAddForm extends AbstractForm
                 $this->variables[$variableName] = (\in_array(
                     $variableName,
                     $integerValues
-                )) ? \abs(\intval($_POST[$variableName])) : StringUtil::trim($_POST[$variableName]);
+                )) ? \abs((int)$_POST[$variableName]) : StringUtil::trim($_POST[$variableName]);
             }
         }
         $this->variables['useFluidLayout'] = isset($_POST['useFluidLayout']) ? 1 : 0;
@@ -431,7 +431,7 @@ class StyleAddForm extends AbstractForm
             $this->styleVersion = StringUtil::trim($_POST['styleVersion']);
         }
         if (isset($_POST['templateGroupID'])) {
-            $this->templateGroupID = \intval($_POST['templateGroupID']);
+            $this->templateGroupID = (int)$_POST['templateGroupID'];
         }
         if (isset($_POST['apiVersion']) && \in_array($_POST['apiVersion'], Style::$supportedApiVersions)) {
             $this->apiVersion = $_POST['apiVersion'];

--- a/wcfsetup/install/files/lib/acp/form/StyleEditForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/StyleEditForm.class.php
@@ -48,7 +48,7 @@ class StyleEditForm extends StyleAddForm
     public function readParameters()
     {
         if (isset($_REQUEST['id'])) {
-            $this->styleID = \intval($_REQUEST['id']);
+            $this->styleID = (int)$_REQUEST['id'];
         }
         $this->style = new Style($this->styleID);
         if (!$this->style->styleID) {

--- a/wcfsetup/install/files/lib/acp/form/StyleExportForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/StyleExportForm.class.php
@@ -72,7 +72,7 @@ class StyleExportForm extends AbstractForm
         parent::readParameters();
 
         if (isset($_REQUEST['id'])) {
-            $this->styleID = \intval($_REQUEST['id']);
+            $this->styleID = (int)$_REQUEST['id'];
         }
         $this->style = new Style($this->styleID);
         if (!$this->style->styleID) {

--- a/wcfsetup/install/files/lib/acp/form/StyleGlobalValuesForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/StyleGlobalValuesForm.class.php
@@ -54,7 +54,7 @@ class StyleGlobalValuesForm extends AbstractForm
             $this->styles = StringUtil::unifyNewlines(StringUtil::trim($_POST['styles']));
         }
         if (isset($_POST['stylesScrollOffset'])) {
-            $this->stylesScrollOffset = \intval($_POST['stylesScrollOffset']);
+            $this->stylesScrollOffset = (int)$_POST['stylesScrollOffset'];
         }
     }
 

--- a/wcfsetup/install/files/lib/acp/form/TagAddForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/TagAddForm.class.php
@@ -83,7 +83,7 @@ class TagAddForm extends AbstractForm
             $this->name = \str_replace(',', '', StringUtil::trim($_POST['name']));
         }
         if (isset($_POST['languageID'])) {
-            $this->languageID = \intval($_POST['languageID']);
+            $this->languageID = (int)$_POST['languageID'];
         }
 
         // actually these are synonyms

--- a/wcfsetup/install/files/lib/acp/form/TagEditForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/TagEditForm.class.php
@@ -50,7 +50,7 @@ class TagEditForm extends TagAddForm
         parent::readParameters();
 
         if (isset($_REQUEST['id'])) {
-            $this->tagID = \intval($_REQUEST['id']);
+            $this->tagID = (int)$_REQUEST['id'];
         }
         $this->tagObj = new Tag($this->tagID);
         if (!$this->tagObj->tagID) {

--- a/wcfsetup/install/files/lib/acp/form/TemplateAddForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/TemplateAddForm.class.php
@@ -91,7 +91,7 @@ class TemplateAddForm extends AbstractForm
         parent::readParameters();
 
         if (!empty($_REQUEST['copy'])) {
-            $this->copy = \intval($_REQUEST['copy']);
+            $this->copy = (int)$_REQUEST['copy'];
             $this->copiedTemplate = new Template($this->copy);
             if (!$this->copiedTemplate->templateID) {
                 throw new IllegalLinkException();
@@ -116,7 +116,7 @@ class TemplateAddForm extends AbstractForm
             $this->templateSource = StringUtil::unifyNewlines($_POST['templateSource']);
         }
         if (isset($_POST['templateGroupID'])) {
-            $this->templateGroupID = \intval($_POST['templateGroupID']);
+            $this->templateGroupID = (int)$_POST['templateGroupID'];
         }
 
         // get package id for this template

--- a/wcfsetup/install/files/lib/acp/form/TemplateEditForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/TemplateEditForm.class.php
@@ -43,7 +43,7 @@ class TemplateEditForm extends TemplateAddForm
         parent::readParameters();
 
         if (isset($_REQUEST['id'])) {
-            $this->templateID = \intval($_REQUEST['id']);
+            $this->templateID = (int)$_REQUEST['id'];
         }
         $this->template = new Template($this->templateID);
         if (!$this->template->templateID || !$this->template->templateGroupID) {

--- a/wcfsetup/install/files/lib/acp/form/TemplateGroupAddForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/TemplateGroupAddForm.class.php
@@ -72,7 +72,7 @@ class TemplateGroupAddForm extends AbstractForm
             }
         }
         if (isset($_POST['parentTemplateGroupID'])) {
-            $this->parentTemplateGroupID = \intval($_POST['parentTemplateGroupID']);
+            $this->parentTemplateGroupID = (int)$_POST['parentTemplateGroupID'];
         }
     }
 

--- a/wcfsetup/install/files/lib/acp/form/TemplateGroupEditForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/TemplateGroupEditForm.class.php
@@ -44,7 +44,7 @@ class TemplateGroupEditForm extends TemplateGroupAddForm
         parent::readParameters();
 
         if (isset($_REQUEST['id'])) {
-            $this->templateGroupID = \intval($_REQUEST['id']);
+            $this->templateGroupID = (int)$_REQUEST['id'];
         }
         $this->templateGroup = new TemplateGroup($this->templateGroupID);
         if (!$this->templateGroup->templateGroupID) {

--- a/wcfsetup/install/files/lib/acp/form/TrophyAddForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/TrophyAddForm.class.php
@@ -190,13 +190,13 @@ class TrophyAddForm extends AbstractAcpForm
         parent::readFormParameters();
 
         if (isset($_POST['categoryID'])) {
-            $this->categoryID = \intval($_POST['categoryID']);
+            $this->categoryID = (int)$_POST['categoryID'];
         }
         if (isset($_POST['type'])) {
-            $this->type = \intval($_POST['type']);
+            $this->type = (int)$_POST['type'];
         }
         if (isset($_POST['isDisabled'])) {
-            $this->isDisabled = \intval($_POST['isDisabled']);
+            $this->isDisabled = (int)$_POST['isDisabled'];
         }
         if (isset($_POST['iconName'])) {
             $this->iconName = StringUtil::trim($_POST['iconName']);
@@ -217,7 +217,7 @@ class TrophyAddForm extends AbstractAcpForm
             $this->trophyUseHtml = 1;
         }
         if (isset($_POST['showOrder'])) {
-            $this->showOrder = \intval($_POST['showOrder']);
+            $this->showOrder = (int)$_POST['showOrder'];
         }
 
         // read file upload

--- a/wcfsetup/install/files/lib/acp/form/TrophyEditForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/TrophyEditForm.class.php
@@ -53,7 +53,7 @@ class TrophyEditForm extends TrophyAddForm
     public function readParameters()
     {
         if (!empty($_REQUEST['id'])) {
-            $this->trophyID = \intval($_REQUEST['id']);
+            $this->trophyID = (int)$_REQUEST['id'];
         }
         $this->trophy = new Trophy($this->trophyID);
 

--- a/wcfsetup/install/files/lib/acp/form/UserAddForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/UserAddForm.class.php
@@ -155,7 +155,7 @@ class UserAddForm extends UserOptionListForm
             $this->visibleLanguages = ArrayUtil::toIntegerArray($_POST['visibleLanguages']);
         }
         if (isset($_POST['languageID'])) {
-            $this->languageID = \intval($_POST['languageID']);
+            $this->languageID = (int)$_POST['languageID'];
         }
         if (isset($_POST['userTitle'])) {
             $this->userTitle = $_POST['userTitle'];

--- a/wcfsetup/install/files/lib/acp/form/UserContentRevertChangesForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/UserContentRevertChangesForm.class.php
@@ -84,7 +84,7 @@ class UserContentRevertChangesForm extends AbstractForm
         parent::readFormParameters();
 
         if (isset($_POST['timeframe'])) {
-            $this->timeframe = \intval($_POST['timeframe']);
+            $this->timeframe = (int)$_POST['timeframe'];
         }
     }
 

--- a/wcfsetup/install/files/lib/acp/form/UserEditForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/UserEditForm.class.php
@@ -165,7 +165,7 @@ class UserEditForm extends UserAddForm
     public function readParameters()
     {
         if (isset($_REQUEST['id'])) {
-            $this->userID = \intval($_REQUEST['id']);
+            $this->userID = (int)$_REQUEST['id'];
         }
         $user = new User($this->userID);
         if (!$user->userID) {
@@ -211,7 +211,7 @@ class UserEditForm extends UserAddForm
         }
         if ($this->banned && !isset($_POST['banNeverExpires'])) {
             if (isset($_POST['banExpires'])) {
-                $this->banExpires = @\intval(\strtotime(StringUtil::trim($_POST['banExpires'])));
+                $this->banExpires = (int)@\strtotime(StringUtil::trim($_POST['banExpires']));
             }
         }
 
@@ -219,7 +219,7 @@ class UserEditForm extends UserAddForm
             $this->avatarType = $_POST['avatarType'];
         }
         if (isset($_POST['styleID'])) {
-            $this->styleID = \intval($_POST['styleID']);
+            $this->styleID = (int)$_POST['styleID'];
         }
 
         if (WCF::getSession()->getPermission('admin.user.canDisableAvatar')) {

--- a/wcfsetup/install/files/lib/acp/form/UserGroupAddForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/UserGroupAddForm.class.php
@@ -121,19 +121,19 @@ class UserGroupAddForm extends AbstractOptionListForm
         }
 
         if (isset($_POST['priority'])) {
-            $this->priority = \intval($_POST['priority']);
+            $this->priority = (int)$_POST['priority'];
         }
         if (isset($_POST['userOnlineMarking'])) {
             $this->userOnlineMarking = StringUtil::trim($_POST['userOnlineMarking']);
         }
         if (isset($_POST['showOnTeamPage'])) {
-            $this->showOnTeamPage = \intval($_POST['showOnTeamPage']);
+            $this->showOnTeamPage = (int)$_POST['showOnTeamPage'];
         }
         if (isset($_POST['allowMention'])) {
-            $this->allowMention = \intval($_POST['allowMention']);
+            $this->allowMention = (int)$_POST['allowMention'];
         }
         if (isset($_POST['requireMultifactor'])) {
-            $this->requireMultifactor = \intval($_POST['requireMultifactor']);
+            $this->requireMultifactor = (int)$_POST['requireMultifactor'];
         }
     }
 

--- a/wcfsetup/install/files/lib/acp/form/UserGroupAssignmentAddForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/UserGroupAssignmentAddForm.class.php
@@ -110,7 +110,7 @@ class UserGroupAssignmentAddForm extends AbstractForm
         parent::readFormParameters();
 
         if (isset($_POST['groupID'])) {
-            $this->groupID = \intval($_POST['groupID']);
+            $this->groupID = (int)$_POST['groupID'];
         }
         if (isset($_POST['isDisabled'])) {
             $this->isDisabled = 1;

--- a/wcfsetup/install/files/lib/acp/form/UserGroupAssignmentEditForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/UserGroupAssignmentEditForm.class.php
@@ -76,7 +76,7 @@ class UserGroupAssignmentEditForm extends UserGroupAssignmentAddForm
         parent::readParameters();
 
         if (isset($_REQUEST['id'])) {
-            $this->assignmentID = \intval($_REQUEST['id']);
+            $this->assignmentID = (int)$_REQUEST['id'];
         }
         $this->assignment = new UserGroupAssignment($this->assignmentID);
         if (!$this->assignment->assignmentID) {

--- a/wcfsetup/install/files/lib/acp/form/UserGroupEditForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/UserGroupEditForm.class.php
@@ -57,7 +57,7 @@ class UserGroupEditForm extends UserGroupAddForm
 
         // get group
         if (isset($_REQUEST['id'])) {
-            $this->groupID = \intval($_REQUEST['id']);
+            $this->groupID = (int)$_REQUEST['id'];
         }
         $group = new UserGroup($this->groupID);
         if (!$group->groupID) {

--- a/wcfsetup/install/files/lib/acp/form/UserGroupOptionForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/UserGroupOptionForm.class.php
@@ -87,7 +87,7 @@ class UserGroupOptionForm extends AbstractForm
         parent::readParameters();
 
         if (isset($_REQUEST['id'])) {
-            $this->userGroupOptionID = \intval($_REQUEST['id']);
+            $this->userGroupOptionID = (int)$_REQUEST['id'];
         }
         $this->userGroupOption = new UserGroupOption($this->userGroupOptionID);
         if (!$this->userGroupOption->optionID) {

--- a/wcfsetup/install/files/lib/acp/form/UserMailForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/UserMailForm.class.php
@@ -97,7 +97,7 @@ class UserMailForm extends AbstractForm
         parent::readParameters();
 
         if (isset($_GET['id'])) {
-            $this->userID = \intval($_GET['id']);
+            $this->userID = (int)$_GET['id'];
         }
 
         $this->activeMenuItem = ($this->action == 'all' ? 'wcf.acp.menu.link.user.mail' : ($this->action == 'group' ? 'wcf.acp.menu.link.group.mail' : 'wcf.acp.menu.link.user.list'));

--- a/wcfsetup/install/files/lib/acp/form/UserMergeForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/UserMergeForm.class.php
@@ -94,7 +94,7 @@ class UserMergeForm extends AbstractForm
         parent::readFormParameters();
 
         if (isset($_POST['destinationUserID'])) {
-            $this->destinationUserID = \intval($_POST['destinationUserID']);
+            $this->destinationUserID = (int)$_POST['destinationUserID'];
         }
     }
 

--- a/wcfsetup/install/files/lib/acp/form/UserOptionAddForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/UserOptionAddForm.class.php
@@ -227,22 +227,22 @@ class UserOptionAddForm extends AbstractForm
             $this->selectOptions = $_POST['selectOptions'];
         }
         if (isset($_POST['required'])) {
-            $this->required = \intval($_POST['required']);
+            $this->required = (int)$_POST['required'];
         }
         if (isset($_POST['askDuringRegistration'])) {
-            $this->askDuringRegistration = \intval($_POST['askDuringRegistration']);
+            $this->askDuringRegistration = (int)$_POST['askDuringRegistration'];
         }
         if (isset($_POST['editable'])) {
-            $this->editable = \intval($_POST['editable']);
+            $this->editable = (int)$_POST['editable'];
         }
         if (isset($_POST['visible'])) {
-            $this->visible = \intval($_POST['visible']);
+            $this->visible = (int)$_POST['visible'];
         }
         if (isset($_POST['searchable'])) {
-            $this->searchable = \intval($_POST['searchable']);
+            $this->searchable = (int)$_POST['searchable'];
         }
         if (isset($_POST['showOrder'])) {
-            $this->showOrder = \intval($_POST['showOrder']);
+            $this->showOrder = (int)$_POST['showOrder'];
         }
         if (isset($_POST['outputClass'])) {
             $this->outputClass = StringUtil::trim($_POST['outputClass']);
@@ -252,10 +252,10 @@ class UserOptionAddForm extends AbstractForm
         }
 
         if ($this->optionType == 'boolean' || $this->optionType == 'integer') {
-            $this->defaultValue = \intval($this->defaultValue);
+            $this->defaultValue = (int)$this->defaultValue;
         }
         if ($this->optionType == 'float') {
-            $this->defaultValue = \floatval($this->defaultValue);
+            $this->defaultValue = (float)$this->defaultValue;
         }
         if ($this->optionType == 'date') {
             if (!\preg_match('/\d{4}-\d{2}-\d{2}/', $this->defaultValue)) {

--- a/wcfsetup/install/files/lib/acp/form/UserOptionCategoryAddForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/UserOptionCategoryAddForm.class.php
@@ -65,7 +65,7 @@ class UserOptionCategoryAddForm extends AbstractForm
             $this->categoryName = I18nHandler::getInstance()->getValue('categoryName');
         }
         if (isset($_POST['showOrder'])) {
-            $this->showOrder = \intval($_POST['showOrder']);
+            $this->showOrder = (int)$_POST['showOrder'];
         }
     }
 

--- a/wcfsetup/install/files/lib/acp/form/UserOptionCategoryEditForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/UserOptionCategoryEditForm.class.php
@@ -44,7 +44,7 @@ class UserOptionCategoryEditForm extends UserOptionCategoryAddForm
         parent::readParameters();
 
         if (isset($_REQUEST['id'])) {
-            $this->categoryID = \intval($_REQUEST['id']);
+            $this->categoryID = (int)$_REQUEST['id'];
         }
         $this->category = new UserOptionCategory($this->categoryID);
         if (!$this->category->categoryID) {

--- a/wcfsetup/install/files/lib/acp/form/UserOptionEditForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/UserOptionEditForm.class.php
@@ -44,7 +44,7 @@ class UserOptionEditForm extends UserOptionAddForm
         parent::readParameters();
 
         if (isset($_REQUEST['id'])) {
-            $this->optionID = \intval($_REQUEST['id']);
+            $this->optionID = (int)$_REQUEST['id'];
         }
         $this->userOption = new UserOption($this->optionID);
         if (!$this->userOption->optionID) {

--- a/wcfsetup/install/files/lib/acp/form/UserOptionSetDefaultsForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/UserOptionSetDefaultsForm.class.php
@@ -60,7 +60,7 @@ class UserOptionSetDefaultsForm extends AbstractForm
         $this->optionHandler->readUserInput($_POST);
 
         if (isset($_POST['applyChangesToExistingUsers'])) {
-            $this->applyChangesToExistingUsers = \intval($_POST['applyChangesToExistingUsers']);
+            $this->applyChangesToExistingUsers = (int)$_POST['applyChangesToExistingUsers'];
         }
     }
 

--- a/wcfsetup/install/files/lib/acp/form/UserRankAddForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/UserRankAddForm.class.php
@@ -167,19 +167,19 @@ class UserRankAddForm extends AbstractForm
             $this->customCssClassName = StringUtil::trim($_POST['customCssClassName']);
         }
         if (isset($_POST['groupID'])) {
-            $this->groupID = \intval($_POST['groupID']);
+            $this->groupID = (int)$_POST['groupID'];
         }
         if (isset($_POST['requiredPoints'])) {
-            $this->requiredPoints = \intval($_POST['requiredPoints']);
+            $this->requiredPoints = (int)$_POST['requiredPoints'];
         }
         if (isset($_POST['repeatImage'])) {
-            $this->repeatImage = \intval($_POST['repeatImage']);
+            $this->repeatImage = (int)$_POST['repeatImage'];
         }
         if (isset($_POST['requiredGender'])) {
-            $this->requiredGender = \intval($_POST['requiredGender']);
+            $this->requiredGender = (int)$_POST['requiredGender'];
         }
         if (isset($_POST['hideTitle'])) {
-            $this->hideTitle = \intval($_POST['hideTitle']);
+            $this->hideTitle = (int)$_POST['hideTitle'];
         }
 
         $this->removedRankImages = UploadHandler::getInstance()->getRemovedFiledByFieldId('rankImage');

--- a/wcfsetup/install/files/lib/acp/form/UserRankEditForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/UserRankEditForm.class.php
@@ -45,7 +45,7 @@ class UserRankEditForm extends UserRankAddForm
         parent::readParameters();
 
         if (isset($_REQUEST['id'])) {
-            $this->rankID = \intval($_REQUEST['id']);
+            $this->rankID = (int)$_REQUEST['id'];
         }
         $this->rank = new UserRank($this->rankID);
         if (!$this->rank->rankID) {

--- a/wcfsetup/install/files/lib/acp/form/UserSearchForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/UserSearchForm.class.php
@@ -101,7 +101,7 @@ class UserSearchForm extends UserOptionListForm
 
         // search user from passed groupID by group-view
         if (isset($_GET['groupID'])) {
-            $this->groupID = \intval($_GET['groupID']);
+            $this->groupID = (int)$_GET['groupID'];
 
             try {
                 // Enforce the visibility of the default columns when filtering the list of
@@ -146,7 +146,7 @@ class UserSearchForm extends UserOptionListForm
         }
 
         if (isset($_POST['itemsPerPage'])) {
-            $this->itemsPerPage = \intval($_POST['itemsPerPage']);
+            $this->itemsPerPage = (int)$_POST['itemsPerPage'];
         }
         if (isset($_POST['sortField'])) {
             $this->sortField = $_POST['sortField'];

--- a/wcfsetup/install/files/lib/acp/form/UserTrophyAddForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/UserTrophyAddForm.class.php
@@ -110,7 +110,7 @@ class UserTrophyAddForm extends AbstractAcpForm
             $this->user = StringUtil::trim($_POST['user']);
         }
         if (isset($_POST['trophyID'])) {
-            $this->trophyID = \intval($_POST['trophyID']);
+            $this->trophyID = (int)$_POST['trophyID'];
         }
         if (isset($_POST['useCustomDescription'])) {
             $this->useCustomDescription = 1;

--- a/wcfsetup/install/files/lib/acp/form/UserTrophyEditForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/UserTrophyEditForm.class.php
@@ -47,7 +47,7 @@ class UserTrophyEditForm extends UserTrophyAddForm
     public function readParameters()
     {
         if (!empty($_REQUEST['id'])) {
-            $this->userTrophyID = \intval($_REQUEST['id']);
+            $this->userTrophyID = (int)$_REQUEST['id'];
         }
         $this->userTrophy = new UserTrophy($this->userTrophyID);
 

--- a/wcfsetup/install/files/lib/acp/page/ACPSessionLogPage.class.php
+++ b/wcfsetup/install/files/lib/acp/page/ACPSessionLogPage.class.php
@@ -71,7 +71,7 @@ class ACPSessionLogPage extends SortablePage
 
         // get session log
         if (isset($_REQUEST['id'])) {
-            $this->sessionLogID = \intval($_REQUEST['id']);
+            $this->sessionLogID = (int)$_REQUEST['id'];
         }
         $this->sessionLog = new ACPSessionLog($this->sessionLogID);
         if (!$this->sessionLog->sessionLogID) {

--- a/wcfsetup/install/files/lib/acp/page/ArticleListPage.class.php
+++ b/wcfsetup/install/files/lib/acp/page/ArticleListPage.class.php
@@ -118,7 +118,7 @@ class ArticleListPage extends SortablePage
         parent::readParameters();
 
         if (isset($_REQUEST['categoryID'])) {
-            $this->categoryID = \intval($_REQUEST['categoryID']);
+            $this->categoryID = (int)$_REQUEST['categoryID'];
         }
         if (!empty($_REQUEST['username'])) {
             $this->username = StringUtil::trim($_REQUEST['username']);
@@ -133,10 +133,10 @@ class ArticleListPage extends SortablePage
             $this->showArticleAddDialog = 1;
         }
         if (isset($_REQUEST['publicationStatus'])) {
-            $this->publicationStatus = \intval($_REQUEST['publicationStatus']);
+            $this->publicationStatus = (int)$_REQUEST['publicationStatus'];
         }
         if (!empty($_REQUEST['isDeleted'])) {
-            $this->isDeleted = \intval($_REQUEST['isDeleted']);
+            $this->isDeleted = (int)$_REQUEST['isDeleted'];
         }
     }
 

--- a/wcfsetup/install/files/lib/acp/page/CacheListPage.class.php
+++ b/wcfsetup/install/files/lib/acp/page/CacheListPage.class.php
@@ -56,7 +56,7 @@ class CacheListPage extends AbstractPage
         parent::readParameters();
 
         if (isset($_REQUEST['cleared'])) {
-            $this->cleared = \intval($_REQUEST['cleared']);
+            $this->cleared = (int)$_REQUEST['cleared'];
         }
     }
 

--- a/wcfsetup/install/files/lib/acp/page/CronjobLogListPage.class.php
+++ b/wcfsetup/install/files/lib/acp/page/CronjobLogListPage.class.php
@@ -78,10 +78,10 @@ class CronjobLogListPage extends SortablePage
         parent::readParameters();
 
         if (!empty($_REQUEST['cronjobID'])) {
-            $this->cronjobID = \intval($_REQUEST['cronjobID']);
+            $this->cronjobID = (int)$_REQUEST['cronjobID'];
         }
         if (isset($_REQUEST['success'])) {
-            $this->success = \intval($_REQUEST['success']);
+            $this->success = (int)$_REQUEST['success'];
         }
     }
 

--- a/wcfsetup/install/files/lib/acp/page/DevtoolsProjectPipEntryListPage.class.php
+++ b/wcfsetup/install/files/lib/acp/page/DevtoolsProjectPipEntryListPage.class.php
@@ -135,7 +135,7 @@ class DevtoolsProjectPipEntryListPage extends AbstractPage
         parent::readParameters();
 
         if (isset($_REQUEST['id'])) {
-            $this->projectID = \intval($_REQUEST['id']);
+            $this->projectID = (int)$_REQUEST['id'];
         }
         $this->project = new DevtoolsProject($this->projectID);
         if (!$this->project->projectID) {
@@ -176,7 +176,7 @@ class DevtoolsProjectPipEntryListPage extends AbstractPage
         }
 
         if (isset($_REQUEST['pageNo'])) {
-            $this->pageNo = \intval($_REQUEST['pageNo']);
+            $this->pageNo = (int)$_REQUEST['pageNo'];
         }
 
         $linkParameters = [
@@ -216,7 +216,7 @@ class DevtoolsProjectPipEntryListPage extends AbstractPage
         }
 
         $this->items = \count($this->entryList->getEntries());
-        $this->pages = \intval(\ceil($this->items / $this->itemsPerPage));
+        $this->pages = (int)\ceil($this->items / $this->itemsPerPage);
 
         // correct active page number
         if ($this->pageNo > $this->pages) {

--- a/wcfsetup/install/files/lib/acp/page/DevtoolsProjectPipListPage.class.php
+++ b/wcfsetup/install/files/lib/acp/page/DevtoolsProjectPipListPage.class.php
@@ -53,7 +53,7 @@ class DevtoolsProjectPipListPage extends AbstractPage
         parent::readParameters();
 
         if (isset($_REQUEST['id'])) {
-            $this->projectID = \intval($_REQUEST['id']);
+            $this->projectID = (int)$_REQUEST['id'];
         }
         $this->project = new DevtoolsProject($this->projectID);
         if (!$this->project->projectID) {

--- a/wcfsetup/install/files/lib/acp/page/DevtoolsProjectSyncPage.class.php
+++ b/wcfsetup/install/files/lib/acp/page/DevtoolsProjectSyncPage.class.php
@@ -53,7 +53,7 @@ class DevtoolsProjectSyncPage extends AbstractPage
         parent::readParameters();
 
         if (isset($_REQUEST['id'])) {
-            $this->objectID = \intval($_REQUEST['id']);
+            $this->objectID = (int)$_REQUEST['id'];
         }
         $this->object = new DevtoolsProject($this->objectID);
         if (!$this->object->projectID) {

--- a/wcfsetup/install/files/lib/acp/page/LabelListPage.class.php
+++ b/wcfsetup/install/files/lib/acp/page/LabelListPage.class.php
@@ -183,7 +183,7 @@ class LabelListPage extends SortablePage
         if (!empty($_POST)) {
             $parameters = [];
             if (!empty($_POST['groupID'])) {
-                $parameters['id'] = \intval($_POST['groupID']);
+                $parameters['id'] = (int)$_POST['groupID'];
             }
             if (!empty($_POST['label'])) {
                 $parameters['label'] = StringUtil::trim($_POST['label']);
@@ -200,7 +200,7 @@ class LabelListPage extends SortablePage
         }
 
         if (isset($_REQUEST['id'])) {
-            $this->groupID = \intval($_REQUEST['id']);
+            $this->groupID = (int)$_REQUEST['id'];
         }
         if (isset($_REQUEST['label'])) {
             $this->label = StringUtil::trim($_REQUEST['label']);

--- a/wcfsetup/install/files/lib/acp/page/LanguageItemListPage.class.php
+++ b/wcfsetup/install/files/lib/acp/page/LanguageItemListPage.class.php
@@ -120,10 +120,10 @@ class LanguageItemListPage extends SortablePage
         parent::readParameters();
 
         if (isset($_REQUEST['languageID'])) {
-            $this->languageID = \intval($_REQUEST['languageID']);
+            $this->languageID = (int)$_REQUEST['languageID'];
         }
         if (isset($_REQUEST['languageCategoryID'])) {
-            $this->languageCategoryID = \intval($_REQUEST['languageCategoryID']);
+            $this->languageCategoryID = (int)$_REQUEST['languageCategoryID'];
         }
         if (isset($_REQUEST['languageItem'])) {
             $this->languageItem = StringUtil::trim($_REQUEST['languageItem']);

--- a/wcfsetup/install/files/lib/acp/page/MediaListPage.class.php
+++ b/wcfsetup/install/files/lib/acp/page/MediaListPage.class.php
@@ -154,7 +154,7 @@ class MediaListPage extends SortablePage
         parent::readParameters();
 
         if (isset($_REQUEST['categoryID'])) {
-            $this->categoryID = \intval($_REQUEST['categoryID']);
+            $this->categoryID = (int)$_REQUEST['categoryID'];
         }
         if (isset($_REQUEST['q'])) {
             $this->query = StringUtil::trim($_REQUEST['q']);

--- a/wcfsetup/install/files/lib/acp/page/MenuItemListPage.class.php
+++ b/wcfsetup/install/files/lib/acp/page/MenuItemListPage.class.php
@@ -55,7 +55,7 @@ class MenuItemListPage extends AbstractPage
         parent::readParameters();
 
         if (isset($_REQUEST['id'])) {
-            $this->menuID = \intval($_REQUEST['id']);
+            $this->menuID = (int)$_REQUEST['id'];
         }
         $this->menu = new Menu($this->menuID);
         if (!$this->menu->menuID) {

--- a/wcfsetup/install/files/lib/acp/page/ModificationLogListPage.class.php
+++ b/wcfsetup/install/files/lib/acp/page/ModificationLogListPage.class.php
@@ -247,10 +247,10 @@ class ModificationLogListPage extends SortablePage
 
             $afterDate = $beforeDate = 0;
             if (!empty($this->afterDate)) {
-                $afterDate = \intval(@\strtotime($this->afterDate));
+                $afterDate = (int)@\strtotime($this->afterDate);
             }
             if (!empty($this->beforeDate)) {
-                $beforeDate = \intval(@\strtotime($this->beforeDate));
+                $beforeDate = (int)@\strtotime($this->beforeDate);
             }
 
             if ($afterDate && $beforeDate) {

--- a/wcfsetup/install/files/lib/acp/page/PackageInstallationConfirmPage.class.php
+++ b/wcfsetup/install/files/lib/acp/page/PackageInstallationConfirmPage.class.php
@@ -63,7 +63,7 @@ class PackageInstallationConfirmPage extends AbstractPage
         parent::readParameters();
 
         if (isset($_REQUEST['queueID'])) {
-            $this->queueID = \intval($_REQUEST['queueID']);
+            $this->queueID = (int)$_REQUEST['queueID'];
         }
         $this->queue = new PackageInstallationQueue($this->queueID);
         if (!$this->queue->queueID || $this->queue->done) {

--- a/wcfsetup/install/files/lib/acp/page/PackagePage.class.php
+++ b/wcfsetup/install/files/lib/acp/page/PackagePage.class.php
@@ -61,7 +61,7 @@ class PackagePage extends AbstractPage
         parent::readParameters();
 
         if (isset($_REQUEST['id'])) {
-            $this->packageID = \intval($_REQUEST['id']);
+            $this->packageID = (int)$_REQUEST['id'];
         }
         $this->package = new Package($this->packageID);
         if (!$this->package->packageID) {
@@ -82,7 +82,7 @@ class PackagePage extends AbstractPage
                     AND pluginStoreFileID <> 0";
         $statement = WCF::getDB()->prepareStatement($sql);
         $statement->execute([$this->package->package]);
-        $this->pluginStoreFileID = \intval($statement->fetchSingleColumn());
+        $this->pluginStoreFileID = (int)$statement->fetchSingleColumn();
     }
 
     /**

--- a/wcfsetup/install/files/lib/acp/page/PageBoxOrderPage.class.php
+++ b/wcfsetup/install/files/lib/acp/page/PageBoxOrderPage.class.php
@@ -57,7 +57,7 @@ class PageBoxOrderPage extends AbstractPage
         parent::readParameters();
 
         if (!empty($_REQUEST['id'])) {
-            $this->pageID = \intval($_REQUEST['id']);
+            $this->pageID = (int)$_REQUEST['id'];
         }
 
         $this->page = PageCache::getInstance()->getPage($this->pageID);

--- a/wcfsetup/install/files/lib/acp/page/PageListPage.class.php
+++ b/wcfsetup/install/files/lib/acp/page/PageListPage.class.php
@@ -124,7 +124,7 @@ class PageListPage extends SortablePage
             $this->content = StringUtil::trim($_REQUEST['content']);
         }
         if (isset($_REQUEST['applicationPackageID'])) {
-            $this->applicationPackageID = \intval($_REQUEST['applicationPackageID']);
+            $this->applicationPackageID = (int)$_REQUEST['applicationPackageID'];
         }
         if (!empty($_REQUEST['pageType'])) {
             $this->pageType = $_REQUEST['pageType'];

--- a/wcfsetup/install/files/lib/acp/page/PaidSubscriptionTransactionLogListPage.class.php
+++ b/wcfsetup/install/files/lib/acp/page/PaidSubscriptionTransactionLogListPage.class.php
@@ -96,7 +96,7 @@ class PaidSubscriptionTransactionLogListPage extends SortablePage
             $this->username = StringUtil::trim($_REQUEST['username']);
         }
         if (isset($_REQUEST['subscriptionID'])) {
-            $this->subscriptionID = \intval($_REQUEST['subscriptionID']);
+            $this->subscriptionID = (int)$_REQUEST['subscriptionID'];
         }
     }
 

--- a/wcfsetup/install/files/lib/acp/page/PaidSubscriptionTransactionLogPage.class.php
+++ b/wcfsetup/install/files/lib/acp/page/PaidSubscriptionTransactionLogPage.class.php
@@ -52,7 +52,7 @@ class PaidSubscriptionTransactionLogPage extends AbstractPage
         parent::readParameters();
 
         if (isset($_REQUEST['id'])) {
-            $this->logID = \intval($_REQUEST['id']);
+            $this->logID = (int)$_REQUEST['id'];
         }
         $this->log = new PaidSubscriptionTransactionLog($this->logID);
         if (!$this->log->logID) {

--- a/wcfsetup/install/files/lib/acp/page/PaidSubscriptionUserListPage.class.php
+++ b/wcfsetup/install/files/lib/acp/page/PaidSubscriptionUserListPage.class.php
@@ -73,7 +73,7 @@ class PaidSubscriptionUserListPage extends SortablePage
             $this->username = StringUtil::trim($_REQUEST['username']);
         }
         if (isset($_REQUEST['subscriptionID'])) {
-            $this->subscriptionID = \intval($_REQUEST['subscriptionID']);
+            $this->subscriptionID = (int)$_REQUEST['subscriptionID'];
         }
     }
 

--- a/wcfsetup/install/files/lib/acp/page/SmileyListPage.class.php
+++ b/wcfsetup/install/files/lib/acp/page/SmileyListPage.class.php
@@ -78,7 +78,7 @@ class SmileyListPage extends MultipleLinkPage
         parent::readParameters();
 
         if (isset($_REQUEST['id'])) {
-            $this->categoryID = \intval($_REQUEST['id']);
+            $this->categoryID = (int)$_REQUEST['id'];
             $this->category = new Category($this->categoryID);
             if (!$this->category->categoryID) {
                 throw new IllegalLinkException();

--- a/wcfsetup/install/files/lib/acp/page/TemplateDiffPage.class.php
+++ b/wcfsetup/install/files/lib/acp/page/TemplateDiffPage.class.php
@@ -70,14 +70,14 @@ class TemplateDiffPage extends AbstractPage
         parent::readParameters();
 
         if (isset($_REQUEST['id'])) {
-            $this->templateID = \intval($_REQUEST['id']);
+            $this->templateID = (int)$_REQUEST['id'];
         }
         $this->template = new Template($this->templateID);
         if (!$this->template->templateID) {
             throw new IllegalLinkException();
         }
         if (isset($_REQUEST['parentID'])) {
-            $this->parentID = \intval($_REQUEST['parentID']);
+            $this->parentID = (int)$_REQUEST['parentID'];
         }
         $this->parent = new Template($this->parentID);
         if ($this->parent->templateID) {

--- a/wcfsetup/install/files/lib/acp/page/TemplateListPage.class.php
+++ b/wcfsetup/install/files/lib/acp/page/TemplateListPage.class.php
@@ -91,7 +91,7 @@ class TemplateListPage extends SortablePage
         parent::readParameters();
 
         if (isset($_REQUEST['templateGroupID'])) {
-            $this->templateGroupID = \intval($_REQUEST['templateGroupID']);
+            $this->templateGroupID = (int)$_REQUEST['templateGroupID'];
         }
         if (isset($_REQUEST['searchTemplateName'])) {
             $this->searchTemplateName = StringUtil::trim($_REQUEST['searchTemplateName']);

--- a/wcfsetup/install/files/lib/acp/page/UserGroupListPage.class.php
+++ b/wcfsetup/install/files/lib/acp/page/UserGroupListPage.class.php
@@ -58,7 +58,7 @@ class UserGroupListPage extends SortablePage
 
         // detect group deletion
         if (isset($_REQUEST['deletedGroups'])) {
-            $this->deletedGroups = \intval($_REQUEST['deletedGroups']);
+            $this->deletedGroups = (int)$_REQUEST['deletedGroups'];
         }
     }
 

--- a/wcfsetup/install/files/lib/acp/page/UserListPage.class.php
+++ b/wcfsetup/install/files/lib/acp/page/UserListPage.class.php
@@ -145,7 +145,7 @@ class UserListPage extends SortablePage
         $this->conditions = new PreparedStatementConditionBuilder();
 
         if (!empty($_REQUEST['id'])) {
-            $this->searchID = \intval($_REQUEST['id']);
+            $this->searchID = (int)$_REQUEST['id'];
             if ($this->searchID) {
                 $this->readSearchResult();
             }
@@ -307,7 +307,7 @@ class UserListPage extends SortablePage
                 $row['editable'] = ($accessible && WCF::getSession()->getPermission('admin.user.canEditUser')) ? 1 : 0;
                 $row['bannable'] = ($accessible && WCF::getSession()->getPermission('admin.user.canBanUser') && $row['userID'] != WCF::getUser()->userID) ? 1 : 0;
                 $row['canBeEnabled'] = ($accessible && WCF::getSession()->getPermission('admin.user.canEnableUser') && $row['userID'] != WCF::getUser()->userID) ? 1 : 0;
-                $row['isMarked'] = \intval(\in_array($row['userID'], $this->markedUsers));
+                $row['isMarked'] = (int)\in_array($row['userID'], $this->markedUsers);
 
                 $this->users[] = new UserProfile(new User(null, $row));
             }

--- a/wcfsetup/install/files/lib/acp/page/UserTrophyListPage.class.php
+++ b/wcfsetup/install/files/lib/acp/page/UserTrophyListPage.class.php
@@ -84,7 +84,7 @@ class UserTrophyListPage extends SortablePage
             $this->username = StringUtil::trim($_REQUEST['username']);
         }
         if (isset($_REQUEST['trophyID'])) {
-            $this->trophyID = \intval($_REQUEST['trophyID']);
+            $this->trophyID = (int)$_REQUEST['trophyID'];
             $this->trophy = new Trophy($this->trophyID);
 
             if (!$this->trophy->getObjectID()) {

--- a/wcfsetup/install/files/lib/acp/page/VersionTrackerListPage.class.php
+++ b/wcfsetup/install/files/lib/acp/page/VersionTrackerListPage.class.php
@@ -105,7 +105,7 @@ class VersionTrackerListPage extends AbstractPage
         parent::readParameters();
 
         if (isset($_REQUEST['objectID'])) {
-            $this->objectID = \intval($_REQUEST['objectID']);
+            $this->objectID = (int)$_REQUEST['objectID'];
         }
         if (isset($_REQUEST['objectType'])) {
             $this->objectType = $_REQUEST['objectType'];
@@ -132,14 +132,14 @@ class VersionTrackerListPage extends AbstractPage
         $this->versions = VersionTracker::getInstance()->getVersions($this->objectType, $this->objectID);
 
         if (isset($_REQUEST['oldID'])) {
-            $this->oldID = \intval($_REQUEST['oldID']);
+            $this->oldID = (int)$_REQUEST['oldID'];
             $this->old = VersionTracker::getInstance()->getVersion($this->objectType, $this->oldID);
             if (!$this->old->versionID) {
                 throw new IllegalLinkException();
             }
 
             if (isset($_REQUEST['newID']) && $_REQUEST['newID'] !== 'current') {
-                $this->newID = \intval($_REQUEST['newID']);
+                $this->newID = (int)$_REQUEST['newID'];
                 $this->new = VersionTracker::getInstance()->getVersion($this->objectType, $this->newID);
                 if (!$this->new->versionID) {
                     throw new IllegalLinkException();

--- a/wcfsetup/install/files/lib/action/GravatarDownloadAction.class.php
+++ b/wcfsetup/install/files/lib/action/GravatarDownloadAction.class.php
@@ -48,7 +48,7 @@ class GravatarDownloadAction extends AbstractAction
         parent::readParameters();
 
         if (isset($_REQUEST['userID'])) {
-            $this->userID = \intval($_REQUEST['userID']);
+            $this->userID = (int)$_REQUEST['userID'];
         }
         $this->user = new User($this->userID);
         if (!$this->user->userID) {

--- a/wcfsetup/install/files/lib/action/MessageQuoteAction.class.php
+++ b/wcfsetup/install/files/lib/action/MessageQuoteAction.class.php
@@ -62,7 +62,7 @@ class MessageQuoteAction extends AJAXProxyAction
             throw new UserInputException('actionName');
         }
         if (isset($_POST['getFullQuoteObjectIDs'])) {
-            $this->_getFullQuoteObjectIDs = \intval($_POST['getFullQuoteObjectIDs']);
+            $this->_getFullQuoteObjectIDs = (int)$_POST['getFullQuoteObjectIDs'];
         }
         if (isset($_POST['objectTypes']) && \is_array($_POST['objectTypes'])) {
             $this->objectTypes = ArrayUtil::trim($_POST['objectTypes']);

--- a/wcfsetup/install/files/lib/action/NotificationConfirmAction.class.php
+++ b/wcfsetup/install/files/lib/action/NotificationConfirmAction.class.php
@@ -51,7 +51,7 @@ class NotificationConfirmAction extends AbstractAction
         parent::readParameters();
 
         if (isset($_REQUEST['id'])) {
-            $this->notificationID = \intval($_REQUEST['id']);
+            $this->notificationID = (int)$_REQUEST['id'];
         }
 
         $this->notification = new UserNotification($this->notificationID);

--- a/wcfsetup/install/files/lib/action/NotificationDisableAction.class.php
+++ b/wcfsetup/install/files/lib/action/NotificationDisableAction.class.php
@@ -44,10 +44,10 @@ class NotificationDisableAction extends AbstractAction
         parent::readParameters();
 
         if (isset($_REQUEST['eventID'])) {
-            $this->eventID = \intval($_REQUEST['eventID']);
+            $this->eventID = (int)$_REQUEST['eventID'];
         }
         if (isset($_REQUEST['userID'])) {
-            $this->userID = \intval($_REQUEST['userID']);
+            $this->userID = (int)$_REQUEST['userID'];
         }
         if (isset($_REQUEST['token'])) {
             $this->token = StringUtil::trim($_REQUEST['token']);

--- a/wcfsetup/install/files/lib/action/PaypalCallbackAction.class.php
+++ b/wcfsetup/install/files/lib/action/PaypalCallbackAction.class.php
@@ -93,7 +93,7 @@ class PaypalCallbackAction extends AbstractAction
                 throw new \Exception('invalid custom item');
             }
             // get payment type object type
-            $objectType = ObjectTypeCache::getInstance()->getObjectType(\intval($tokenParts[0]));
+            $objectType = ObjectTypeCache::getInstance()->getObjectType((int)$tokenParts[0]);
             if ($objectType === null || !($objectType->getProcessor() instanceof IPaymentType)) {
                 throw new \Exception('invalid payment type id');
             }

--- a/wcfsetup/install/files/lib/data/AbstractDatabaseObjectAction.class.php
+++ b/wcfsetup/install/files/lib/data/AbstractDatabaseObjectAction.class.php
@@ -558,7 +558,7 @@ abstract class AbstractDatabaseObjectAction implements IDatabaseObjectAction, ID
                     }
                 } else {
                     if ($structure === self::STRUCT_FLAT) {
-                        $target[$variableName] = \intval($target[$variableName]);
+                        $target[$variableName] = (int)$target[$variableName];
                         if (!$allowEmpty && !$target[$variableName]) {
                             throw new UserInputException($variableName);
                         }

--- a/wcfsetup/install/files/lib/data/attachment/AttachmentAction.class.php
+++ b/wcfsetup/install/files/lib/data/attachment/AttachmentAction.class.php
@@ -116,8 +116,8 @@ class AttachmentAction extends AbstractDatabaseObjectAction implements ISortable
         // check upload permissions
         if (
             !$processor->canUpload(
-                (!empty($this->parameters['objectID']) ? \intval($this->parameters['objectID']) : 0),
-                (!empty($this->parameters['parentObjectID']) ? \intval($this->parameters['parentObjectID']) : 0)
+                (!empty($this->parameters['objectID']) ? (int)$this->parameters['objectID'] : 0),
+                (!empty($this->parameters['parentObjectID']) ? (int)$this->parameters['parentObjectID'] : 0)
             )
         ) {
             throw new PermissionDeniedException();
@@ -126,7 +126,7 @@ class AttachmentAction extends AbstractDatabaseObjectAction implements ISortable
         // check max count of uploads
         $handler = new AttachmentHandler(
             $this->parameters['objectType'],
-            \intval($this->parameters['objectID']),
+            (int)$this->parameters['objectID'],
             $this->parameters['tmpHash']
         );
         /** @noinspection PhpUndefinedMethodInspection */
@@ -161,7 +161,7 @@ class AttachmentAction extends AbstractDatabaseObjectAction implements ISortable
             'generateThumbnails' => true,
             'rotateImages' => true,
         ], [
-            'objectID' => \intval($this->parameters['objectID']),
+            'objectID' => (int)$this->parameters['objectID'],
             'objectTypeID' => $objectType->objectTypeID,
             'tmpHash' => !$this->parameters['objectID'] ? $this->parameters['tmpHash'] : '',
         ]);

--- a/wcfsetup/install/files/lib/data/category/CategoryEditor.class.php
+++ b/wcfsetup/install/files/lib/data/category/CategoryEditor.class.php
@@ -83,7 +83,7 @@ class CategoryEditor extends DatabaseObjectEditor implements IEditableCachedObje
                 $row = $statement->fetchArray();
                 $maxShowOrder = 0;
                 if (!empty($row)) {
-                    $maxShowOrder = \intval($row['showOrder']);
+                    $maxShowOrder = (int)$row['showOrder'];
                 }
 
                 if ($showOrder > $maxShowOrder) {
@@ -181,7 +181,7 @@ class CategoryEditor extends DatabaseObjectEditor implements IEditableCachedObje
         $row = $statement->fetchArray();
         $maxShowOrder = 0;
         if (!empty($row)) {
-            $maxShowOrder = \intval($row['showOrder']);
+            $maxShowOrder = (int)$row['showOrder'];
         }
 
         if ($maxShowOrder && $showOrder <= $maxShowOrder) {

--- a/wcfsetup/install/files/lib/data/custom/option/CustomOption.class.php
+++ b/wcfsetup/install/files/lib/data/custom/option/CustomOption.class.php
@@ -145,13 +145,13 @@ abstract class CustomOption extends Option implements ITitledObject
                 $year = $month = $day = 0;
                 $optionValue = \explode('-', $this->optionValue);
                 if (isset($optionValue[0])) {
-                    $year = \intval($optionValue[0]);
+                    $year = (int)$optionValue[0];
                 }
                 if (isset($optionValue[1])) {
-                    $month = \intval($optionValue[1]);
+                    $month = (int)$optionValue[1];
                 }
                 if (isset($optionValue[2])) {
-                    $day = \intval($optionValue[2]);
+                    $day = (int)$optionValue[2];
                 }
 
                 return DateUtil::format(
@@ -160,10 +160,10 @@ abstract class CustomOption extends Option implements ITitledObject
                 );
 
             case 'float':
-                return StringUtil::formatDouble(\doubleval($this->optionValue));
+                return StringUtil::formatDouble((double)$this->optionValue);
 
             case 'integer':
-                return StringUtil::formatInteger(\intval($this->optionValue));
+                return StringUtil::formatInteger((int)$this->optionValue);
 
             case 'radioButton':
             case 'select':

--- a/wcfsetup/install/files/lib/data/language/LanguageEditor.class.php
+++ b/wcfsetup/install/files/lib/data/language/LanguageEditor.class.php
@@ -707,7 +707,7 @@ class LanguageEditor extends DatabaseObjectEditor implements IEditableCachedObje
             $category = \preg_quote($category, '~');
         }
         if ($languageID != '.*') {
-            $languageID = \intval($languageID);
+            $languageID = (int)$languageID;
         }
 
         DirectoryUtil::getInstance(WCF_DIR . 'language/')->removePattern(new Regex($languageID . '_' . $category . '\.php$'));

--- a/wcfsetup/install/files/lib/data/media/MediaAction.class.php
+++ b/wcfsetup/install/files/lib/data/media/MediaAction.class.php
@@ -288,9 +288,9 @@ class MediaAction extends AbstractDatabaseObjectAction implements ISearchAction,
                 ];
             }
 
-            $mediaData[$row['mediaID']]['altText'][\intval($row['languageID'])] = $row['altText'];
-            $mediaData[$row['mediaID']]['caption'][\intval($row['languageID'])] = $row['caption'];
-            $mediaData[$row['mediaID']]['title'][\intval($row['languageID'])] = $row['title'];
+            $mediaData[$row['mediaID']]['altText'][(int)$row['languageID']] = $row['altText'];
+            $mediaData[$row['mediaID']]['caption'][(int)$row['languageID']] = $row['caption'];
+            $mediaData[$row['mediaID']]['title'][(int)$row['languageID']] = $row['title'];
         }
 
         $i18nMediaData = [];
@@ -392,7 +392,7 @@ class MediaAction extends AbstractDatabaseObjectAction implements ISearchAction,
             }
 
             // isMultilingual: convert boolean to integer
-            $this->parameters['data']['isMultilingual'] = \intval($this->parameters['data']['isMultilingual']);
+            $this->parameters['data']['isMultilingual'] = (int)$this->parameters['data']['isMultilingual'];
         } else {
             $this->parameters['data']['isMultilingual'] = 0;
             $this->parameters['data']['languageID'] = WCF::getLanguage()->languageID;

--- a/wcfsetup/install/files/lib/data/option/OptionEditor.class.php
+++ b/wcfsetup/install/files/lib/data/option/OptionEditor.class.php
@@ -168,7 +168,7 @@ class OptionEditor extends DatabaseObjectEditor implements IEditableCachedObject
             if ($writeValue === null) {
                 $writeValue = "''";
             } elseif ($option->optionType == 'boolean' || $option->optionType == 'integer') {
-                $writeValue = \intval($option->optionValue);
+                $writeValue = (int)$option->optionValue;
             } else {
                 $writeValue = "'" . \addcslashes($option->optionValue, "'\\") . "'";
             }

--- a/wcfsetup/install/files/lib/data/package/installation/queue/PackageInstallationQueue.class.php
+++ b/wcfsetup/install/files/lib/data/package/installation/queue/PackageInstallationQueue.class.php
@@ -40,6 +40,6 @@ class PackageInstallationQueue extends DatabaseObject
         $statement->execute();
         $row = $statement->fetchArray();
 
-        return \intval($row['processNo']) + 1;
+        return (int)$row['processNo'] + 1;
     }
 }

--- a/wcfsetup/install/files/lib/data/style/Style.class.php
+++ b/wcfsetup/install/files/lib/data/style/Style.class.php
@@ -146,7 +146,7 @@ class Style extends DatabaseObject
                 $r = $matches[1];
                 $g = $matches[2];
                 $b = $matches[3];
-                $a = \floatval($matches[4]);
+                $a = (float)$matches[4];
 
                 // calculate alpha value assuming a white canvas, source rgb will be (255,255,255) or #fff
                 // see https://stackoverflow.com/a/2049362
@@ -156,7 +156,7 @@ class Style extends DatabaseObject
                     $b = ((1 - $a) * 255) + ($a * $b);
 
                     $clamp = static function ($v) {
-                        return \max(0, \min(255, \intval($v)));
+                        return \max(0, \min(255, (int)$v));
                     };
 
                     $r = $clamp($r);

--- a/wcfsetup/install/files/lib/data/user/UserBirthdayAction.class.php
+++ b/wcfsetup/install/files/lib/data/user/UserBirthdayAction.class.php
@@ -58,13 +58,13 @@ class UserBirthdayAction extends UserProfileAction implements IGroupedUserListAc
         $year = $month = $day = 0;
         $value = \explode('-', $this->parameters['date']);
         if (isset($value[0])) {
-            $year = \intval($value[0]);
+            $year = (int)$value[0];
         }
         if (isset($value[1])) {
-            $month = \intval($value[1]);
+            $month = (int)$value[1];
         }
         if (isset($value[2])) {
-            $day = \intval($value[2]);
+            $day = (int)$value[2];
         }
 
         // get users

--- a/wcfsetup/install/files/lib/data/user/UserProfile.class.php
+++ b/wcfsetup/install/files/lib/data/user/UserProfile.class.php
@@ -796,7 +796,7 @@ class UserProfile extends DatabaseObjectDecorator implements ITitledLinkObject
                 $birthdayYear = 0;
                 $value = \explode('-', $this->birthday);
                 if (isset($value[0])) {
-                    $birthdayYear = \intval($value[0]);
+                    $birthdayYear = (int)$value[0];
                 }
                 if ($birthdayYear) {
                     return $year - $birthdayYear;
@@ -829,13 +829,13 @@ class UserProfile extends DatabaseObjectDecorator implements ITitledLinkObject
         $birthdayYear = $month = $day = 0;
         $value = \explode('-', $this->birthday);
         if (isset($value[0])) {
-            $birthdayYear = \intval($value[0]);
+            $birthdayYear = (int)$value[0];
         }
         if (isset($value[1])) {
-            $month = \intval($value[1]);
+            $month = (int)$value[1];
         }
         if (isset($value[2])) {
-            $day = \intval($value[2]);
+            $day = (int)$value[2];
         }
 
         if (!$month || !$day) {

--- a/wcfsetup/install/files/lib/data/user/UserProfileAction.class.php
+++ b/wcfsetup/install/files/lib/data/user/UserProfileAction.class.php
@@ -708,7 +708,7 @@ class UserProfileAction extends UserAction implements IPopoverAction
     public function uploadCoverPhoto()
     {
         $saveStrategy = new UserCoverPhotoUploadFileSaveStrategy(
-            (!empty($this->parameters['userID']) ? \intval($this->parameters['userID']) : WCF::getUser()->userID)
+            (!empty($this->parameters['userID']) ? (int)$this->parameters['userID'] : WCF::getUser()->userID)
         );
         /** @noinspection PhpUndefinedMethodInspection */
         $this->parameters['__files']->saveFiles($saveStrategy);

--- a/wcfsetup/install/files/lib/data/user/avatar/UserAvatarAction.class.php
+++ b/wcfsetup/install/files/lib/data/user/avatar/UserAvatarAction.class.php
@@ -82,7 +82,7 @@ class UserAvatarAction extends AbstractDatabaseObjectAction
     {
         /** @var UploadFile $file */
         $file = $this->parameters['__files']->getFiles()[0];
-        $saveStrategy = new AvatarUploadFileSaveStrategy((!empty($this->parameters['userID']) ? \intval($this->parameters['userID']) : WCF::getUser()->userID));
+        $saveStrategy = new AvatarUploadFileSaveStrategy((!empty($this->parameters['userID']) ? (int)$this->parameters['userID'] : WCF::getUser()->userID));
         /** @noinspection PhpUndefinedMethodInspection */
         $this->parameters['__files']->saveFiles($saveStrategy);
 

--- a/wcfsetup/install/files/lib/data/user/ignore/UserIgnoreAction.class.php
+++ b/wcfsetup/install/files/lib/data/user/ignore/UserIgnoreAction.class.php
@@ -257,7 +257,7 @@ class UserIgnoreAction extends AbstractDatabaseObjectAction
                 new CustomFormDataProcessor(
                     'type',
                     static function (IFormDocument $document, array $parameters) {
-                        $parameters['data']['type'] = \intval($parameters['data']['type']);
+                        $parameters['data']['type'] = (int)$parameters['data']['type'];
 
                         return $parameters;
                     }

--- a/wcfsetup/install/files/lib/data/user/object/watch/UserObjectWatchAction.class.php
+++ b/wcfsetup/install/files/lib/data/user/object/watch/UserObjectWatchAction.class.php
@@ -145,7 +145,7 @@ class UserObjectWatchAction extends AbstractDatabaseObjectAction
 
         UserObjectWatchEditor::create([
             'userID' => WCF::getUser()->userID,
-            'objectID' => \intval($this->parameters['data']['objectID']),
+            'objectID' => (int)$this->parameters['data']['objectID'],
             'objectTypeID' => $objectType->objectTypeID,
             'notification' => !empty($this->parameters['enableNotification']) ? 1 : 0,
         ]);
@@ -170,7 +170,7 @@ class UserObjectWatchAction extends AbstractDatabaseObjectAction
             $userObjectWatch = UserObjectWatch::getUserObjectWatch(
                 $objectType->objectTypeID,
                 WCF::getUser()->userID,
-                \intval($this->parameters['data']['objectID'])
+                (int)$this->parameters['data']['objectID']
             );
         }
         $editor = new UserObjectWatchEditor($userObjectWatch);
@@ -198,13 +198,13 @@ class UserObjectWatchAction extends AbstractDatabaseObjectAction
         }
 
         // validate object id
-        $objectType->getProcessor()->validateObjectID(\intval($this->parameters['data']['objectID']));
+        $objectType->getProcessor()->validateObjectID((int)$this->parameters['data']['objectID']);
 
         // get existing subscription
         $this->userObjectWatch = UserObjectWatch::getUserObjectWatch(
             $objectType->objectTypeID,
             WCF::getUser()->userID,
-            \intval($this->parameters['data']['objectID'])
+            (int)$this->parameters['data']['objectID']
         );
     }
 

--- a/wcfsetup/install/files/lib/data/user/option/UserOptionEditor.class.php
+++ b/wcfsetup/install/files/lib/data/user/option/UserOptionEditor.class.php
@@ -112,7 +112,7 @@ class UserOptionEditor extends DatabaseObjectEditor implements IEditableCachedOb
      */
     public function enable($enable = true)
     {
-        $value = \intval(!$enable);
+        $value = (int)!$enable;
 
         $sql = "UPDATE  wcf" . WCF_N . "_user_option
                 SET     isDisabled = ?

--- a/wcfsetup/install/files/lib/data/user/profile/menu/item/UserProfileMenuItemEditor.class.php
+++ b/wcfsetup/install/files/lib/data/user/profile/menu/item/UserProfileMenuItemEditor.class.php
@@ -113,7 +113,7 @@ class UserProfileMenuItemEditor extends DatabaseObjectEditor implements IEditabl
             $statement->execute();
             $row = $statement->fetchArray();
             if (!empty($row)) {
-                $showOrder = \intval($row['showOrder']) + 1;
+                $showOrder = (int)$row['showOrder'] + 1;
             } else {
                 $showOrder = 1;
             }

--- a/wcfsetup/install/files/lib/form/AbstractModerationForm.class.php
+++ b/wcfsetup/install/files/lib/form/AbstractModerationForm.class.php
@@ -96,7 +96,7 @@ abstract class AbstractModerationForm extends AbstractForm
         ModerationQueueManager::getInstance()->getOutstandingModerationCount();
 
         if (isset($_REQUEST['id'])) {
-            $this->queueID = \intval($_REQUEST['id']);
+            $this->queueID = (int)$_REQUEST['id'];
         }
         $this->queue = ViewableModerationQueue::getViewableModerationQueue($this->queueID);
         if ($this->queue === null) {

--- a/wcfsetup/install/files/lib/form/AccountManagementForm.class.php
+++ b/wcfsetup/install/files/lib/form/AccountManagementForm.class.php
@@ -182,36 +182,36 @@ class AccountManagementForm extends AbstractForm
             $this->username = StringUtil::trim($_POST['username']);
         }
         if (isset($_POST['quit'])) {
-            $this->quit = \intval($_POST['quit']);
+            $this->quit = (int)$_POST['quit'];
         }
         if (isset($_POST['cancelQuit'])) {
-            $this->cancelQuit = \intval($_POST['cancelQuit']);
+            $this->cancelQuit = (int)$_POST['cancelQuit'];
         }
         if (isset($_POST['githubDisconnect'])) {
-            $this->githubDisconnect = \intval($_POST['githubDisconnect']);
+            $this->githubDisconnect = (int)$_POST['githubDisconnect'];
         }
         if (isset($_POST['twitterDisconnect'])) {
-            $this->twitterDisconnect = \intval($_POST['twitterDisconnect']);
+            $this->twitterDisconnect = (int)$_POST['twitterDisconnect'];
         }
         if (isset($_POST['facebookDisconnect'])) {
-            $this->facebookDisconnect = \intval($_POST['facebookDisconnect']);
+            $this->facebookDisconnect = (int)$_POST['facebookDisconnect'];
         }
         if (isset($_POST['googleDisconnect'])) {
-            $this->googleDisconnect = \intval($_POST['googleDisconnect']);
+            $this->googleDisconnect = (int)$_POST['googleDisconnect'];
         }
 
         if (!WCF::getUser()->hasAdministrativeAccess()) {
             if (isset($_POST['facebookConnect'])) {
-                $this->facebookConnect = \intval($_POST['facebookConnect']);
+                $this->facebookConnect = (int)$_POST['facebookConnect'];
             }
             if (isset($_POST['githubConnect'])) {
-                $this->githubConnect = \intval($_POST['githubConnect']);
+                $this->githubConnect = (int)$_POST['githubConnect'];
             }
             if (isset($_POST['googleConnect'])) {
-                $this->googleConnect = \intval($_POST['googleConnect']);
+                $this->googleConnect = (int)$_POST['googleConnect'];
             }
             if (isset($_POST['twitterConnect'])) {
-                $this->twitterConnect = \intval($_POST['twitterConnect']);
+                $this->twitterConnect = (int)$_POST['twitterConnect'];
             }
         }
     }

--- a/wcfsetup/install/files/lib/form/ContactForm.class.php
+++ b/wcfsetup/install/files/lib/form/ContactForm.class.php
@@ -120,7 +120,7 @@ class ContactForm extends AbstractCaptchaForm
             $this->name = StringUtil::trim($_POST['name']);
         }
         if (isset($_POST['recipientID'])) {
-            $this->recipientID = \intval($_POST['recipientID']);
+            $this->recipientID = (int)$_POST['recipientID'];
         }
         if (!empty($_POST['privacyPolicyConfirmed'])) {
             $this->privacyPolicyConfirmed = 1;

--- a/wcfsetup/install/files/lib/form/EmailActivationForm.class.php
+++ b/wcfsetup/install/files/lib/form/EmailActivationForm.class.php
@@ -48,10 +48,10 @@ class EmailActivationForm extends AbstractForm
         parent::readParameters();
 
         if (isset($_GET['u']) && !empty($_GET['u'])) {
-            $this->userID = \intval($_GET['u']);
+            $this->userID = (int)$_GET['u'];
         }
         if (isset($_GET['a']) && !empty($_GET['a'])) {
-            $this->activationCode = \intval($_GET['a']);
+            $this->activationCode = (int)$_GET['a'];
         }
     }
 
@@ -63,10 +63,10 @@ class EmailActivationForm extends AbstractForm
         parent::readFormParameters();
 
         if (isset($_POST['u']) && !empty($_POST['u'])) {
-            $this->userID = \intval($_POST['u']);
+            $this->userID = (int)$_POST['u'];
         }
         if (isset($_POST['a']) && !empty($_POST['a'])) {
-            $this->activationCode = \intval($_POST['a']);
+            $this->activationCode = (int)$_POST['a'];
         }
     }
 

--- a/wcfsetup/install/files/lib/form/MessageForm.class.php
+++ b/wcfsetup/install/files/lib/form/MessageForm.class.php
@@ -169,7 +169,7 @@ abstract class MessageForm extends AbstractCaptchaForm
 
         // multilingualism
         if (isset($_POST['languageID'])) {
-            $this->languageID = \intval($_POST['languageID']);
+            $this->languageID = (int)$_POST['languageID'];
         }
     }
 

--- a/wcfsetup/install/files/lib/form/MultifactorAuthenticationForm.class.php
+++ b/wcfsetup/install/files/lib/form/MultifactorAuthenticationForm.class.php
@@ -104,7 +104,7 @@ class MultifactorAuthenticationForm extends AbstractFormBuilderForm
 
         $setupId = \array_keys($this->setups)[0];
         if (isset($_GET['id'])) {
-            $setupId = \intval($_GET['id']);
+            $setupId = (int)$_GET['id'];
         }
 
         if (!isset($this->setups[$setupId])) {

--- a/wcfsetup/install/files/lib/form/MultifactorManageForm.class.php
+++ b/wcfsetup/install/files/lib/form/MultifactorManageForm.class.php
@@ -81,7 +81,7 @@ class MultifactorManageForm extends AbstractFormBuilderForm
             throw new IllegalLinkException();
         }
 
-        $objectType = ObjectTypeCache::getInstance()->getObjectType(\intval($_GET['id']));
+        $objectType = ObjectTypeCache::getInstance()->getObjectType((int)$_GET['id']);
 
         if (!$objectType) {
             throw new IllegalLinkException();

--- a/wcfsetup/install/files/lib/form/NewPasswordForm.class.php
+++ b/wcfsetup/install/files/lib/form/NewPasswordForm.class.php
@@ -71,7 +71,7 @@ class NewPasswordForm extends AbstractForm
         parent::readParameters();
 
         if (isset($_GET['id']) && isset($_GET['k'])) {
-            $this->userID = \intval($_GET['id']);
+            $this->userID = (int)$_GET['id'];
             $this->lostPasswordKey = StringUtil::trim($_GET['k']);
             if (!$this->userID || !$this->lostPasswordKey) {
                 throw new IllegalLinkException();
@@ -101,7 +101,7 @@ class NewPasswordForm extends AbstractForm
             if (!\is_array(WCF::getSession()->getVar('lostPasswordRequest'))) {
                 throw new PermissionDeniedException();
             }
-            $this->userID = \intval(WCF::getSession()->getVar('lostPasswordRequest')['userID']);
+            $this->userID = (int)WCF::getSession()->getVar('lostPasswordRequest')['userID'];
 
             $this->user = new User($this->userID);
             if (!$this->user->userID) {

--- a/wcfsetup/install/files/lib/form/NotificationUnsubscribeForm.class.php
+++ b/wcfsetup/install/files/lib/form/NotificationUnsubscribeForm.class.php
@@ -60,7 +60,7 @@ class NotificationUnsubscribeForm extends AbstractForm
         parent::readParameters();
 
         if (isset($_REQUEST['userID'])) {
-            $this->user = new User(\intval($_REQUEST['userID']));
+            $this->user = new User((int)$_REQUEST['userID']);
             if (!$this->user->userID) {
                 throw new IllegalLinkException();
             }
@@ -75,7 +75,7 @@ class NotificationUnsubscribeForm extends AbstractForm
         }
 
         if (!empty($_REQUEST['eventID'])) {
-            $this->event = new UserNotificationEvent(\intval($_REQUEST['eventID']));
+            $this->event = new UserNotificationEvent((int)$_REQUEST['eventID']);
             if (!$this->event->eventID) {
                 throw new IllegalLinkException();
             }

--- a/wcfsetup/install/files/lib/form/RegisterActivationForm.class.php
+++ b/wcfsetup/install/files/lib/form/RegisterActivationForm.class.php
@@ -50,7 +50,7 @@ class RegisterActivationForm extends AbstractForm
         parent::readParameters();
 
         if (!empty($_GET['u'])) {
-            $userID = \intval($_GET['u']);
+            $userID = (int)$_GET['u'];
             $this->user = new User($userID);
             if ($this->user->userID) {
                 $this->username = $this->user->username;

--- a/wcfsetup/install/files/lib/form/SearchForm.class.php
+++ b/wcfsetup/install/files/lib/form/SearchForm.class.php
@@ -159,7 +159,7 @@ class SearchForm extends AbstractCaptchaForm
             $this->username = StringUtil::trim($_REQUEST['username']);
         }
         if (isset($_REQUEST['userID'])) {
-            $this->userID = \intval($_REQUEST['userID']);
+            $this->userID = (int)$_REQUEST['userID'];
         }
         if (isset($_REQUEST['types']) && \is_array($_REQUEST['types'])) {
             $this->selectedObjectTypes = $_REQUEST['types'];
@@ -182,7 +182,7 @@ class SearchForm extends AbstractCaptchaForm
         $this->submit = (!empty($_POST) || !empty($this->query) || !empty($this->username) || $this->userID);
 
         if (isset($_REQUEST['modify'])) {
-            $this->modifySearchID = \intval($_REQUEST['modify']);
+            $this->modifySearchID = (int)$_REQUEST['modify'];
             $this->modifySearch = new Search($this->modifySearchID);
 
             if (!$this->modifySearch->searchID || ($this->modifySearch->userID && $this->modifySearch->userID != WCF::getUser()->userID)) {
@@ -260,10 +260,10 @@ class SearchForm extends AbstractCaptchaForm
 
         $this->nameExactly = 0;
         if (isset($_POST['nameExactly'])) {
-            $this->nameExactly = \intval($_POST['nameExactly']);
+            $this->nameExactly = (int)$_POST['nameExactly'];
         }
         if (isset($_POST['subjectOnly'])) {
-            $this->subjectOnly = \intval($_POST['subjectOnly']);
+            $this->subjectOnly = (int)$_POST['subjectOnly'];
         }
         if (isset($_POST['startDate'])) {
             $this->startDate = $_POST['startDate'];

--- a/wcfsetup/install/files/lib/form/SettingsForm.class.php
+++ b/wcfsetup/install/files/lib/form/SettingsForm.class.php
@@ -154,10 +154,10 @@ class SettingsForm extends AbstractForm
                 $this->contentLanguageIDs = ArrayUtil::toIntegerArray($_POST['contentLanguageIDs']);
             }
             if (isset($_POST['languageID'])) {
-                $this->languageID = \intval($_POST['languageID']);
+                $this->languageID = (int)$_POST['languageID'];
             }
             if (isset($_POST['styleID'])) {
-                $this->styleID = \intval($_POST['styleID']);
+                $this->styleID = (int)$_POST['styleID'];
             }
             if (isset($_POST['specialTrophies'])) {
                 $this->specialTrophies = ArrayUtil::toIntegerArray($_POST['specialTrophies']);

--- a/wcfsetup/install/files/lib/form/TagSearchForm.class.php
+++ b/wcfsetup/install/files/lib/form/TagSearchForm.class.php
@@ -77,7 +77,7 @@ class TagSearchForm extends AbstractCaptchaForm
         parent::readFormParameters();
 
         if (isset($_POST['languageID'])) {
-            $this->languageID = \intval($_POST['languageID']);
+            $this->languageID = (int)$_POST['languageID'];
         }
         if (isset($_POST['tagNames']) && \is_array($_POST['tagNames'])) {
             $this->tagNames = ArrayUtil::trim($_POST['tagNames']);

--- a/wcfsetup/install/files/lib/page/AbstractArticlePage.class.php
+++ b/wcfsetup/install/files/lib/page/AbstractArticlePage.class.php
@@ -78,7 +78,7 @@ abstract class AbstractArticlePage extends AbstractPage
         parent::readParameters();
 
         if (isset($_REQUEST['id'])) {
-            $this->articleContentID = \intval($_REQUEST['id']);
+            $this->articleContentID = (int)$_REQUEST['id'];
         }
         $this->articleContent = ViewableArticleContent::getArticleContent($this->articleContentID);
         if ($this->articleContent === null) {

--- a/wcfsetup/install/files/lib/page/ArticleFeedPage.class.php
+++ b/wcfsetup/install/files/lib/page/ArticleFeedPage.class.php
@@ -39,7 +39,7 @@ class ArticleFeedPage extends AbstractFeedPage
         parent::readParameters();
 
         if (isset($_REQUEST['id'])) {
-            $this->categoryID = \intval($_REQUEST['id']);
+            $this->categoryID = (int)$_REQUEST['id'];
             $this->category = ArticleCategory::getCategory($this->categoryID);
             if ($this->category === null) {
                 throw new IllegalLinkException();

--- a/wcfsetup/install/files/lib/page/ArticleListPage.class.php
+++ b/wcfsetup/install/files/lib/page/ArticleListPage.class.php
@@ -134,7 +134,7 @@ class ArticleListPage extends SortablePage
         }
 
         if (!empty($_GET['userID'])) {
-            $this->user = new User(\intval($_GET['userID']));
+            $this->user = new User((int)$_GET['userID']);
             if (!$this->user->userID) {
                 throw new IllegalLinkException();
             }

--- a/wcfsetup/install/files/lib/page/AttachmentPage.class.php
+++ b/wcfsetup/install/files/lib/page/AttachmentPage.class.php
@@ -89,7 +89,7 @@ class AttachmentPage extends AbstractPage
         parent::readParameters();
 
         if (isset($_REQUEST['id'])) {
-            $this->attachmentID = \intval($_REQUEST['id']);
+            $this->attachmentID = (int)$_REQUEST['id'];
         }
         $this->attachment = new Attachment($this->attachmentID);
         if (!$this->attachment->attachmentID) {
@@ -98,11 +98,11 @@ class AttachmentPage extends AbstractPage
 
         $parameters = ['object' => $this->attachment];
         if (isset($_REQUEST['tiny']) && $this->attachment->tinyThumbnailType) {
-            $this->tiny = \intval($_REQUEST['tiny']);
+            $this->tiny = (int)$_REQUEST['tiny'];
             $parameters['tiny'] = $this->tiny;
         }
         if (isset($_REQUEST['thumbnail']) && $this->attachment->thumbnailType) {
-            $this->thumbnail = \intval($_REQUEST['thumbnail']);
+            $this->thumbnail = (int)$_REQUEST['thumbnail'];
             $parameters['thumbnail'] = $this->thumbnail;
         }
 

--- a/wcfsetup/install/files/lib/page/CategoryArticleListPage.class.php
+++ b/wcfsetup/install/files/lib/page/CategoryArticleListPage.class.php
@@ -46,7 +46,7 @@ class CategoryArticleListPage extends ArticleListPage
     public function readParameters()
     {
         if (isset($_REQUEST['id'])) {
-            $this->categoryID = \intval($_REQUEST['id']);
+            $this->categoryID = (int)$_REQUEST['id'];
         }
         $this->category = ArticleCategory::getCategory($this->categoryID);
         if ($this->category === null) {

--- a/wcfsetup/install/files/lib/page/CategoryTrophyListPage.class.php
+++ b/wcfsetup/install/files/lib/page/CategoryTrophyListPage.class.php
@@ -43,7 +43,7 @@ class CategoryTrophyListPage extends TrophyListPage
         parent::readParameters();
 
         if (isset($_REQUEST['id'])) {
-            $this->categoryID = \intval($_REQUEST['id']);
+            $this->categoryID = (int)$_REQUEST['id'];
         }
 
         $this->category = TrophyCategoryCache::getInstance()->getCategoryByID($this->categoryID);

--- a/wcfsetup/install/files/lib/page/EditHistoryPage.class.php
+++ b/wcfsetup/install/files/lib/page/EditHistoryPage.class.php
@@ -93,14 +93,14 @@ class EditHistoryPage extends AbstractPage
         parent::readParameters();
 
         if (isset($_REQUEST['oldID'])) {
-            $this->oldID = \intval($_REQUEST['oldID']);
+            $this->oldID = (int)$_REQUEST['oldID'];
             $this->old = new EditHistoryEntry($this->oldID);
             if (!$this->old->entryID) {
                 throw new IllegalLinkException();
             }
 
             if (isset($_REQUEST['newID']) && $_REQUEST['newID'] !== 'current') {
-                $this->newID = \intval($_REQUEST['newID']);
+                $this->newID = (int)$_REQUEST['newID'];
                 $this->new = new EditHistoryEntry($this->newID);
                 if (!$this->new->entryID) {
                     throw new IllegalLinkException();
@@ -122,7 +122,7 @@ class EditHistoryPage extends AbstractPage
             $this->objectID = $this->old->objectID;
             $this->objectType = ObjectTypeCache::getInstance()->getObjectType($this->old->objectTypeID);
         } elseif (isset($_REQUEST['objectID']) && isset($_REQUEST['objectType'])) {
-            $this->objectID = \intval($_REQUEST['objectID']);
+            $this->objectID = (int)$_REQUEST['objectID'];
             $this->objectType = ObjectTypeCache::getInstance()->getObjectTypeByName(
                 'com.woltlab.wcf.edit.historySavingObject',
                 $_REQUEST['objectType']

--- a/wcfsetup/install/files/lib/page/MediaPage.class.php
+++ b/wcfsetup/install/files/lib/page/MediaPage.class.php
@@ -120,7 +120,7 @@ class MediaPage extends AbstractPage
         parent::readParameters();
 
         if (isset($_REQUEST['id'])) {
-            $this->mediaID = \intval($_REQUEST['id']);
+            $this->mediaID = (int)$_REQUEST['id'];
         }
         $this->media = new Media($this->mediaID);
         if (!$this->media->mediaID) {

--- a/wcfsetup/install/files/lib/page/MembersListPage.class.php
+++ b/wcfsetup/install/files/lib/page/MembersListPage.class.php
@@ -100,7 +100,7 @@ class MembersListPage extends SortablePage
         }
 
         if (!empty($_REQUEST['id'])) {
-            $this->searchID = \intval($_REQUEST['id']);
+            $this->searchID = (int)$_REQUEST['id'];
             $this->search = new Search($this->searchID);
             if (!$this->search->searchID || $this->search->userID != WCF::getUser()->userID || $this->search->searchType != 'users') {
                 throw new IllegalLinkException();

--- a/wcfsetup/install/files/lib/page/ModerationListPage.class.php
+++ b/wcfsetup/install/files/lib/page/ModerationListPage.class.php
@@ -91,15 +91,15 @@ class ModerationListPage extends SortablePage
         parent::readParameters();
 
         if (isset($_REQUEST['assignedUserID'])) {
-            $this->assignedUserID = \intval($_REQUEST['assignedUserID']);
+            $this->assignedUserID = (int)$_REQUEST['assignedUserID'];
         }
         if (isset($_REQUEST['status'])) {
-            $this->status = \intval($_REQUEST['status']);
+            $this->status = (int)$_REQUEST['status'];
         }
 
         $this->availableDefinitions = ModerationQueueManager::getInstance()->getDefinitions();
         if (isset($_REQUEST['definitionID'])) {
-            $this->definitionID = \intval($_REQUEST['definitionID']);
+            $this->definitionID = (int)$_REQUEST['definitionID'];
             if ($this->definitionID && !isset($this->availableDefinitions[$this->definitionID])) {
                 throw new IllegalLinkException();
             }

--- a/wcfsetup/install/files/lib/page/MultipleLinkPage.class.php
+++ b/wcfsetup/install/files/lib/page/MultipleLinkPage.class.php
@@ -103,7 +103,7 @@ abstract class MultipleLinkPage extends AbstractPage
 
         // read page number parameter
         if (isset($_REQUEST['pageNo'])) {
-            $this->pageNo = \intval($_REQUEST['pageNo']);
+            $this->pageNo = (int)$_REQUEST['pageNo'];
         }
     }
 
@@ -183,7 +183,7 @@ abstract class MultipleLinkPage extends AbstractPage
 
         // calculate number of pages
         $this->items = $this->countItems();
-        $this->pages = \intval(\ceil($this->items / $this->itemsPerPage));
+        $this->pages = (int)\ceil($this->items / $this->itemsPerPage);
 
         // correct active page number
         if ($this->pageNo > $this->pages) {

--- a/wcfsetup/install/files/lib/page/SearchResultPage.class.php
+++ b/wcfsetup/install/files/lib/page/SearchResultPage.class.php
@@ -89,7 +89,7 @@ class SearchResultPage extends MultipleLinkPage
             $this->highlight = $_REQUEST['highlight'];
         }
         if (isset($_REQUEST['id'])) {
-            $this->searchID = \intval($_REQUEST['id']);
+            $this->searchID = (int)$_REQUEST['id'];
         }
         $this->search = new Search($this->searchID);
         if (!$this->search->searchID || $this->search->searchType != 'messages') {

--- a/wcfsetup/install/files/lib/page/TaggedPage.class.php
+++ b/wcfsetup/install/files/lib/page/TaggedPage.class.php
@@ -69,7 +69,7 @@ class TaggedPage extends MultipleLinkPage
 
         // get tag id
         if (isset($_REQUEST['id'])) {
-            $this->tagID = \intval($_REQUEST['id']);
+            $this->tagID = (int)$_REQUEST['id'];
         }
         $this->tag = new Tag($this->tagID);
         if (!$this->tag->tagID) {

--- a/wcfsetup/install/files/lib/page/TrophyPage.class.php
+++ b/wcfsetup/install/files/lib/page/TrophyPage.class.php
@@ -129,7 +129,7 @@ class TrophyPage extends MultipleLinkPage
         parent::readParameters();
 
         if (isset($_REQUEST['id'])) {
-            $this->trophyID = \intval($_REQUEST['id']);
+            $this->trophyID = (int)$_REQUEST['id'];
         }
 
         $this->trophy = TrophyCache::getInstance()->getTrophyByID($this->trophyID);

--- a/wcfsetup/install/files/lib/page/UserPage.class.php
+++ b/wcfsetup/install/files/lib/page/UserPage.class.php
@@ -87,7 +87,7 @@ class UserPage extends AbstractPage
         parent::readParameters();
 
         if (isset($_REQUEST['id'])) {
-            $this->userID = \intval($_REQUEST['id']);
+            $this->userID = (int)$_REQUEST['id'];
         }
         $this->user = UserProfileRuntimeCache::getInstance()->getObject($this->userID);
         if ($this->user === null) {

--- a/wcfsetup/install/files/lib/system/WCF.class.php
+++ b/wcfsetup/install/files/lib/system/WCF.class.php
@@ -515,7 +515,7 @@ class WCF
     protected function initLanguage()
     {
         if (isset($_GET['l']) && !self::getUser()->userID) {
-            self::getSession()->setLanguageID(\intval($_GET['l']));
+            self::getSession()->setLanguageID((int)$_GET['l']);
         }
 
         // set mb settings
@@ -548,7 +548,7 @@ class WCF
     {
         /** @deprecated The 'styleID' parameter is deprecated. */
         if (isset($_REQUEST['styleID'])) {
-            self::getSession()->setStyleID(\intval($_REQUEST['styleID']));
+            self::getSession()->setStyleID((int)$_REQUEST['styleID']);
         }
 
         $styleHandler = StyleHandler::getInstance();

--- a/wcfsetup/install/files/lib/system/WCFSetup.class.php
+++ b/wcfsetup/install/files/lib/system/WCFSetup.class.php
@@ -110,9 +110,9 @@ class WCFSetup extends WCF
     protected static function getDeveloperMode()
     {
         if (isset($_GET['dev'])) {
-            self::$developerMode = \intval($_GET['dev']);
+            self::$developerMode = (int)$_GET['dev'];
         } elseif (isset($_POST['dev'])) {
-            self::$developerMode = \intval($_POST['dev']);
+            self::$developerMode = (int)$_POST['dev'];
         }
     }
 
@@ -303,7 +303,7 @@ class WCFSetup extends WCF
             case 'createDB':
                 $currentStep = 6;
                 if (isset($_POST['offset'])) {
-                    $currentStep += \intval($_POST['offset']);
+                    $currentStep += (int)$_POST['offset'];
                 }
 
                 $this->calcProgress($currentStep);
@@ -391,7 +391,7 @@ class WCFSetup extends WCF
 
         // upload_max_filesize
         $system['uploadMaxFilesize']['value'] = \min(\ini_get('upload_max_filesize'), \ini_get('post_max_size'));
-        $system['uploadMaxFilesize']['result'] = (\intval($system['uploadMaxFilesize']['value']) > 0);
+        $system['uploadMaxFilesize']['result'] = ((int)$system['uploadMaxFilesize']['value'] > 0);
 
         // graphics library
         $system['graphicsLibrary']['result'] = false;
@@ -685,7 +685,7 @@ class WCFSetup extends WCF
 
             // ensure that $dbNumber is zero or a positive integer
             if (isset($_POST['dbNumber'])) {
-                $dbNumber = \max(0, \intval($_POST['dbNumber']));
+                $dbNumber = \max(0, (int)$_POST['dbNumber']);
             }
 
             // get port
@@ -693,7 +693,7 @@ class WCFSetup extends WCF
             $dbPort = 0;
             if (\preg_match('/^(.+?):(\d+)$/', $dbHost, $match)) {
                 $dbHostWithoutPort = $match[1];
-                $dbPort = \intval($match[2]);
+                $dbPort = (int)$match[2];
             }
 
             // test connection
@@ -871,7 +871,7 @@ class WCFSetup extends WCF
 
         // split by offsets
         $sqlData = \explode('/* SQL_PARSER_OFFSET */', $sql);
-        $offset = isset($_POST['offset']) ? \intval($_POST['offset']) : 0;
+        $offset = isset($_POST['offset']) ? (int)$_POST['offset'] : 0;
         if (!isset($sqlData[$offset])) {
             throw new SystemException("Offset for SQL parser is out of bounds, " . $offset . " was requested, but there are only " . \count($sqlData) . " sections");
         }
@@ -1236,7 +1236,7 @@ class WCFSetup extends WCF
         $statement = self::getDB()->prepareStatement($sql);
         $statement->execute();
         $result = $statement->fetchArray();
-        $processNo = \intval($result['processNo']) + 1;
+        $processNo = (int)$result['processNo'] + 1;
 
         // search existing wcf package
         $sql = "SELECT  COUNT(*) AS count

--- a/wcfsetup/install/files/lib/system/bbcode/GroupBBCode.class.php
+++ b/wcfsetup/install/files/lib/system/bbcode/GroupBBCode.class.php
@@ -21,7 +21,7 @@ class GroupBBCode extends AbstractBBCode
      */
     public function getParsedTag(array $openingTag, $content, array $closingTag, BBCodeParser $parser)
     {
-        $groupID = (!empty($openingTag['attributes'][0])) ? \intval($openingTag['attributes'][0]) : 0;
+        $groupID = (!empty($openingTag['attributes'][0])) ? (int)$openingTag['attributes'][0] : 0;
         $group = UserGroup::getGroupByID($groupID);
         if ($group === null || !$group->canBeMentioned()) {
             return "[group]{$content}[/group]";

--- a/wcfsetup/install/files/lib/system/bbcode/UserBBCode.class.php
+++ b/wcfsetup/install/files/lib/system/bbcode/UserBBCode.class.php
@@ -22,7 +22,7 @@ class UserBBCode extends AbstractBBCode
      */
     public function getParsedTag(array $openingTag, $content, array $closingTag, BBCodeParser $parser)
     {
-        $userID = (!empty($openingTag['attributes'][0])) ? \intval($openingTag['attributes'][0]) : 0;
+        $userID = (!empty($openingTag['attributes'][0])) ? (int)$openingTag['attributes'][0] : 0;
         if (!$userID) {
             return "[user]{$content}[/user]";
         }

--- a/wcfsetup/install/files/lib/system/bbcode/WoltLabSuiteArticleBBCode.class.php
+++ b/wcfsetup/install/files/lib/system/bbcode/WoltLabSuiteArticleBBCode.class.php
@@ -26,7 +26,7 @@ class WoltLabSuiteArticleBBCode extends AbstractBBCode
     {
         $objectID = 0;
         if (isset($openingTag['attributes'][0])) {
-            $objectID = \intval($openingTag['attributes'][0]);
+            $objectID = (int)$openingTag['attributes'][0];
         }
         if (!$objectID) {
             return '';

--- a/wcfsetup/install/files/lib/system/bbcode/WoltLabSuiteMediaBBCode.class.php
+++ b/wcfsetup/install/files/lib/system/bbcode/WoltLabSuiteMediaBBCode.class.php
@@ -31,7 +31,7 @@ class WoltLabSuiteMediaBBCode extends AbstractBBCode
      */
     public function getParsedTag(array $openingTag, $content, array $closingTag, BBCodeParser $parser)
     {
-        $mediaID = (!empty($openingTag['attributes'][0])) ? \intval($openingTag['attributes'][0]) : 0;
+        $mediaID = (!empty($openingTag['attributes'][0])) ? (int)$openingTag['attributes'][0] : 0;
         if (!$mediaID) {
             return '';
         }

--- a/wcfsetup/install/files/lib/system/bbcode/WoltLabSuitePageBBCode.class.php
+++ b/wcfsetup/install/files/lib/system/bbcode/WoltLabSuitePageBBCode.class.php
@@ -22,7 +22,7 @@ class WoltLabSuitePageBBCode extends AbstractBBCode
      */
     public function getParsedTag(array $openingTag, $content, array $closingTag, BBCodeParser $parser)
     {
-        $pageID = (!empty($openingTag['attributes'][0])) ? \intval($openingTag['attributes'][0]) : 0;
+        $pageID = (!empty($openingTag['attributes'][0])) ? (int)$openingTag['attributes'][0] : 0;
         if (!$pageID) {
             return '';
         }

--- a/wcfsetup/install/files/lib/system/bbcode/media/provider/YouTubeBBCodeMediaProvider.class.php
+++ b/wcfsetup/install/files/lib/system/bbcode/media/provider/YouTubeBBCodeMediaProvider.class.php
@@ -42,16 +42,16 @@ class YouTubeBBCodeMediaProvider implements IBBCodeMediaProvider
         $result = 0;
         if (\preg_match('~^(?:(?:(?P<h>\d+)h)?(?P<m>\d+)m(?P<s>\d+))|(?P<t>\d+)~', $time, $match)) {
             if (!empty($match['h'])) {
-                $result += \intval($match['h']) * 3600;
+                $result += (int)$match['h'] * 3600;
             }
             if (!empty($match['m'])) {
-                $result += \intval($match['m']) * 60;
+                $result += (int)$match['m'] * 60;
             }
             if (!empty($match['s'])) {
-                $result += \intval($match['s']);
+                $result += (int)$match['s'];
             }
             if (!empty($match['t'])) {
-                $result += \intval($match['t']);
+                $result += (int)$match['t'];
             }
         }
 

--- a/wcfsetup/install/files/lib/system/box/AbstractDatabaseObjectListBoxController.class.php
+++ b/wcfsetup/install/files/lib/system/box/AbstractDatabaseObjectListBoxController.class.php
@@ -348,7 +348,7 @@ abstract class AbstractDatabaseObjectListBoxController extends AbstractBoxContro
     public function readConditions()
     {
         if (isset($_POST['limit'])) {
-            $this->limit = \intval($_POST['limit']);
+            $this->limit = (int)$_POST['limit'];
         }
         if (isset($_POST['sortField'])) {
             $this->sortField = StringUtil::trim($_POST['sortField']);

--- a/wcfsetup/install/files/lib/system/bulk/processing/user/SendMailUserBulkProcessingAction.class.php
+++ b/wcfsetup/install/files/lib/system/bulk/processing/user/SendMailUserBulkProcessingAction.class.php
@@ -113,7 +113,7 @@ class SendMailUserBulkProcessingAction extends AbstractUserBulkProcessingAction
     public function readFormParameters()
     {
         if (isset($_POST['enableHTML'])) {
-            $this->enableHTML = \intval($_POST['enableHTML']);
+            $this->enableHTML = (int)$_POST['enableHTML'];
         }
         if (isset($_POST['from'])) {
             $this->from = StringUtil::trim($_POST['from']);

--- a/wcfsetup/install/files/lib/system/cli/command/ImportCLICommand.class.php
+++ b/wcfsetup/install/files/lib/system/cli/command/ImportCLICommand.class.php
@@ -462,7 +462,7 @@ class ImportCLICommand implements ICLICommand
                     }
 
                     // validate selected secondary import data type
-                    if ($selectedSecondaryObjectTypeIndex == \intval($selectedSecondaryObjectTypeIndex) && !$selectedSecondaryObjectTypeIndex) {
+                    if ($selectedSecondaryObjectTypeIndex == (int)$selectedSecondaryObjectTypeIndex && !$selectedSecondaryObjectTypeIndex) {
                         // selected all secondary import data type
                         $selectedData[$selectedObjectType] = \array_merge(
                             $selectedData[$selectedObjectType],
@@ -528,7 +528,7 @@ class ImportCLICommand implements ICLICommand
             if ($this->userMergeMode === null) {
                 exit;
             }
-            switch (\intval($this->userMergeMode)) {
+            switch ((int)$this->userMergeMode) {
                 case 1:
                     $this->userMergeMode = UserImporter::MERGE_MODE_EMAIL;
                     break;

--- a/wcfsetup/install/files/lib/system/cli/command/PackageCLICommand.class.php
+++ b/wcfsetup/install/files/lib/system/cli/command/PackageCLICommand.class.php
@@ -190,7 +190,7 @@ class PackageCLICommand implements IArgumentedCLICommand
             'packageID' => ($package !== null) ? $package->packageID : null,
             'archive' => $file,
             'action' => $package !== null ? 'update' : 'install',
-            'isApplication' => ($package !== null) ? $package->isApplication : \intval($archive->getPackageInfo('isApplication')),
+            'isApplication' => ($package !== null) ? $package->isApplication : (int)$archive->getPackageInfo('isApplication'),
         ]);
 
         // PackageInstallationDispatcher::openQueue()

--- a/wcfsetup/install/files/lib/system/comment/CommentHandler.class.php
+++ b/wcfsetup/install/files/lib/system/comment/CommentHandler.class.php
@@ -266,7 +266,7 @@ class CommentHandler extends SingletonFactory
             $notificationList->sqlJoins .= "
                 LEFT JOIN   wcf" . WCF_N . "_comment comment
                 ON          comment.commentID = user_notification.objectID
-                        AND comment.objectTypeID = " . \intval($this->getObjectTypeID($objectType));
+                        AND comment.objectTypeID = " . (int)$this->getObjectTypeID($objectType);
             $notificationList->getConditionBuilder()->add('comment.objectID IN (?)', [$objectIDs]);
             $notificationList->getConditionBuilder()->add('comment.time <= ?', [$time]);
             $notificationList->readObjects();
@@ -315,7 +315,7 @@ class CommentHandler extends SingletonFactory
             $notificationList->sqlJoins .= "
                 LEFT JOIN   wcf" . WCF_N . "_comment comment
                 ON          comment.commentID = user_notification.baseObjectID
-                        AND comment.objectTypeID = " . \intval($this->getObjectTypeID($objectType));
+                        AND comment.objectTypeID = " . (int)$this->getObjectTypeID($objectType);
             $notificationList->getConditionBuilder()->add('comment.objectID IN (?)', [$objectIDs]);
             $notificationList->getConditionBuilder()->add('comment.time <= ?', [$time]);
             $notificationList->readObjects();

--- a/wcfsetup/install/files/lib/system/condition/AbstractIntegerCondition.class.php
+++ b/wcfsetup/install/files/lib/system/condition/AbstractIntegerCondition.class.php
@@ -205,13 +205,13 @@ HTML;
             isset($_POST['lessThan_' . $this->getIdentifier()])
             && \strlen($_POST['lessThan_' . $this->getIdentifier()])
         ) {
-            $this->lessThan = \intval($_POST['lessThan_' . $this->getIdentifier()]);
+            $this->lessThan = (int)$_POST['lessThan_' . $this->getIdentifier()];
         }
         if (
             isset($_POST['greaterThan_' . $this->getIdentifier()])
             && \strlen($_POST['greaterThan_' . $this->getIdentifier()])
         ) {
-            $this->greaterThan = \intval($_POST['greaterThan_' . $this->getIdentifier()]);
+            $this->greaterThan = (int)$_POST['greaterThan_' . $this->getIdentifier()];
         }
     }
 

--- a/wcfsetup/install/files/lib/system/condition/AbstractSelectCondition.class.php
+++ b/wcfsetup/install/files/lib/system/condition/AbstractSelectCondition.class.php
@@ -120,7 +120,7 @@ abstract class AbstractSelectCondition extends AbstractSingleFieldCondition
     public function readFormParameters()
     {
         if (isset($_POST[$this->fieldName])) {
-            $this->fieldValue = \intval($_POST[$this->fieldName]);
+            $this->fieldValue = (int)$_POST[$this->fieldName];
         }
     }
 

--- a/wcfsetup/install/files/lib/system/condition/UserUserIDCondition.class.php
+++ b/wcfsetup/install/files/lib/system/condition/UserUserIDCondition.class.php
@@ -80,7 +80,7 @@ class UserUserIDCondition extends AbstractSingleFieldCondition implements
     public function readFormParameters()
     {
         if (!empty($_POST['userID'])) {
-            $this->userID = \intval($_POST['userID']);
+            $this->userID = (int)$_POST['userID'];
         }
     }
 

--- a/wcfsetup/install/files/lib/system/condition/user/UserLastActivityTimeIntervalDaysCondition.class.php
+++ b/wcfsetup/install/files/lib/system/condition/user/UserLastActivityTimeIntervalDaysCondition.class.php
@@ -192,7 +192,7 @@ HTML;
     {
         $endDays = $startDays = null;
         if (\strlen($this->startDays)) {
-            $startDays = \intval($this->startDays);
+            $startDays = (int)$this->startDays;
             if ($startDays <= 0) {
                 $this->errorMessage = 'wcf.user.condition.lastActivityTimeIntervalDays.error.invalidStart';
 
@@ -200,7 +200,7 @@ HTML;
             }
         }
         if (\strlen($this->endDays)) {
-            $endDays = \intval($this->endDays);
+            $endDays = (int)$this->endDays;
             if ($endDays <= 0) {
                 $this->errorMessage = 'wcf.user.condition.lastActivityTimeIntervalDays.error.invalidEnd';
 

--- a/wcfsetup/install/files/lib/system/database/Database.class.php
+++ b/wcfsetup/install/files/lib/system/database/Database.class.php
@@ -381,8 +381,8 @@ abstract class Database
      */
     public function handleLimitParameter($query, $limit = 0, $offset = 0)
     {
-        $limit = \intval($limit);
-        $offset = \intval($offset);
+        $limit = (int)$limit;
+        $offset = (int)$offset;
         if ($limit < 0) {
             throw new \InvalidArgumentException('The limit must not be negative.');
         }

--- a/wcfsetup/install/files/lib/system/database/DatabaseException.class.php
+++ b/wcfsetup/install/files/lib/system/database/DatabaseException.class.php
@@ -82,7 +82,7 @@ class DatabaseException extends SystemException
             $this->errorDesc = $this->db->getErrorDesc();
         }
 
-        parent::__construct($message, \intval($this->errorNumber));
+        parent::__construct($message, (int)$this->errorNumber);
     }
 
     /**

--- a/wcfsetup/install/files/lib/system/devtools/package/DevtoolsPackageXmlWriter.class.php
+++ b/wcfsetup/install/files/lib/system/devtools/package/DevtoolsPackageXmlWriter.class.php
@@ -257,7 +257,7 @@ class DevtoolsPackageXmlWriter
         if (!empty($this->packageXmlData['isApplication'])) {
             $this->xmlWriter->writeElement(
                 'isapplication',
-                \intval($this->packageXmlData['isApplication']),
+                (int)$this->packageXmlData['isApplication'],
                 [],
                 false
             );

--- a/wcfsetup/install/files/lib/system/email/transport/SmtpEmailTransport.class.php
+++ b/wcfsetup/install/files/lib/system/email/transport/SmtpEmailTransport.class.php
@@ -95,7 +95,7 @@ class SmtpEmailTransport implements IStatusReportingEmailTransport
         $starttls = MAIL_SMTP_STARTTLS
     ) {
         $this->host = StringUtil::trim($host);
-        $this->port = \intval($port);
+        $this->port = (int)$port;
         $this->username = StringUtil::trim($username);
         $this->password = StringUtil::trim($password);
 
@@ -190,7 +190,7 @@ class SmtpEmailTransport implements IStatusReportingEmailTransport
 
             if (\preg_match('/^(\d{3})([- ])(.*)$/', $data, $matches)) {
                 if ($code === null) {
-                    $code = \intval($matches[1]);
+                    $code = (int)$matches[1];
 
                     if (!\in_array($code, $expectedCodes)) {
                         // 4xx is a transient failure

--- a/wcfsetup/install/files/lib/system/form/builder/field/AbstractNumericFormField.class.php
+++ b/wcfsetup/install/files/lib/system/form/builder/field/AbstractNumericFormField.class.php
@@ -141,9 +141,9 @@ abstract class AbstractNumericFormField extends AbstractFormField implements
 
             if ($value !== '') {
                 if ($this->integerValues) {
-                    $this->value = \intval($value);
+                    $this->value = (int)$value;
                 } else {
-                    $this->value = \floatval($value);
+                    $this->value = (float)$value;
                 }
             }
         }
@@ -222,9 +222,9 @@ abstract class AbstractNumericFormField extends AbstractFormField implements
         if ($value !== null) {
             if (\is_string($value) && \is_numeric($value)) {
                 if (\preg_match('~^-?\d+$~', $value)) {
-                    $value = \intval($value);
+                    $value = (int)$value;
                 } else {
-                    $value = \floatval($value);
+                    $value = (float)$value;
                 }
             }
 

--- a/wcfsetup/install/files/lib/system/form/builder/field/RatingFormField.class.php
+++ b/wcfsetup/install/files/lib/system/form/builder/field/RatingFormField.class.php
@@ -186,7 +186,7 @@ class RatingFormField extends AbstractFormField implements
             if ($this->isNullable() && $value === '') {
                 $this->value = null;
             } else {
-                $this->value = \intval($value);
+                $this->value = (int)$value;
             }
         }
 

--- a/wcfsetup/install/files/lib/system/form/builder/field/dependency/ValueIntervalFormFieldDependency.class.php
+++ b/wcfsetup/install/files/lib/system/form/builder/field/dependency/ValueIntervalFormFieldDependency.class.php
@@ -39,7 +39,7 @@ final class ValueIntervalFormFieldDependency extends AbstractFormFieldDependency
             return false;
         }
 
-        $value = \floatval($value);
+        $value = (float)$value;
 
         if ($this->minimum !== null && $this->minimum > $value) {
             return false;

--- a/wcfsetup/install/files/lib/system/form/builder/field/devtools/project/DevtoolsProjectRequiredPackagesFormField.class.php
+++ b/wcfsetup/install/files/lib/system/form/builder/field/devtools/project/DevtoolsProjectRequiredPackagesFormField.class.php
@@ -79,7 +79,7 @@ class DevtoolsProjectRequiredPackagesFormField extends AbstractFormField
                 continue;
             }
 
-            $package['file'] = \intval($package['file']);
+            $package['file'] = (int)$package['file'];
 
             $requiredPackages[] = $package;
         }

--- a/wcfsetup/install/files/lib/system/form/builder/field/label/LabelFormField.class.php
+++ b/wcfsetup/install/files/lib/system/form/builder/field/label/LabelFormField.class.php
@@ -164,7 +164,7 @@ class LabelFormField extends AbstractFormField implements IObjectTypeFormNode
     public function readValue()
     {
         if ($this->getDocument()->hasRequestData($this->getPrefixedId())) {
-            $this->value = \intval($this->getDocument()->getRequestData($this->getPrefixedId()));
+            $this->value = (int)$this->getDocument()->getRequestData($this->getPrefixedId());
         }
 
         return $this;

--- a/wcfsetup/install/files/lib/system/form/builder/field/language/ContentLanguageFormField.class.php
+++ b/wcfsetup/install/files/lib/system/form/builder/field/language/ContentLanguageFormField.class.php
@@ -65,7 +65,7 @@ class ContentLanguageFormField extends AbstractFormField implements IImmutableFo
     public function readValue()
     {
         if ($this->getDocument()->hasRequestData($this->getPrefixedId())) {
-            $this->value = \intval($this->getDocument()->getRequestData($this->getPrefixedId()));
+            $this->value = (int)$this->getDocument()->getRequestData($this->getPrefixedId());
 
             if (!$this->isRequired() && !$this->value) {
                 $this->value = null;

--- a/wcfsetup/install/files/lib/system/form/builder/field/poll/PollOptionsFormField.class.php
+++ b/wcfsetup/install/files/lib/system/form/builder/field/poll/PollOptionsFormField.class.php
@@ -67,7 +67,7 @@ class PollOptionsFormField extends AbstractFormField
             foreach ($value as $showOrder => $option) {
                 [$optionID, $optionValue] = \explode('_', $option, 2);
                 $this->value[$showOrder] = [
-                    'optionID' => \intval($optionID),
+                    'optionID' => (int)$optionID,
                     'optionValue' => StringUtil::trim($optionValue),
                 ];
             }

--- a/wcfsetup/install/files/lib/system/html/input/node/HtmlInputNodeImg.class.php
+++ b/wcfsetup/install/files/lib/system/html/input/node/HtmlInputNodeImg.class.php
@@ -98,7 +98,7 @@ class HtmlInputNodeImg extends AbstractHtmlInputNode
      */
     protected function handleAttachment(\DOMElement $element, $class)
     {
-        $attachmentID = \intval($element->getAttribute('data-attachment-id'));
+        $attachmentID = (int)$element->getAttribute('data-attachment-id');
         if (!$attachmentID) {
             return;
         }
@@ -134,7 +134,7 @@ class HtmlInputNodeImg extends AbstractHtmlInputNode
      */
     protected function handleMedium(\DOMElement $element, $class)
     {
-        $mediumID = \intval($element->getAttribute('data-media-id'));
+        $mediumID = (int)$element->getAttribute('data-media-id');
         if (!$mediumID) {
             return;
         }

--- a/wcfsetup/install/files/lib/system/html/metacode/converter/CodeMetacodeConverter.class.php
+++ b/wcfsetup/install/files/lib/system/html/metacode/converter/CodeMetacodeConverter.class.php
@@ -32,7 +32,7 @@ class CodeMetacodeConverter extends AbstractMetacodeConverter
 
             case 1:
                 if (\is_numeric($attributes[0])) {
-                    $line = \intval($attributes[0]);
+                    $line = (int)$attributes[0];
                 } elseif (\mb_strpos($attributes[0], '.') === false) {
                     $highlighter = $attributes[0];
                 } else {
@@ -42,7 +42,7 @@ class CodeMetacodeConverter extends AbstractMetacodeConverter
 
             case 2:
                 if (\is_numeric($attributes[0])) {
-                    $line = \intval($attributes[0]);
+                    $line = (int)$attributes[0];
                     if (\mb_strpos($attributes[1], '.') === false) {
                         $highlighter = $attributes[1];
                     } else {
@@ -56,7 +56,7 @@ class CodeMetacodeConverter extends AbstractMetacodeConverter
 
             default:
                 $highlighter = $attributes[0];
-                $line = \intval($attributes[1]);
+                $line = (int)$attributes[1];
                 $file = $attributes[2];
                 break;
         }

--- a/wcfsetup/install/files/lib/system/html/toc/HtmlToc.class.php
+++ b/wcfsetup/install/files/lib/system/html/toc/HtmlToc.class.php
@@ -74,7 +74,7 @@ class HtmlToc
 
             $hElement->setAttribute('id', $id);
 
-            $headings[] = new HtmlTocItem(\intval(\substr($hElement->tagName, 1, 1)), $id, $title);
+            $headings[] = new HtmlTocItem((int)\substr($hElement->tagName, 1, 1), $id, $title);
         }
 
         if (\count($headings) < 3) {

--- a/wcfsetup/install/files/lib/system/html/toc/HtmlTocItem.class.php
+++ b/wcfsetup/install/files/lib/system/html/toc/HtmlTocItem.class.php
@@ -55,7 +55,7 @@ class HtmlTocItem implements \Countable, \RecursiveIterator
         return \preg_replace_callback('/^\s*(\d+)([\.):]|\s*-)\s*/', function ($matches) {
             // Strip of a enumeration prefix if the prefixed number matches
             // the current offset within the ToC.
-            if ($this->getParent() && \intval($matches[1]) === ($this->getParent()->position + 1)) {
+            if ($this->getParent() && (int)$matches[1] === ($this->getParent()->position + 1)) {
                 return '';
             }
 

--- a/wcfsetup/install/files/lib/system/importer/UserImporter.class.php
+++ b/wcfsetup/install/files/lib/system/importer/UserImporter.class.php
@@ -155,14 +155,14 @@ class UserImporter extends AbstractImporter
                         break;
 
                     case 'integer':
-                        $optionValue = \intval($optionValue);
+                        $optionValue = (int)$optionValue;
                         if ($optionValue > 2147483647) {
                             $optionValue = 2147483647;
                         }
                         break;
 
                     case 'float':
-                        $optionValue = \floatval($optionValue);
+                        $optionValue = (float)$optionValue;
                         break;
 
                     case 'textarea':

--- a/wcfsetup/install/files/lib/system/importer/UserOptionImporter.class.php
+++ b/wcfsetup/install/files/lib/system/importer/UserOptionImporter.class.php
@@ -64,7 +64,7 @@ class UserOptionImporter extends AbstractImporter
 
         if ($data['optionType'] == 'boolean' || $data['optionType'] == 'integer') {
             if (isset($data['defaultValue'])) {
-                $data['defaultValue'] = \intval($data['defaultValue']);
+                $data['defaultValue'] = (int)$data['defaultValue'];
             }
         }
 

--- a/wcfsetup/install/files/lib/system/io/ZipWriter.class.php
+++ b/wcfsetup/install/files/lib/system/io/ZipWriter.class.php
@@ -197,7 +197,7 @@ class ZipWriter
     protected static function getDosDatetime($date)
     {
         // Ensure we have a numeric value
-        $date = \intval($date);
+        $date = (int)$date;
 
         if ($date < 315532800) {
             return "\x00\x00\x00\x00";

--- a/wcfsetup/install/files/lib/system/language/I18nPlural.class.php
+++ b/wcfsetup/install/files/lib/system/language/I18nPlural.class.php
@@ -69,7 +69,7 @@ class I18nPlural
             return 0;
         }
 
-        return \intval(\substr($n, $pos + 1));
+        return (int)\substr($n, $pos + 1);
     }
 
     /**

--- a/wcfsetup/install/files/lib/system/message/QuickReplyManager.class.php
+++ b/wcfsetup/install/files/lib/system/message/QuickReplyManager.class.php
@@ -129,17 +129,17 @@ class QuickReplyManager extends SingletonFactory
             );
         }
 
-        $parameters['lastPostTime'] = isset($parameters['lastPostTime']) ? \intval($parameters['lastPostTime']) : 0;
+        $parameters['lastPostTime'] = isset($parameters['lastPostTime']) ? (int)$parameters['lastPostTime'] : 0;
         if (!$parameters['lastPostTime']) {
             throw new UserInputException('lastPostTime');
         }
 
-        $parameters['pageNo'] = isset($parameters['pageNo']) ? \intval($parameters['pageNo']) : 0;
+        $parameters['pageNo'] = isset($parameters['pageNo']) ? (int)$parameters['pageNo'] : 0;
         if (!$parameters['pageNo']) {
             throw new UserInputException('pageNo');
         }
 
-        $parameters['objectID'] = isset($parameters['objectID']) ? \intval($parameters['objectID']) : 0;
+        $parameters['objectID'] = isset($parameters['objectID']) ? (int)$parameters['objectID'] : 0;
         if (!$parameters['objectID']) {
             throw new UserInputException('objectID');
         }

--- a/wcfsetup/install/files/lib/system/message/embedded/object/ArticleMessageEmbeddedObjectHandler.class.php
+++ b/wcfsetup/install/files/lib/system/message/embedded/object/ArticleMessageEmbeddedObjectHandler.class.php
@@ -26,7 +26,7 @@ class ArticleMessageEmbeddedObjectHandler extends AbstractSimpleMessageEmbeddedO
         $articleIDs = [];
         if (!empty($embeddedData['wsa'])) {
             for ($i = 0, $length = \count($embeddedData['wsa']); $i < $length; $i++) {
-                $articleIDs[] = \intval($embeddedData['wsa'][$i][0]);
+                $articleIDs[] = (int)$embeddedData['wsa'][$i][0];
             }
         }
 

--- a/wcfsetup/install/files/lib/system/message/embedded/object/AttachmentMessageEmbeddedObjectHandler.class.php
+++ b/wcfsetup/install/files/lib/system/message/embedded/object/AttachmentMessageEmbeddedObjectHandler.class.php
@@ -28,7 +28,7 @@ class AttachmentMessageEmbeddedObjectHandler extends AbstractMessageEmbeddedObje
         $attachmentIDs = [];
         for ($i = 0, $length = \count($embeddedData['attach']); $i < $length; $i++) {
             $attributes = $embeddedData['attach'][$i];
-            $attachmentID = (!empty($attributes[0])) ? \intval($attributes[0]) : 0;
+            $attachmentID = (!empty($attributes[0])) ? (int)$attributes[0] : 0;
 
             if ($attachmentID > 0) {
                 $attachmentIDs[] = $attachmentID;

--- a/wcfsetup/install/files/lib/system/message/embedded/object/MessageEmbeddedObjectManager.class.php
+++ b/wcfsetup/install/files/lib/system/message/embedded/object/MessageEmbeddedObjectManager.class.php
@@ -391,7 +391,7 @@ class MessageEmbeddedObjectManager extends SingletonFactory
         // now yields `false` where it was previously true.
         //
         // See https://wiki.php.net/rfc/string_to_number_comparison
-        $objectID = \intval($objectID);
+        $objectID = (int)$objectID;
 
         $embeddedObjectTypeID = ObjectTypeCache::getInstance()
             ->getObjectTypeIDByName('com.woltlab.wcf.message.embeddedObject', $embeddedObjectType);

--- a/wcfsetup/install/files/lib/system/message/embedded/object/PageMessageEmbeddedObjectHandler.class.php
+++ b/wcfsetup/install/files/lib/system/message/embedded/object/PageMessageEmbeddedObjectHandler.class.php
@@ -25,7 +25,7 @@ class PageMessageEmbeddedObjectHandler extends AbstractSimpleMessageEmbeddedObje
         $pageIDs = [];
         if (!empty($embeddedData['wsp'])) {
             for ($i = 0, $length = \count($embeddedData['wsp']); $i < $length; $i++) {
-                $pageIDs[] = \intval($embeddedData['wsp'][$i][0]);
+                $pageIDs[] = (int)$embeddedData['wsp'][$i][0];
             }
         }
 
@@ -55,8 +55,8 @@ class PageMessageEmbeddedObjectHandler extends AbstractSimpleMessageEmbeddedObje
     public function validateValues($objectType, $objectID, array $values)
     {
         // Pages can be referenced as `123#Some Text`, where everything after the number
-        // is a comment for better readability. Converting the values to integers via
-        // `intval()` will discard the everything after the ID.
+        // is a comment for better readability. Casting the values to integers via
+        // `(int)` will discard the everything after the ID.
         $values = ArrayUtil::toIntegerArray($values);
 
         return \array_filter($values, static function ($value) {

--- a/wcfsetup/install/files/lib/system/message/embedded/object/UnfurlUrlEmbeddedObjectHandler.class.php
+++ b/wcfsetup/install/files/lib/system/message/embedded/object/UnfurlUrlEmbeddedObjectHandler.class.php
@@ -37,7 +37,7 @@ class UnfurlUrlEmbeddedObjectHandler extends AbstractMessageEmbeddedObjectHandle
         $unfurlUrlIDs = [];
         foreach ($htmlInputProcessor->getHtmlInputNodeProcessor()->getDocument()->getElementsByTagName('a') as $element) {
             /** @var \DOMElement $element */
-            $id = \intval($element->getAttribute(HtmlNodeUnfurlLink::UNFURL_URL_ID_ATTRIBUTE_NAME));
+            $id = (int)$element->getAttribute(HtmlNodeUnfurlLink::UNFURL_URL_ID_ATTRIBUTE_NAME);
 
             if (!empty($id)) {
                 $unfurlUrlIDs[] = $id;

--- a/wcfsetup/install/files/lib/system/message/embedded/object/UserMessageEmbeddedObjectHandler.class.php
+++ b/wcfsetup/install/files/lib/system/message/embedded/object/UserMessageEmbeddedObjectHandler.class.php
@@ -23,7 +23,7 @@ class UserMessageEmbeddedObjectHandler extends AbstractMessageEmbeddedObjectHand
         $objectIDs = [];
         if (!empty($embeddedData['user'])) {
             for ($i = 0, $length = \count($embeddedData['user']); $i < $length; $i++) {
-                $objectIDs[] = \intval($embeddedData['user'][$i][0]);
+                $objectIDs[] = (int)$embeddedData['user'][$i][0];
             }
         }
 

--- a/wcfsetup/install/files/lib/system/message/quote/MessageQuoteManager.class.php
+++ b/wcfsetup/install/files/lib/system/message/quote/MessageQuoteManager.class.php
@@ -557,7 +557,7 @@ class MessageQuoteManager extends SingletonFactory
     public function readParameters()
     {
         if (isset($_REQUEST['quoteMessageID'])) {
-            $this->quoteMessageID = \intval($_REQUEST['quoteMessageID']);
+            $this->quoteMessageID = (int)$_REQUEST['quoteMessageID'];
         }
     }
 

--- a/wcfsetup/install/files/lib/system/option/BirthdayOptionType.class.php
+++ b/wcfsetup/install/files/lib/system/option/BirthdayOptionType.class.php
@@ -57,10 +57,10 @@ class BirthdayOptionType extends DateOptionType
     {
         $ageFrom = $ageTo = '';
         if (!empty($value['ageFrom'])) {
-            $ageFrom = \intval($value['ageFrom']);
+            $ageFrom = (int)$value['ageFrom'];
         }
         if (!empty($value['ageTo'])) {
-            $ageTo = \intval($value['ageTo']);
+            $ageTo = (int)$value['ageTo'];
         }
 
         WCF::getTPL()->assign([
@@ -81,8 +81,8 @@ class BirthdayOptionType extends DateOptionType
             return false;
         }
 
-        $ageFrom = \intval($value['ageFrom']);
-        $ageTo = \intval($value['ageTo']);
+        $ageFrom = (int)$value['ageFrom'];
+        $ageTo = (int)$value['ageTo'];
         if ($ageFrom < 0 || $ageFrom > 120) {
             return false;
         }
@@ -120,8 +120,8 @@ class BirthdayOptionType extends DateOptionType
      */
     public function addCondition(UserList $userList, Option $option, $value)
     {
-        $ageFrom = \intval($value['ageFrom']);
-        $ageTo = \intval($value['ageTo']);
+        $ageFrom = (int)$value['ageFrom'];
+        $ageTo = (int)$value['ageTo'];
 
         if ($ageFrom < 0 || $ageFrom > 120 || $ageTo < 0 || $ageTo > 120) {
             return;
@@ -165,8 +165,8 @@ class BirthdayOptionType extends DateOptionType
             return false;
         }
 
-        $ageFrom = \intval($value['ageFrom']);
-        $ageTo = \intval($value['ageTo']);
+        $ageFrom = (int)$value['ageFrom'];
+        $ageTo = (int)$value['ageTo'];
 
         $userAge = DateUtil::getAge($user->birthday);
 

--- a/wcfsetup/install/files/lib/system/option/BooleanOptionType.class.php
+++ b/wcfsetup/install/files/lib/system/option/BooleanOptionType.class.php
@@ -79,7 +79,7 @@ class BooleanOptionType extends AbstractOptionType implements ISearchableConditi
             return false;
         }
 
-        $conditions->add("option_value.userOption" . $option->optionID . " = ?", [\intval($value)]);
+        $conditions->add("option_value.userOption" . $option->optionID . " = ?", [(int)$value]);
 
         return true;
     }
@@ -91,7 +91,7 @@ class BooleanOptionType extends AbstractOptionType implements ISearchableConditi
     {
         $userList->getConditionBuilder()->add(
             'user_option_value.userOption' . $option->optionID . ' = ?',
-            [\intval($value)]
+            [(int)$value]
         );
     }
 

--- a/wcfsetup/install/files/lib/system/option/DateOptionType.class.php
+++ b/wcfsetup/install/files/lib/system/option/DateOptionType.class.php
@@ -38,7 +38,7 @@ class DateOptionType extends TextOptionType
             throw new UserInputException($option->optionName, 'validationFailed');
         }
 
-        if (!\checkdate(\intval($match[2]), \intval($match[3]), \intval($match[1]))) {
+        if (!\checkdate((int)$match[2], (int)$match[3], (int)$match[1])) {
             throw new UserInputException($option->optionName, 'validationFailed');
         }
     }

--- a/wcfsetup/install/files/lib/system/option/FileSizeOptionType.class.php
+++ b/wcfsetup/install/files/lib/system/option/FileSizeOptionType.class.php
@@ -71,7 +71,7 @@ class FileSizeOptionType extends TextOptionType
      */
     public function getFormElement(Option $option, $value)
     {
-        $value = FileUtil::formatFilesize(\intval($value));
+        $value = FileUtil::formatFilesize((int)$value);
 
         return parent::getFormElement($option, $value);
     }

--- a/wcfsetup/install/files/lib/system/option/FloatOptionType.class.php
+++ b/wcfsetup/install/files/lib/system/option/FloatOptionType.class.php
@@ -78,6 +78,6 @@ class FloatOptionType extends TextOptionType
         $value = \str_replace(WCF::getLanguage()->get('wcf.global.thousandsSeparator'), '', $value);
         $value = \str_replace(WCF::getLanguage()->get('wcf.global.decimalPoint'), '.', $value);
 
-        return \floatval($value);
+        return (float)$value;
     }
 }

--- a/wcfsetup/install/files/lib/system/option/IntegerOptionType.class.php
+++ b/wcfsetup/install/files/lib/system/option/IntegerOptionType.class.php
@@ -40,7 +40,7 @@ class IntegerOptionType extends TextOptionType
      */
     public function getData(Option $option, $newValue)
     {
-        return \intval($newValue);
+        return (int)$newValue;
     }
 
     /**

--- a/wcfsetup/install/files/lib/system/option/user/DateUserOptionOutput.class.php
+++ b/wcfsetup/install/files/lib/system/option/user/DateUserOptionOutput.class.php
@@ -52,13 +52,13 @@ class DateUserOptionOutput implements IUserOptionOutput
         $year = $month = $day = 0;
         $optionValue = \explode('-', $value);
         if (isset($optionValue[0])) {
-            $year = \intval($optionValue[0]);
+            $year = (int)$optionValue[0];
         }
         if (isset($optionValue[1])) {
-            $month = \intval($optionValue[1]);
+            $month = (int)$optionValue[1];
         }
         if (isset($optionValue[2])) {
-            $day = \intval($optionValue[2]);
+            $day = (int)$optionValue[2];
         }
 
         return ['year' => $year, 'month' => $month, 'day' => $day];

--- a/wcfsetup/install/files/lib/system/package/PackageArchive.class.php
+++ b/wcfsetup/install/files/lib/system/package/PackageArchive.class.php
@@ -232,7 +232,7 @@ class PackageArchive
                     break;
 
                 case 'isapplication':
-                    $this->packageInfo['isApplication'] = \intval($element->nodeValue);
+                    $this->packageInfo['isApplication'] = (int)$element->nodeValue;
                     break;
 
                 case 'applicationdirectory':

--- a/wcfsetup/install/files/lib/system/package/PackageUpdateDispatcher.class.php
+++ b/wcfsetup/install/files/lib/system/package/PackageUpdateDispatcher.class.php
@@ -359,12 +359,12 @@ class PackageUpdateDispatcher extends SingletonFactory
                     break;
 
                 case 'isapplication':
-                    $packageInfo['isApplication'] = \intval($element->nodeValue);
+                    $packageInfo['isApplication'] = (int)$element->nodeValue;
                     break;
 
                 case 'pluginStoreFileID':
                     if ($updateServer->isWoltLabStoreServer()) {
-                        $packageInfo['pluginStoreFileID'] = \intval($element->nodeValue);
+                        $packageInfo['pluginStoreFileID'] = (int)$element->nodeValue;
                     }
                     break;
             }

--- a/wcfsetup/install/files/lib/system/package/plugin/AbstractOptionPackageInstallationPlugin.class.php
+++ b/wcfsetup/install/files/lib/system/package/plugin/AbstractOptionPackageInstallationPlugin.class.php
@@ -196,7 +196,7 @@ abstract class AbstractOptionPackageInstallationPlugin extends AbstractXMLPackag
                 'options' => isset($data['options']) ? StringUtil::normalizeCsv($data['options']) : '',
                 'parentCategoryName' => $data['parent'] ?? '',
                 'permissions' => isset($data['permissions']) ? StringUtil::normalizeCsv($data['permissions']) : '',
-                'showOrder' => isset($data['showorder']) ? \intval($data['showorder']) : null,
+                'showOrder' => isset($data['showorder']) ? (int)$data['showorder'] : null,
             ];
 
             // adjust show order

--- a/wcfsetup/install/files/lib/system/package/plugin/BBCodePackageInstallationPlugin.class.php
+++ b/wcfsetup/install/files/lib/system/package/plugin/BBCodePackageInstallationPlugin.class.php
@@ -215,7 +215,7 @@ class BBCodePackageInstallationPlugin extends AbstractXMLPackageInstallationPlug
 
         if (!empty($this->attributes)) {
             foreach ($this->attributes as $bbcodeID => $bbcodeAttributes) {
-                if ($bbcodeID != \intval($bbcodeID)) {
+                if ($bbcodeID != (int)$bbcodeID) {
                     $bbcodeID = BBCode::getBBCodeByTag($bbcodeID)->bbcodeID;
                 }
 

--- a/wcfsetup/install/files/lib/system/package/plugin/ClipboardActionPackageInstallationPlugin.class.php
+++ b/wcfsetup/install/files/lib/system/package/plugin/ClipboardActionPackageInstallationPlugin.class.php
@@ -93,7 +93,7 @@ class ClipboardActionPackageInstallationPlugin extends AbstractXMLPackageInstall
      */
     protected function prepareImport(array $data)
     {
-        $showOrder = isset($data['elements']['showorder']) ? \intval($data['elements']['showorder']) : null;
+        $showOrder = isset($data['elements']['showorder']) ? (int)$data['elements']['showorder'] : null;
         $showOrder = $this->getShowOrder($showOrder, $data['elements']['actionclassname'], 'actionClassName');
 
         return [

--- a/wcfsetup/install/files/lib/system/package/plugin/CronjobPackageInstallationPlugin.class.php
+++ b/wcfsetup/install/files/lib/system/package/plugin/CronjobPackageInstallationPlugin.class.php
@@ -106,12 +106,12 @@ class CronjobPackageInstallationPlugin extends AbstractXMLPackageInstallationPlu
     protected function prepareImport(array $data)
     {
         return [
-            'canBeDisabled' => isset($data['elements']['canbedisabled']) ? \intval($data['elements']['canbedisabled']) : 1,
-            'canBeEdited' => isset($data['elements']['canbeedited']) ? \intval($data['elements']['canbeedited']) : 1,
+            'canBeDisabled' => isset($data['elements']['canbedisabled']) ? (int)$data['elements']['canbedisabled'] : 1,
+            'canBeEdited' => isset($data['elements']['canbeedited']) ? (int)$data['elements']['canbeedited'] : 1,
             'className' => $data['elements']['classname'] ?? '',
             'cronjobName' => $data['attributes']['name'] ?? '',
             'description' => $data['elements']['description'] ?? '',
-            'isDisabled' => isset($data['elements']['isdisabled']) ? \intval($data['elements']['isdisabled']) : 0,
+            'isDisabled' => isset($data['elements']['isdisabled']) ? (int)$data['elements']['isdisabled'] : 0,
             'options' => isset($data['elements']['options']) ? StringUtil::normalizeCsv($data['elements']['options']) : '',
             'startDom' => $data['elements']['startdom'],
             'startDow' => $data['elements']['startdow'],

--- a/wcfsetup/install/files/lib/system/package/plugin/EventListenerPackageInstallationPlugin.class.php
+++ b/wcfsetup/install/files/lib/system/package/plugin/EventListenerPackageInstallationPlugin.class.php
@@ -94,7 +94,7 @@ class EventListenerPackageInstallationPlugin extends AbstractXMLPackageInstallat
      */
     protected function prepareImport(array $data)
     {
-        $nice = isset($data['elements']['nice']) ? \intval($data['elements']['nice']) : 0;
+        $nice = isset($data['elements']['nice']) ? (int)$data['elements']['nice'] : 0;
         if ($nice < -128) {
             $nice = -128;
         } elseif ($nice > 127) {
@@ -110,7 +110,7 @@ class EventListenerPackageInstallationPlugin extends AbstractXMLPackageInstallat
             'environment' => $data['elements']['environment'] ?? 'user',
             'eventClassName' => $data['elements']['eventclassname'],
             'eventName' => $eventName,
-            'inherit' => isset($data['elements']['inherit']) ? \intval($data['elements']['inherit']) : 0,
+            'inherit' => isset($data['elements']['inherit']) ? (int)$data['elements']['inherit'] : 0,
             'listenerClassName' => $data['elements']['listenerclassname'],
             'listenerName' => $data['attributes']['name'] ?? '',
             'niceValue' => $nice,

--- a/wcfsetup/install/files/lib/system/package/plugin/OptionPackageInstallationPlugin.class.php
+++ b/wcfsetup/install/files/lib/system/package/plugin/OptionPackageInstallationPlugin.class.php
@@ -94,10 +94,10 @@ class OptionPackageInstallationPlugin extends AbstractOptionPackageInstallationP
             $enableOptions = StringUtil::normalizeCsv($option['enableoptions']);
         }
         if (isset($option['showorder'])) {
-            $showOrder = \intval($option['showorder']);
+            $showOrder = (int)$option['showorder'];
         }
         if (isset($option['hidden'])) {
-            $hidden = \intval($option['hidden']);
+            $hidden = (int)$option['hidden'];
         }
         $showOrder = $this->getShowOrder($showOrder, $categoryName, 'categoryName');
         if (isset($option['selectoptions'])) {

--- a/wcfsetup/install/files/lib/system/package/plugin/TemplateListenerPackageInstallationPlugin.class.php
+++ b/wcfsetup/install/files/lib/system/package/plugin/TemplateListenerPackageInstallationPlugin.class.php
@@ -75,7 +75,7 @@ class TemplateListenerPackageInstallationPlugin extends AbstractXMLPackageInstal
      */
     protected function prepareImport(array $data)
     {
-        $niceValue = isset($data['elements']['nice']) ? \intval($data['elements']['nice']) : 0;
+        $niceValue = isset($data['elements']['nice']) ? (int)$data['elements']['nice'] : 0;
         if ($niceValue < -128) {
             $niceValue = -128;
         } elseif ($niceValue > 127) {

--- a/wcfsetup/install/files/lib/system/package/plugin/UserGroupOptionPackageInstallationPlugin.class.php
+++ b/wcfsetup/install/files/lib/system/package/plugin/UserGroupOptionPackageInstallationPlugin.class.php
@@ -113,7 +113,7 @@ class UserGroupOptionPackageInstallationPlugin extends AbstractOptionPackageInst
             $validationPattern = $option['validationpattern'];
         }
         if (!empty($option['showorder'])) {
-            $showOrder = \intval($option['showorder']);
+            $showOrder = (int)$option['showorder'];
         }
         $showOrder = $this->getShowOrder($showOrder, $categoryName, 'categoryName');
         if (isset($option['enableoptions'])) {

--- a/wcfsetup/install/files/lib/system/package/plugin/UserOptionPackageInstallationPlugin.class.php
+++ b/wcfsetup/install/files/lib/system/package/plugin/UserOptionPackageInstallationPlugin.class.php
@@ -136,22 +136,22 @@ class UserOptionPackageInstallationPlugin extends AbstractOptionPackageInstallat
             $validationPattern = $option['validationpattern'];
         }
         if (isset($option['required'])) {
-            $required = \intval($option['required']);
+            $required = (int)$option['required'];
         }
         if (isset($option['askduringregistration'])) {
-            $askDuringRegistration = \intval($option['askduringregistration']);
+            $askDuringRegistration = (int)$option['askduringregistration'];
         }
         if (isset($option['editable'])) {
-            $editable = \intval($option['editable']);
+            $editable = (int)$option['editable'];
         }
         if (isset($option['visible'])) {
-            $visible = \intval($option['visible']);
+            $visible = (int)$option['visible'];
         }
         if (isset($option['searchable'])) {
-            $searchable = \intval($option['searchable']);
+            $searchable = (int)$option['searchable'];
         }
         if (isset($option['showorder'])) {
-            $showOrder = \intval($option['showorder']);
+            $showOrder = (int)$option['showorder'];
         }
         if (isset($option['outputclass'])) {
             $outputClass = $option['outputclass'];
@@ -163,7 +163,7 @@ class UserOptionPackageInstallationPlugin extends AbstractOptionPackageInstallat
             $enableOptions = StringUtil::normalizeCsv($option['enableoptions']);
         }
         if (isset($option['isdisabled'])) {
-            $isDisabled = \intval($option['isdisabled']);
+            $isDisabled = (int)$option['isdisabled'];
         }
         $showOrder = $this->getShowOrder($showOrder, $categoryName, 'categoryName');
         if (isset($option['permissions'])) {

--- a/wcfsetup/install/files/lib/system/package/plugin/UserProfileMenuPackageInstallationPlugin.class.php
+++ b/wcfsetup/install/files/lib/system/package/plugin/UserProfileMenuPackageInstallationPlugin.class.php
@@ -225,7 +225,7 @@ class UserProfileMenuPackageInstallationPlugin extends AbstractXMLPackageInstall
 
         $showOrder = $element->getElementsByTagName('showorder')->item(0);
         if ($showOrder) {
-            $data['showOrder'] = \intval($showOrder->nodeValue);
+            $data['showOrder'] = (int)$showOrder->nodeValue;
         }
         if ($saveData && $this->editedEntry === null) {
             // only set explicit showOrder when adding new menu item

--- a/wcfsetup/install/files/lib/system/page/PageLocationManager.class.php
+++ b/wcfsetup/install/files/lib/system/page/PageLocationManager.class.php
@@ -56,7 +56,7 @@ class PageLocationManager extends SingletonFactory
                 $pageID = $page->pageID;
 
                 if (!empty($_REQUEST['id'])) {
-                    $pageObjectID = \intval($_REQUEST['id']);
+                    $pageObjectID = (int)$_REQUEST['id'];
                 }
             }
         }

--- a/wcfsetup/install/files/lib/system/payment/type/PaidSubscriptionPaymentType.class.php
+++ b/wcfsetup/install/files/lib/system/payment/type/PaidSubscriptionPaymentType.class.php
@@ -41,13 +41,13 @@ class PaidSubscriptionPaymentType extends AbstractPaymentType
             [$userID, $subscriptionID] = $tokenParts;
 
             // get user object
-            $user = new User(\intval($userID));
+            $user = new User((int)$userID);
             if (!$user->userID) {
                 throw new SystemException('invalid user');
             }
 
             // get subscription object
-            $subscription = new PaidSubscription(\intval($subscriptionID));
+            $subscription = new PaidSubscription((int)$subscriptionID);
             if (!$subscription->subscriptionID) {
                 throw new SystemException('invalid subscription');
             }

--- a/wcfsetup/install/files/lib/system/poll/PollManager.class.php
+++ b/wcfsetup/install/files/lib/system/poll/PollManager.class.php
@@ -120,7 +120,7 @@ class PollManager extends SingletonFactory
             throw new SystemException("Object type '" . $objectType . "' is unknown");
         }
 
-        $this->objectID = \intval($objectID);
+        $this->objectID = (int)$objectID;
         $this->objectType = $objectType;
         $this->pollID = $pollID;
 
@@ -181,7 +181,7 @@ class PollManager extends SingletonFactory
         }
 
         if (isset($postData['pollMaxVotes'])) {
-            $this->pollData['maxVotes'] = \max(\intval($postData['pollMaxVotes']), 1); // force a minimum of 1
+            $this->pollData['maxVotes'] = \max((int)$postData['pollMaxVotes'], 1); // force a minimum of 1
         }
         if (isset($postData['pollQuestion'])) {
             $this->pollData['question'] = StringUtil::trim($postData['pollQuestion']);
@@ -204,7 +204,7 @@ class PollManager extends SingletonFactory
             foreach ($postData['pollOptions'] as $showOrder => $value) {
                 [$optionID, $optionValue] = \explode('_', $value, 2);
                 $this->pollOptions[$showOrder] = [
-                    'optionID' => \intval($optionID),
+                    'optionID' => (int)$optionID,
                     'optionValue' => StringUtil::trim($optionValue),
                 ];
             }
@@ -262,7 +262,7 @@ class PollManager extends SingletonFactory
     public function save($objectID = null)
     {
         if ($objectID !== null) {
-            $this->objectID = \intval($objectID);
+            $this->objectID = (int)$objectID;
         }
 
         // create a new poll

--- a/wcfsetup/install/files/lib/system/search/ArticleSearch.class.php
+++ b/wcfsetup/install/files/lib/system/search/ArticleSearch.class.php
@@ -99,7 +99,7 @@ class ArticleSearch extends AbstractSearchProvider
     public function getConditionBuilder(array $parameters): ?PreparedStatementConditionBuilder
     {
         if (!empty($parameters['articleCategoryID'])) {
-            $this->articleCategoryID = \intval($parameters['articleCategoryID']);
+            $this->articleCategoryID = (int)$parameters['articleCategoryID'];
         }
 
         $articleCategoryIDs = $this->getArticleCategoryIDs($this->articleCategoryID);

--- a/wcfsetup/install/files/lib/system/stat/LikeStatDailyHandler.class.php
+++ b/wcfsetup/install/files/lib/system/stat/LikeStatDailyHandler.class.php
@@ -24,14 +24,14 @@ class LikeStatDailyHandler extends AbstractStatDailyHandler
                 WHERE   time BETWEEN ? AND ?";
         $statement = WCF::getDB()->prepareStatement($sql);
         $statement->execute([$date, $date + 86399]);
-        $counter = \intval($statement->fetchSingleColumn());
+        $counter = (int)$statement->fetchSingleColumn();
 
         $sql = "SELECT  COUNT(*)
                 FROM    wcf" . WCF_N . "_like
                 WHERE   time < ?";
         $statement = WCF::getDB()->prepareStatement($sql);
         $statement->execute([$date + 86400]);
-        $total = \intval($statement->fetchSingleColumn());
+        $total = (int)$statement->fetchSingleColumn();
 
         return [
             'counter' => $counter,

--- a/wcfsetup/install/files/lib/system/template/plugin/CurrencyModifierTemplatePlugin.class.php
+++ b/wcfsetup/install/files/lib/system/template/plugin/CurrencyModifierTemplatePlugin.class.php
@@ -27,7 +27,7 @@ class CurrencyModifierTemplatePlugin implements IModifierTemplatePlugin
      */
     public function execute($tagArgs, TemplateEngine $tplObj)
     {
-        $decimals = \intval($tagArgs[1] ?? 2);
+        $decimals = (int)$tagArgs[1] ?? 2;
 
         return \number_format(
             \round($tagArgs[0], $decimals),

--- a/wcfsetup/install/files/lib/system/template/plugin/DateIntervalFunctionTemplatePlugin.class.php
+++ b/wcfsetup/install/files/lib/system/template/plugin/DateIntervalFunctionTemplatePlugin.class.php
@@ -44,10 +44,10 @@ class DateIntervalFunctionTemplatePlugin implements IFunctionTemplatePlugin
         }
 
         if (isset($tagArgs['start'])) {
-            $start = \intval($tagArgs['start']);
+            $start = (int)$tagArgs['start'];
         }
         if (isset($tagArgs['end'])) {
-            $end = \intval($tagArgs['end']);
+            $end = (int)$tagArgs['end'];
         }
 
         $startTime = DateUtil::getDateTimeByTimestamp($start);

--- a/wcfsetup/install/files/lib/system/template/plugin/PageBlockTemplatePlugin.class.php
+++ b/wcfsetup/install/files/lib/system/template/plugin/PageBlockTemplatePlugin.class.php
@@ -51,7 +51,7 @@ class PageBlockTemplatePlugin implements IBlockTemplatePlugin
     {
         $pageID = null;
         if (!empty($tagArgs['pageID'])) {
-            $pageID = \intval($tagArgs['pageID']);
+            $pageID = (int)$tagArgs['pageID'];
         } elseif (!empty($blockContent)) {
             $page = Page::getPageByIdentifier($blockContent);
             $pageID = $page ? $page->pageID : 0;
@@ -63,7 +63,7 @@ class PageBlockTemplatePlugin implements IBlockTemplatePlugin
 
         $languageID = -1;
         if (!empty($tagArgs['languageID'])) {
-            $languageID = \intval($tagArgs['languageID']);
+            $languageID = (int)$tagArgs['languageID'];
         } elseif (!empty($tagArgs['language'])) {
             $language = LanguageFactory::getInstance()->getLanguageByCode($tagArgs['language']);
             if ($language !== null) {

--- a/wcfsetup/install/files/lib/system/template/plugin/PagesFunctionTemplatePlugin.class.php
+++ b/wcfsetup/install/files/lib/system/template/plugin/PagesFunctionTemplatePlugin.class.php
@@ -217,8 +217,8 @@ class PagesFunctionTemplatePlugin implements IFunctionTemplatePlugin
                 $left -= $half - $linksAfterPage;
             }
 
-            $right = \intval(\ceil($right));
-            $left = \intval(\ceil($left));
+            $right = (int)\ceil($right);
+            $left = (int)\ceil($left);
             if ($left < 1) {
                 $left = 1;
             }

--- a/wcfsetup/install/files/lib/system/template/plugin/TimeModifierTemplatePlugin.class.php
+++ b/wcfsetup/install/files/lib/system/template/plugin/TimeModifierTemplatePlugin.class.php
@@ -26,7 +26,7 @@ class TimeModifierTemplatePlugin implements IModifierTemplatePlugin
      */
     public function execute($tagArgs, TemplateEngine $tplObj)
     {
-        $timestamp = \intval($tagArgs[0]);
+        $timestamp = (int)$tagArgs[0];
         $dateTimeObject = DateUtil::getDateTimeByTimestamp($timestamp);
         $date = DateUtil::format($dateTimeObject, DateUtil::DATE_FORMAT);
         $time = DateUtil::format($dateTimeObject, DateUtil::TIME_FORMAT);

--- a/wcfsetup/install/files/lib/system/template/plugin/TruncateModifierTemplatePlugin.class.php
+++ b/wcfsetup/install/files/lib/system/template/plugin/TruncateModifierTemplatePlugin.class.php
@@ -31,7 +31,7 @@ class TruncateModifierTemplatePlugin implements IModifierTemplatePlugin
         // get values
         $string = $tagArgs[0];
         if (isset($tagArgs[1])) {
-            $length = \intval($tagArgs[1]);
+            $length = (int)$tagArgs[1];
         }
         if (isset($tagArgs[2])) {
             $etc = $tagArgs[2];

--- a/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/DoubleBcrypt.class.php
+++ b/wcfsetup/install/files/lib/system/user/authentication/password/algorithm/DoubleBcrypt.class.php
@@ -131,8 +131,8 @@ final class DoubleBcrypt implements IPasswordAlgorithm
      */
     private static function isDifferentBlowfish($hash)
     {
-        $currentCost = \intval(self::BCRYPT_COST);
-        $hashCost = \intval(\mb_substr($hash, 4, 2, '8bit'));
+        $currentCost = (int)self::BCRYPT_COST;
+        $hashCost = (int)\mb_substr($hash, 4, 2, '8bit');
 
         if ($currentCost != $hashCost) {
             return true;

--- a/wcfsetup/install/files/lib/system/user/multifactor/Setup.class.php
+++ b/wcfsetup/install/files/lib/system/user/multifactor/Setup.class.php
@@ -98,7 +98,7 @@ final class Setup implements IIDObject
             $this->getId(),
         ]);
 
-        $setupId = \intval($statement->fetchSingleColumn());
+        $setupId = (int)$statement->fetchSingleColumn();
         \assert($setupId === $this->getId());
 
         return $this;

--- a/wcfsetup/install/files/lib/system/user/multifactor/totp/Totp.class.php
+++ b/wcfsetup/install/files/lib/system/user/multifactor/totp/Totp.class.php
@@ -72,7 +72,7 @@ final class Totp
      */
     public function generateTotpCode(\DateTime $time): string
     {
-        $counter = \intval($time->getTimestamp() / self::TIME_STEP);
+        $counter = (int)$time->getTimestamp() / self::TIME_STEP;
 
         return $this->generateHotpCode($counter);
     }
@@ -85,7 +85,7 @@ final class Totp
      */
     public function validateTotpCode(string $userCode, int &$minCounter, \DateTime $time): bool
     {
-        $counter = \intval($time->getTimestamp() / self::TIME_STEP);
+        $counter = (int)$time->getTimestamp() / self::TIME_STEP;
 
         for ($offset = -self::LEEWAY; $offset < self::LEEWAY; $offset++) {
             $possibleCode = $this->generateHotpCode($counter + $offset);

--- a/wcfsetup/install/files/lib/system/version/VersionTracker.class.php
+++ b/wcfsetup/install/files/lib/system/version/VersionTracker.class.php
@@ -239,8 +239,8 @@ class VersionTracker extends SingletonFactory implements IAJAXInvokeAction
         }
 
         $objectTypeName = (isset($_POST['parameters']['objectType'])) ? StringUtil::trim($_POST['parameters']['objectType']) : '';
-        $objectID = (isset($_POST['parameters']['objectID'])) ? \intval($_POST['parameters']['objectID']) : 0;
-        $versionID = (isset($_POST['parameters']['versionID'])) ? \intval($_POST['parameters']['versionID']) : 0;
+        $objectID = (isset($_POST['parameters']['objectID'])) ? (int)$_POST['parameters']['objectID'] : 0;
+        $versionID = (isset($_POST['parameters']['versionID'])) ? (int)$_POST['parameters']['versionID'] : 0;
 
         $objectType = $this->getObjectType($objectTypeName);
         /** @var IVersionTrackerProvider $processor */

--- a/wcfsetup/install/files/lib/system/worker/AbstractRebuildDataWorker.class.php
+++ b/wcfsetup/install/files/lib/system/worker/AbstractRebuildDataWorker.class.php
@@ -176,7 +176,7 @@ abstract class AbstractRebuildDataWorker extends AbstractWorker implements IRebu
      */
     protected function getBulkUserPermissionValue(array &$userPermissions, $userID, $permission)
     {
-        $userID = \intval($userID);
+        $userID = (int)$userID;
 
         // resolve non-existing users against the guest permission
         if ($userID && !isset($userPermissions[$userID])) {

--- a/wcfsetup/install/files/lib/util/ArrayUtil.class.php
+++ b/wcfsetup/install/files/lib/util/ArrayUtil.class.php
@@ -40,7 +40,7 @@ final class ArrayUtil
     }
 
     /**
-     * Applies intval() to all elements of the given array.
+     * Casts all elements of the given array to integer.
      *
      * @param array|string $array
      * @return  array|string
@@ -48,7 +48,7 @@ final class ArrayUtil
     public static function toIntegerArray($array)
     {
         if (!\is_array($array)) {
-            return \intval($array);
+            return (int)$array;
         } else {
             foreach ($array as $key => $val) {
                 $array[$key] = self::toIntegerArray($val);

--- a/wcfsetup/install/files/lib/util/CronjobUtil.class.php
+++ b/wcfsetup/install/files/lib/util/CronjobUtil.class.php
@@ -344,7 +344,7 @@ final class CronjobUtil
         $addAnDay = false;
 
         // compare hour
-        $currentHour = \intval(\date('G', $timeBase));
+        $currentHour = (int)\date('G', $timeBase);
         $index = self::findKey($currentHour, $values['hour'], false);
         if ($index === false) {
             $index = self::findKey($currentHour, $values['hour']);
@@ -633,7 +633,7 @@ final class CronjobUtil
                         $right = $compare['1'];
                     }
                     // now check the values.
-                    if (\intval($left) > \intval($right)) {
+                    if ((int)$left > (int)$right) {
                         throw new SystemException("invalid value '" . $value . "' given for cronjob attribute '" . $name . "'");
                     }
                 }

--- a/wcfsetup/install/files/lib/util/DateUtil.class.php
+++ b/wcfsetup/install/files/lib/util/DateUtil.class.php
@@ -443,13 +443,13 @@ final class DateUtil
         $year = $month = $day = 0;
         $value = \explode('-', $date);
         if (isset($value[0])) {
-            $year = \intval($value[0]);
+            $year = (int)$value[0];
         }
         if (isset($value[1])) {
-            $month = \intval($value[1]);
+            $month = (int)$value[1];
         }
         if (isset($value[2])) {
-            $day = \intval($value[2]);
+            $day = (int)$value[2];
         }
 
         // calc
@@ -492,7 +492,7 @@ final class DateUtil
     public static function getFirstDayOfTheWeek()
     {
         if (self::$firstDayOfTheWeek === null) {
-            self::$firstDayOfTheWeek = \intval(WCF::getLanguage()->get('wcf.date.firstDayOfTheWeek'));
+            self::$firstDayOfTheWeek = (int)WCF::getLanguage(->get('wcf.date.firstDayOfTheWeek'));
             if (self::$firstDayOfTheWeek != 1 && self::$firstDayOfTheWeek != 0) {
                 self::$firstDayOfTheWeek = 0;
             }

--- a/wcfsetup/install/files/lib/util/ExifUtil.class.php
+++ b/wcfsetup/install/files/lib/util/ExifUtil.class.php
@@ -132,11 +132,11 @@ final class ExifUtil
         $creationTime = 0;
         if (isset($exifData['EXIF'])) {
             if (isset($exifData['EXIF']['DateTimeOriginal'])) {
-                $creationTime = @\intval(\strtotime($exifData['EXIF']['DateTimeOriginal']));
+                $creationTime = @(int)\strtotime($exifData['EXIF']['DateTimeOriginal']);
             } elseif (isset($exifData['EXIF']['DateTimeDigitized'])) {
-                $creationTime = @\intval(\strtotime($exifData['EXIF']['DateTimeDigitized']));
+                $creationTime = @(int)\strtotime($exifData['EXIF']['DateTimeDigitized']);
             } elseif (!empty($exifData['EXIF']['DateTime'])) {
-                $creationTime = @\intval(\strtotime($exifData['EXIF']['DateTime']));
+                $creationTime = @(int)\strtotime($exifData['EXIF']['DateTime']);
             }
         }
         if ($creationTime < 0 || $creationTime > 2147483647) {
@@ -224,11 +224,11 @@ final class ExifUtil
         }
         if (isset($rawExifData['ISOSpeedRatings'])) {
             // CCD sensitivity equivalent to Ag-Hr film speedrate. (unsigned short)
-            $exifData['ISOSpeedRatings'] = \intval($rawExifData['ISOSpeedRatings']);
+            $exifData['ISOSpeedRatings'] = (int)$rawExifData['ISOSpeedRatings'];
         }
         if (isset($rawExifData['Flash'])) {
             // Indicates the status of flash when the image was shot. (unsigned short)
-            $exifData['Flash'] = \intval($rawExifData['Flash']);
+            $exifData['Flash'] = (int)$rawExifData['Flash'];
         }
 
         return $exifData;
@@ -244,7 +244,7 @@ final class ExifUtil
     {
         $orientation = self::ORIENTATION_ORIGINAL;
         if (isset($exifData['IFD0']['Orientation'])) {
-            $orientation = \intval($exifData['IFD0']['Orientation']);
+            $orientation = (int)$exifData['IFD0']['Orientation'];
             if ($orientation < self::ORIENTATION_ORIGINAL || $orientation > self::ORIENTATION_270_ROTATE) {
                 $orientation = self::ORIENTATION_ORIGINAL;
             }
@@ -284,15 +284,15 @@ final class ExifUtil
     {
         $data = \explode('/', $rational);
         if (\count($data) == 1) {
-            return \floatval($rational);
+            return (float)$rational;
         }
 
         // prevent division by zero if 2nd value is invalid
-        $data[1] = \floatval($data[1]);
+        $data[1] = (float)$data[1];
         if (!$data[1]) {
             return 0.0;
         }
 
-        return \floatval($data[0]) / $data[1];
+        return (float)$data[0] / $data[1];
     }
 }

--- a/wcfsetup/install/files/lib/util/FileReader.class.php
+++ b/wcfsetup/install/files/lib/util/FileReader.class.php
@@ -119,9 +119,9 @@ class FileReader
                 $regex = new Regex('^bytes=(?:(\d+)-(\d+)?|-(\d+))$');
                 if ($regex->match($_SERVER['HTTP_RANGE'])) {
                     $matches = $regex->getMatches();
-                    $start = (isset($matches[1]) && $matches[1] !== '' ? \intval($matches[1]) : null);
-                    $end = (isset($matches[2]) && $matches[2] !== '' ? \intval($matches[2]) : null);
-                    $last = (isset($matches[3]) && $matches[3] !== '' ? \intval($matches[3]) : null);
+                    $start = (isset($matches[1]) && $matches[1] !== '' ? (int)$matches[1] : null);
+                    $end = (isset($matches[2]) && $matches[2] !== '' ? (int)$matches[2] : null);
+                    $last = (isset($matches[3]) && $matches[3] !== '' ? (int)$matches[3] : null);
 
                     if ($start !== null) {
                         $this->startByte = $start;

--- a/wcfsetup/install/files/lib/util/MessageUtil.class.php
+++ b/wcfsetup/install/files/lib/util/MessageUtil.class.php
@@ -32,7 +32,7 @@ class MessageUtil
 
         // convert html entities (utf-8)
         $text = Regex::compile('&#(3[2-9]|[4-9][0-9]|\d{3,5});')->replace($text, static function ($matches) {
-            return StringUtil::getCharacter(\intval($matches[1]));
+            return StringUtil::getCharacter((int)$matches[1]);
         });
 
         // unify new lines

--- a/wcfsetup/install/files/lib/util/PasswordUtil.class.php
+++ b/wcfsetup/install/files/lib/util/PasswordUtil.class.php
@@ -88,8 +88,8 @@ final class PasswordUtil
      */
     public static function isDifferentBlowfish($hash)
     {
-        $currentCost = \intval(self::BCRYPT_COST);
-        $hashCost = \intval(\substr($hash, 4, 2));
+        $currentCost = (int)self::BCRYPT_COST;
+        $hashCost = (int)\substr($hash, 4, 2);
 
         if ($currentCost != $hashCost) {
             return true;

--- a/wcfsetup/install/files/lib/util/StringUtil.class.php
+++ b/wcfsetup/install/files/lib/util/StringUtil.class.php
@@ -185,7 +185,7 @@ final class StringUtil
             if (\floatval($numeric) - (float)\intval($numeric)) {
                 return self::formatDouble($numeric);
             } else {
-                return self::formatInteger(\intval($numeric));
+                return self::formatInteger((int)$numeric);
             }
         }
     }


### PR DESCRIPTION
Since there's no base used for conversion, we can safely switch from function invocation to explicit casts, which can increase the performance greatly. This also saves us 4 bytes per replacement.