### PR TITLE
Fix double implements in TimeDatabaseTableColumn

### DIFF
--- a/wcfsetup/install/files/lib/system/database/table/column/TimeDatabaseTableColumn.class.php
+++ b/wcfsetup/install/files/lib/system/database/table/column/TimeDatabaseTableColumn.class.php
@@ -11,7 +11,7 @@ namespace wcf\system\database\table\column;
  * @package WoltLabSuite\Core\System\Database\Table\Column
  * @since   5.2
  */
-class TimeDatabaseTableColumn extends AbstractDatabaseTableColumnimplements implements IDefaultValueDatabaseTableColumn
+class TimeDatabaseTableColumn extends AbstractDatabaseTableColumn implements IDefaultValueDatabaseTableColumn
 {
     use TDefaultValueDatabaseTableColumn;
 


### PR DESCRIPTION
In class `TimeDatabaseTableColumn` was a double `implements`. The first `implements` was appended to the abstract class name. Because of this the `extends` was wrong.