### PR TITLE
Lock WCFSetup once files are extracted

### DIFF
--- a/wcfsetup/install.php
+++ b/wcfsetup/install.php
@@ -1255,6 +1255,7 @@ if ($prefix === null) {
 	$dir = INSTALL_SCRIPT_DIR . "/WCFSetup-{$prefix}/";
 	\mkdir($dir);
 	BasicFileUtil::makeWritable($dir);
+	\file_put_contents($dir . 'lastStep', '0');
 }
 
 \define('TMP_FILE_PREFIX', $prefix);

--- a/wcfsetup/install/files/lib/system/WCFSetup.class.php
+++ b/wcfsetup/install/files/lib/system/WCFSetup.class.php
@@ -210,6 +210,21 @@ final class WCFSetup extends WCF
     }
 
     /**
+     * Throws an exception if it appears that the 'unzipFiles' step already ran.
+     */
+    protected function assertNotUnzipped()
+    {
+        if (
+            \is_file(INSTALL_SCRIPT_DIR . 'lib/system/WCF.class.php')
+            || \is_file(INSTALL_SCRIPT_DIR . 'global.php')
+        ) {
+            throw new \Exception(
+                'Target directory seems to be an existing installation of WoltLab Suite Core, refusing to continue.'
+            );
+        }
+    }
+
+    /**
      * Executes the setup steps.
      */
     protected function dispatch(): ResponseInterface
@@ -231,21 +246,25 @@ final class WCFSetup extends WCF
         switch ($step) {
             case 'selectSetupLanguage':
                 $this->calcProgress(0);
+                $this->assertNotUnzipped();
 
                 return $this->selectSetupLanguage();
 
             case 'showLicense':
                 $this->calcProgress(1);
+                $this->assertNotUnzipped();
 
                 return $this->showLicense();
 
             case 'showSystemRequirements':
                 $this->calcProgress(2);
+                $this->assertNotUnzipped();
 
                 return $this->showSystemRequirements();
 
             case 'configureDB':
                 $this->calcProgress(3);
+                $this->assertNotUnzipped();
 
                 return $this->configureDB();
 
@@ -256,11 +275,13 @@ final class WCFSetup extends WCF
                 }
 
                 $this->calcProgress($currentStep);
+                $this->assertNotUnzipped();
 
                 return $this->createDB();
 
             case 'unzipFiles':
                 $this->calcProgress(18);
+                $this->assertNotUnzipped();
 
                 return $this->unzipFiles();
 
@@ -746,13 +767,6 @@ final class WCFSetup extends WCF
      */
     protected function unzipFiles(): ResponseInterface
     {
-        // WCF seems to be installed, abort
-        if (@\is_file(INSTALL_SCRIPT_DIR . 'lib/system/WCF.class.php')) {
-            throw new SystemException(
-                'Target directory seems to be an existing installation of WCF, unable to continue.'
-            );
-        }
-
         $this->initDB();
 
         $fileHandler = new SetupFileHandler();

--- a/wcfsetup/install/files/lib/system/WCFSetup.class.php
+++ b/wcfsetup/install/files/lib/system/WCFSetup.class.php
@@ -191,11 +191,19 @@ final class WCFSetup extends WCF
 
     /**
      * Calculates the current state of the progress bar.
-     *
-     * @param int $currentStep
      */
-    protected function calcProgress($currentStep)
+    protected function calcProgress(int $currentStep)
     {
+        $lastStep = \intval(\file_get_contents(\TMP_DIR . 'lastStep'));
+        if ($lastStep > $currentStep) {
+            throw new \Exception('Refusing to step back to a previous step.');
+        }
+        if ($lastStep !== $currentStep - 1 && $lastStep !== $currentStep) {
+            throw new \Exception('Refusing to skip a step.');
+        }
+
+        \file_put_contents(\TMP_DIR . 'lastStep', $currentStep);
+
         // calculate progress
         $progress = \round((100 / 22) * ++$currentStep, 0);
         self::getTPL()->assign(['progress' => $progress]);


### PR DESCRIPTION
As the target directory is fixed now, we can reliably lock WCFSetup once the
files are extracted to prevent existing installations from being affected if
install.php + WCFSetup.tar.gz are uploaded by accident.
