### PR TITLE
Add new template event

### DIFF
--- a/com.woltlab.wcf/templates/headIncludeJavaScript.tpl
+++ b/com.woltlab.wcf/templates/headIncludeJavaScript.tpl
@@ -203,6 +203,7 @@ window.addEventListener('pageshow', function(event) {
 					{if 'LinkedIn'|in_array:$__shareProviders}["LinkedIn", "{jslang}wcf.message.share.linkedIn{/jslang}", {icon size=24 name='linkedin-in' type='brand' encodeJson=true}],{/if} 
 					{if 'Pinterest'|in_array:$__shareProviders}["Pinterest", "{jslang}wcf.message.share.pinterest{/jslang}", {icon size=24 name='pinterest' type='brand' encodeJson=true}],{/if} 
 					{if 'XING'|in_array:$__shareProviders}["XING", "{jslang}wcf.message.share.xing{/jslang}", {icon size=24 name='xing' type='brand' encodeJson=true}],{/if} 
+					{event name='javascriptShareButtonProviders'}
 				],
 			{/if}
 			styleChanger: {if $__wcf->getStyleHandler()->showStyleChanger()}true{else}false{/if}


### PR DESCRIPTION
In 6.0, the way how share-button providers are initialized has been changed. Unfortunately, with this change, it became somewhat impossible to add new providers to the sharing dialog, because there's no longer a way to extend the list.

With this PR, a new template event is introduced, that allows adding individual providers easily.