### PR TITLE
Remove the deprecated `__sessionKeepAlive` template variable

### DIFF
--- a/wcfsetup/install/files/lib/system/WCF.class.php
+++ b/wcfsetup/install/files/lib/system/WCF.class.php
@@ -601,9 +601,6 @@ class WCF
             foreach ($loadedApplications as $application) {
                 $application->__run();
             }
-
-            /** @deprecated The below variable is deprecated. */
-            self::getTPL()->assign('__sessionKeepAlive', 59 * 60);
         }
     }
 


### PR DESCRIPTION
It does not really belong in this location.

see 96bd897793928400a889a19de0f6878901a89d64
