### PR TITLE
Remove comments column from ACP's ArticleListPage

### DIFF
--- a/wcfsetup/install/files/acp/templates/articleList.tpl
+++ b/wcfsetup/install/files/acp/templates/articleList.tpl
@@ -129,7 +129,6 @@
 					<th class="columnMark"><label><input type="checkbox" class="jsClipboardMarkAll"></label></th>
 					<th class="columnID columnArticleID{if $sortField == 'articleID'} active {@$sortOrder}{/if}" colspan="2"><a href="{link controller='ArticleList'}pageNo={@$pageNo}&sortField=articleID&sortOrder={if $sortField == 'articleID' && $sortOrder == 'ASC'}DESC{else}ASC{/if}{@$linkParameters}{/link}">{lang}wcf.global.objectID{/lang}</a></th>
 					<th class="columnText columnArticleTitle{if $sortField == 'title'} active {@$sortOrder}{/if}"><a href="{link controller='ArticleList'}pageNo={@$pageNo}&sortField=title&sortOrder={if $sortField == 'title' && $sortOrder == 'ASC'}DESC{else}ASC{/if}{@$linkParameters}{/link}">{lang}wcf.global.title{/lang}</a></th>
-					<th class="columnDigits columnComments{if $sortField == 'comments'} active {@$sortOrder}{/if}"><a href="{link controller='ArticleList'}pageNo={@$pageNo}&sortField=comments&sortOrder={if $sortField == 'comments' && $sortOrder == 'ASC'}DESC{else}ASC{/if}{@$linkParameters}{/link}">{lang}wcf.global.comments{/lang}</a></th>
 					<th class="columnDigits columnViews{if $sortField == 'views'} active {@$sortOrder}{/if}"><a href="{link controller='ArticleList'}pageNo={@$pageNo}&sortField=views&sortOrder={if $sortField == 'views' && $sortOrder == 'ASC'}DESC{else}ASC{/if}{@$linkParameters}{/link}">{lang}wcf.acp.article.views{/lang}</a></th>
 					<th class="columnDate columnTime{if $sortField == 'time'} active {@$sortOrder}{/if}"><a href="{link controller='ArticleList'}pageNo={@$pageNo}&sortField=time&sortOrder={if $sortField == 'time' && $sortOrder == 'ASC'}DESC{else}ASC{/if}{@$linkParameters}{/link}">{lang}wcf.global.date{/lang}</a></th>
 					
@@ -199,7 +198,6 @@
 								</div>
 							</div>
 						</td>
-						<td class="columnDigits columnComments">{#$article->comments}</td>
 						<td class="columnDigits columnViews">{#$article->views}</td>
 						<td class="columnDate columnTime">{@$article->time|time}</td>
 						

--- a/wcfsetup/install/files/lib/acp/page/ArticleListPage.class.php
+++ b/wcfsetup/install/files/lib/acp/page/ArticleListPage.class.php
@@ -62,7 +62,7 @@ class ArticleListPage extends SortablePage
     /**
      * @inheritDoc
      */
-    public $validSortFields = ['articleID', 'title', 'time', 'views', 'comments'];
+    public $validSortFields = ['articleID', 'title', 'time', 'views'];
 
     /**
      * @inheritDoc


### PR DESCRIPTION
This column was effectively broken since the introduction of pluggable
discussion providers and is completely broken (always showing zero) since the
`comments` column was moved the the article to the article content in
75c21dfd1231389b2e3f527fc202dfec8f5c808b.
