### PR TITLE
Add experimental context filter for search backends

### DIFF
--- a/wcfsetup/install/files/lib/system/search/IContextAwareSearchEngine.class.php
+++ b/wcfsetup/install/files/lib/system/search/IContextAwareSearchEngine.class.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace wcf\system\search;
+
+use wcf\system\database\util\PreparedStatementConditionBuilder;
+
+/**
+ * Default interface for search engines that support
+ * filtering by context.
+ *
+ * @author Alexander Ebert
+ * @copyright 2001-2022 WoltLab GmbH
+ * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @package WoltLabSuite\Core\System\Search
+ * @since 6.0
+ */
+interface IContextAwareSearchEngine extends ISearchEngine
+{
+    /**
+     * Returns the condition builder class name required to provide conditions for getInnerJoin().
+     *
+     * @return  string
+     */
+    public function getConditionBuilderClassName();
+
+    /**
+     * Returns the inner join query and the condition parameters. This method is allowed to return NULL for both the
+     * 'fulltextCondition' and 'searchIndexCondition' index instead of a PreparedStatementConditionBuilder instance:
+     *
+     * array(
+     *  'fulltextCondition' => $fulltextCondition || null,
+     *  'searchIndexCondition' => $searchIndexCondition || null,
+     *  'sql' => $sql
+     * );
+     */
+    public function getInnerJoinWithContext(
+        string $objectTypeName,
+        string $q,
+        bool $subjectOnly = false,
+        ?PreparedStatementConditionBuilder $searchIndexCondition = null,
+        array $contextFilter,
+        string $orderBy = 'time DESC',
+        int $limit = 1000
+    ): array;
+
+    /**
+     * Searches for the given string and returns the data of the found messages.
+     */
+    public function searchWithContext(
+        string $q,
+        array $objectTypes,
+        bool $subjectOnly = false,
+        ?PreparedStatementConditionBuilder $searchIndexCondition = null,
+        array $contextFilter,
+        array $additionalConditions = [],
+        string $orderBy = 'time DESC',
+        int $limit = 1000
+    ): array;
+}

--- a/wcfsetup/install/files/lib/system/search/IContextAwareSearchEngine.class.php
+++ b/wcfsetup/install/files/lib/system/search/IContextAwareSearchEngine.class.php
@@ -25,13 +25,13 @@ interface IContextAwareSearchEngine extends ISearchEngine
 
     /**
      * Returns the inner join query and the condition parameters. This method is allowed to return NULL for both the
-     * 'fulltextCondition' and 'searchIndexCondition' index instead of a PreparedStatementConditionBuilder instance:
+     * 'fulltextCondition' and 'searchIndexCondition' index instead of a PreparedStatementConditionBuilder instance.
      *
-     * array(
-     *  'fulltextCondition' => $fulltextCondition || null,
-     *  'searchIndexCondition' => $searchIndexCondition || null,
-     *  'sql' => $sql
-     * );
+     * @return  array{
+     *              fulltextCondition: ?PreparedStatementConditionBuilder
+     *              searchIndexCondition: ?PreparedStatementConditionBuilder
+     *              sql: string
+     *          }
      */
     public function getInnerJoinWithContext(
         string $objectTypeName,

--- a/wcfsetup/install/files/lib/system/search/IContextAwareSearchEngine.class.php
+++ b/wcfsetup/install/files/lib/system/search/IContextAwareSearchEngine.class.php
@@ -8,6 +8,9 @@ use wcf\system\database\util\PreparedStatementConditionBuilder;
  * Default interface for search engines that support
  * filtering by context.
  *
+ * CAUTION: This is an experimental API that is not designed
+ *          for general consumption.
+ *
  * @author Alexander Ebert
  * @copyright 2001-2022 WoltLab GmbH
  * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>

--- a/wcfsetup/install/files/lib/system/search/IContextAwareSearchEngine.class.php
+++ b/wcfsetup/install/files/lib/system/search/IContextAwareSearchEngine.class.php
@@ -38,7 +38,7 @@ interface IContextAwareSearchEngine extends ISearchEngine
         string $q,
         bool $subjectOnly = false,
         ?PreparedStatementConditionBuilder $searchIndexCondition = null,
-        array $contextFilter,
+        array $contextFilter = [],
         string $orderBy = 'time DESC',
         int $limit = 1000
     ): array;
