### PR TITLE
Remove deletion of script PIP files after execution

### DIFF
--- a/wcfsetup/install/files/lib/system/package/plugin/DatabasePackageInstallationPlugin.class.php
+++ b/wcfsetup/install/files/lib/system/package/plugin/DatabasePackageInstallationPlugin.class.php
@@ -11,7 +11,7 @@ use wcf\util\FileUtil;
  * Executes individual database scripts during installation.
  *
  * @author  Matthias Schmidt
- * @copyright   2001-2021 WoltLab GmbH
+ * @copyright   2001-2023 WoltLab GmbH
  * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
  * @package WoltLabSuite\Core\System\Package\Plugin
  */
@@ -46,17 +46,6 @@ class DatabasePackageInstallationPlugin extends AbstractPackageInstallationPlugi
         $scriptPath = $path . $this->instruction['value'];
 
         $this->updateDatabase($scriptPath);
-
-        if (@\unlink($scriptPath)) {
-            $sql = "DELETE FROM wcf1_package_installation_file_log
-                    WHERE       packageID = ?
-                            AND filename = ?";
-            $statement = WCF::getDB()->prepare($sql);
-            $statement->execute([
-                $this->installation->getPackageID(),
-                $this->instruction['value'],
-            ]);
-        }
     }
 
     /**

--- a/wcfsetup/install/files/lib/system/package/plugin/ScriptPackageInstallationPlugin.class.php
+++ b/wcfsetup/install/files/lib/system/package/plugin/ScriptPackageInstallationPlugin.class.php
@@ -4,15 +4,13 @@ namespace wcf\system\package\plugin;
 
 use wcf\system\cache\CacheHandler;
 use wcf\system\exception\SystemException;
-use wcf\system\form\FormDocument;
-use wcf\system\WCF;
 use wcf\util\FileUtil;
 
 /**
  * Executes individual PHP scripts during installation.
  *
  * @author  Alexander Ebert
- * @copyright   2001-2019 WoltLab GmbH
+ * @copyright   2001-2023 WoltLab GmbH
  * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
  * @package WoltLabSuite\Core\System\Package\Plugin
  */
@@ -55,31 +53,13 @@ class ScriptPackageInstallationPlugin extends AbstractPackageInstallationPlugin
             CacheHandler::getInstance()->flushAll();
         }
 
-        // run script
-        $result = $this->run($path . $this->instruction['value']);
-
-        // delete script
-        if (!($result instanceof FormDocument) && @\unlink($path . $this->instruction['value'])) {
-            // delete file log entry
-            $sql = "DELETE FROM wcf1_package_installation_file_log
-                    WHERE       packageID = ?
-                            AND filename = ?";
-            $statement = WCF::getDB()->prepare($sql);
-            $statement->execute([
-                $this->installation->getPackageID(),
-                $this->instruction['value'],
-            ]);
-        }
-
-        return $result;
+        return $this->run($path . $this->instruction['value']);
     }
 
     /**
      * Runs the script with the given path.
-     *
-     * @param string $scriptPath
      */
-    private function run($scriptPath)
+    private function run(string $scriptPath)
     {
         return include($scriptPath);
     }


### PR DESCRIPTION
This does not bring any benefit and rather causes unexpected behavior:

- Devtools cannot be used to repeatedly execute the database PIP, without also
  executing the file PIP.
- Updates might reintroduce deleted files, especially `install_foo.php`
  scripts, inversely any newly installed package will have the update scripts
  lying around, making the state of the installation effectively undefined.

With the `fileDelete` PIP there is a reliable solution to delete files and
without the automated deletion of script PIPs the state of two installations
with identical package versions should also be identical in the best case.
