### PR TITLE
Add the prefilter `{jsphrase}` to easily register phrases in templates

### DIFF
--- a/wcfsetup/install/files/lib/system/WCF.class.php
+++ b/wcfsetup/install/files/lib/system/WCF.class.php
@@ -807,7 +807,7 @@ class WCF
             $wcf = new TemplateScriptingCore($wcf);
         }
 
-        self::getTPL()->registerPrefilter(['event', 'hascontent', 'lang', 'jslang', 'csrfToken', 'icon']);
+        self::getTPL()->registerPrefilter(['event', 'hascontent', 'lang', 'jsphrase', 'jslang', 'csrfToken', 'icon']);
         self::getTPL()->assign([
             '__wcf' => $wcf,
         ]);

--- a/wcfsetup/install/files/lib/system/template/plugin/JsphraseFunctionTemplatePlugin.class.php
+++ b/wcfsetup/install/files/lib/system/template/plugin/JsphraseFunctionTemplatePlugin.class.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace wcf\system\template\plugin;
+
+use wcf\system\exception\SystemException;
+use wcf\system\template\TemplateEngine;
+
+/**
+ * See JsphrasePrefilterTemplatePlugin.
+ * 
+ * This function exists to catch misuses of {jsphrase}
+ * that violate the specs and have not been caught
+ * by the prefilter.
+ *
+ * @author Alexander Ebert
+ * @copyright 2001-2022 WoltLab GmbH
+ * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @package WoltLabSuite\Core\System\Template\Plugin
+ * @since 6.0
+ */
+final class JsphraseFunctionTemplatePlugin implements IFunctionTemplatePlugin
+{
+    /**
+     * @inheritDoc
+     */
+    public function execute($tagArgs, TemplateEngine $tplObj)
+    {
+        $name = $tagArgs['name'] ?? '';
+        if ($name === '') {
+            throw new SystemException("missing 'name' argument in jsphrase tag");
+        }
+
+        if (!\preg_match('~[A-z0-9-_]+(\.[A-z0-9-_]+){2,}~', $name)) {
+            throw new SystemException("The provided name does not appear to be a valid phrase identifier.");
+        }
+
+        throw new \LogicException("Unreachable");
+    }
+}

--- a/wcfsetup/install/files/lib/system/template/plugin/JsphrasePrefilterTemplatePlugin.class.php
+++ b/wcfsetup/install/files/lib/system/template/plugin/JsphrasePrefilterTemplatePlugin.class.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace wcf\system\template\plugin;
+
+use wcf\system\template\TemplateScriptingCompiler;
+
+/**
+ * Registers static phrases for use in JavaScript/TypeScript
+ * modules on runtime. Dynamic phrases or does requiring
+ * a literal handling need to be manually registered.
+ *
+ * @author Alexander Ebert
+ * @copyright 2001-2022 WoltLab GmbH
+ * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @package WoltLabSuite\Core\System\Template\Plugin
+ * @since 6.0
+ */
+final class JsphrasePrefilterTemplatePlugin implements IPrefilterTemplatePlugin
+{
+    /**
+     * @inheritDoc
+     */
+    public function execute($templateName, $sourceContent, TemplateScriptingCompiler $compiler)
+    {
+        $ldq = \preg_quote($compiler->getLeftDelimiter(), '~');
+        $rdq = \preg_quote($compiler->getRightDelimiter(), '~');
+
+        return \preg_replace_callback(
+            "~{$ldq}jsphrase name='(?<name>[A-z0-9-_]+(\.[A-z0-9-_]+){2,})'{$rdq}~",
+            static function ($match) {
+                $name = $match['name'];
+
+                return \sprintf(
+                    "WoltLabLanguage.add('%s', '{jslang}%s{/jslang}');",
+                    $name,
+                    $name,
+                );
+            },
+            $sourceContent
+        );
+    }
+}


### PR DESCRIPTION
The preloading of phrases makes it easy to provide phrases that either need to be implicitly available or that are very likely to be used on runtime.

For all other phrases, that only appear in very limited scopes, these continue to be registered manually in the template like this:

```js
require(["WoltLabSuite/Core/Language"], ({ registerPhrase }) => {
  registerPhrase('some.fancy.phrase', '{jslang}some.fancy.phrase{/jslang}');
});
```

This PR intends to simply this process by adding a convenient template function that removes the guesswork and slims down the code required:

```smarty
{jsphrase name='some.fancy.phrase'}
```

(This code is effectively identical to the JS code block above).