@@ -51,7 +51,7 @@ interface IContextAwareSearchEngine extends ISearchEngine
         array $objectTypes,
         bool $subjectOnly = false,
         ?PreparedStatementConditionBuilder $searchIndexCondition = null,
-        array $contextFilter,
+        array $contextFilter = [],
         array $additionalConditions = [],
         string $orderBy = 'time DESC',
         int $limit = 1000

--- a/wcfsetup/install/files/lib/system/search/IContextAwareSearchIndexManager.class.php
+++ b/wcfsetup/install/files/lib/system/search/IContextAwareSearchIndexManager.class.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace wcf\system\search;
+
+/**
+ * Context aware search index managers are able to support
+ * the parent id and container id of a message.
+ *
+ * @author Alexander Ebert
+ * @copyright 2001-2022 WoltLab GmbH
+ * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @package WoltLabSuite\Core\System\Search
+ * @since 6.0
+ */
+interface IContextAwareSearchIndexManager extends ISearchIndexManager
+{
+    /**
+     * Upserts a message into the search index.
+     */
+    public function setWithContext(
+        string $objectType,
+        int $objectID,
+        int $parentID,
+        int $containerID,
+        string $message,
+        string $subject,
+        int $time,
+        ?int $userID,
+        string $username,
+        ?int $languageID = null,
+        string $metaData = ''
+    ): void;
+}

--- a/wcfsetup/install/files/lib/system/search/IContextAwareSearchIndexManager.class.php
+++ b/wcfsetup/install/files/lib/system/search/IContextAwareSearchIndexManager.class.php
@@ -6,6 +6,9 @@ namespace wcf\system\search;
  * Context aware search index managers are able to support
  * the parent id and container id of a message.
  *
+ * CAUTION: This is an experimental API that is not designed
+ *          for general consumption.
+ *
  * @author Alexander Ebert
  * @copyright 2001-2022 WoltLab GmbH
  * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>

--- a/wcfsetup/install/files/lib/system/search/IContextAwareSearchProvider.class.php
+++ b/wcfsetup/install/files/lib/system/search/IContextAwareSearchProvider.class.php
@@ -6,6 +6,9 @@ namespace wcf\system\search;
  * Interface for full-text search providers that provide
  * additional context information for messages.
  *
+ * CAUTION: This is an experimental API that is not designed
+ *          for general consumption.
+ *
  * @author Alexander Ebert
  * @copyright 2001-2022 WoltLab GmbH
  * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>

--- a/wcfsetup/install/files/lib/system/search/IContextAwareSearchProvider.class.php
+++ b/wcfsetup/install/files/lib/system/search/IContextAwareSearchProvider.class.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace wcf\system\search;
+
+use wcf\data\search\ISearchResultObject;
+use wcf\system\database\util\PreparedStatementConditionBuilder;
+
+/**
+ * Interface for full-text search providers that provide
+ * additional context information for messages.
+ *
+ * @author Alexander Ebert
+ * @copyright 2001-2022 WoltLab GmbH
+ * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @package WoltLabSuite\Core\System\Search
+ * @since 6.0
+ */
+interface IContextAwareSearchProvider extends ISearchProvider
+{
+    /**
+     * Returns the context filter that is being applied
+     * to the inner search query.
+     */
+    public function getContextFilter(array $parameters): array;
+}

--- a/wcfsetup/install/files/lib/system/search/IContextAwareSearchProvider.class.php
+++ b/wcfsetup/install/files/lib/system/search/IContextAwareSearchProvider.class.php
@@ -2,9 +2,6 @@
 
 namespace wcf\system\search;
 
