### PR TITLE
Migrate the forced check of the background queue to a HTTP response header

### DIFF
--- a/ts/WoltLabSuite/Core/Ajax/DboAction.ts
+++ b/ts/WoltLabSuite/Core/Ajax/DboAction.ts
@@ -23,7 +23,6 @@ import * as Core from "../Core";
 type Payload = Record<string, unknown>;
 type ResponseData = {
   actionName: string;
-  forceBackgroundQueuePerform?: boolean;
   objectIDs: number[];
   returnValues: unknown;
 };
@@ -148,7 +147,7 @@ export class DboAction {
         throw new InvalidJson(response);
       }
 
-      if (response.headers.get("woltlab-background-queue-check") === "yes" || json.forceBackgroundQueuePerform) {
+      if (response.headers.get("woltlab-background-queue-check") === "yes") {
         void import("../BackgroundQueue").then((BackgroundQueue) => BackgroundQueue.invoke());
       }
 

--- a/ts/WoltLabSuite/Core/Ajax/DboAction.ts
+++ b/ts/WoltLabSuite/Core/Ajax/DboAction.ts
@@ -148,7 +148,7 @@ export class DboAction {
         throw new InvalidJson(response);
       }
 
-      if (json.forceBackgroundQueuePerform) {
+      if (response.headers.get("woltlab-background-queue-check") === "yes" || json.forceBackgroundQueuePerform) {
         void import("../BackgroundQueue").then((BackgroundQueue) => BackgroundQueue.invoke());
       }
 

--- a/ts/WoltLabSuite/Core/Ajax/Request.ts
+++ b/ts/WoltLabSuite/Core/Ajax/Request.ts
@@ -250,10 +250,7 @@ class AjaxRequest {
         }
 
         // force-invoke the background queue
-        if (
-          xhr.getResponseHeader("woltlab-background-queue-check") === "yes" ||
-          (data && data.forceBackgroundQueuePerform)
-        ) {
+        if (xhr.getResponseHeader("woltlab-background-queue-check") === "yes") {
           void import("../BackgroundQueue").then((backgroundQueue) => backgroundQueue.invoke());
         }
       }

--- a/ts/WoltLabSuite/Core/Ajax/Request.ts
+++ b/ts/WoltLabSuite/Core/Ajax/Request.ts
@@ -250,7 +250,10 @@ class AjaxRequest {
         }
 
         // force-invoke the background queue
-        if (data && data.forceBackgroundQueuePerform) {
+        if (
+          xhr.getResponseHeader("woltlab-background-queue-check") === "yes" ||
+          (data && data.forceBackgroundQueuePerform)
+        ) {
           void import("../BackgroundQueue").then((backgroundQueue) => backgroundQueue.invoke());
         }
       }

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ajax/DboAction.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ajax/DboAction.js
@@ -104,7 +104,7 @@ define(["require", "exports", "tslib", "./Error", "./Status", "../Core"], functi
                 catch (e) {
                     throw new Error_1.InvalidJson(response);
                 }
-                if (json.forceBackgroundQueuePerform) {
+                if (response.headers.get("woltlab-background-queue-check") === "yes" || json.forceBackgroundQueuePerform) {
                     void new Promise((resolve_1, reject_1) => { require(["../BackgroundQueue"], resolve_1, reject_1); }).then(tslib_1.__importStar).then((BackgroundQueue) => BackgroundQueue.invoke());
                 }
                 return json.returnValues;

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ajax/DboAction.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ajax/DboAction.js
@@ -104,7 +104,7 @@ define(["require", "exports", "tslib", "./Error", "./Status", "../Core"], functi
                 catch (e) {
                     throw new Error_1.InvalidJson(response);
                 }
-                if (response.headers.get("woltlab-background-queue-check") === "yes" || json.forceBackgroundQueuePerform) {
+                if (response.headers.get("woltlab-background-queue-check") === "yes") {
                     void new Promise((resolve_1, reject_1) => { require(["../BackgroundQueue"], resolve_1, reject_1); }).then(tslib_1.__importStar).then((BackgroundQueue) => BackgroundQueue.invoke());
                 }
                 return json.returnValues;

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ajax/Request.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ajax/Request.js
@@ -214,8 +214,7 @@ define(["require", "exports", "tslib", "./Status", "../Core", "../Dom/Change/Lis
                         data.returnValues.template = data.returnValues.template.trim();
                     }
                     // force-invoke the background queue
-                    if (xhr.getResponseHeader("woltlab-background-queue-check") === "yes" ||
-                        (data && data.forceBackgroundQueuePerform)) {
+                    if (xhr.getResponseHeader("woltlab-background-queue-check") === "yes") {
                         void new Promise((resolve_1, reject_1) => { require(["../BackgroundQueue"], resolve_1, reject_1); }).then(tslib_1.__importStar).then((backgroundQueue) => backgroundQueue.invoke());
                     }
                 }

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ajax/Request.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ajax/Request.js
@@ -214,7 +214,8 @@ define(["require", "exports", "tslib", "./Status", "../Core", "../Dom/Change/Lis
                         data.returnValues.template = data.returnValues.template.trim();
                     }
                     // force-invoke the background queue
-                    if (data && data.forceBackgroundQueuePerform) {
+                    if (xhr.getResponseHeader("woltlab-background-queue-check") === "yes" ||
+                        (data && data.forceBackgroundQueuePerform)) {
                         void new Promise((resolve_1, reject_1) => { require(["../BackgroundQueue"], resolve_1, reject_1); }).then(tslib_1.__importStar).then((backgroundQueue) => backgroundQueue.invoke());
                     }
                 }

--- a/wcfsetup/install/files/lib/action/AJAXProxyAction.class.php
+++ b/wcfsetup/install/files/lib/action/AJAXProxyAction.class.php
@@ -3,13 +3,12 @@
 namespace wcf\action;
 
 use wcf\data\IDatabaseObjectAction;
-use wcf\http\middleware\TriggerBackgroundQueue;
+use wcf\system\background\BackgroundQueueHandler;
 use wcf\system\exception\ImplementationException;
 use wcf\system\exception\ParentClassException;
 use wcf\system\exception\UserInputException;
 use wcf\system\request\RequestHandler;
 use wcf\system\WCF;
-use wcf\system\WCFACP;
 use wcf\util\ArrayUtil;
 use wcf\util\StringUtil;
 
@@ -120,8 +119,8 @@ class AJAXProxyAction extends AJAXInvokeAction
             @\header(
                 \sprintf(
                     '%s: %s',
-                    TriggerBackgroundQueue::HEADER_NAME,
-                    TriggerBackgroundQueue::HEADER_VALUE,
+                    BackgroundQueueHandler::FORCE_CHECK_HTTP_HEADER_NAME,
+                    BackgroundQueueHandler::FORCE_CHECK_HTTP_HEADER_VALUE,
                 )
             );
         }

--- a/wcfsetup/install/files/lib/action/AJAXProxyAction.class.php
+++ b/wcfsetup/install/files/lib/action/AJAXProxyAction.class.php
@@ -114,11 +114,6 @@ class AJAXProxyAction extends AJAXInvokeAction
             }
         }
 
-        // force background queue invocation
-        if (!\class_exists(WCFACP::class, false) && WCF::getSession()->getVar('forceBackgroundQueuePerform')) {
-            $this->response['forceBackgroundQueuePerform'] = true;
-        }
-
         parent::sendResponse();
     }
 }

--- a/wcfsetup/install/files/lib/action/AJAXProxyAction.class.php
+++ b/wcfsetup/install/files/lib/action/AJAXProxyAction.class.php
@@ -3,9 +3,11 @@
 namespace wcf\action;
 
 use wcf\data\IDatabaseObjectAction;
+use wcf\http\middleware\TriggerBackgroundQueue;
 use wcf\system\exception\ImplementationException;
 use wcf\system\exception\ParentClassException;
 use wcf\system\exception\UserInputException;
+use wcf\system\request\RequestHandler;
 use wcf\system\WCF;
 use wcf\system\WCFACP;
 use wcf\util\ArrayUtil;
@@ -112,6 +114,16 @@ class AJAXProxyAction extends AJAXInvokeAction
                 /** @noinspection PhpUndefinedMethodInspection */
                 $this->response['benchmark']['items'] = WCF::getBenchmark()->getItems();
             }
+        }
+
+        if (!RequestHandler::getInstance()->isACPRequest() && WCF::getSession()->getVar('forceBackgroundQueuePerform')) {
+            @\header(
+                \sprintf(
+                    '%s: %s',
+                    TriggerBackgroundQueue::HEADER_NAME,
+                    TriggerBackgroundQueue::HEADER_VALUE,
+                )
+            );
         }
 
         parent::sendResponse();

--- a/wcfsetup/install/files/lib/http/middleware/TriggerBackgroundQueue.class.php
+++ b/wcfsetup/install/files/lib/http/middleware/TriggerBackgroundQueue.class.php
@@ -8,7 +8,7 @@ use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use wcf\http\LegacyPlaceholderResponse;
 use wcf\system\background\BackgroundQueueHandler;
-use wcf\system\WCFACP;
+use wcf\system\request\RequestHandler;
 
 /**
  * Adds 'woltlab-background-queue-check: yes' to the response
@@ -26,10 +26,12 @@ final class TriggerBackgroundQueue implements MiddlewareInterface
     private const HEADER_VALUE = 'yes';
 
     private readonly BackgroundQueueHandler $backgroundQueueHandler;
+    private readonly RequestHandler $requestHandler;
 
     public function __construct()
     {
         $this->backgroundQueueHandler = BackgroundQueueHandler::getInstance();
+        $this->requestHandler = RequestHandler::getInstance();
     }
 
     /**
@@ -39,7 +41,7 @@ final class TriggerBackgroundQueue implements MiddlewareInterface
     {
         $response = $handler->handle($request);
         if (
-            \class_exists(WCFACP::class, false)
+            $this->requestHandler->isACPRequest()
             || !$this->backgroundQueueHandler->hasPendingCheck()
         ) {
             return $response;

--- a/wcfsetup/install/files/lib/http/middleware/TriggerBackgroundQueue.class.php
+++ b/wcfsetup/install/files/lib/http/middleware/TriggerBackgroundQueue.class.php
@@ -22,9 +22,6 @@ use wcf\system\request\RequestHandler;
  */
 final class TriggerBackgroundQueue implements MiddlewareInterface
 {
-    public const HEADER_NAME = 'woltlab-background-queue-check';
-    public const HEADER_VALUE = 'yes';
-
     private readonly BackgroundQueueHandler $backgroundQueueHandler;
     private readonly RequestHandler $requestHandler;
 
@@ -51,6 +48,9 @@ final class TriggerBackgroundQueue implements MiddlewareInterface
             return $response;
         }
 
-        return $response->withHeader(self::HEADER_NAME, self::HEADER_VALUE);
+        return $response->withHeader(
+            BackgroundQueueHandler::FORCE_CHECK_HTTP_HEADER_NAME,
+            BackgroundQueueHandler::FORCE_CHECK_HTTP_HEADER_VALUE,
+        );
     }
 }

