### PR TITLE
Implicit XSRF checks for PSR-15 controllers with opt-out

### DIFF
--- a/wcfsetup/install/files/lib/http/attribute/DisableXsrfCheck.class.php
+++ b/wcfsetup/install/files/lib/http/attribute/DisableXsrfCheck.class.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace wcf\http\attribute;
+
+/**
+ * Disables the built-in XSRF validation of PSR-15 controllers.
+ *
+ * @author Alexander Ebert
+ * @copyright 2001-2022 WoltLab GmbH
+ * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @package WoltLabSuite\Core\Http\Attribute
+ * @since 6.0
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+final class DisableXsrfCheck
+{
+}

--- a/wcfsetup/install/files/lib/http/middleware/Xsrf.class.php
+++ b/wcfsetup/install/files/lib/http/middleware/Xsrf.class.php
@@ -54,14 +54,19 @@ final class Xsrf implements MiddlewareInterface
         );
 
         if (
-            $request->getMethod() !== 'GET'
-            && $request->getMethod() !== 'HEAD'
+            $this->isSafeHttpMethod($request->getMethod())
             && $this->requestHandler->getActiveRequest()
         ) {
             $this->assertHasValidXsrfToken($this->requestHandler->getActiveRequest(), $hasValidXsrfToken);
         }
 
         return $handler->handle($request);
+    }
+
+    private function isSafeHttpMethod(string $verb): bool {
+        // HTTP requests using the 'GET' or 'HEAD' verb are safe
+        // by design, because those should not alter the state.
+        return $verb === 'GET' || $verb === 'HEAD';
     }
 
     private function assertHasValidXsrfToken(Request $request, $hasValidXsrfToken): void

--- a/wcfsetup/install/files/lib/http/middleware/Xsrf.class.php
+++ b/wcfsetup/install/files/lib/http/middleware/Xsrf.class.php
@@ -6,6 +6,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use wcf\http\attribute\DisableXsrfCheck;
 use wcf\system\exception\InvalidSecurityTokenException;
 use wcf\system\request\Request;
 use wcf\system\request\RequestHandler;
@@ -71,7 +72,7 @@ final class Xsrf implements MiddlewareInterface
         }
 
         $reflectionClass = new \ReflectionClass($request->getClassName());
-        if ($reflectionClass->getAttributes('DisableXsrfCheck') !== []) {
+        if ($reflectionClass->getAttributes(DisableXsrfCheck::class) !== []) {
             // Controller has opted out of the XSRF check.
             return;
         }
@@ -80,9 +81,4 @@ final class Xsrf implements MiddlewareInterface
             throw new InvalidSecurityTokenException();
         }
     }
-}
-
-#[\Attribute(\Attribute::TARGET_CLASS)]
-final class DisableXsrfCheck
-{
 }

--- a/wcfsetup/install/files/lib/http/middleware/Xsrf.class.php
+++ b/wcfsetup/install/files/lib/http/middleware/Xsrf.class.php
@@ -54,7 +54,7 @@ final class Xsrf implements MiddlewareInterface
         );
 
         if (
-            $this->isSafeHttpMethod($request->getMethod())
+            !$this->isSafeHttpMethod($request->getMethod())
             && $this->requestHandler->getActiveRequest()
         ) {
             $this->assertHasValidXsrfToken($this->requestHandler->getActiveRequest(), $hasValidXsrfToken);
@@ -69,7 +69,7 @@ final class Xsrf implements MiddlewareInterface
         return $verb === 'GET' || $verb === 'HEAD';
     }
 
-    private function assertHasValidXsrfToken(Request $request, $hasValidXsrfToken): void
+    private function assertHasValidXsrfToken(Request $request, bool $hasValidXsrfToken): void
     {
         if (!\is_subclass_of($request->getClassName(), RequestHandlerInterface::class)) {
             // Skip the XSRF check for legacy controllers.

--- a/wcfsetup/install/files/lib/http/middleware/Xsrf.class.php
+++ b/wcfsetup/install/files/lib/http/middleware/Xsrf.class.php
@@ -71,6 +71,11 @@ final class Xsrf implements MiddlewareInterface
 
     private function assertHasValidXsrfToken(Request $request, bool $hasValidXsrfToken): void
     {
+        if ($hasValidXsrfToken) {
+            // No need to do anything for a valid token.
+            return;
+        }
+
         if (!\is_subclass_of($request->getClassName(), RequestHandlerInterface::class)) {
             // Skip the XSRF check for legacy controllers.
             return;
@@ -82,8 +87,8 @@ final class Xsrf implements MiddlewareInterface
             return;
         }
 
-        if (!$hasValidXsrfToken) {
-            throw new InvalidSecurityTokenException();
-        }
+        // The controller requires a valid XSRF Token and no valid
+        // token was provided, abort the processing.
+        throw new InvalidSecurityTokenException();
     }
 }


### PR DESCRIPTION
Calls to PSR-15 controllers will implicitly validate the XSRF-Token for requests using any HTTP verb other than `GET` or `HEAD`. This “security by default” approach makes it easy to use controllers without worrying too much about security.

Controllers can explicitly opt-out of the XSRF validation through the attribute `#[DisableXsrfCheck]`.