-use wcf\data\search\ISearchResultObject;
-use wcf\system\database\util\PreparedStatementConditionBuilder;
-
 /**
  * Interface for full-text search providers that provide
  * additional context information for messages.

--- a/wcfsetup/install/files/lib/system/search/ISearchEngine.class.php
+++ b/wcfsetup/install/files/lib/system/search/ISearchEngine.class.php
@@ -23,13 +23,7 @@ interface ISearchEngine
 
     /**
      * Returns the inner join query and the condition parameters. This method is allowed to return NULL for both the
-     * 'fulltextCondition' and 'searchIndexCondition' index instead of a PreparedStatementConditionBuilder instance:
-     *
-     * array(
-     *  'fulltextCondition' => $fulltextCondition || null,
-     *  'searchIndexCondition' => $searchIndexCondition || null,
-     *  'sql' => $sql
-     * );
+     * 'fulltextCondition' and 'searchIndexCondition' index instead of a PreparedStatementConditionBuilder instance.
      *
      * @param string $objectTypeName
      * @param string $q
@@ -37,7 +31,11 @@ interface ISearchEngine
      * @param PreparedStatementConditionBuilder $searchIndexCondition
      * @param string $orderBy
      * @param int $limit
-     * @return  array
+     * @return  array{
+     *              fulltextCondition: ?PreparedStatementConditionBuilder
+     *              searchIndexCondition: ?PreparedStatementConditionBuilder
+     *              sql: string
+     *          }
      */
     public function getInnerJoin(
         $objectTypeName,

--- a/wcfsetup/install/files/lib/system/search/SearchEngine.class.php
+++ b/wcfsetup/install/files/lib/system/search/SearchEngine.class.php
@@ -123,7 +123,7 @@ class SearchEngine extends SingletonFactory implements IContextAwareSearchEngine
         array $objectTypes,
         bool $subjectOnly = false,
         ?PreparedStatementConditionBuilder $searchIndexCondition = null,
-        array $contextFilter,
+        array $contextFilter = [],
         array $additionalConditions = [],
         string $orderBy = 'time DESC',
         int $limit = 1000
@@ -181,7 +181,7 @@ class SearchEngine extends SingletonFactory implements IContextAwareSearchEngine
         string $q,
         bool $subjectOnly = false,
         ?PreparedStatementConditionBuilder $searchIndexCondition = null,
-        array $contextFilter,
+        array $contextFilter = [],
         string $orderBy = 'time DESC',
         int $limit = 1000
     ): array {

--- a/wcfsetup/install/files/lib/system/search/SearchEngine.class.php
+++ b/wcfsetup/install/files/lib/system/search/SearchEngine.class.php
@@ -16,7 +16,7 @@ use wcf\system\SingletonFactory;
  * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
  * @package WoltLabSuite\Core\System\Search
  */
-class SearchEngine extends SingletonFactory implements ISearchEngine
+class SearchEngine extends SingletonFactory implements IContextAwareSearchEngine
 {
     /**
      * limit for inner search limits
@@ -118,6 +118,44 @@ class SearchEngine extends SingletonFactory implements ISearchEngine
     /**
      * @inheritDoc
      */
+    public function searchWithContext(
+        string $q,
+        array $objectTypes,
+        bool $subjectOnly = false,
+        ?PreparedStatementConditionBuilder $searchIndexCondition = null,
+        array $contextFilter,
+        array $additionalConditions = [],
+        string $orderBy = 'time DESC',
+        int $limit = 1000
+    ): array {
+        $searchEngine = $this->getSearchEngine();
+        if ($searchEngine instanceof IContextAwareSearchEngine) {
+            return $searchEngine->searchWithContext(
+                $q,
+                $objectTypes,
+                $subjectOnly,
+                $searchIndexCondition,
+                $contextFilter,
+                $additionalConditions,
+                $orderBy,
+                $limit
+            );
+        }
+
+        return $searchEngine->search(
+            $q,
+            $objectTypes,
+            $subjectOnly,
+            $searchIndexCondition,
+            $additionalConditions,
+            $orderBy,
+            $limit
+        );
+    }
+
+    /**
+     * @inheritDoc
+     */
     public function getInnerJoin(
         $objectTypeName,
         $q,
@@ -133,6 +171,46 @@ class SearchEngine extends SingletonFactory implements ISearchEngine
 
         return $this->getSearchEngine()
             ->getInnerJoin($objectTypeName, $q, $subjectOnly, $searchIndexCondition, $orderBy, $limit);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getInnerJoinWithContext(
+        string $objectTypeName,
+        string $q,
+        bool $subjectOnly = false,
+        ?PreparedStatementConditionBuilder $searchIndexCondition = null,
+        array $contextFilter,
+        string $orderBy = 'time DESC',
+        int $limit = 1000
+    ): array {
+        $conditionBuilderClassName = $this->getConditionBuilderClassName();
+        if ($searchIndexCondition !== null && !($searchIndexCondition instanceof $conditionBuilderClassName)) {
+            throw new SystemException("Search engine '" . SEARCH_ENGINE . "' requires a different condition builder, please use 'SearchEngine::getInstance()->getConditionBuilderClassName()'!");
+        }
+
+        $searchEngine = $this->getSearchEngine();
+        if ($searchEngine instanceof IContextAwareSearchEngine) {
+            return $searchEngine->getInnerJoinWithContext(
+                $objectTypeName,
+                $q,
+                $subjectOnly,
+                $searchIndexCondition,
+                $contextFilter,
+                $orderBy,
+                $limit
+            );
+        }
+
+        return $searchEngine->getInnerJoin(
+            $objectTypeName,
+            $q,
+            $subjectOnly,
+            $searchIndexCondition,
+            $orderBy,
+            $limit
+        );
     }
 
     /**

--- a/wcfsetup/install/files/lib/system/search/SearchEngine.class.php
+++ b/wcfsetup/install/files/lib/system/search/SearchEngine.class.php
@@ -228,4 +228,15 @@ class SearchEngine extends SingletonFactory implements IContextAwareSearchEngine
     {
         return $this->getSearchEngine()->removeSpecialCharacters($string);
     }
+
+    /**
+     * Returns true if the search backend supports
+     * context information for messages.
+     *
+     * @since 6.0
+     */
+    public function isContextAware(): bool
+    {
+        return ($this->getSearchEngine() instanceof IContextAwareSearchEngine);
+    }
 }

--- a/wcfsetup/install/files/lib/system/search/SearchHandler.class.php
+++ b/wcfsetup/install/files/lib/system/search/SearchHandler.class.php
@@ -45,6 +45,11 @@ final class SearchHandler
     private $typeBasedConditionBuilders = [];
 
     /**
+     * @var mixed[]
+     */
+    private $typeBasedContextFilter = [];
+
+    /**
      * @var int[]
      */
     private $userIDs;
@@ -182,7 +187,8 @@ final class SearchHandler
                 }
 
                 if ($objectType instanceof ISearchProvider) {
-                    if (($conditionBuilder = $objectType->getConditionBuilder((\count($this->objectTypeNames) === 1 ? $this->parameters : []))) !== null) {
+                    $parameters = \count($this->objectTypeNames) === 1 ? $this->parameters : [];
+                    if (($conditionBuilder = $objectType->getConditionBuilder($parameters)) !== null) {
                         $this->typeBasedConditionBuilders[$objectTypeName] = $conditionBuilder;
                     }
 
@@ -191,6 +197,10 @@ final class SearchHandler
                         && ($newSortField = $objectType->getCustomSortField($this->parameters['sortField']))
                     ) {
                         $this->parameters['sortField'] = $newSortField;
+                    }
+
+                    if ($objectType instanceof IContextAwareSearchProvider) {
+                        $this->typeBasedContextFilter[$objectTypeName] = $objectType->getContextFilter($parameters);
                     }
                 } else {
                     if (($conditionBuilder = $objectType->getConditions($form)) !== null) {
@@ -269,6 +279,7 @@ final class SearchHandler
             $this->parameters['subjectOnly'] ?? 0,
             $this->conditionBuilder,
             $this->typeBasedConditionBuilders,
+            $this->typeBasedContextFilter,
             $this->parameters['sortField'],
             $this->parameters['sortOrder'],
             $this->getAdditionalData(),
@@ -303,12 +314,13 @@ final class SearchHandler
 
     private function loadResults(): bool
     {
-        $this->results = SearchEngine::getInstance()->search(
+        $this->results = SearchEngine::getInstance()->searchWithContext(
             $this->parameters['q'] ?? '',
             $this->objectTypeNames,
             $this->parameters['subjectOnly'] ?? 0,
             $this->conditionBuilder,
             $this->typeBasedConditionBuilders,
+            $this->typeBasedContextFilter,
             $this->parameters['sortField'] . ' ' . $this->parameters['sortOrder']
         );
 

--- a/wcfsetup/install/files/lib/system/search/SearchHandler.class.php
+++ b/wcfsetup/install/files/lib/system/search/SearchHandler.class.php
@@ -319,8 +319,8 @@ final class SearchHandler
             $this->objectTypeNames,
             $this->parameters['subjectOnly'] ?? 0,
             $this->conditionBuilder,
-            $this->typeBasedConditionBuilders,
             $this->typeBasedContextFilter,
+            $this->typeBasedConditionBuilders,
             $this->parameters['sortField'] . ' ' . $this->parameters['sortOrder']
         );
 

--- a/wcfsetup/install/files/lib/system/search/SearchIndexManager.class.php
+++ b/wcfsetup/install/files/lib/system/search/SearchIndexManager.class.php
@@ -19,7 +19,7 @@ use wcf\util\StringUtil;
  * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
  * @package WoltLabSuite\Core\System\Search
  */
-class SearchIndexManager extends SingletonFactory implements ISearchIndexManager
+class SearchIndexManager extends SingletonFactory implements IContextAwareSearchIndexManager
 {
     /**
      * list of available object types
@@ -121,6 +121,46 @@ class SearchIndexManager extends SingletonFactory implements ISearchIndexManager
 
         $this->getSearchIndexManager()
             ->set($objectType, $objectID, $message, $subject, $time, $userID, $username, $languageID, $metaData);
+    }
+
+    /**
+     * @inheritDoc
+     * @since 6.0
+     */
+    public function setWithContext(
+        string $objectType,
+        int $objectID,
+        int $parentID,
+        int $containerID,
+        string $message,
+        string $subject,
+        int $time,
+        ?int $userID,
+        string $username,
+        ?int $languageID = null,
+        string $metaData = ''
+    ): void {
+        $searchIndexManager = $this->getSearchIndexManager();
+        if ($searchIndexManager instanceof IContextAwareSearchIndexManager) {
+            $message = StringUtil::trim(StringUtil::stripHTML($message));
+
+            $searchIndexManager->setWithContext(
+                $objectType,
+                $objectID,
+                $parentID,
+                $containerID,
+                $message,
+                $subject,
+                $time,
+                $userID,
+                $username,
+                $languageID,
+                $metaData
+            );
+        } else {
+            $searchIndexManager
+                ->set($objectType, $objectID, $message, $subject, $time, $userID, $username, $languageID, $metaData);
+        }
     }
 
     /**


### PR DESCRIPTION
Every search consists of an outer and inner query, with the inner query directly targeting the search backend. For performance reasons the results from the inner query are capped (although at a much greater limit). This limitation can cause issue if the filters on the outer query remove too many results, because the inner query was too broad.