### PR TITLE
Generate favicons in bigger sizes

### DIFF
--- a/wcfsetup/install/files/lib/data/style/StyleAction.class.php
+++ b/wcfsetup/install/files/lib/data/style/StyleAction.class.php
@@ -331,8 +331,7 @@ class StyleAction extends AbstractDatabaseObjectAction implements IToggleAction
 
                     // Create ICO file.
                     $ico = @new \PHP_ICO($file->getLocation(), [
-                        [16, 16],
-                        [32, 32],
+                        [48, 48],
                     ]);
                     $ico->save_ico($style->getAssetPath() . "favicon.ico");
 


### PR DESCRIPTION
As [recommended by Google](https://developers.google.com/search/docs/appearance/favicon-in-search#guidelines), favicons should be at least 48x48 pixels. Currently, a favicon will be generated with a maximum dimension of 32x32 pixels.

> Your favicon must be a multiple of 48px square, for example: 48x48px, 96x96px, 144x144px and so on.

However, I don't think there's any need for anything else but 48px. Following the Google recommendation (generating a favicon in 48, 96 & 144px), the generated favicon file would exceed 100 kB, while the single-size favicon is reasonably tiny in file size.