### PR TITLE
Fix validation in AbstractFileDeletePackageInstallationPlugin

### DIFF
--- a/wcfsetup/install/files/lib/system/package/plugin/AbstractFileDeletePackageInstallationPlugin.class.php
+++ b/wcfsetup/install/files/lib/system/package/plugin/AbstractFileDeletePackageInstallationPlugin.class.php
@@ -101,10 +101,7 @@ abstract class AbstractFileDeletePackageInstallationPlugin extends AbstractXMLPa
             foreach ($files as $file) {
                 $filePackageID = $logFiles[$application][$file] ?? null;
                 if ($filePackageID !== null && $filePackageID != $this->installation->getPackageID()) {
-                    throw new \UnexpectedValueException(
-                        "'{$file}' does not belong to package '{$this->installation->getPackage()->package}'
-                        but to package '" . PackageCache::getInstance()->getPackage($filePackageID)->package . "'."
-                    );
+                    continue;
                 }
 
                 $filePath = $this->getFilePath($file, $application);

--- a/wcfsetup/install/files/lib/system/package/plugin/AbstractFileDeletePackageInstallationPlugin.class.php
+++ b/wcfsetup/install/files/lib/system/package/plugin/AbstractFileDeletePackageInstallationPlugin.class.php
@@ -82,7 +82,6 @@ abstract class AbstractFileDeletePackageInstallationPlugin extends AbstractXMLPa
             $conditions = new PreparedStatementConditionBuilder();
             $conditions->add("{$this->getFilenameTableColumn()} IN (?)", [$files]);
             $conditions->add('application = ?', [$application]);
-            $conditions->add('packageID = ?', [$this->installation->getPackageID()]);
 
             $sql = "SELECT  packageID, application, {$this->getFilenameTableColumn()}
                     FROM    {$this->getLogTableName()}


### PR DESCRIPTION
The query for logged files must not include the `packageID` in its condition,
as the entire purpose is retrieving all the `packageID`s for installed files to
compare them against the package that is currently installed or updated. Thus
by selecting only files for the current packageID the purpose is defeated.

see 672cd6166b684767a3fc8ee1fd6a4516d2061285
