### PR TITLE
Clean up the API in Psr15DialogForm

### DIFF
--- a/wcfsetup/install/files/lib/action/ModerationQueueAssignUserAction.class.php
+++ b/wcfsetup/install/files/lib/action/ModerationQueueAssignUserAction.class.php
@@ -76,9 +76,9 @@ final class ModerationQueueAssignUserAction implements RequestHandlerInterface
         $form = $this->getForm($moderationQueue);
 
         if ($request->getMethod() === 'GET') {
-            return $form->toJsonResponse();
+            return $form->toResponse();
         } elseif ($request->getMethod() === 'POST') {
-            $response = $form->validatePsr7Request($request);
+            $response = $form->validateRequest($request);
             if ($response !== null) {
                 return $response;
             }

--- a/wcfsetup/install/files/lib/system/form/builder/Psr15DialogForm.class.php
+++ b/wcfsetup/install/files/lib/system/form/builder/Psr15DialogForm.class.php
@@ -34,18 +34,18 @@ final class Psr15DialogForm extends FormDocument
 
     /**
      * Processes the form using the request's parsed body. Returns 'null'
-     * if validation succeeded and the result of 'toJsonResponse()' otherwise.
+     * if validation succeeded and the result of 'toResponse()' otherwise.
      *
-     * @see Psr15DialogForm::toJsonResponse()
+     * @see Psr15DialogForm::toResponse()
      */
-    public function validatePsr7Request(ServerRequestInterface $request): ?ResponseInterface
+    public function validateRequest(ServerRequestInterface $request): ?ResponseInterface
     {
         $this->requestData($request->getParsedBody());
         $this->readValues();
         $this->validate();
 
         if ($this->hasValidationErrors()) {
-            return $this->toJsonResponse();
+            return $this->toResponse();
         }
 
         return null;
@@ -54,7 +54,7 @@ final class Psr15DialogForm extends FormDocument
     /**
      * Returns a response that can be consumed by JavaScript's `dialogFactory().usingFormBuilder()`.
      */
-    public function toJsonResponse(): ResponseInterface
+    public function toResponse(): ResponseInterface
     {
         return new JsonResponse([
             'dialog' => $this->getHtml(),

--- a/wcfsetup/install/files/lib/system/form/builder/Psr15DialogForm.class.php
+++ b/wcfsetup/install/files/lib/system/form/builder/Psr15DialogForm.class.php
@@ -3,6 +3,7 @@
 namespace wcf\system\form\builder;
 
 use Laminas\Diactoros\Response\JsonResponse;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use wcf\system\form\builder\button\IFormButton;
 
@@ -31,7 +32,13 @@ final class Psr15DialogForm extends FormDocument
         $this->ajax = true;
     }
 
-    public function validatePsr7Request(ServerRequestInterface $request): ?JsonResponse
+    /**
+     * Processes the form using the request's parsed body. Returns 'null'
+     * if validation succeeded and the result of 'toJsonResponse()' otherwise.
+     *
+     * @see Psr15DialogForm::toJsonResponse()
+     */
+    public function validatePsr7Request(ServerRequestInterface $request): ?ResponseInterface
     {
         $this->requestData($request->getParsedBody());
         $this->readValues();
@@ -44,7 +51,10 @@ final class Psr15DialogForm extends FormDocument
         return null;
     }
 
-    public function toJsonResponse(): JsonResponse
+    /**
+     * Returns a response that can be consumed by JavaScript's `dialogFactory().usingFormBuilder()`.
+     */
+    public function toJsonResponse(): ResponseInterface
     {
         return new JsonResponse([
             'dialog' => $this->getHtml(),


### PR DESCRIPTION
This commit adds PHPDoc explanation to the PSR-15 “API” of the DialogForm. It
also adjusts the return type to the generic ResponseInterface: The methods
guarantee that the returned response is appropriate for consumption by the JS
API, but should not make any further guarantees.
