### PR TITLE
Fix dropping of misnamed foreign keys in PHP DDL

### DIFF
--- a/wcfsetup/install/files/lib/system/database/table/DatabaseTableChangeProcessor.class.php
+++ b/wcfsetup/install/files/lib/system/database/table/DatabaseTableChangeProcessor.class.php
@@ -485,7 +485,7 @@ class DatabaseTableChangeProcessor
                             if (!isset($this->foreignKeysToDrop[$tableName])) {
                                 $this->foreignKeysToDrop[$tableName] = [];
                             }
-                            $this->foreignKeysToDrop[$tableName][] = $foreignKey;
+                            $this->foreignKeysToDrop[$tableName][] = $matchingExistingForeignKey;
 
                             $this->splitNodeMessage .= "Dropped foreign key '{$tableName}." . \implode(
                                 ',',


### PR DESCRIPTION
Foreign keys are matched up by their `getDiffData()` which includes the column
list, referenced column list and referenced table, but does not include the name.

This effectively ensures that only a single foreign key exists for each
possible combination of source and target columns.

Dropping foreign keys however relies on the foreign key’s name being sent to
the database and this is currently broken when the foreign key name differs
from the expected name:

The misnamed key will be matched up, but the DROP query will send the expected
name, instead of the actual name.

Fix this by inserting the `$matchingExistingForeignKey` into the list of keys
to drop, which makes sense, because the existing key is what should be dropped
in the first place.
