### PR TITLE
Clean up coreObjects

### DIFF
--- a/com.woltlab.wcf/coreObject.xml
+++ b/com.woltlab.wcf/coreObject.xml
@@ -14,9 +14,6 @@
 			<objectname>wcf\system\benchmark\Benchmark</objectname>
 		</coreobject>
 		<coreobject>
-			<objectname>wcf\system\user\authentication\UserAuthenticationFactory</objectname>
-		</coreobject>
-		<coreobject>
 			<objectname>wcf\system\MetaTagHandler</objectname>
 		</coreobject>
 		<coreobject>
@@ -62,4 +59,7 @@
 			<objectname>wcf\system\file\upload\UploadHandler</objectname>
 		</coreobject>
 	</import>
+	<delete>
+		<coreobject name="wcf\system\user\authentication\UserAuthenticationFactory"/>
+	</delete>
 </data>

--- a/com.woltlab.wcf/coreObject.xml
+++ b/com.woltlab.wcf/coreObject.xml
@@ -5,9 +5,6 @@
 			<objectname>wcf\system\breadcrumb\Breadcrumbs</objectname>
 		</coreobject>
 		<coreobject>
-			<objectname>wcf\system\request\LinkHandler</objectname>
-		</coreobject>
-		<coreobject>
 			<objectname>wcf\system\menu\acp\ACPMenu</objectname>
 		</coreobject>
 		<coreobject>
@@ -61,5 +58,6 @@
 	</import>
 	<delete>
 		<coreobject name="wcf\system\user\authentication\UserAuthenticationFactory"/>
+		<coreobject name="wcf\system\request\LinkHandler"/>
 	</delete>
 </data>


### PR DESCRIPTION
This PR removes unused coreObjects to reduce the cache size, improving lookup
performance and memory usage for the remaining ones.
