### PR TITLE
Force enable E_ALL error_reporting

### DIFF
--- a/wcfsetup/install/files/lib/system/WCF.class.php
+++ b/wcfsetup/install/files/lib/system/WCF.class.php
@@ -52,6 +52,10 @@ if (!@\ini_get('date.timezone')) {
     @\date_default_timezone_set('Europe/London');
 }
 
+// Force enable the reporting of all errors, no matter what's
+// configured in php.ini.
+\error_reporting(E_ALL);
+
 // Make stack traces more useful with PHP 8.2 (which has SensitiveParameter).
 if (\PHP_VERSION_ID >= 80200) {
     @\ini_set('zend.exception_ignore_args', 0);


### PR DESCRIPTION
Previously the error_reporting value in php.ini was implicitly used which
might've suppressed some errors, specifically `E_NOTICE` was not reporting by
default in PHP 7.x and earlier. While this is fixed now, since the minimum
version is PHP 8.1, nothing prevents an administrator or webhoster from
reconfiguring the error_reporting themselves.

By configuring E_ALL in WCF.class.php we can ensure a consistent behavior of
the application.

Resolves #5136
