### PR TITLE
Fix validation of changed indices in PHP DDL

### DIFF
--- a/wcfsetup/install/files/lib/system/database/table/DatabaseTableChangeProcessor.class.php
+++ b/wcfsetup/install/files/lib/system/database/table/DatabaseTableChangeProcessor.class.php
@@ -1252,7 +1252,7 @@ class DatabaseTableChangeProcessor
 
                         foreach ($table->getIndices() as $index) {
                             foreach ($existingIndices as $existingIndex) {
-                                if (empty(\array_diff_assoc($index->getData(), $existingIndex->getData()))) {
+                                if (!$this->diffIndices($existingIndex, $index)) {
                                     if ($index->willBeDropped()) {
                                         if ($this->getIndexPackageID($table, $index) !== $this->package->packageID) {
                                             $errors[] = [


### PR DESCRIPTION
The validation of the to-be-performed DDL operation currently identifies
indices by their data (i.e. column list and type), whereas the actual DDL
operation uses the `->diffIndices()` operation which also takes into account
the name of the index.

This mismatch allows a package to drop a foreign index, consider the following
situation:

Package A:

    DatabaseTable::create('wcf1_test')
        ->columns([
            NotNullInt10DatabaseTableColumn::create('a'),
            NotNullInt10DatabaseTableColumn::create('b'),
        ])
        ->indices([
            DatabaseTableIndex::create('testing')
                ->columns(['a']),
        ])

The package creates a table with two columns and a named index (“testing”) that
includes one of the columns.

Now Package B:

    DatabaseTable::create('wcf1_test')
        ->indices([
            DatabaseTableIndex::create('testing')
                ->columns(['a', 'b'])
                ->drop(),
        ])

This definition drops the named index (“testing”), but with a different column
definition. Thus the validation believes the indices to be different, allowing
the operation to proceed. The actual operation however identifies the index by
its name and thus drops the “testing” index that belongs to a different
package.