### PR TITLE
Refuse to execute `cli.php` as `root`

### DIFF
--- a/wcfsetup/install/files/cli.php
+++ b/wcfsetup/install/files/cli.php
@@ -14,6 +14,12 @@ if (\PHP_SAPI !== 'cli') {
     exit;
 }
 
+if (function_exists('posix_getuid') && posix_getuid() === 0) {
+    fwrite(STDERR, "Refusing to execute as root.\n");
+
+    exit(1);
+}
+
 // include config
 require_once(__DIR__ . '/app.config.inc.php');
 


### PR DESCRIPTION
Executing `cli.php` as `root` is always almost a mistake and will lead to
downstream permission issues, e.g. because some cache files are not accessible
to the user web requests execute with.
