### PR TITLE
Generate cleaner output in EmailGrammar::encodeQuotedPrintableHeader()

### DIFF
--- a/wcfsetup/install/files/lib/data/language/LanguageEditor.class.php
+++ b/wcfsetup/install/files/lib/data/language/LanguageEditor.class.php
@@ -290,6 +290,7 @@ class LanguageEditor extends DatabaseObjectEditor implements IEditableCachedObje
         $conditions = new PreparedStatementConditionBuilder();
         $conditions->add('packageID = ?', [$packageID]);
         $conditions->add('languageItem IN (?)', [$languageItems]);
+        $conditions->add('languageID = ?', [$this->languageID]);
         $sql = "DELETE FROM wcf1_language_item
                 {$conditions}";
         $statement = WCF::getDB()->prepare($sql);


### PR DESCRIPTION
Best reviewed with whitespace changes ignored. Please also ignore the change to LanguageEditor, I forgot to push to master before updating this PR and thus it is erroneously included in GitHub's PR diff.