### PR TITLE
Do not attempt to update the accessToken on a live object in UserEditor::update()

### DIFF
--- a/wcfsetup/install/files/lib/data/user/UserEditor.class.php
+++ b/wcfsetup/install/files/lib/data/user/UserEditor.class.php
@@ -109,9 +109,6 @@ class UserEditor extends DatabaseObjectEditor implements IEditableCachedObject
         if (\array_key_exists('password', $parameters) && $parameters['password'] !== '') {
             $parameters['password'] = self::getPasswordHash($parameters['password']);
             $parameters['accessToken'] = Hex::encode(\random_bytes(20));
-
-            // update accessToken
-            $this->accessToken = $parameters['accessToken'];
         } else {
             unset($parameters['password'], $parameters['accessToken']);
         }


### PR DESCRIPTION
The purpose of this is not entirely clear, but when taking a look at the commit
that added the line 6a41a21e09894236c26daa10019d0e0a859f963b, one can see that
the update of the accessToken was added beneath an update of the (dedicated)
salt that still existed back then. Notably absent is an update of the new
*hash*, though.

No other property that is updated via an *Editor class is actively attempted to
be updated on a live object and even in this case, only a dynamic property was
created on the UserEditor, instead of actually updating the accessToken in the
underlying user object (which would be possible, because the DBOEditors inherit
from the DBO class, allowing clean access to the `->data` property).

Thus we simply remove the attempted update to fix the creation of this dynamic
property which is deprecated as of PHP 8.2.

Fixes #5164
