### PR TITLE
Add `allowCaching()` option to BackendRequest

### DIFF
--- a/ts/WoltLabSuite/Core/Ajax/Backend.ts
+++ b/ts/WoltLabSuite/Core/Ajax/Backend.ts
@@ -33,8 +33,8 @@ class SetupRequest {
     this.url = url;
   }
 
-  get(): BackendRequest {
-    return new BackendRequest(this.url, RequestType.GET);
+  get(): GetRequest {
+    return new GetRequest(this.url, RequestType.GET);
   }
 
   post(payload?: Payload): BackendRequest {
@@ -73,7 +73,7 @@ class BackendRequest {
     return this;
   }
 
-  allowCaching(): this {
+  protected allowCaching(): this {
     this.#allowCaching = true;
 
     return this;
@@ -187,6 +187,14 @@ class BackendRequest {
         LoadingIndicator.hide();
       }
     }
+  }
+}
+
+class GetRequest extends BackendRequest {
+  public allowCaching(): this {
+    super.allowCaching();
+
+    return this;
   }
 }
 

--- a/ts/WoltLabSuite/Core/Ajax/Backend.ts
+++ b/ts/WoltLabSuite/Core/Ajax/Backend.ts
@@ -51,6 +51,7 @@ class BackendRequest {
   readonly #payload?: Payload;
   #abortController?: AbortController;
   #showLoadingIndicator = true;
+  #allowCaching = false;
 
   constructor(url: string, type: RequestType, payload?: Payload) {
     this.#url = url;
@@ -68,6 +69,12 @@ class BackendRequest {
 
   disableLoadingIndicator(): this {
     this.#showLoadingIndicator = false;
+
+    return this;
+  }
+
+  allowCaching(): this {
+    this.#allowCaching = true;
 
     return this;
   }
@@ -114,7 +121,7 @@ class BackendRequest {
         },
         mode: "same-origin",
         credentials: "same-origin",
-        cache: "no-store",
+        cache: this.#allowCaching ? "default" : "no-store",
         redirect: "error",
       },
       requestOptions,

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ajax/Backend.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ajax/Backend.js
@@ -32,6 +32,7 @@ define(["require", "exports", "tslib", "./Status", "./Error", "../Core"], functi
         #payload;
         #abortController;
         #showLoadingIndicator = true;
+        #allowCaching = false;
         constructor(url, type, payload) {
             this.#url = url;
             this.#type = type;
@@ -45,6 +46,10 @@ define(["require", "exports", "tslib", "./Status", "./Error", "../Core"], functi
         }
         disableLoadingIndicator() {
             this.#showLoadingIndicator = false;
+            return this;
+        }
+        allowCaching() {
+            this.#allowCaching = true;
             return this;
         }
         async fetchAsJson() {
@@ -82,7 +87,7 @@ define(["require", "exports", "tslib", "./Status", "./Error", "../Core"], functi
                 },
                 mode: "same-origin",
                 credentials: "same-origin",
-                cache: "no-store",
+                cache: this.#allowCaching ? "default" : "no-store",
                 redirect: "error",
             }, requestOptions);
             if (this.#type === 1 /* RequestType.POST */) {

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ajax/Backend.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ajax/Backend.js
@@ -18,7 +18,7 @@ define(["require", "exports", "tslib", "./Status", "./Error", "../Core"], functi
             this.url = url;
         }
         get() {
-            return new BackendRequest(this.url, 0 /* RequestType.GET */);
+            return new GetRequest(this.url, 0 /* RequestType.GET */);
         }
         post(payload) {
             return new BackendRequest(this.url, 1 /* RequestType.POST */, payload);
@@ -147,6 +147,12 @@ define(["require", "exports", "tslib", "./Status", "./Error", "../Core"], functi
                     LoadingIndicator.hide();
                 }
             }
+        }
+    }
+    class GetRequest extends BackendRequest {
+        allowCaching() {
+            super.allowCaching();
+            return this;
         }
     }
     function prepareRequest(url) {


### PR DESCRIPTION
Not sure of this is placed correctly on the `BackendRequest`, it's not really
useful for `POST` requests and thus not providing it for
`prepareRequest().post()` might make sense. WDYT?
