### PR TITLE
Remove legacy cookie banner

### DIFF
--- a/com.woltlab.wcf/option.xml
+++ b/com.woltlab.wcf/option.xml
@@ -287,11 +287,6 @@
 				<optiontype>boolean</optiontype>
 				<defaultvalue>1</defaultvalue>
 			</option>
-			<option name="module_cookie_policy_page">
-				<categoryname>module.system</categoryname>
-				<optiontype>boolean</optiontype>
-				<defaultvalue>0</defaultvalue>
-			</option>
 			<option name="module_article">
 				<categoryname>module.content</categoryname>
 				<optiontype>boolean</optiontype>
@@ -1622,5 +1617,6 @@ DESC:wcf.global.sortOrder.descending</selectoptions>
 		<option name="cache_source_memcached_host"/>
 		<option name="module_gravatar"/>
 		<option name="gravatar_default_type"/>
+		<option name="module_cookie_policy_page"/>
 	</delete>
 </data>

--- a/com.woltlab.wcf/templates/ampFooter.tpl
+++ b/com.woltlab.wcf/templates/ampFooter.tpl
@@ -51,13 +51,6 @@
 			</ol>
 		</amp-sidebar>
 		
-		{if MODULE_COOKIE_POLICY_PAGE && !$__wcf->user->userID}
-			<amp-user-notification layout="nodisplay" id="cookie-policy-notice">
-				{lang}wcf.page.cookiePolicy.info{/lang}
-				<button type="button" on="tap:cookie-policy-notice.dismiss">{lang}wcf.global.button.close{/lang}</button>
-			</amp-user-notification>
-		{/if}
-		
 		<footer class="footer">
 			<div class="copyright">{lang}wcf.page.copyright{/lang}</div>
 		</footer>

--- a/com.woltlab.wcf/templates/footer.tpl
+++ b/com.woltlab.wcf/templates/footer.tpl
@@ -108,23 +108,6 @@
 {event name='footer'}
 
 <div class="pageFooterStickyNotice">
-	{if MODULE_COOKIE_POLICY_PAGE && $__wcf->session->isFirstVisit() && !$__wcf->user->userID}
-		<div class="info cookiePolicyNotice">
-			<div class="layoutBoundary">
-				<span class="cookiePolicyNoticeText">{lang}wcf.page.cookiePolicy.info{/lang}</span>
-				<a href="{page}com.woltlab.wcf.CookiePolicy{/page}" class="button buttonPrimary small cookiePolicyNoticeMoreInformation">{lang}wcf.page.cookiePolicy.info.moreInformation{/lang}</a>
-				<a href="#" class="button small jsOnly cookiePolicyNoticeDismiss">{lang}wcf.global.button.close{/lang}</a>
-				<script data-relocate="true">
-					elBySel('.cookiePolicyNoticeDismiss').addEventListener('click', function(event) {
-						event.preventDefault();
-
-						elRemove(elBySel('.cookiePolicyNotice'));
-					});
-				</script>
-			</div>
-		</div>
-	{/if}
-	
 	{event name='pageFooterStickyNotice'}
 	
 	<noscript>

--- a/constants.php
+++ b/constants.php
@@ -26,7 +26,6 @@
 \define('LOG_IP_ADDRESS', 1);
 \define('ENABLE_WOLTLAB_NEWS', 1);
 \define('MODULE_SYSTEM_RECAPTCHA', 1);
-\define('MODULE_COOKIE_POLICY_PAGE', 1);
 \define('MODULE_ATTACHMENT', 1);
 \define('MODULE_SMILEY', 1);
 \define('MODULE_USERS_ONLINE', 1);

--- a/wcfsetup/install/files/lib/system/WCF.class.php
+++ b/wcfsetup/install/files/lib/system/WCF.class.php
@@ -539,6 +539,9 @@ class WCF
         // The option for article visit tracking was removed in 6.0.
         // https://github.com/WoltLab/WCF/issues/4965
         \define('ARTICLE_ENABLE_VISIT_TRACKING', 1);