--- a/wcfsetup/install/files/lib/http/middleware/TriggerBackgroundQueue.class.php
+++ b/wcfsetup/install/files/lib/http/middleware/TriggerBackgroundQueue.class.php
@@ -8,6 +8,7 @@ use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use wcf\http\LegacyPlaceholderResponse;
 use wcf\system\background\BackgroundQueueHandler;
+use wcf\system\WCFACP;
 
 /**
  * Adds 'woltlab-background-queue-check: yes' to the response
@@ -37,7 +38,10 @@ final class TriggerBackgroundQueue implements MiddlewareInterface
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         $response = $handler->handle($request);
-        if (!$this->backgroundQueueHandler->hasPendingCheck()) {
+        if (
+            \class_exists(WCFACP::class, false)
+            || !$this->backgroundQueueHandler->hasPendingCheck()
+        ) {
             return $response;
         }
 

--- a/wcfsetup/install/files/lib/http/middleware/TriggerBackgroundQueue.class.php
+++ b/wcfsetup/install/files/lib/http/middleware/TriggerBackgroundQueue.class.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace wcf\http\middleware;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use wcf\http\LegacyPlaceholderResponse;
+use wcf\system\background\BackgroundQueueHandler;
+
+/**
+ * Adds 'woltlab-background-queue-check: yes' to the response
+ * whenever a check was requested.
+ *
+ * @author Alexander Ebert
+ * @copyright 2001-2022 WoltLab GmbH
+ * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @package WoltLabSuite\Core\Http\Middleware
+ * @since 6.0
+ */
+final class TriggerBackgroundQueue implements MiddlewareInterface
+{
+    private const HEADER_NAME = 'woltlab-background-queue-check';
+    private const HEADER_VALUE = 'yes';
+
+    private readonly BackgroundQueueHandler $backgroundQueueHandler;
+
+    public function __construct()
+    {
+        $this->backgroundQueueHandler = BackgroundQueueHandler::getInstance();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $response = $handler->handle($request);
+        if (!$this->backgroundQueueHandler->hasPendingCheck()) {
+            return $response;
+        }
+
+        if ($response instanceof LegacyPlaceholderResponse) {
+            \header(
+                \sprintf('%s: %s', self::HEADER_NAME, self::HEADER_VALUE)
+            );
+
+            return $response;
+        }
+
+        return $response->withHeader(self::HEADER_NAME, self::HEADER_VALUE);
+    }
+}

