### PR TITLE
fix handling of multi-selection fields as search parameters

### DIFF
--- a/ts/WoltLabSuite/Core/Ui/Search/Extended.ts
+++ b/ts/WoltLabSuite/Core/Ui/Search/Extended.ts
@@ -38,6 +38,10 @@ const enum SearchAction {
   Init,
 }
 
+type CombinedFormData = {
+  [key: string]: string | string[];
+}
+
 export class UiSearchExtended {
   private readonly form: HTMLFormElement;
   private readonly queryInput: HTMLInputElement;
@@ -143,11 +147,29 @@ export class UiSearchExtended {
 
     if (searchAction !== SearchAction.Navigation) {
       this.searchParameters = [];
+      const formData: CombinedFormData = {};
       new FormData(this.form).forEach((value, key) => {
         if (value.toString().trim()) {
-          this.searchParameters.push([key, value.toString().trim()]);
+          if (formData[key] === undefined) {
+            formData[key] = value.toString().trim();
+          } else {
+            if (!Array.isArray(formData[key])) {
+              formData[key] = [formData[key] as string];
+            }
+
+            (formData[key] as Array<string>).push(value.toString().trim());
+          }
         }
       });
+      for (const [key, value] of Object.entries(formData)) {
+        if (!Array.isArray(value)) {
+          this.searchParameters.push([key, value]);
+        } else {
+          value.forEach((itemValue) => {
+            this.searchParameters.push([key + "[]", itemValue]);
+          })
+        }
+      }
     }
     const parameters = this.searchParameters.slice();
 
@@ -167,7 +189,15 @@ export class UiSearchExtended {
     const data = {};
     new FormData(this.form).forEach((value, key) => {
       if (value.toString()) {
-        data[key] = value;
+        if (data[key] === undefined) {
+          data[key] = value;
+        } else {
+          if (!Array.isArray(data[key])) {
+            data[key] = [data[key]];
+          }
+
+          (data[key] as Array<any>).push(value);
+        }
       }
     });
     if (this.activePage > 1) {

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Search/Extended.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Search/Extended.js
@@ -105,11 +105,30 @@ define(["require", "exports", "tslib", "../../Ajax", "../../Date/Picker", "../..
             url.search += url.search !== "" ? "&" : "?";
             if (searchAction !== 1 /* SearchAction.Navigation */) {
                 this.searchParameters = [];
+                const formData = {};
                 new FormData(this.form).forEach((value, key) => {
                     if (value.toString().trim()) {
-                        this.searchParameters.push([key, value.toString().trim()]);
+                        if (formData[key] === undefined) {
+                            formData[key] = value.toString().trim();
+                        }
+                        else {
+                            if (!Array.isArray(formData[key])) {
+                                formData[key] = [formData[key]];
+                            }
+                            formData[key].push(value.toString().trim());
+                        }
                     }
                 });
+                for (const [key, value] of Object.entries(formData)) {
+                    if (!Array.isArray(value)) {
+                        this.searchParameters.push([key, value]);
+                    }
+                    else {
+                        value.forEach((itemValue) => {
+                            this.searchParameters.push([key + "[]", itemValue]);
+                        });
+                    }
+                }
             }
             const parameters = this.searchParameters.slice();
             if (this.activePage > 1) {
@@ -127,7 +146,15 @@ define(["require", "exports", "tslib", "../../Ajax", "../../Date/Picker", "../..
             const data = {};
             new FormData(this.form).forEach((value, key) => {
                 if (value.toString()) {
-                    data[key] = value;
+                    if (data[key] === undefined) {
+                        data[key] = value;
+                    }
+                    else {
+                        if (!Array.isArray(data[key])) {
+                            data[key] = [data[key]];
+                        }
+                        data[key].push(value);
+                    }
                 }
             });
             if (this.activePage > 1) {


### PR DESCRIPTION
Using the following additional search parameter field:
```HTML
<select name="fooCategoryIDs" id="fooCategoryIDs" multiple>
    <option value="1">1</option>
    <option value="2">2</option>
    <option value="3">3</option>
</select>
```

Select 1, 2, 3.
Expectation: The request contains a comma-separated list of the values or an array containing the selected values.
Current behavior: The request contains only the last value (of the list => `3`), which means the submitted data is unreliable.

![image](https://user-images.githubusercontent.com/1749344/210372850-453b607b-887c-4c58-8dbd-3bd996d48bf0.png)
![image](https://user-images.githubusercontent.com/1749344/210373203-bb8946f7-a4d9-4602-b9b4-b79bf2747c4b.png)
![image](https://user-images.githubusercontent.com/1749344/210373308-23dd9b47-0428-4f95-894c-8dd6c6c2cf61.png)

The change processes the form data before using it. In case one parameter-key appears more than once, the value is translated to an `Array<string>` instead of overriding the `string`-value every time the key appears:
![image](https://user-images.githubusercontent.com/1749344/210382048-a587e9f8-5def-47d6-a12e-88db0660c2e4.png)
