### PR TITLE
Add EnforceNoCacheForTemporaryRedirects middleware

### DIFF
--- a/wcfsetup/install/files/lib/http/middleware/EnforceNoCacheForTemporaryRedirects.class.php
+++ b/wcfsetup/install/files/lib/http/middleware/EnforceNoCacheForTemporaryRedirects.class.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace wcf\http\middleware;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use wcf\http\LegacyPlaceholderResponse;
+use wcf\util\HeaderUtil;
+
+/**
+ * Sets headers disabling caching if the response status code
+ * indicates a temporary redirect.
+ *
+ * This avoids some issues with misconfigured HTTP servers or CDNs.
+ *
+ * @author  Tim Duesterhus
+ * @copyright   2001-2022 WoltLab GmbH
+ * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @package WoltLabSuite\Core\Http\Middleware
+ * @since   6.0
+ */
+final class EnforceNoCacheForTemporaryRedirects implements MiddlewareInterface
+{
+    private const TEMPORARY_REDIRECT = [
+        302, // Found
+        303, // See Other
+        307, // Temporary Redirect
+    ];
+
+    /**
+     * @inheritDoc
+     */
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $response = $handler->handle($request);
+
+        if ($response instanceof LegacyPlaceholderResponse) {
+            return $response;
+        }
+
+        if (\in_array($response->getStatusCode(), self::TEMPORARY_REDIRECT, true)) {
+            return HeaderUtil::withNoCacheHeaders($response);
+        } else {
+            return $response;
+        }
+    }
+}

--- a/wcfsetup/install/files/lib/system/request/RequestHandler.class.php
+++ b/wcfsetup/install/files/lib/system/request/RequestHandler.class.php
@@ -19,6 +19,7 @@ use wcf\http\middleware\CheckUserBan;
 use wcf\http\middleware\EnforceAcpAuthentication;
 use wcf\http\middleware\EnforceCacheControlPrivate;
 use wcf\http\middleware\EnforceFrameOptions;
+use wcf\http\middleware\EnforceNoCacheForTemporaryRedirects;
 use wcf\http\middleware\HandleStartupErrors;
 use wcf\http\middleware\HandleValinorMappingErrors;
 use wcf\http\middleware\JsonBody;
@@ -104,6 +105,7 @@ final class RequestHandler extends SingletonFactory
                     new PreventMimeSniffing(),
                     new AddAcpSecurityHeaders(),
                     new EnforceCacheControlPrivate(),
+                    new EnforceNoCacheForTemporaryRedirects(),
                     new EnforceFrameOptions(),
                     new CheckHttpMethod(),
                     new Xsrf(),


### PR DESCRIPTION
Unfortunately this is unable to catch responses created by
`HeaderUtil::redirect()`, and we can't reliably set the appropriate headers in
that method, because `sendStatusCode` defaults to `false`, allowing the
user to set an arbitrary status before calling it.