--- a/wcfsetup/install/files/lib/http/middleware/TriggerBackgroundQueue.class.php
+++ b/wcfsetup/install/files/lib/http/middleware/TriggerBackgroundQueue.class.php
@@ -36,15 +36,17 @@ final class TriggerBackgroundQueue implements MiddlewareInterface
      */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
+        if ($this->requestHandler->isACPRequest()) {
+            return $handler->handle($request);
+        }
+
         $response = $handler->handle($request);
-        if (
-            $this->requestHandler->isACPRequest()
-            || !$this->backgroundQueueHandler->hasPendingCheck()
-        ) {
+
+        if ($response instanceof LegacyPlaceholderResponse) {
             return $response;
         }
 
-        if ($response instanceof LegacyPlaceholderResponse) {
+        if (!$this->backgroundQueueHandler->hasPendingCheck()) {
             return $response;
         }
 

--- a/wcfsetup/install/files/lib/http/middleware/TriggerBackgroundQueue.class.php
+++ b/wcfsetup/install/files/lib/http/middleware/TriggerBackgroundQueue.class.php
@@ -22,8 +22,8 @@ use wcf\system\request\RequestHandler;
  */
 final class TriggerBackgroundQueue implements MiddlewareInterface
 {
-    private const HEADER_NAME = 'woltlab-background-queue-check';
-    private const HEADER_VALUE = 'yes';
+    public const HEADER_NAME = 'woltlab-background-queue-check';
+    public const HEADER_VALUE = 'yes';
 
     private readonly BackgroundQueueHandler $backgroundQueueHandler;
     private readonly RequestHandler $requestHandler;
@@ -48,10 +48,6 @@ final class TriggerBackgroundQueue implements MiddlewareInterface
         }
 
         if ($response instanceof LegacyPlaceholderResponse) {
-            \header(
-                \sprintf('%s: %s', self::HEADER_NAME, self::HEADER_VALUE)
-            );
-
             return $response;
         }
 

--- a/wcfsetup/install/files/lib/system/background/BackgroundQueueHandler.class.php
+++ b/wcfsetup/install/files/lib/system/background/BackgroundQueueHandler.class.php
@@ -21,6 +21,12 @@ use wcf\system\WCF;
 final class BackgroundQueueHandler extends SingletonFactory
 {
     /**
+     * Indicates that the client should trigger a check for
+     * pending jobs in the background queue.
+     */
+    private bool $hasPendingCheck = false;
+
+    /**
      * Forces checking whether a background queue item is due.
      * This means that the AJAX request to BackgroundQueuePerformAction is triggered.
      */
@@ -31,6 +37,8 @@ final class BackgroundQueueHandler extends SingletonFactory
         WCF::getTPL()->assign([
             'forceBackgroundQueuePerform' => true,
         ]);
+
+        $this->hasPendingCheck = true;
     }
 
     /**
@@ -226,5 +234,13 @@ final class BackgroundQueueHandler extends SingletonFactory
         $statement->execute(['ready', TIME_NOW]);
 
         return $statement->fetchSingleColumn();
+    }
+
+    /**
+     * @since 6.0
+     */
+    public function hasPendingCheck(): bool
+    {
+        return $this->hasPendingCheck;
     }
 }

--- a/wcfsetup/install/files/lib/system/background/BackgroundQueueHandler.class.php
+++ b/wcfsetup/install/files/lib/system/background/BackgroundQueueHandler.class.php
@@ -20,6 +20,9 @@ use wcf\system\WCF;
  */
 final class BackgroundQueueHandler extends SingletonFactory
 {
+    public const FORCE_CHECK_HTTP_HEADER_NAME = 'woltlab-background-queue-check';
+    public const FORCE_CHECK_HTTP_HEADER_VALUE = 'yes';
+
     private bool $hasPendingCheck = false;
 
     /**

--- a/wcfsetup/install/files/lib/system/background/BackgroundQueueHandler.class.php
+++ b/wcfsetup/install/files/lib/system/background/BackgroundQueueHandler.class.php
@@ -20,10 +20,6 @@ use wcf\system\WCF;
  */
 final class BackgroundQueueHandler extends SingletonFactory
 {
-    /**
-     * Indicates that the client should trigger a check for
-     * pending jobs in the background queue.
-     */
     private bool $hasPendingCheck = false;
 
     /**
@@ -237,6 +233,9 @@ final class BackgroundQueueHandler extends SingletonFactory
     }
 
     /**
+     * Indicates that the client should trigger a check for
+     * pending jobs in the background queue.
+     *
      * @since 6.0
      */
     public function hasPendingCheck(): bool

--- a/wcfsetup/install/files/lib/system/request/RequestHandler.class.php
+++ b/wcfsetup/install/files/lib/system/request/RequestHandler.class.php
@@ -21,6 +21,7 @@ use wcf\http\middleware\EnforceFrameOptions;
 use wcf\http\middleware\HandleStartupErrors;
 use wcf\http\middleware\JsonBody;
 use wcf\http\middleware\PreventMimeSniffing;
+use wcf\http\middleware\TriggerBackgroundQueue;
 use wcf\http\middleware\Xsrf;
 use wcf\http\Pipeline;
 use wcf\system\application\ApplicationHandler;
@@ -110,6 +111,7 @@ final class RequestHandler extends SingletonFactory
                     new CheckForExpiredAppEvaluation(),
                     new CheckForOfflineMode(),
                     new JsonBody(),
+                    new TriggerBackgroundQueue(),
                 ]);
 
                 $response = $pipeline->process($psrRequest, $this->getActiveRequest());


### PR DESCRIPTION
Some AJAX actions triggered background jobs that should be attempted to be executed immediately. This was communicated to the client by injecting a property into the JSON response which is both cumbersome and does not play nice with non-JSON-responses.

Using the custom header `woltlab-background-queue-check: yes` allows us to provide the hint regardless of the actual response.