### PR TITLE
Merge `INTERNAL_HOSTNAMES` into list of allowed image domains

### DIFF
--- a/wcfsetup/install/files/lib/system/bbcode/BBCodeHandler.class.php
+++ b/wcfsetup/install/files/lib/system/bbcode/BBCodeHandler.class.php
@@ -174,7 +174,14 @@ class BBCodeHandler extends SingletonFactory
         $hosts = [];
         // Hide these hosts unless external sources are actually denied.
         if (!IMAGE_ALLOW_EXTERNAL_SOURCE) {
-            $hosts = ArrayUtil::trim(\explode("\n", IMAGE_EXTERNAL_SOURCE_WHITELIST));
+            $hosts = ArrayUtil::trim(\explode(
+                "\n",
+                \sprintf(
+                    "%s\n%s",
+                    \IMAGE_EXTERNAL_SOURCE_WHITELIST,
+                    \INTERNAL_HOSTNAMES
+                )
+            ));
         }
 
         foreach (ApplicationHandler::getInstance()->getApplications() as $application) {


### PR DESCRIPTION
Written for 5.5, but this is possibly a relevant behavioral change, so maybe
should be applied to 6.0 only? Feel free to adjust the target branch, it
applies cleanly to both 5.5 and 6.0.

-----------------

Fixes #5146