+
+        // The option for the legacy cookie banner was removed in 6.0.
+        \define('MODULE_COOKIE_POLICY_PAGE', 0);
     }
 
     /**

--- a/wcfsetup/install/lang/de.xml
+++ b/wcfsetup/install/lang/de.xml
@@ -1549,8 +1549,6 @@ GmbH=Gesellschaft mit beschränkter Haftung]]></item>
 		<item name="wcf.acp.option.google_maps_default_longitude"><![CDATA[Standard-Kartenposition (Längengrad)]]></item>
 		<item name="wcf.acp.option.google_maps_access_user_location"><![CDATA[Aktuelle Benutzerposition verwenden]]></item>
 		<item name="wcf.acp.option.google_maps_access_user_location.description"><![CDATA[Bei der Angabe von Positionen wird die aktuelle Position des Benutzers als Ausgangspunkt auf der Karte verwendet.]]></item>
-		<item name="wcf.acp.option.module_cookie_policy_page"><![CDATA[Erklärung zum „Einsatz von Cookies“ aktivieren]]></item>
-		<item name="wcf.acp.option.module_cookie_policy_page.description"><![CDATA[Weist Besucher beim ersten Aufruf der Seite gemäß EU-Richtlinie 2009/136/EG auf den Einsatz von Cookies hin.]]></item>
 		<item name="wcf.acp.option.show_update_notice_frontend"><![CDATA[Hinweis bei neuen Updates für Pakete im Frontend anzeigen]]></item>
 		<item name="wcf.acp.option.url_omit_index_php"><![CDATA[Link-Umschreibungen aktivieren]]></item>
 		<item name="wcf.acp.option.url_omit_index_php.button.runTestAgain"><![CDATA[Test erneut durchführen]]></item>
@@ -4370,8 +4368,6 @@ Dateianhänge:
 		<item name="wcf.page.pagePosition"><![CDATA[Seite {#$pageNo} von {#$pages}]]></item>
 		<item name="wcf.page.javascriptDisabled"><![CDATA[In {if LANGUAGE_USE_INFORMAL_VARIANT}deinem{else}Ihrem{/if} Webbrowser ist JavaScript deaktiviert. Um alle Funktionen dieser Website nutzen zu können, muss JavaScript aktiviert sein.]]></item>
 		<item name="wcf.page.requestedPage"><![CDATA[Aufgerufene Seite]]></item>
-		<item name="wcf.page.cookiePolicy.info"><![CDATA[Diese Seite verwendet Cookies. Durch die Nutzung unserer Seite {if LANGUAGE_USE_INFORMAL_VARIANT}erklärst du dich{else}erklären Sie sich{/if} damit einverstanden, dass wir Cookies setzen.]]></item>
-		<item name="wcf.page.cookiePolicy.info.moreInformation"><![CDATA[Weitere Informationen]]></item>
 		<item name="wcf.page.copyright"><![CDATA[<a href="https://www.woltlab.com/de/" rel="nofollow"{if EXTERNAL_LINK_TARGET_BLANK} target="_blank"{/if}>Community-Software: <strong>WoltLab Suite&trade;{if SHOW_VERSION_NUMBER} {@WCF_VERSION}{/if}</strong></a>]]></item>
 		<item name="wcf.page.onlineLocation.com.woltlab.wcf.Article"><![CDATA[Artikel <a href="{$article->getLink()}">{$article->getTitle()}</a>]]></item>
 		<item name="wcf.page.onlineLocation.com.woltlab.wcf.CategoryArticleList"><![CDATA[Artikel-Kategorie <a href="{$category->getLink()}">{$category->getTitle()}</a>]]></item>
@@ -5592,5 +5588,9 @@ Benachrichtigungen auf <a href="{link isHtmlEmail=true}{/link}">{PAGE_TITLE|phra
 	<item name="wcf.cli.error.language.notFound"/>
 	<item name="wcf.cli.help.noLongHelp"/>
 	<item name="wcf.cli.help.exitOnFail.description"/>
+	<item name="wcf.acp.option.module_cookie_policy_page"/>
+	<item name="wcf.acp.option.module_cookie_policy_page.description"/>
+	<item name="wcf.page.cookiePolicy.info"/>
+	<item name="wcf.page.cookiePolicy.info.moreInformation"/>
 </delete>
 </language>

--- a/wcfsetup/install/lang/en.xml
+++ b/wcfsetup/install/lang/en.xml
@@ -1531,8 +1531,6 @@ You can access the error log at: {link controller='ExceptionLogView' isEmail=tru
 		<item name="wcf.acp.option.google_maps_default_longitude"><![CDATA[Default Map Position (Longitude)]]></item>
 		<item name="wcf.acp.option.google_maps_access_user_location"><![CDATA[Use current user location]]></item>
 		<item name="wcf.acp.option.google_maps_access_user_location.description"><![CDATA[When entering a location, the current location of the user is used as start point on the map.]]></item>
-		<item name="wcf.acp.option.module_cookie_policy_page"><![CDATA[Enable explanation on cookie usage]]></item>
-		<item name="wcf.acp.option.module_cookie_policy_page.description"><![CDATA[Displays a notice on cookie usage according to EU Directive 2009/136/EG upon first visit.]]></item>
 		<item name="wcf.acp.option.show_update_notice_frontend"><![CDATA[Display a notice for outstanding updates on the frontend]]></item>
 		<item name="wcf.acp.option.url_omit_index_php"><![CDATA[Enable url-rewrite]]></item>
 		<item name="wcf.acp.option.url_omit_index_php.button.runTestAgain"><![CDATA[Rerun Test]]></item>
@@ -4319,8 +4317,6 @@ Attachments:
 		<item name="wcf.page.pagePosition"><![CDATA[Page {#$pageNo} of {#$pages}]]></item>
 		<item name="wcf.page.javascriptDisabled"><![CDATA[Your browser has JavaScript disabled. If you would like to use all features of this site, it is mandatory to enable JavaScript.]]></item>
 		<item name="wcf.page.requestedPage"><![CDATA[Requested Page]]></item>
-		<item name="wcf.page.cookiePolicy.info"><![CDATA[This site uses cookies. By continuing to browse this site, you are agreeing to our use of cookies.]]></item>
-		<item name="wcf.page.cookiePolicy.info.moreInformation"><![CDATA[More Details]]></item>
 		<item name="wcf.page.copyright"><![CDATA[<a href="https://www.woltlab.com" rel="nofollow"{if EXTERNAL_LINK_TARGET_BLANK} target="_blank"{/if}>Powered by <strong>WoltLab Suite&trade;{if SHOW_VERSION_NUMBER} {@WCF_VERSION}{/if}</strong></a>]]></item>
 		<item name="wcf.page.onlineLocation.com.woltlab.wcf.Article"><![CDATA[Article <a href="{$article->getLink()}">{$article->getTitle()}</a>]]></item>
 		<item name="wcf.page.onlineLocation.com.woltlab.wcf.CategoryArticleList"><![CDATA[Article category <a href="{$category->getLink()}">{$category->getTitle()}</a>]]></item>
@@ -5594,5 +5590,9 @@ your notifications on <a href="{link isHtmlEmail=true}{/link}">{PAGE_TITLE|phras
 	<item name="wcf.cli.error.language.notFound"/>
 	<item name="wcf.cli.help.noLongHelp"/>
 	<item name="wcf.cli.help.exitOnFail.description"/>
+	<item name="wcf.acp.option.module_cookie_policy_page"/>
+	<item name="wcf.acp.option.module_cookie_policy_page.description"/>
+	<item name="wcf.page.cookiePolicy.info"/>
+	<item name="wcf.page.cookiePolicy.info.moreInformation"/>
 </delete>
 </language>


### PR DESCRIPTION
From a legal point of view, this type of cookie banner is useless.