### PR TITLE
Remove the global `escapeString()` function

### DIFF
--- a/wcfsetup/install/files/lib/core.functions.php
+++ b/wcfsetup/install/files/lib/core.functions.php
@@ -19,13 +19,6 @@ namespace {
 	spl_autoload_register([WCF::class, 'autoload'], true, true);
 	
 	/**
-	 * @deprecated 5.5 Use prepared statements if possible. Directly call WCF::getDB()->escapeString() if prepared statements cannot be used.
-	 */
-	function escapeString($string) {
-		return WCF::getDB()->escapeString($string);
-	}
-	
-	/**
 	 * Helper method to output debug data for all passed variables,
 	 * uses `print_r()` for arrays and objects, `var_dump()` otherwise.
 	 */


### PR DESCRIPTION
This function is trivially replaced if still used and the removal cleans up
core.functions.php a little further.
