### PR TITLE
Use absolute paths in require() calls during script init

### DIFF
--- a/wcfsetup/install/files/acp/global.php
+++ b/wcfsetup/install/files/acp/global.php
@@ -16,7 +16,7 @@ if (!\defined('RELATIVE_WCF_DIR')) {
 }
 
 // include config
-require_once(RELATIVE_WCF_DIR . 'app.config.inc.php');
+require_once(__DIR__ . '/../app.config.inc.php');
 
 // starting wcf acp
 require_once(WCF_DIR . 'lib/system/WCF.class.php');

--- a/wcfsetup/install/files/acp/index.php
+++ b/wcfsetup/install/files/acp/index.php
@@ -7,5 +7,5 @@
  * @package WoltLabSuite\Core
  */
 
-require_once('./global.php');
+require_once(__DIR__ . '/global.php');
 wcf\system\request\RequestHandler::getInstance()->handle('wcf', true);

--- a/wcfsetup/install/files/index.php
+++ b/wcfsetup/install/files/index.php
@@ -7,5 +7,5 @@
  * @package WoltLabSuite\Core
  */
 
-require_once('./global.php');
+require_once(__DIR__ . '/global.php');
 \wcf\system\request\RequestHandler::getInstance()->handle('wcf');


### PR DESCRIPTION
Relative paths in `require()` are relative to the accessed “entrypoint” (i.e.
not the script that calls `require()`). By using absolute paths the requiring
is more resilient and more specifically the `acp/global.php` no longer depends
on an application correctly configuring `RELATIVE_WCF_DIR`, removing one of the
remaining users of the `RELATIVE_*` constants.
