### PR TITLE
Overhaul of the exception visualization

### DIFF
--- a/ts/WoltLabSuite/Core/Acp/Ui/Devtools/Project/Sync.ts
+++ b/ts/WoltLabSuite/Core/Acp/Ui/Devtools/Project/Sync.ts
@@ -1,9 +1,9 @@
 import * as Ajax from "../../../../Ajax";
 import * as Language from "../../../../Language";
-import UiDialog from "../../../../Ui/Dialog";
 import * as UiNotification from "../../../../Ui/Notification";
 import { AjaxCallbackSetup, AjaxResponseException } from "../../../../Ajax/Data";
 import { DialogCallbackSetup } from "../../../../Ui/Dialog/Data";
+import { dialogFactory } from "../../../../Component/Dialog";
 
 interface PipData {
   dependencies: string[];
@@ -225,7 +225,17 @@ class AcpUiDevtoolsProjectSync {
     buttonStatus.children[0].addEventListener("click", (event) => {
       event.preventDefault();
 
-      UiDialog.open(this, Ajax.getRequestObject(this).getErrorHtml(data, xhr));
+      const html = Ajax.getRequestObject(this).getErrorHtml(data, xhr);
+      if (html instanceof HTMLIFrameElement) {
+        const dialog = dialogFactory()
+          .fromHtml(`<div class="dialog__iframeContainer">${html.outerHTML}</div>`)
+          .asAlert();
+        dialog.show(Language.get("wcf.global.error.title"));
+        dialog.querySelector("dialog")!.classList.add("dialog--iframe");
+      } else if (html) {
+        const dialog = dialogFactory().fromHtml(html).asAlert();
+        dialog.show(Language.get("wcf.global.error.title"));
+      }
     });
 
     this.buttonSyncAll!.classList.remove("disabled");

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Acp/Ui/Devtools/Project/Sync.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Acp/Ui/Devtools/Project/Sync.js
@@ -1,10 +1,9 @@
-define(["require", "exports", "tslib", "../../../../Ajax", "../../../../Language", "../../../../Ui/Dialog", "../../../../Ui/Notification"], function (require, exports, tslib_1, Ajax, Language, Dialog_1, UiNotification) {
+define(["require", "exports", "tslib", "../../../../Ajax", "../../../../Language", "../../../../Ui/Notification", "../../../../Component/Dialog"], function (require, exports, tslib_1, Ajax, Language, UiNotification, Dialog_1) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.init = void 0;
     Ajax = tslib_1.__importStar(Ajax);
     Language = tslib_1.__importStar(Language);
-    Dialog_1 = tslib_1.__importDefault(Dialog_1);
     UiNotification = tslib_1.__importStar(UiNotification);
     class AcpUiDevtoolsProjectSync {
         buttons = new Map();
@@ -154,7 +153,18 @@ define(["require", "exports", "tslib", "../../../../Ajax", "../../../../Language
             buttonStatus.innerHTML = '<a href="#">' + Language.get("wcf.acp.devtools.sync.status.failure") + "</a>";
             buttonStatus.children[0].addEventListener("click", (event) => {
                 event.preventDefault();
-                Dialog_1.default.open(this, Ajax.getRequestObject(this).getErrorHtml(data, xhr));
+                const html = Ajax.getRequestObject(this).getErrorHtml(data, xhr);
+                if (html instanceof HTMLIFrameElement) {
+                    const dialog = (0, Dialog_1.dialogFactory)()
+                        .fromHtml(`<div class="dialog__iframeContainer">${html.outerHTML}</div>`)
+                        .asAlert();
+                    dialog.show(Language.get("wcf.global.error.title"));
+                    dialog.querySelector("dialog").classList.add("dialog--iframe");
+                }
+                else if (html) {
+                    const dialog = (0, Dialog_1.dialogFactory)().fromHtml(html).asAlert();
+                    dialog.show(Language.get("wcf.global.error.title"));
+                }
             });
             this.buttonSyncAll.classList.remove("disabled");
             return true;

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ajax/Error.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ajax/Error.js
@@ -15,7 +15,12 @@ define(["require", "exports", "tslib", "../Component/Dialog", "../Core", "../Lan
     Language = tslib_1.__importStar(Language);
     async function genericError(error) {
         const html = await getErrorHtml(error);
-        if (html !== "") {
+        if (html instanceof HTMLIFrameElement) {
+            const dialog = (0, Dialog_1.dialogFactory)().fromHtml(`<div class="dialog__iframeContainer">${html.outerHTML}</div>`).asAlert();
+            dialog.show(Language.get("wcf.global.error.title"));
+            dialog.querySelector("dialog").classList.add("dialog--iframe");
+        }
+        else if (html !== "") {
             const dialog = (0, Dialog_1.dialogFactory)().fromHtml(html).asAlert();
             dialog.show(Language.get("wcf.global.error.title"));
         }
@@ -62,6 +67,13 @@ define(["require", "exports", "tslib", "../Component/Dialog", "../Core", "../Lan
                         details += `<hr><p>${previous.message}</p>`;
                         details += `<br><p>Stacktrace</p><p>${previous.stacktrace}</p>`;
                     });
+                }
+                else if (json === undefined) {
+                    // The content is possibly HTML, use an iframe for rendering.
+                    const iframe = document.createElement("iframe");
+                    iframe.classList.add("dialog__iframe");
+                    iframe.srcdoc = message;
+                    return iframe;
                 }
             }
         }

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ajax/Request.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ajax/Request.js
@@ -248,7 +248,14 @@ define(["require", "exports", "tslib", "./Status", "../Core", "../Dom/Change/Lis
             }
             if (options.ignoreError !== true && showError) {
                 const html = this.getErrorHtml(data, xhr);
-                if (html) {
+                if (html instanceof HTMLIFrameElement) {
+                    const dialog = (0, Dialog_1.dialogFactory)()
+                        .fromHtml(`<div class="dialog__iframeContainer">${html.outerHTML}</div>`)
+                        .asAlert();
+                    dialog.show(Language.get("wcf.global.error.title"));
+                    dialog.querySelector("dialog").classList.add("dialog--iframe");
+                }
+                else if (html) {
                     const dialog = (0, Dialog_1.dialogFactory)().fromHtml(html).asAlert();
                     dialog.show(Language.get("wcf.global.error.title"));
                 }
@@ -279,6 +286,13 @@ define(["require", "exports", "tslib", "./Status", "../Core", "../Dom/Change/Lis
                     details += `<hr><p>${previous.message}</p>`;
                     details += `<br><p>Stacktrace</p><p>${previous.stacktrace}</p>`;
                 });
+            }
+            else if (xhr.getResponseHeader("content-type")?.startsWith("text/html")) {
+                // The content is possibly HTML, use an iframe for rendering.
+                const iframe = document.createElement("iframe");
+                iframe.classList.add("dialog__iframe");
+                iframe.srcdoc = xhr.responseText;
+                return iframe;
             }
             else {
                 message = xhr.responseText;

--- a/wcfsetup/install/files/lib/core.functions.php
+++ b/wcfsetup/install/files/lib/core.functions.php
@@ -624,11 +624,11 @@ EXPLANATION;
 									<p class="exceptionFieldValue"><?php echo StringUtil::encodeHTML($e->getMessage()); ?></p>
 								</li>
 								<li>
-									<p class="exceptionFieldTitle">
+									<p class="exceptionFieldTitle">Error Type<span class="exceptionColon">:</span></p>
+									<p class="exceptionFieldValue">
+										<?php echo StringUtil::encodeHTML(get_class($e)); ?>
 										<?php if ($e->getCode()) { ?>
-											Error Type (<?php echo StringUtil::encodeHTML($e->getCode()); ?>)<span class="exceptionColon">:</span>
-										<?php } else { ?>
-											Error Type<span class="exceptionColon">:</span>
+											(<?php echo StringUtil::encodeHTML($e->getCode()); ?>)
 										<?php } ?>
 									</p>
 									<p class="exceptionFieldValue"><?php echo StringUtil::encodeHTML(get_class($e)); ?></p>

--- a/wcfsetup/install/files/lib/core.functions.php
+++ b/wcfsetup/install/files/lib/core.functions.php
@@ -432,10 +432,16 @@ EXPLANATION;
 					margin-top: 10px;
 				}
 
+				.exceptionFieldDetails {
+					padding-left: 20px;
+					word-break: break-all;
+				}
+
 				.exceptionStacktraceFile {
 					padding-left: 40px;
 				}
 
+				.exceptionFieldDetails,
 				.exceptionStacktraceFile {
 					color: rgb(115 115 115) !important;
 					font-size: 13px !important;
@@ -614,22 +620,19 @@ EXPLANATION;
 							<?php } ?>
 							<ul class="exceptionErrorDetails">
 								<li>
-									<p class="exceptionFieldTitle">Error Type<span class="exceptionColon">:</span></p>
-									<p class="exceptionFieldValue"><?php echo StringUtil::encodeHTML(get_class($e)); ?></p>
-								</li>
-								<li>
 									<p class="exceptionFieldTitle">Error Message<span class="exceptionColon">:</span></p>
 									<p class="exceptionFieldValue"><?php echo StringUtil::encodeHTML($e->getMessage()); ?></p>
 								</li>
-								<?php if ($e->getCode()) { ?>
-									<li>
-										<p class="exceptionFieldTitle">Error Code<span class="exceptionColon">:</span></p>
-										<p class="exceptionFieldValue"><?php echo StringUtil::encodeHTML($e->getCode()); ?></p>
-									</li>
-								<?php } ?>
 								<li>
-									<p class="exceptionFieldTitle">File<span class="exceptionColon">:</span></p>
-									<p class="exceptionFieldValue" style="word-break: break-all"><?php echo StringUtil::encodeHTML(sanitizePath($e->getFile())); ?> (<?php echo $e->getLine(); ?>)</p>
+									<p class="exceptionFieldTitle">
+										<?php if ($e->getCode()) { ?>
+											Error Type (<?php echo StringUtil::encodeHTML($e->getCode()); ?>)<span class="exceptionColon">:</span>
+										<?php } else { ?>
+											Error Type<span class="exceptionColon">:</span>
+										<?php } ?>
+									</p>
+									<p class="exceptionFieldValue"><?php echo StringUtil::encodeHTML(get_class($e)); ?></p>
+									<p class="exceptionFieldDetails"><?php echo StringUtil::encodeHTML(sanitizePath($e->getFile())); ?>:<?php echo $e->getLine(); ?></p>
 								</li>
 
 								<?php

--- a/wcfsetup/install/files/lib/core.functions.php
+++ b/wcfsetup/install/files/lib/core.functions.php
@@ -674,17 +674,19 @@ EXPLANATION;
 							<ul class="exceptionStacktrace">
 								<?php
 								$trace = sanitizeStacktrace($e);
+								$foundMiddlewareEnd = false;
 								for ($i = 0, $max = count($trace); $i < $max; $i++) {
 									// The stacktrace is in reverse order, therefore we need to check for
 									// the end of the middleware first.
 									if (isMiddlewareEnd($trace[$i])) {
+										$foundMiddlewareEnd = true;
 								?>
 										<li class="exceptionStacktraceMiddleware">
 											<details>
 												<summary>Middleware</summary>
 												<ul>
 												<?php
-											} elseif (isMiddlewareStart($trace[$i])) {
+											} elseif (isMiddlewareStart($trace[$i]) && $foundMiddlewareEnd) {
 												?>
 												</ul>
 											</details>

--- a/wcfsetup/install/files/lib/core.functions.php
+++ b/wcfsetup/install/files/lib/core.functions.php
@@ -631,7 +631,7 @@ EXPLANATION;
 											(<?php echo StringUtil::encodeHTML($e->getCode()); ?>)
 										<?php } ?>
 									</p>
-									<p class="exceptionFieldDetails"><?php echo StringUtil::encodeHTML(sanitizePath($e->getFile(), false)); ?>:<?php echo $e->getLine(); ?></p>
+									<p class="exceptionFieldDetails"><?php echo formatPath(sanitizePath($e->getFile(), false), $e->getLine()); ?></p>
 								</li>
 
 								<?php
@@ -866,6 +866,22 @@ EXPLANATION;
 		}
 
 		return '*/' . FileUtil::removeTrailingSlash(FileUtil::getRelativePath(WCF_DIR, $path));
+	}
+
+	function formatPath(string $path, int $lineNumber): string
+	{
+		$path = FileUtil::unifyDirSeparator($path);
+		[
+			'dirname' => $dirname,
+			'basename' => $basename
+		] = \pathinfo($path);
+
+		return \sprintf(
+			'%s/<strong>%s</strong>:<strong>%s</strong>',
+			StringUtil::encodeHTML($dirname),
+			StringUtil::encodeHTML($basename),
+			$lineNumber,
+		);
 	}
 
 	function isMiddlewareStart(array $segment): bool

--- a/wcfsetup/install/files/lib/core.functions.php
+++ b/wcfsetup/install/files/lib/core.functions.php
@@ -631,8 +631,7 @@ EXPLANATION;
 											(<?php echo StringUtil::encodeHTML($e->getCode()); ?>)
 										<?php } ?>
 									</p>
-									<p class="exceptionFieldValue"><?php echo StringUtil::encodeHTML(get_class($e)); ?></p>
-									<p class="exceptionFieldDetails"><?php echo StringUtil::encodeHTML(sanitizePath($e->getFile())); ?>:<?php echo $e->getLine(); ?></p>
+									<p class="exceptionFieldDetails"><?php echo StringUtil::encodeHTML(sanitizePath($e->getFile(), false)); ?>:<?php echo $e->getLine(); ?></p>
 								</li>
 
 								<?php
@@ -857,13 +856,10 @@ EXPLANATION;
 	/**
 	 * Returns the given path relative to `WCF_DIR`, unless both,
 	 * `EXCEPTION_PRIVACY` is `public` and the debug mode is enabled.
-	 * 
-	 * @param	string		$path
-	 * @return	string
 	 */
-	function sanitizePath(string $path): string
+	function sanitizePath(string $path, bool $removePath = true): string
 	{
-		if (WCF::debugModeIsEnabled() && defined('EXCEPTION_PRIVACY') && EXCEPTION_PRIVACY === 'public') {
+		if (!$removePath && WCF::debugModeIsEnabled() && defined('EXCEPTION_PRIVACY') && EXCEPTION_PRIVACY === 'public') {
 			return $path;
 		}
 

--- a/wcfsetup/install/files/lib/core.functions.php
+++ b/wcfsetup/install/files/lib/core.functions.php
@@ -100,9 +100,11 @@ namespace wcf {
 
 namespace wcf\functions\exception {
 
+	use wcf\http\Pipeline;
 	use wcf\system\WCF;
 	use wcf\system\exception\IExtraInformationException;
 	use wcf\system\exception\SystemException;
+	use wcf\system\request\Request;
 	use wcf\util\FileUtil;
 	use wcf\util\StringUtil;
 
@@ -886,11 +888,11 @@ EXPLANATION;
 
 	function isMiddlewareStart(array $segment): bool
 	{
-		return $segment['class'] === 'wcf\http\Pipeline';
+		return $segment['class'] === Pipeline::class && $segment['function'] === 'process';
 	}
 
 	function isMiddlewareEnd(array $segment): bool
 	{
-		return $segment['class'] === 'wcf\system\request\Request';
+		return $segment['class'] === Request::class && $segment['function'] === 'handle';
 	}
 }

--- a/wcfsetup/install/files/style/ui/dialog.scss
+++ b/wcfsetup/install/files/style/ui/dialog.scss
@@ -283,6 +283,8 @@
 
 .dialog {
 	--dialog-border-radius: 8px;
+	--dialog-max-height: 80%;
+	--dialog-max-width: 80%;
 	--dialog-padding: 20px;
 
 	animation: 0.24s dialog;
@@ -292,8 +294,8 @@
 	box-shadow: rgb(0 0 0 / 20%) 0 12px 28px 0, rgb(0 0 0 / 10%) 0 2px 4px 0;
 	display: flex;
 	flex-direction: column;
-	max-height: 80%;
-	max-width: 80%;
+	max-height: var(--dialog-max-height);
+	max-width: var(--dialog-max-width);
 	min-height: 0;
 	min-width: 500px;
 	padding: 0;
@@ -362,7 +364,7 @@
 	min-height: 0;
 }
 
-.dialog[role="alert"],
+.dialog[role="alert"]:not(.dialog--iframe),
 .dialog[role="alertdialog"] {
 	max-width: 500px;
 }
@@ -420,10 +422,33 @@
 	}
 }
 
+/* <iframe> as the result of an unexpected HTTP response */
+.dialog.dialog--iframe {
+	height: var(--dialog-max-height);
+	width: var(--dialog-max-width);
+}
+
+.dialog.dialog--iframe .dialog__document,
+.dialog.dialog--iframe .dialog__form,
+.dialog.dialog--iframe .dialog__content {
+	height: 100%;
+}
+
+.dialog.dialog--iframe .dialog__iframeContainer {
+	border: 2px dashed red;
+	height: 100%;
+	padding: 5px;
+}
+
+.dialog.dialog--iframe .dialog__iframe {
+	height: 100%;
+	width: 100%;
+}
+
 @include screen-xs {
 	.dialog {
-		max-height: calc(100% - 20px);
-		max-width: calc(100% - 20px);
+		--dialog-max-height: calc(100% - 20px);
+		--dialog-max-width: calc(100% - 20px);
 		min-width: 0;
 	}
 }


### PR DESCRIPTION
# Changes to the Exception View

The following changes have been made:
* Update the typography to match our most recent UI conventions.
* Move the stack trace into a dedicated section.
* Changes the order of the stack trace values to highlight the class instead of the file.
* Highlight the class names in the stack trace to make them easier to identify.
* Highlight redacted values represented by `SensitiveParameterValue`
* Strip the full path from the output to remove visual clutter.
* Hide the middleware behind a `<details>` element.

Closes #4878 
Fixes #5093

## Full Exception

![exception-page](https://user-images.githubusercontent.com/208610/199293480-a8ab40a5-89de-4965-a5c1-f9e29f518eb7.png)

## Exception With Expanded Middleware Block

The middleware is hidden by default to clean up the stack trace, making it easier to focus on the relevant parts of the stack. The contents can be revealed by clicking on the “Middleware” button which is built upon the native `<details>` element.

![exception-middleware](https://user-images.githubusercontent.com/208610/199293496-b2c54e7a-67a3-4e17-b027-df3fd329a7bb.png)

## Exception Rendered in an Iframe Inside a Dialog

The dialog will always take up its maximum dimensions. In addition the iframe will be rendered with an ugly red border to signal that something is off. This is intended to provide a clear separation that this is an embedded `<iframe>` and not the actual content one was possibly looking for.

![exception-ajax](https://user-images.githubusercontent.com/208610/199293499-afacb754-48a8-417d-912d-c3eba9e0f24c.png)