### PR TITLE
fix creation of reason-field in `Confirmation.softDelete()`

### DIFF
--- a/ts/WoltLabSuite/Core/Component/Confirmation.ts
+++ b/ts/WoltLabSuite/Core/Component/Confirmation.ts
@@ -82,7 +82,7 @@ class ConfirmationPrefab {
       `;
       reason = dl.querySelector("textarea")!;
 
-      dialog.append(reason);
+      dialog.content.append(dl);
     }
 
     const question = Language.get("wcf.dialog.confirmation.softDelete", { title });

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Component/Confirmation.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Component/Confirmation.js
@@ -67,7 +67,7 @@ define(["require", "exports", "tslib", "./Dialog", "../Language", "../Dom/Util",
         <dd><textarea id="${id}" cols="40" rows="3"></textarea></dd>
       `;
                 reason = dl.querySelector("textarea");
-                dialog.append(reason);
+                dialog.content.append(dl);
             }
             const question = Language.get("wcf.dialog.confirmation.softDelete", { title });
             dialog.show(question);


### PR DESCRIPTION
The integration of the optional reason-field when calling `softDelete(string, true)` is completely broken.
The current logic creates a `dl`-element containing the textarea, but only the textarea is appended to the dialog.
The second mistake is that the textarea (which should be the whole `dl`-element) get's appended to the upper dialog-element before everything else is even initialized, causing the textarea being hidden.

![image](https://user-images.githubusercontent.com/1749344/210277206-fa9272de-f571-4e3d-8871-62ab8fad547e.png)
![image](https://user-images.githubusercontent.com/1749344/210277238-251a73ee-19a1-441d-83b5-becaeb21cc79.png)
