### PR TITLE
Treewide replace `value="{@$` with `value="{$` in *.tpl

### DIFF
--- a/com.woltlab.wcf/templates/__contentLanguageFormField.tpl
+++ b/com.woltlab.wcf/templates/__contentLanguageFormField.tpl
@@ -4,7 +4,7 @@
 			<option>{lang}wcf.global.language.noSelection{/lang}</option>
 		{/if}
 		{foreach from=$field->getContentLanguages() item=contentLanguage}
-			<option value="{@$contentLanguage->languageID}">{$contentLanguage}</option>
+			<option value="{$contentLanguage->languageID}">{$contentLanguage}</option>
 		{/foreach}
 	</select>
 </noscript>

--- a/com.woltlab.wcf/templates/__labelFormField.tpl
+++ b/com.woltlab.wcf/templates/__labelFormField.tpl
@@ -18,7 +18,7 @@
 <noscript>
 	<select name="{$field->getPrefixedId()}[{@$field->getLabelGroup()->groupID}]">
 		{foreach from=$field->getLabelGroup() item=label}
-			<option value="{@$label->labelID}">{$label->getTitle()}</option>
+			<option value="{$label->labelID}">{$label->getTitle()}</option>
 		{/foreach}
 	</select>
 </noscript>

--- a/com.woltlab.wcf/templates/__labelSelection.tpl
+++ b/com.woltlab.wcf/templates/__labelSelection.tpl
@@ -21,7 +21,7 @@
 							<option value="0">{lang}wcf.label.none{/lang}</option>
 							<option value="-1">{lang}wcf.label.withoutSelection{/lang}</option>
 							{foreach from=$labelGroup item=label}
-								<option value="{@$label->labelID}"{if $labelIDs[$labelGroup->groupID]|isset && $labelIDs[$labelGroup->groupID] == $label->labelID} selected{/if}>{$label->getTitle()}</option>
+								<option value="{$label->labelID}"{if $labelIDs[$labelGroup->groupID]|isset && $labelIDs[$labelGroup->groupID] == $label->labelID} selected{/if}>{$label->getTitle()}</option>
 							{/foreach}
 						</select>
 					{/foreach}

--- a/com.woltlab.wcf/templates/__messageFormPoll.tpl
+++ b/com.woltlab.wcf/templates/__messageFormPoll.tpl
@@ -61,7 +61,7 @@
 				<label for="pollMaxVotes">{lang}wcf.poll.maxVotes{/lang}</label>
 			</dt>
 			<dd>
-				<input type="number" name="pollMaxVotes" id="pollMaxVotes" value="{@$pollMaxVotes}" min="1" class="tiny">
+				<input type="number" name="pollMaxVotes" id="pollMaxVotes" value="{$pollMaxVotes}" min="1" class="tiny">
 				{if $errorField == 'pollMaxVotes'}
 					<small class="innerError">
 						{lang}wcf.poll.maxVotes.error.{@$errorType}{/lang}

--- a/com.woltlab.wcf/templates/__messageFormPollInline.tpl
+++ b/com.woltlab.wcf/templates/__messageFormPollInline.tpl
@@ -46,7 +46,7 @@
 				<label for="pollMaxVotes_{$wysiwygSelector}">{lang}wcf.poll.maxVotes{/lang}</label>
 			</dt>
 			<dd>
-				<input type="number" name="pollMaxVotes" id="pollMaxVotes_{$wysiwygSelector}" value="{@$pollMaxVotes}" min="1" class="tiny">
+				<input type="number" name="pollMaxVotes" id="pollMaxVotes_{$wysiwygSelector}" value="{$pollMaxVotes}" min="1" class="tiny">
 			</dd>
 		</dl>
 		<dl>

--- a/com.woltlab.wcf/templates/__ratingFormField.tpl
+++ b/com.woltlab.wcf/templates/__ratingFormField.tpl
@@ -21,7 +21,7 @@
 <noscript>
 	<select name="{$field->getPrefixedId()}" {if $field->isImmutable()} disabled{/if}>
 		{foreach from=$field->getRatings() item=rating}
-			<option value="{@$rating}">{@$rating}</option>
+			<option value="{$rating}">{@$rating}</option>
 		{/foreach}
 	</select>
 </noscript>

--- a/com.woltlab.wcf/templates/aclSimple.tpl
+++ b/com.woltlab.wcf/templates/aclSimple.tpl
@@ -60,7 +60,7 @@
 						<button type="button" class="aclItemDeleteButton jsTooltip" title="{lang}wcf.global.button.delete{/lang}">
 							<fa-icon name="xmark"></fa-icon>
 						</button>
-						<input type="hidden" name="{@$__aclInputName}[group][]" value="{@$aclGroup->groupID}">
+						<input type="hidden" name="{@$__aclInputName}[group][]" value="{$aclGroup->groupID}">
 					</li>
 				{/foreach}
 				{foreach from=$aclValues[user] item=aclUser}
@@ -70,7 +70,7 @@
 						<button type="button" class="aclItemDeleteButton jsTooltip" title="{lang}wcf.global.button.delete{/lang}">
 							<fa-icon name="xmark"></fa-icon>
 						</button>
-						<input type="hidden" name="{@$__aclInputName}[user][]" value="{@$aclUser->userID}">
+						<input type="hidden" name="{@$__aclInputName}[user][]" value="{$aclUser->userID}">
 					</li>
 				{/foreach}
 			</ul>

--- a/com.woltlab.wcf/templates/articleAdd.tpl
+++ b/com.woltlab.wcf/templates/articleAdd.tpl
@@ -145,7 +145,7 @@
 					<option value="0">{lang}wcf.global.noSelection{/lang}</option>
 					
 					{foreach from=$categoryNodeList item=category}
-						<option value="{@$category->categoryID}"{if !$category->categoryID|in_array:$accessibleCategoryIDs} disabled{elseif $category->categoryID == $categoryID} selected{/if}>{if $category->getDepth() > 1}{@"&nbsp;&nbsp;&nbsp;&nbsp;"|str_repeat:($category->getDepth() - 1)}{/if}{$category->getTitle()}</option>
+						<option value="{$category->categoryID}"{if !$category->categoryID|in_array:$accessibleCategoryIDs} disabled{elseif $category->categoryID == $categoryID} selected{/if}>{if $category->getDepth() > 1}{@"&nbsp;&nbsp;&nbsp;&nbsp;"|str_repeat:($category->getDepth() - 1)}{/if}{$category->getTitle()}</option>
 					{/foreach}
 				</select>
 				{if $errorField == 'categoryID'}
@@ -183,7 +183,7 @@
 							<noscript>
 								<select name="labelIDs[{@$labelGroup->groupID}]">
 									{foreach from=$labelGroup item=label}
-										<option value="{@$label->labelID}">{$label->getTitle()}</option>
+										<option value="{$label->labelID}">{$label->getTitle()}</option>
 									{/foreach}
 								</select>
 							</noscript>
@@ -285,7 +285,7 @@
 							{/if}
 						</div>
 						<p class="button jsMediaSelectButton" data-store="imageID0" data-display="imageDisplay">{lang}wcf.media.chooseImage{/lang}</p>
-						<input type="hidden" name="imageID[0]" id="imageID0"{if $imageID[0]|isset} value="{@$imageID[0]}"{/if}>
+						<input type="hidden" name="imageID[0]" id="imageID0"{if $imageID[0]|isset} value="{$imageID[0]}"{/if}>
 						{if $errorField == 'image'}
 							<small class="innerError">{lang}wcf.acp.article.image.error.{@$errorType}{/lang}</small>
 						{/if}
@@ -310,7 +310,7 @@
 							{/if}
 						</div>
 						<p class="button jsMediaSelectButton" data-store="teaserImageID0" data-display="teaserImageDisplay">{lang}wcf.media.chooseImage{/lang}</p>
-						<input type="hidden" name="teaserImageID[0]" id="teaserImageID0"{if $teaserImageID[0]|isset} value="{@$teaserImageID[0]}"{/if}>
+						<input type="hidden" name="teaserImageID[0]" id="teaserImageID0"{if $teaserImageID[0]|isset} value="{$teaserImageID[0]}"{/if}>
 						{if $errorField == 'teaserImage'}
 							<small class="innerError">{lang}wcf.acp.article.image.error.{@$errorType}{/lang}</small>
 						{/if}
@@ -442,7 +442,7 @@
 										{/if}
 									</div>
 									<p class="button jsMediaSelectButton" data-store="imageID{@$availableLanguage->languageID}" data-display="imageDisplay{@$availableLanguage->languageID}">{lang}wcf.media.chooseImage{/lang}</p>
-									<input type="hidden" name="imageID[{@$availableLanguage->languageID}]" id="imageID{@$availableLanguage->languageID}"{if $imageID[$availableLanguage->languageID]|isset} value="{@$imageID[$availableLanguage->languageID]}"{/if}>
+									<input type="hidden" name="imageID[{@$availableLanguage->languageID}]" id="imageID{@$availableLanguage->languageID}"{if $imageID[$availableLanguage->languageID]|isset} value="{$imageID[$availableLanguage->languageID]}"{/if}>
 									{if $errorField == 'image'|concat:$availableLanguage->languageID}
 										<small class="innerError">{lang}wcf.acp.article.image.error.{@$errorType}{/lang}</small>
 									{/if}
@@ -467,7 +467,7 @@
 										{/if}
 									</div>
 									<p class="button jsMediaSelectButton" data-store="teaserImageID{@$availableLanguage->languageID}" data-display="teaserImageDisplay{@$availableLanguage->languageID}">{lang}wcf.media.chooseImage{/lang}</p>
-									<input type="hidden" name="teaserImageID[{@$availableLanguage->languageID}]" id="teaserImageID{@$availableLanguage->languageID}"{if $teaserImageID[$availableLanguage->languageID]|isset} value="{@$teaserImageID[$availableLanguage->languageID]}"{/if}>
+									<input type="hidden" name="teaserImageID[{@$availableLanguage->languageID}]" id="teaserImageID{@$availableLanguage->languageID}"{if $teaserImageID[$availableLanguage->languageID]|isset} value="{$teaserImageID[$availableLanguage->languageID]}"{/if}>
 									{if $errorField == 'teaserImage'|concat:$availableLanguage->languageID}
 										<small class="innerError">{lang}wcf.acp.article.image.error.{@$errorType}{/lang}</small>
 									{/if}
@@ -587,7 +587,7 @@
 	<div class="formSubmit">
 		<input type="submit" value="{lang}wcf.global.button.submit{/lang}" accesskey="s">
 		<button type="button" id="buttonMessagePreview" class="button jsOnly">{lang}wcf.global.button.preview{/lang}</button>
-		<input type="hidden" name="isMultilingual" value="{@$isMultilingual}">
+		<input type="hidden" name="isMultilingual" value="{$isMultilingual}">
 		<input type="hidden" name="timeNowReference" value="{@TIME_NOW}">
 		{csrfToken}
 	</div>

--- a/com.woltlab.wcf/templates/birthdaySearchableOptionType.tpl
+++ b/com.woltlab.wcf/templates/birthdaySearchableOptionType.tpl
@@ -1,5 +1,5 @@
-<input type="number" id="{$option->optionName}" name="values[{$option->optionName}][ageFrom]" value="{@$valueAgeFrom}" placeholder="{lang}wcf.user.birthday.age.from{/lang}" min="0" max="120" class="tiny">
-<input type="number" id="{$option->optionName}_age_to" name="values[{$option->optionName}][ageTo]" value="{@$valueAgeTo}" placeholder="{lang}wcf.user.birthday.age.to{/lang}" min="0" max="120" class="tiny">
+<input type="number" id="{$option->optionName}" name="values[{$option->optionName}][ageFrom]" value="{$valueAgeFrom}" placeholder="{lang}wcf.user.birthday.age.from{/lang}" min="0" max="120" class="tiny">
+<input type="number" id="{$option->optionName}_age_to" name="values[{$option->optionName}][ageTo]" value="{$valueAgeTo}" placeholder="{lang}wcf.user.birthday.age.to{/lang}" min="0" max="120" class="tiny">
 
 <script data-relocate="true">
 $(function() {

--- a/com.woltlab.wcf/templates/contact.tpl
+++ b/com.woltlab.wcf/templates/contact.tpl
@@ -51,7 +51,7 @@
 					<select name="recipientID" id="recipientID" required>
 						<option value="">{lang}wcf.global.noSelection{/lang}</option>
 						{foreach from=$recipientList item=recipient}
-							<option value="{@$recipient->recipientID}"{if $recipient->recipientID == $recipientID} selected{/if}>{$recipient}</option>
+							<option value="{$recipient->recipientID}"{if $recipient->recipientID == $recipientID} selected{/if}>{$recipient}</option>
 						{/foreach}
 					</select>
 					{if $errorField == 'recipientID'}

--- a/com.woltlab.wcf/templates/editHistory.tpl
+++ b/com.woltlab.wcf/templates/editHistory.tpl
@@ -96,7 +96,7 @@
 							<button type="button" class="jsRevertButton jsTooltip" title="{lang}wcf.edit.revert{/lang}" data-object-id="{@$edit->entryID}" data-confirm-message="{lang __encode=true}wcf.edit.revert.sure{/lang}">
 								{icon name='rotate-left'}
 							</button>
-							<input type="radio" name="oldID" value="{@$edit->entryID}"{if $oldID == $edit->entryID} checked{/if}> <input type="radio" name="newID" value="{@$edit->entryID}"{if $newID == $edit->entryID} checked{/if}>
+							<input type="radio" name="oldID" value="{$edit->entryID}"{if $oldID == $edit->entryID} checked{/if}> <input type="radio" name="newID" value="{$edit->entryID}"{if $newID == $edit->entryID} checked{/if}>
 							{event name='rowButtons'}
 						</td>
 						<td class="columnID">{#($tpl[foreach][edit][total] - $tpl[foreach][edit][iteration] + 1)}</td>

--- a/com.woltlab.wcf/templates/emailActivation.tpl
+++ b/com.woltlab.wcf/templates/emailActivation.tpl
@@ -7,7 +7,7 @@
 		<dl{if $errorField == 'u'} class="formError"{/if}>
 			<dt><label for="userID">{lang}wcf.user.userID{/lang}</label></dt>
 			<dd>
-				<input type="text" id="userID" name="u" value="{@$u}" required class="medium">
+				<input type="text" id="userID" name="u" value="{$u}" required class="medium">
 				{if $errorField == 'u'}
 					<small class="innerError">
 						{if $errorType == 'empty'}
@@ -23,7 +23,7 @@
 		<dl{if $errorField == 'a'} class="formError"{/if}>
 			<dt><label for="activationCode">{lang}wcf.user.activationCode{/lang}</label></dt>
 			<dd>
-				<input type="text" id="activationCode" maxlength="9" name="a" value="{@$a}" required class="medium">
+				<input type="text" id="activationCode" maxlength="9" name="a" value="{$a}" required class="medium">
 				{if $errorField == 'a'}
 					<small class="innerError">
 						{if $errorType == 'empty'}

--- a/com.woltlab.wcf/templates/flexibleCategoryList.tpl
+++ b/com.woltlab.wcf/templates/flexibleCategoryList.tpl
@@ -6,20 +6,20 @@
 	{foreach from=$flexibleCategoryList item=categoryItem}
 		<li>
 			<div class="containerHeadline">
-				<h3><label{if $categoryItem->getDescription()} class="jsTooltip" title="{if $categoryItem->descriptionUseHtml}{$categoryItem->getDescription()|strip_tags}{else}{$categoryItem->getDescription()}{/if}"{/if}><input type="checkbox" name="{$flexibleCategoryListName}[]" value="{@$categoryItem->categoryID}" class="jsCategory"{if $categoryItem->categoryID|in_array:$flexibleCategoryListSelectedIDs} checked{/if}> {$categoryItem->getTitle()}</label></h3>
+				<h3><label{if $categoryItem->getDescription()} class="jsTooltip" title="{if $categoryItem->descriptionUseHtml}{$categoryItem->getDescription()|strip_tags}{else}{$categoryItem->getDescription()}{/if}"{/if}><input type="checkbox" name="{$flexibleCategoryListName}[]" value="{$categoryItem->categoryID}" class="jsCategory"{if $categoryItem->categoryID|in_array:$flexibleCategoryListSelectedIDs} checked{/if}> {$categoryItem->getTitle()}</label></h3>
 			</div>
 			
 			{if $categoryItem->hasChildren()}
 				<ol>
 					{foreach from=$categoryItem item=subCategoryItem}
 						<li>
-							<label{if $subCategoryItem->getDescription()} class="jsTooltip" title="{if $subCategoryItem->descriptionUseHtml}{$subCategoryItem->getDescription()|strip_tags}{else}{$subCategoryItem->getDescription()}{/if}"{/if} style="font-size: 1rem;"><input type="checkbox" name="{$flexibleCategoryListName}[]" value="{@$subCategoryItem->categoryID}" class="jsChildCategory"{if $subCategoryItem->categoryID|in_array:$flexibleCategoryListSelectedIDs} checked{/if}> {$subCategoryItem->getTitle()}</label>
+							<label{if $subCategoryItem->getDescription()} class="jsTooltip" title="{if $subCategoryItem->descriptionUseHtml}{$subCategoryItem->getDescription()|strip_tags}{else}{$subCategoryItem->getDescription()}{/if}"{/if} style="font-size: 1rem;"><input type="checkbox" name="{$flexibleCategoryListName}[]" value="{$subCategoryItem->categoryID}" class="jsChildCategory"{if $subCategoryItem->categoryID|in_array:$flexibleCategoryListSelectedIDs} checked{/if}> {$subCategoryItem->getTitle()}</label>
 							
 							{if $subCategoryItem->hasChildren()}
 								<ol>
 									{foreach from=$subCategoryItem item=subSubCategoryItem}
 										<li>
-											<label{if $subSubCategoryItem->getDescription()} class="jsTooltip" title="{if $subSubCategoryItem->descriptionUseHtml}{$subSubCategoryItem->getDescription()|strip_tags}{else}{$subSubCategoryItem->getDescription()}{/if}"{/if}><input type="checkbox" name="{$flexibleCategoryListName}[]" value="{@$subSubCategoryItem->categoryID}" class="jsSubChildCategory"{if $subSubCategoryItem->categoryID|in_array:$flexibleCategoryListSelectedIDs} checked{/if}> {$subSubCategoryItem->getTitle()}</label>
+											<label{if $subSubCategoryItem->getDescription()} class="jsTooltip" title="{if $subSubCategoryItem->descriptionUseHtml}{$subSubCategoryItem->getDescription()|strip_tags}{else}{$subSubCategoryItem->getDescription()}{/if}"{/if}><input type="checkbox" name="{$flexibleCategoryListName}[]" value="{$subSubCategoryItem->categoryID}" class="jsSubChildCategory"{if $subSubCategoryItem->categoryID|in_array:$flexibleCategoryListSelectedIDs} checked{/if}> {$subSubCategoryItem->getTitle()}</label>
 										</li>
 									{/foreach}
 								</ol>

--- a/com.woltlab.wcf/templates/languageChooser.tpl
+++ b/com.woltlab.wcf/templates/languageChooser.tpl
@@ -8,7 +8,7 @@
 			<noscript>
 				<select name="{@$__languageChooserPrefix}languageID" id="{@$__languageChooserPrefix}languageID">
 					{foreach from=$languages item=_language}
-						<option value="{@$_language->languageID}">{$_language}</option>
+						<option value="{$_language->languageID}">{$_language}</option>
 					{/foreach}
 				</select>
 			</noscript>

--- a/com.woltlab.wcf/templates/messageFormMultilingualism.tpl
+++ b/com.woltlab.wcf/templates/messageFormMultilingualism.tpl
@@ -5,7 +5,7 @@
 			<noscript>
 				<select name="languageID" id="languageID">
 					{foreach from=$availableContentLanguages item=contentLanguage}
-						<option value="{@$contentLanguage->languageID}">{$contentLanguage}</option>
+						<option value="{$contentLanguage->languageID}">{$contentLanguage}</option>
 					{/foreach}
 				</select>
 			</noscript>

--- a/com.woltlab.wcf/templates/moderationList.tpl
+++ b/com.woltlab.wcf/templates/moderationList.tpl
@@ -204,7 +204,7 @@
 					<select name="assignedUserID" id="assignedUserID">
 						<option value="-1"{if $assignedUserID == -1} selected{/if}>{lang}wcf.moderation.filterByUser.allEntries{/lang}</option>
 						<option value="0"{if $assignedUserID == 0} selected{/if}>{lang}wcf.moderation.filterByUser.nobody{/lang}</option>
-						<option value="{@$__wcf->getUser()->userID}"{if $assignedUserID == $__wcf->getUser()->userID} selected{/if}>{lang}wcf.moderation.filterByUser.myself{/lang}</option>
+						<option value="{$__wcf->getUser()->userID}"{if $assignedUserID == $__wcf->getUser()->userID} selected{/if}>{lang}wcf.moderation.filterByUser.myself{/lang}</option>
 						
 						{event name='filterAssignedUser'}
 					</select>

--- a/com.woltlab.wcf/templates/pollVote.tpl
+++ b/com.woltlab.wcf/templates/pollVote.tpl
@@ -3,7 +3,7 @@
 		<dt></dt>
 		<dd>
 			<label>
-				{if $poll->canVote()}<input type="{if $poll->maxVotes > 1}checkbox{else}radio{/if}" name="pollOptions{@$poll->pollID}[]" value="{@$option->optionID}"{if $option->voted} checked{/if}>{/if}
+				{if $poll->canVote()}<input type="{if $poll->maxVotes > 1}checkbox{else}radio{/if}" name="pollOptions{@$poll->pollID}[]" value="{$option->optionID}"{if $option->voted} checked{/if}>{/if}
 				{$option->optionValue}
 			</label>
 		</dd>

--- a/com.woltlab.wcf/templates/register.tpl
+++ b/com.woltlab.wcf/templates/register.tpl
@@ -174,7 +174,7 @@
 					<noscript>
 						<select name="languageID" id="languageID">
 							{foreach from=$availableLanguages item=language}
-								<option value="{@$language->languageID}"{if $language->languageID == $languageID} selected{/if}>{$language}</option>
+								<option value="{$language->languageID}"{if $language->languageID == $languageID} selected{/if}>{$language}</option>
 							{/foreach}
 						</select>
 					</noscript>
@@ -187,7 +187,7 @@
 					<dd class="floated">
 					{content}
 						{foreach from=$availableContentLanguages item=language}
-							<label><input name="visibleLanguages[]" type="checkbox" value="{@$language->languageID}"{if $language->languageID|in_array:$visibleLanguages} checked{/if}> {$language}</label>
+							<label><input name="visibleLanguages[]" type="checkbox" value="{$language->languageID}"{if $language->languageID|in_array:$visibleLanguages} checked{/if}> {$language}</label>
 						{/foreach}
 					{/content}
 					<small>{lang}wcf.user.visibleLanguages.description{/lang}</small></dd>

--- a/com.woltlab.wcf/templates/scrollablePageCheckboxList.tpl
+++ b/com.woltlab.wcf/templates/scrollablePageCheckboxList.tpl
@@ -17,7 +17,7 @@
 <ul class="scrollableCheckboxList" id="{@$pageCheckboxListContainerID}">
 	{foreach from=$pageNodeList item=pageNode}
 		<li{if $pageNode->getDepth() > 1} style="padding-left: {$pageNode->getDepth()*20-20}px"{/if}>
-			<label><input type="checkbox" name="{@$pageCheckboxID}[]" value="{@$pageNode->pageID}" data-identifier="{@$pageNode->identifier}"{if $pageNode->pageID|in_array:$pageIDs} checked{/if}> {$pageNode->name}</label>
+			<label><input type="checkbox" name="{@$pageCheckboxID}[]" value="{$pageNode->pageID}" data-identifier="{@$pageNode->identifier}"{if $pageNode->pageID|in_array:$pageIDs} checked{/if}> {$pageNode->name}</label>
 		</li>
 	{/foreach}
 </ul>

--- a/com.woltlab.wcf/templates/search.tpl
+++ b/com.woltlab.wcf/templates/search.tpl
@@ -8,7 +8,7 @@
 				<option value="">{lang}wcf.search.type.everywhere{/lang}</option>
 				{foreach from=$objectTypes key=objectTypeName item=objectType}
 					{if $objectType->isAccessible()}
-						<option value="{@$objectTypeName}">{lang}wcf.search.type.{@$objectTypeName}{/lang}</option>
+						<option value="{$objectTypeName}">{lang}wcf.search.type.{@$objectTypeName}{/lang}</option>
 					{/if}
 				{/foreach}
 			</select>

--- a/com.woltlab.wcf/templates/searchArticle.tpl
+++ b/com.woltlab.wcf/templates/searchArticle.tpl
@@ -4,7 +4,7 @@
 		<select name="articleCategoryID" id="articleCategoryID">
 			<option value="">{lang}wcf.global.noSelection{/lang}</option>
 			{foreach from=$articleCategoryList item=category}
-				<option value="{@$category->categoryID}">{if $category->getDepth() > 1}{@'&nbsp;&nbsp;&nbsp;&nbsp;'|str_repeat:-1+$category->getDepth()}{/if}{$category->getTitle()}</option>
+				<option value="{$category->categoryID}">{if $category->getDepth() > 1}{@'&nbsp;&nbsp;&nbsp;&nbsp;'|str_repeat:-1+$category->getDepth()}{/if}{$category->getTitle()}</option>
 			{/foreach}
 		</select>
 	</dd>

--- a/com.woltlab.wcf/templates/settings.tpl
+++ b/com.woltlab.wcf/templates/settings.tpl
@@ -44,7 +44,7 @@
 						<noscript>
 							<select name="languageID" id="languageID">
 								{foreach from=$availableLanguages item=language}
-									<option value="{@$language->languageID}"{if $language->languageID == $languageID} selected{/if}>{$language}</option>
+									<option value="{$language->languageID}"{if $language->languageID == $languageID} selected{/if}>{$language}</option>
 								{/foreach}
 							</select>
 						</noscript>
@@ -57,7 +57,7 @@
 						<dd class="floated">
 						{content}
 							{foreach from=$availableContentLanguages item=language}
-								<label><input name="contentLanguageIDs[]" type="checkbox" value="{@$language->languageID}"{if $language->languageID|in_array:$contentLanguageIDs} checked{/if}> {$language}</label>
+								<label><input name="contentLanguageIDs[]" type="checkbox" value="{$language->languageID}"{if $language->languageID|in_array:$contentLanguageIDs} checked{/if}> {$language}</label>
 							{/foreach}
 						{/content}
 						<small>{lang}wcf.user.visibleLanguages.description{/lang}</small></dd>
@@ -78,7 +78,7 @@
 						<select id="styleID" name="styleID">
 							<option value="0">{lang}wcf.global.defaultValue{/lang}</option>
 							{foreach from=$availableStyles item=style}
-								<option value="{@$style->styleID}"{if $style->styleID == $styleID} selected{/if}>{$style->styleName}</option>
+								<option value="{$style->styleID}"{if $style->styleID == $styleID} selected{/if}>{$style->styleName}</option>
 							{/foreach}
 						</select>
 						<small>{lang}wcf.user.style.description{/lang}</small>

--- a/wcfsetup/install/files/acp/templates/__contentLanguageFormField.tpl
+++ b/wcfsetup/install/files/acp/templates/__contentLanguageFormField.tpl
@@ -4,7 +4,7 @@
 			<option>{lang}wcf.global.language.noSelection{/lang}</option>
 		{/if}
 		{foreach from=$field->getContentLanguages() item=contentLanguage}
-			<option value="{@$contentLanguage->languageID}">{$contentLanguage}</option>
+			<option value="{$contentLanguage->languageID}">{$contentLanguage}</option>
 		{/foreach}
 	</select>
 </noscript>

--- a/wcfsetup/install/files/acp/templates/__devtoolsProjectInstructionsFormField.tpl
+++ b/wcfsetup/install/files/acp/templates/__devtoolsProjectInstructionsFormField.tpl
@@ -62,7 +62,7 @@
 						<select id="{$field->getPrefixedId()}_instructions{literal}{$instructionsId}{/literal}_pip">
 							<option value="" selected disabled>{lang}wcf.acp.devtools.project.instruction.packageInstallationPlugin{/lang}</option>
 							{foreach from=$packageInstallationPlugins item=packageInstallationPlugin}
-								<option value="{@$packageInstallationPlugin->pluginName}">{@$packageInstallationPlugin->pluginName}</option>
+								<option value="{$packageInstallationPlugin->pluginName}">{@$packageInstallationPlugin->pluginName}</option>
 							{/foreach}
 						</select>
 					</dd>
@@ -82,7 +82,7 @@
 						<select id="{$field->getPrefixedId()}_instructions{literal}{$instructionsId}{/literal}_application">
 							<option value="" selected disabled>{lang}wcf.acp.devtools.project.instruction.application{/lang}</option>
 							{foreach from=$apps item=app}
-								<option value="{@$app->getAbbreviation()}">{@$app->getAbbreviation()}</option>
+								<option value="{$app->getAbbreviation()}">{@$app->getAbbreviation()}</option>
 							{/foreach}
 						</select>
 					</dd>
@@ -129,7 +129,7 @@
 						<select name="pip">
 							<option value="" selected>{lang}wcf.global.noSelection{/lang}</option>
 							{foreach from=$packageInstallationPlugins item=packageInstallationPlugin}
-								<option value="{@$packageInstallationPlugin->pluginName}">{@$packageInstallationPlugin->pluginName}</option>
+								<option value="{$packageInstallationPlugin->pluginName}">{@$packageInstallationPlugin->pluginName}</option>
 							{/foreach}
 						</select>
 					</dd>
@@ -149,7 +149,7 @@
 						<select name="application">
 							<option value="" selected>{lang}wcf.global.noSelection{/lang}</option>
 							{foreach from=$apps item=app}
-								<option value="{@$app->getAbbreviation()}">{@$app->getAbbreviation()}</option>
+								<option value="{$app->getAbbreviation()}">{@$app->getAbbreviation()}</option>
 							{/foreach}
 						</select>
 					</dd>

--- a/wcfsetup/install/files/acp/templates/__labelFormField.tpl
+++ b/wcfsetup/install/files/acp/templates/__labelFormField.tpl
@@ -18,7 +18,7 @@
 <noscript>
 	<select name="{$field->getPrefixedId()}[{@$field->getLabelGroup()->groupID}]">
 		{foreach from=$field->getLabelGroup() item=label}
-			<option value="{@$label->labelID}">{$label->getTitle()}</option>
+			<option value="{$label->labelID}">{$label->getTitle()}</option>
 		{/foreach}
 	</select>
 </noscript>

--- a/wcfsetup/install/files/acp/templates/__ratingFormField.tpl
+++ b/wcfsetup/install/files/acp/templates/__ratingFormField.tpl
@@ -21,7 +21,7 @@
 <noscript>
 	<select name="{$field->getPrefixedId()}" {if $field->isImmutable()} disabled{/if}>
 		{foreach from=$field->getRatings() item=rating}
-			<option value="{@$rating}">{@$rating}</option>
+			<option value="{$rating}">{@$rating}</option>
 		{/foreach}
 	</select>
 </noscript>

--- a/wcfsetup/install/files/acp/templates/aclSimple.tpl
+++ b/wcfsetup/install/files/acp/templates/aclSimple.tpl
@@ -60,7 +60,7 @@
 						<button type="button" class="aclItemDeleteButton jsTooltip" title="{lang}wcf.global.button.delete{/lang}">
 							<fa-icon name="xmark"></fa-icon>
 						</button>
-						<input type="hidden" name="{@$__aclInputName}[group][]" value="{@$aclGroup->groupID}">
+						<input type="hidden" name="{@$__aclInputName}[group][]" value="{$aclGroup->groupID}">
 					</li>
 				{/foreach}
 				{foreach from=$aclValues[user] item=aclUser}
@@ -70,7 +70,7 @@
 						<button type="button" class="aclItemDeleteButton jsTooltip" title="{lang}wcf.global.button.delete{/lang}">
 							<fa-icon name="xmark"></fa-icon>
 						</button>
-						<input type="hidden" name="{@$__aclInputName}[user][]" value="{@$aclUser->userID}">
+						<input type="hidden" name="{@$__aclInputName}[user][]" value="{$aclUser->userID}">
 					</li>
 				{/foreach}
 			</ul>

--- a/wcfsetup/install/files/acp/templates/adAdd.tpl
+++ b/wcfsetup/install/files/acp/templates/adAdd.tpl
@@ -75,7 +75,7 @@
 						{assign var='__firstLocationID' value=$locationGroup|key}
 						<optgroup label="{$locationGroupLabel}" data-category-name="{@$locationObjectTypes[$__firstLocationID]->categoryname}">
 							{foreach from=$locationGroup key='locationID' item='location'}
-								<option value="{@$locationID}"{if $locationObjectTypes[$locationID]->page} data-page="{$locationObjectTypes[$locationID]->page}"{/if}{if $objectTypeID == $locationID} selected{/if}>{$location}</option>
+								<option value="{$locationID}"{if $locationObjectTypes[$locationID]->page} data-page="{$locationObjectTypes[$locationID]->page}"{/if}{if $objectTypeID == $locationID} selected{/if}>{$location}</option>
 							{/foreach}
 						</optgroup>
 					{/foreach}

--- a/wcfsetup/install/files/acp/templates/applicationManagement.tpl
+++ b/wcfsetup/install/files/acp/templates/applicationManagement.tpl
@@ -101,7 +101,7 @@
 									
 									{foreach from=$pageNodeList item=pageNode}
 										{if !$pageNode->isDisabled && !$pageNode->requireObjectID && !$pageNode->excludeFromLandingPage}
-											<option value="{@$pageNode->pageID}"{if $pageNode->pageID == $application->landingPageID} selected{/if} data-identifier="{@$pageNode->identifier}">{if $pageNode->getDepth() > 1}{@"&nbsp;&nbsp;&nbsp;&nbsp;"|str_repeat:($pageNode->getDepth() - 1)}{/if}{$pageNode->name}</option>
+											<option value="{$pageNode->pageID}"{if $pageNode->pageID == $application->landingPageID} selected{/if} data-identifier="{@$pageNode->identifier}">{if $pageNode->getDepth() > 1}{@"&nbsp;&nbsp;&nbsp;&nbsp;"|str_repeat:($pageNode->getDepth() - 1)}{/if}{$pageNode->name}</option>
 										{/if}
 									{/foreach}
 								</select>

--- a/wcfsetup/install/files/acp/templates/articleAdd.tpl
+++ b/wcfsetup/install/files/acp/templates/articleAdd.tpl
@@ -146,7 +146,7 @@
 					<option value="0">{lang}wcf.global.noSelection{/lang}</option>
 					
 					{foreach from=$categoryNodeList item=category}
-						<option value="{@$category->categoryID}"{if !$category->categoryID|in_array:$accessibleCategoryIDs} disabled{elseif $category->categoryID == $categoryID} selected{/if}>{if $category->getDepth() > 1}{@"&nbsp;&nbsp;&nbsp;&nbsp;"|str_repeat:($category->getDepth() - 1)}{/if}{$category->getTitle()}</option>
+						<option value="{$category->categoryID}"{if !$category->categoryID|in_array:$accessibleCategoryIDs} disabled{elseif $category->categoryID == $categoryID} selected{/if}>{if $category->getDepth() > 1}{@"&nbsp;&nbsp;&nbsp;&nbsp;"|str_repeat:($category->getDepth() - 1)}{/if}{$category->getTitle()}</option>
 					{/foreach}
 				</select>
 				{if $errorField == 'categoryID'}
@@ -184,7 +184,7 @@
 							<noscript>
 								<select name="labelIDs[{@$labelGroup->groupID}]">
 									{foreach from=$labelGroup item=label}
-										<option value="{@$label->labelID}">{$label->getTitle()}</option>
+										<option value="{$label->labelID}">{$label->getTitle()}</option>
 									{/foreach}
 								</select>
 							</noscript>
@@ -286,7 +286,7 @@
 							{/if}
 						</div>
 						<p class="button jsMediaSelectButton" data-store="imageID0" data-display="imageDisplay">{lang}wcf.media.chooseImage{/lang}</p>
-						<input type="hidden" name="imageID[0]" id="imageID0"{if $imageID[0]|isset} value="{@$imageID[0]}"{/if}>
+						<input type="hidden" name="imageID[0]" id="imageID0"{if $imageID[0]|isset} value="{$imageID[0]}"{/if}>
 						{if $errorField == 'image'}
 							<small class="innerError">{lang}wcf.acp.article.image.error.{@$errorType}{/lang}</small>
 						{/if}
@@ -311,7 +311,7 @@
 							{/if}
 						</div>
 						<p class="button jsMediaSelectButton" data-store="teaserImageID0" data-display="teaserImageDisplay">{lang}wcf.media.chooseImage{/lang}</p>
-						<input type="hidden" name="teaserImageID[0]" id="teaserImageID0"{if $teaserImageID[0]|isset} value="{@$teaserImageID[0]}"{/if}>
+						<input type="hidden" name="teaserImageID[0]" id="teaserImageID0"{if $teaserImageID[0]|isset} value="{$teaserImageID[0]}"{/if}>
 						{if $errorField == 'teaserImage'}
 							<small class="innerError">{lang}wcf.acp.article.image.error.{@$errorType}{/lang}</small>
 						{/if}
@@ -443,7 +443,7 @@
 										{/if}
 									</div>
 									<p class="button jsMediaSelectButton" data-store="imageID{@$availableLanguage->languageID}" data-display="imageDisplay{@$availableLanguage->languageID}">{lang}wcf.media.chooseImage{/lang}</p>
-									<input type="hidden" name="imageID[{@$availableLanguage->languageID}]" id="imageID{@$availableLanguage->languageID}"{if $imageID[$availableLanguage->languageID]|isset} value="{@$imageID[$availableLanguage->languageID]}"{/if}>
+									<input type="hidden" name="imageID[{@$availableLanguage->languageID}]" id="imageID{@$availableLanguage->languageID}"{if $imageID[$availableLanguage->languageID]|isset} value="{$imageID[$availableLanguage->languageID]}"{/if}>
 									{if $errorField == 'image'|concat:$availableLanguage->languageID}
 										<small class="innerError">{lang}wcf.acp.article.image.error.{@$errorType}{/lang}</small>
 									{/if}
@@ -468,7 +468,7 @@
 										{/if}
 									</div>
 									<p class="button jsMediaSelectButton" data-store="teaserImageID{@$availableLanguage->languageID}" data-display="teaserImageDisplay{@$availableLanguage->languageID}">{lang}wcf.media.chooseImage{/lang}</p>
-									<input type="hidden" name="teaserImageID[{@$availableLanguage->languageID}]" id="teaserImageID{@$availableLanguage->languageID}"{if $teaserImageID[$availableLanguage->languageID]|isset} value="{@$teaserImageID[$availableLanguage->languageID]}"{/if}>
+									<input type="hidden" name="teaserImageID[{@$availableLanguage->languageID}]" id="teaserImageID{@$availableLanguage->languageID}"{if $teaserImageID[$availableLanguage->languageID]|isset} value="{$teaserImageID[$availableLanguage->languageID]}"{/if}>
 									{if $errorField == 'teaserImage'|concat:$availableLanguage->languageID}
 										<small class="innerError">{lang}wcf.acp.article.image.error.{@$errorType}{/lang}</small>
 									{/if}
@@ -588,7 +588,7 @@
 	<div class="formSubmit">
 		<input type="submit" value="{lang}wcf.global.button.submit{/lang}" accesskey="s">
 		<button type="button" id="buttonMessagePreview" class="button jsOnly">{lang}wcf.global.button.preview{/lang}</button>
-		<input type="hidden" name="isMultilingual" value="{@$isMultilingual}">
+		<input type="hidden" name="isMultilingual" value="{$isMultilingual}">
 		<input type="hidden" name="timeNowReference" value="{@TIME_NOW}">
 		{csrfToken}
 	</div>

--- a/wcfsetup/install/files/acp/templates/articleCategoryDialog.tpl
+++ b/wcfsetup/install/files/acp/templates/articleCategoryDialog.tpl
@@ -6,7 +6,7 @@
 				<option value="0">{lang}wcf.global.noSelection{/lang}</option>
 				
 				{foreach from=$categoryNodeList item=category}
-					<option value="{@$category->categoryID}">{if $category->getDepth() > 1}{@"&nbsp;&nbsp;&nbsp;&nbsp;"|str_repeat:($category->getDepth() - 1)}{/if}{$category->getTitle()}</option>
+					<option value="{$category->categoryID}">{if $category->getDepth() > 1}{@"&nbsp;&nbsp;&nbsp;&nbsp;"|str_repeat:($category->getDepth() - 1)}{/if}{$category->getTitle()}</option>
 				{/foreach}
 			</select>
 		</dd>

--- a/wcfsetup/install/files/acp/templates/articleList.tpl
+++ b/wcfsetup/install/files/acp/templates/articleList.tpl
@@ -49,7 +49,7 @@
 						<option value="0">{lang}wcf.acp.article.category{/lang}</option>
 						
 						{foreach from=$categoryNodeList item=category}
-							<option value="{@$category->categoryID}"{if $category->categoryID == $categoryID} selected{/if}>{if $category->getDepth() > 1}{@"&nbsp;&nbsp;&nbsp;&nbsp;"|str_repeat:($category->getDepth() - 1)}{/if}{$category->getTitle()}</option>
+							<option value="{$category->categoryID}"{if $category->categoryID == $categoryID} selected{/if}>{if $category->getDepth() > 1}{@"&nbsp;&nbsp;&nbsp;&nbsp;"|str_repeat:($category->getDepth() - 1)}{/if}{$category->getTitle()}</option>
 						{/foreach}
 					</select>
 				</dd>

--- a/wcfsetup/install/files/acp/templates/birthdaySearchableOptionType.tpl
+++ b/wcfsetup/install/files/acp/templates/birthdaySearchableOptionType.tpl
@@ -1,5 +1,5 @@
-<input type="number" id="{$option->optionName}_age_from" name="values[{$option->optionName}][ageFrom]" value="{@$valueAgeFrom}" placeholder="{lang}wcf.user.birthday.age.from{/lang}" min="0" max="120" class="tiny">
-<input type="number" id="{$option->optionName}_age_to" name="values[{$option->optionName}][ageTo]" value="{@$valueAgeTo}" placeholder="{lang}wcf.user.birthday.age.to{/lang}" min="0" max="120" class="tiny">
+<input type="number" id="{$option->optionName}_age_from" name="values[{$option->optionName}][ageFrom]" value="{$valueAgeFrom}" placeholder="{lang}wcf.user.birthday.age.from{/lang}" min="0" max="120" class="tiny">
+<input type="number" id="{$option->optionName}_age_to" name="values[{$option->optionName}][ageTo]" value="{$valueAgeTo}" placeholder="{lang}wcf.user.birthday.age.to{/lang}" min="0" max="120" class="tiny">
 
 <script data-relocate="true">
 $(function() {

--- a/wcfsetup/install/files/acp/templates/boxAdd.tpl
+++ b/wcfsetup/install/files/acp/templates/boxAdd.tpl
@@ -127,7 +127,7 @@
 						<dd>
 							<select name="boxControllerID" id="boxControllerID">
 								{foreach from=$availableBoxControllers item=availableBoxController}
-									<option value="{@$availableBoxController->objectTypeID}"{if $boxController && $availableBoxController->objectTypeID == $boxController->objectTypeID} selected{/if} data-supported-positions='[{implode from=$availableBoxPositions[$availableBoxController->objectTypeID] item=$__position}"{$__position}"{/implode}]'>{lang}wcf.acp.box.boxController.{@$availableBoxController->objectType}{/lang}</option>
+									<option value="{$availableBoxController->objectTypeID}"{if $boxController && $availableBoxController->objectTypeID == $boxController->objectTypeID} selected{/if} data-supported-positions='[{implode from=$availableBoxPositions[$availableBoxController->objectTypeID] item=$__position}"{$__position}"{/implode}]'>{lang}wcf.acp.box.boxController.{@$availableBoxController->objectType}{/lang}</option>
 								{/foreach}
 							</select>
 
@@ -149,7 +149,7 @@
 					<dd>
 						<select name="position" id="position">
 							{foreach from=$availablePositions item=availablePosition}
-								<option value="{@$availablePosition}"{if $availablePosition == $position} selected{/if}>{lang}wcf.acp.box.position.{@$availablePosition}{/lang}</option>
+								<option value="{$availablePosition}"{if $availablePosition == $position} selected{/if}>{lang}wcf.acp.box.position.{@$availablePosition}{/lang}</option>
 							{/foreach}
 						</select>
 
@@ -168,7 +168,7 @@
 				<dl>
 					<dt><label for="showOrder">{lang}wcf.global.showOrder{/lang}</label></dt>
 					<dd>
-						<input type="number" id="showOrder" name="showOrder" value="{@$showOrder}" class="tiny" min="0">
+						<input type="number" id="showOrder" name="showOrder" value="{$showOrder}" class="tiny" min="0">
 					</dd>
 				</dl>
 
@@ -227,7 +227,7 @@
 								<option value="0">{lang}wcf.global.noSelection{/lang}</option>
 
 								{foreach from=$pageNodeList item=pageNode}
-									<option value="{@$pageNode->pageID}"{if $pageNode->pageID == $linkPageID} selected{/if} data-identifier="{@$pageNode->identifier}">{if $pageNode->getDepth() > 1}{@"&nbsp;&nbsp;&nbsp;&nbsp;"|str_repeat:($pageNode->getDepth() - 1)}{/if}{$pageNode->name}</option>
+									<option value="{$pageNode->pageID}"{if $pageNode->pageID == $linkPageID} selected{/if} data-identifier="{@$pageNode->identifier}">{if $pageNode->getDepth() > 1}{@"&nbsp;&nbsp;&nbsp;&nbsp;"|str_repeat:($pageNode->getDepth() - 1)}{/if}{$pageNode->name}</option>
 								{/foreach}
 							</select>
 							{if $errorField == 'linkPageID'}
@@ -301,7 +301,7 @@
 									{/if}
 								</div>
 								<p class="button jsMediaSelectButton" data-store="imageID0" data-display="imageDisplay">{lang}wcf.media.chooseImage{/lang}</p>
-								<input type="hidden" name="imageID[0]" id="imageID0"{if $imageID[0]|isset} value="{@$imageID[0]}"{/if}>
+								<input type="hidden" name="imageID[0]" id="imageID0"{if $imageID[0]|isset} value="{$imageID[0]}"{/if}>
 								{if $errorField == 'image'}
 									<small class="innerError">{lang}wcf.acp.box.image.error.{@$errorType}{/lang}</small>
 								{/if}
@@ -377,7 +377,7 @@
 													{/if}
 												</div>
 												<p class="button jsMediaSelectButton" data-store="imageID{@$availableLanguage->languageID}" data-display="imageDisplay{@$availableLanguage->languageID}">{lang}wcf.media.chooseImage{/lang}</p>
-												<input type="hidden" name="imageID[{@$availableLanguage->languageID}]" id="imageID{@$availableLanguage->languageID}"{if $imageID[$availableLanguage->languageID]|isset} value="{@$imageID[$availableLanguage->languageID]}"{/if}>
+												<input type="hidden" name="imageID[{@$availableLanguage->languageID}]" id="imageID{@$availableLanguage->languageID}"{if $imageID[$availableLanguage->languageID]|isset} value="{$imageID[$availableLanguage->languageID]}"{/if}>
 												{if $errorField == 'image'|concat:$availableLanguage->languageID}
 													<small class="innerError">{lang}wcf.acp.box.image.error.{@$errorType}{/lang}</small>
 												{/if}
@@ -512,7 +512,7 @@
 
 	<div class="formSubmit">
 		<input type="submit" value="{lang}wcf.global.button.submit{/lang}" accesskey="s">
-		<input type="hidden" name="isMultilingual" value="{@$isMultilingual}">
+		<input type="hidden" name="isMultilingual" value="{$isMultilingual}">
 		<input type="hidden" name="boxType" value="{$boxType}">
 		{csrfToken}
 	</div>

--- a/wcfsetup/install/files/acp/templates/boxList.tpl
+++ b/wcfsetup/install/files/acp/templates/boxList.tpl
@@ -51,7 +51,7 @@
 					<select name="position" id="boxPosition">
 						<option value="0">{lang}wcf.acp.box.position{/lang}</option>
 						{foreach from=$availablePositions item=availablePosition}
-							<option value="{@$availablePosition}"{if $availablePosition == $position} selected{/if}>{lang}wcf.acp.box.position.{@$availablePosition}{/lang}</option>
+							<option value="{$availablePosition}"{if $availablePosition == $position} selected{/if}>{lang}wcf.acp.box.position.{@$availablePosition}{/lang}</option>
 						{/foreach}
 					</select>
 				</dd>

--- a/wcfsetup/install/files/acp/templates/bulkProcessing.tpl
+++ b/wcfsetup/install/files/acp/templates/bulkProcessing.tpl
@@ -46,7 +46,7 @@
 			<dt></dt>
 			<dd>
 				{foreach from=$actions item=actionObjectType}
-					<label><input type="radio" name="action" value="{@$actionObjectType->action}"{if $actionObjectType->action == $action} checked{/if}> {lang}{$objectType->getProcessor()->getLanguageItemPrefix()}.{@$actionObjectType->action}{/lang}</label>
+					<label><input type="radio" name="action" value="{$actionObjectType->action}"{if $actionObjectType->action == $action} checked{/if}> {lang}{$objectType->getProcessor()->getLanguageItemPrefix()}.{@$actionObjectType->action}{/lang}</label>
 				{/foreach}
 				
 				{if $errorField == 'action'}

--- a/wcfsetup/install/files/acp/templates/contactRecipientAdd.tpl
+++ b/wcfsetup/install/files/acp/templates/contactRecipientAdd.tpl
@@ -84,7 +84,7 @@
 	
 	<div class="formSubmit">
 		<input type="submit" value="{lang}wcf.global.button.submit{/lang}" accesskey="s">
-		<input type="hidden" name="action" value="{@$action}">
+		<input type="hidden" name="action" value="{$action}">
 		{csrfToken}
 	</div>
 </form>

--- a/wcfsetup/install/files/acp/templates/cronjobLogList.tpl
+++ b/wcfsetup/install/files/acp/templates/cronjobLogList.tpl
@@ -42,7 +42,7 @@
 					<select name="cronjobID" aria-label="{lang}wcf.acp.cronjob.description{/lang}">
 						<option value="0">{lang}wcf.acp.cronjob.description{/lang}</option>
 						{foreach from=$availableCronjobs item=availableCronjob}
-							<option value="{@$availableCronjob->cronjobID}"{if $availableCronjob->cronjobID == $cronjobID} selected{/if}>{$availableCronjob->getDescription()}</option>
+							<option value="{$availableCronjob->cronjobID}"{if $availableCronjob->cronjobID == $cronjobID} selected{/if}>{$availableCronjob->getDescription()}</option>
 						{/foreach}
 					</select>
 				</dd>

--- a/wcfsetup/install/files/acp/templates/customOptionAdd.tpl
+++ b/wcfsetup/install/files/acp/templates/customOptionAdd.tpl
@@ -55,7 +55,7 @@
 	<dl>
 		<dt><label for="showOrder">{lang}wcf.acp.customOption.showOrder{/lang}</label></dt>
 		<dd>
-			<input type="number" id="showOrder" name="showOrder" value="{@$showOrder}" class="short">
+			<input type="number" id="showOrder" name="showOrder" value="{$showOrder}" class="short">
 		</dd>
 	</dl>
 	

--- a/wcfsetup/install/files/acp/templates/dataImport.tpl
+++ b/wcfsetup/install/files/acp/templates/dataImport.tpl
@@ -75,7 +75,7 @@
 					<dd>
 						<select name="exporterName" id="exporterName">
 							{foreach from=$availableExporters key=availableExporterName item=availableExporter}
-								<option value="{@$availableExporterName}">{lang}wcf.acp.dataImport.exporter.{@$availableExporterName}{/lang}</option>
+								<option value="{$availableExporterName}">{lang}wcf.acp.dataImport.exporter.{@$availableExporterName}{/lang}</option>
 							{/foreach}
 						</select>
 						{if $errorField == 'exporterName'}
@@ -112,10 +112,10 @@
 				<dl class="wide">
 					<dt></dt>
 					<dd class="jsImportCollection">
-						<label><input type="checkbox" name="selectedData[]" value="{@$objectTypeName}" class="jsImportSection"{if $objectTypeName|in_array:$selectedData} checked{/if}> {lang}wcf.acp.dataImport.data.{@$objectTypeName}{/lang}</label>
+						<label><input type="checkbox" name="selectedData[]" value="{$objectTypeName}" class="jsImportSection"{if $objectTypeName|in_array:$selectedData} checked{/if}> {lang}wcf.acp.dataImport.data.{@$objectTypeName}{/lang}</label>
 						<p>
 							{foreach from=$objectTypes item=objectTypeName}
-								<label><input type="checkbox" name="selectedData[]" value="{@$objectTypeName}" class="jsImportItem"{if $objectTypeName|in_array:$selectedData} checked{/if}> {lang}wcf.acp.dataImport.data.{@$objectTypeName}{/lang}</label>
+								<label><input type="checkbox" name="selectedData[]" value="{$objectTypeName}" class="jsImportItem"{if $objectTypeName|in_array:$selectedData} checked{/if}> {lang}wcf.acp.dataImport.data.{@$objectTypeName}{/lang}</label>
 							{/foreach}
 						</p>
 					</dd>

--- a/wcfsetup/install/files/acp/templates/labelAdd.tpl
+++ b/wcfsetup/install/files/acp/templates/labelAdd.tpl
@@ -49,7 +49,7 @@
 					<select id="groupID" name="groupID"{if $action == 'edit'} disabled{/if}>
 						<option value="0">{lang}wcf.global.noSelection{/lang}</option>
 						{foreach from=$labelGroupList item=group}
-							<option value="{@$group->groupID}"{if $group->groupID == $groupID} selected{/if}>{$group}{if $group->groupDescription} / {$group->groupDescription}{/if}</option>
+							<option value="{$group->groupID}"{if $group->groupID == $groupID} selected{/if}>{$group}{if $group->groupDescription} / {$group->groupDescription}{/if}</option>
 						{/foreach}
 					</select>
 					<small>{lang}wcf.acp.label.group.permanentSelection{/lang}</small>

--- a/wcfsetup/install/files/acp/templates/labelGroupAdd.tpl
+++ b/wcfsetup/install/files/acp/templates/labelGroupAdd.tpl
@@ -105,7 +105,7 @@
 								{foreach from=$container item=objectType}
 									<li class="{if $objectType->isCategory()} category{/if}"{if $objectType->getDepth()} style="padding-left: {$objectType->getDepth() * 20}px"{/if} data-depth="{@$objectType->getDepth()}">
 										<span>{$objectType->getLabel()}</span>
-										<label><input id="checkbox_{@$container->getObjectTypeID()}_{@$objectType->getObjectID()}" type="checkbox" name="objectTypes[{@$container->getObjectTypeID()}][]" value="{@$objectType->getObjectID()}"{if $objectType->getOptionValue()} checked{/if}></label>
+										<label><input id="checkbox_{@$container->getObjectTypeID()}_{@$objectType->getObjectID()}" type="checkbox" name="objectTypes[{@$container->getObjectTypeID()}][]" value="{$objectType->getObjectID()}"{if $objectType->getOptionValue()} checked{/if}></label>
 									</li>
 								{/foreach}
 							</ul>

--- a/wcfsetup/install/files/acp/templates/labelList.tpl
+++ b/wcfsetup/install/files/acp/templates/labelList.tpl
@@ -48,7 +48,7 @@
 						<select id="groupID" name="groupID">
 							<option value="0">{lang}wcf.acp.label.group{/lang}</option>
 							{foreach from=$labelGroupList item=group}
-								<option value="{@$group->groupID}"{if $group->groupID == $groupID} selected{/if}>{$group}{if $group->groupDescription} / {$group->groupDescription}{/if}</option>
+								<option value="{$group->groupID}"{if $group->groupID == $groupID} selected{/if}>{$group}{if $group->groupDescription} / {$group->groupDescription}{/if}</option>
 							{/foreach}
 						</select>
 					</dd>

--- a/wcfsetup/install/files/acp/templates/languageAdd.tpl
+++ b/wcfsetup/install/files/acp/templates/languageAdd.tpl
@@ -97,7 +97,7 @@
 				<dd>
 					<select id="sourceLanguageID" name="sourceLanguageID">
 						{foreach from=$languages item=language}
-							<option value="{@$language->languageID}"{if $language->languageID == $sourceLanguageID} selected{/if}>{$language->languageName} ({$language->languageCode})</option>
+							<option value="{$language->languageID}"{if $language->languageID == $sourceLanguageID} selected{/if}>{$language->languageName} ({$language->languageCode})</option>
 						{/foreach}
 					</select>
 					{if $errorField == 'sourceLanguageID'}

--- a/wcfsetup/install/files/acp/templates/languageChooser.tpl
+++ b/wcfsetup/install/files/acp/templates/languageChooser.tpl
@@ -8,7 +8,7 @@
 			<noscript>
 				<select name="{@$__languageChooserPrefix}languageID" id="{@$__languageChooserPrefix}languageID">
 					{foreach from=$languages item=_language}
-						<option value="{@$_language->languageID}">{$_language}</option>
+						<option value="{$_language->languageID}">{$_language}</option>
 					{/foreach}
 				</select>
 			</noscript>

--- a/wcfsetup/install/files/acp/templates/languageExport.tpl
+++ b/wcfsetup/install/files/acp/templates/languageExport.tpl
@@ -42,7 +42,7 @@
 					<option value="-">--------------------</option>
 					{foreach from=$packages item=package}
 						{assign var=loop value=$packageNameLength-$package->packageNameLength}
-						<option value="{@$package->packageID}"{if $selectedPackages[$package->packageID]|isset} selected{/if}>{$package->getName()} {section name=i loop=$loop}&nbsp;{/section}&nbsp;&nbsp;{$package->package}</option>
+						<option value="{$package->packageID}"{if $selectedPackages[$package->packageID]|isset} selected{/if}>{$package->getName()} {section name=i loop=$loop}&nbsp;{/section}&nbsp;&nbsp;{$package->package}</option>
 					{/foreach}
 				</select>
 				<small>{lang}wcf.global.multiSelect{/lang}</small>

--- a/wcfsetup/install/files/acp/templates/languageImport.tpl
+++ b/wcfsetup/install/files/acp/templates/languageImport.tpl
@@ -43,7 +43,7 @@
 			<dd>
 				<select id="sourceLanguageID" name="sourceLanguageID">
 					{foreach from=$languages item=language}
-						<option value="{@$language->languageID}"{if $language->languageID == $sourceLanguageID} selected{/if}>{$language->languageName} ({$language->languageCode})</option>
+						<option value="{$language->languageID}"{if $language->languageID == $sourceLanguageID} selected{/if}>{$language->languageName} ({$language->languageCode})</option>
 					{/foreach}
 				</select>
 				{if $errorField == 'sourceLanguageID'}

--- a/wcfsetup/install/files/acp/templates/languageItemEditDialog.tpl
+++ b/wcfsetup/install/files/acp/templates/languageItemEditDialog.tpl
@@ -43,7 +43,7 @@
 	</section>
 {/if}
 
-<input type="hidden" name="languageItemID" id="overlayLanguageItemID" value="{@$item->languageItemID}">
+<input type="hidden" name="languageItemID" id="overlayLanguageItemID" value="{$item->languageItemID}">
 
 <div class="formSubmit">
 	<button type="button" class="button buttonPrimary jsSubmitLanguageItem" accesskey="s">{lang}wcf.global.button.submit{/lang}</button>

--- a/wcfsetup/install/files/acp/templates/languageItemList.tpl
+++ b/wcfsetup/install/files/acp/templates/languageItemList.tpl
@@ -36,7 +36,7 @@
 					<select name="languageID" id="languageID">
 						<option value="0">{lang}wcf.user.language{/lang}</option>
 						{foreach from=$availableLanguages item=availableLanguage}
-							<option value="{@$availableLanguage->languageID}"{if $availableLanguage->languageID == $languageID} selected{/if}>{$availableLanguage->languageName} ({$availableLanguage->languageCode})</option>
+							<option value="{$availableLanguage->languageID}"{if $availableLanguage->languageID == $languageID} selected{/if}>{$availableLanguage->languageName} ({$availableLanguage->languageCode})</option>
 						{/foreach}
 					</select>
 				</dd>
@@ -48,7 +48,7 @@
 					<select name="languageCategoryID" id="languageCategoryID">
 						<option value="0">{lang}wcf.acp.language.category{/lang}</option>
 						{foreach from=$availableLanguageCategories item=availableLanguageCategory}
-							<option value="{@$availableLanguageCategory->languageCategoryID}"{if $availableLanguageCategory->languageCategoryID == $languageCategoryID} selected{/if}>{$availableLanguageCategory->languageCategory}</option>
+							<option value="{$availableLanguageCategory->languageCategoryID}"{if $availableLanguageCategory->languageCategoryID == $languageCategoryID} selected{/if}>{$availableLanguageCategory->languageCategory}</option>
 						{/foreach}
 					</select>
 				</dd>

--- a/wcfsetup/install/files/acp/templates/languageMultilingualism.tpl
+++ b/wcfsetup/install/files/acp/templates/languageMultilingualism.tpl
@@ -38,7 +38,7 @@
 			<dt><label for="languageIDs">{lang}wcf.acp.language.multilingualism.languages{/lang}</label></dt>
 			<dd class="floated">
 				{foreach from=$languages item='language'}
-					<label><input type="checkbox" name="languageIDs[]" value="{@$language->languageID}"{if $language->languageID == $defaultLanguageID} checked disabled{elseif $language->languageID|in_array:$languageIDs} checked{/if}> {$language}</label>
+					<label><input type="checkbox" name="languageIDs[]" value="{$language->languageID}"{if $language->languageID == $defaultLanguageID} checked disabled{elseif $language->languageID|in_array:$languageIDs} checked{/if}> {$language}</label>
 				{/foreach}
 				
 				{if $errorField == 'languageIDs'}

--- a/wcfsetup/install/files/acp/templates/menuAdd.tpl
+++ b/wcfsetup/install/files/acp/templates/menuAdd.tpl
@@ -77,7 +77,7 @@
 						<dd>
 							<select name="position" id="position">
 								{foreach from=$availablePositions item=availablePosition}
-									<option value="{@$availablePosition}"{if $availablePosition == $position} selected{/if}>{lang}wcf.acp.box.position.{@$availablePosition}{/lang}</option>
+									<option value="{$availablePosition}"{if $availablePosition == $position} selected{/if}>{lang}wcf.acp.box.position.{@$availablePosition}{/lang}</option>
 								{/foreach}
 							</select>
 							
@@ -96,7 +96,7 @@
 					<dl>
 						<dt><label for="showOrder">{lang}wcf.global.showOrder{/lang}</label></dt>
 						<dd>
-							<input type="number" id="showOrder" name="showOrder" value="{@$showOrder}" class="tiny" min="0">
+							<input type="number" id="showOrder" name="showOrder" value="{$showOrder}" class="tiny" min="0">
 						</dd>
 					</dl>
 					

--- a/wcfsetup/install/files/acp/templates/menuItemAdd.tpl
+++ b/wcfsetup/install/files/acp/templates/menuItemAdd.tpl
@@ -72,7 +72,7 @@
 					
 					{foreach from=$menuItemNodeList item=menuItemNode}
 						<option
-							value="{@$menuItemNode->itemID}"
+							value="{$menuItemNode->itemID}"
 							{if $menuItemNode->itemID == $parentItemID} selected{/if}
 							{if $action === 'edit' && $menuItemNode->itemID == $itemID} disabled{/if}
 						>
@@ -113,7 +113,7 @@
 		<dl>
 			<dt><label for="showOrder">{lang}wcf.global.showOrder{/lang}</label></dt>
 			<dd>
-				<input type="number" name="showOrder" id="showOrder" value="{@$showOrder}" class="tiny" min="0">
+				<input type="number" name="showOrder" id="showOrder" value="{$showOrder}" class="tiny" min="0">
 			</dd>
 		</dl>
 		
@@ -148,7 +148,7 @@
 					
 					{foreach from=$pageNodeList item=pageNode}
 						{if !$pageNode->requireObjectID || $pageHandlers[$pageNode->pageID]|isset}
-							<option value="{@$pageNode->pageID}"{if $pageNode->pageID == $pageID} selected{/if} data-identifier="{@$pageNode->identifier}">{if $pageNode->getDepth() > 1}{@"&nbsp;&nbsp;&nbsp;&nbsp;"|str_repeat:($pageNode->getDepth() - 1)}{/if}{$pageNode->name}</option>
+							<option value="{$pageNode->pageID}"{if $pageNode->pageID == $pageID} selected{/if} data-identifier="{@$pageNode->identifier}">{if $pageNode->getDepth() > 1}{@"&nbsp;&nbsp;&nbsp;&nbsp;"|str_repeat:($pageNode->getDepth() - 1)}{/if}{$pageNode->name}</option>
 						{/if}
 					{/foreach}
 				</select>
@@ -208,7 +208,7 @@
 	
 	<div class="formSubmit">
 		<input type="submit" value="{lang}wcf.global.button.submit{/lang}">
-		{if $action == 'add'}<input type="hidden" name="menuID" value="{@$menuID}">{/if}
+		{if $action == 'add'}<input type="hidden" name="menuID" value="{$menuID}">{/if}
 		{csrfToken}
 	</div>
 </form>

--- a/wcfsetup/install/files/acp/templates/modificationLogList.tpl
+++ b/wcfsetup/install/files/acp/templates/modificationLogList.tpl
@@ -47,7 +47,7 @@
 						{foreach from=$actions key=_packageID item=$availableActions}
 							{assign var=_package value=$packages[$_packageID]}
 							
-							<option value="{@$_package->packageID}"{if $action == $_package->packageID} selected{/if}>{lang package=$_package}wcf.acp.modificationLog.action.allPackageActions{/lang}</option>
+							<option value="{$_package->packageID}"{if $action == $_package->packageID} selected{/if}>{lang package=$_package}wcf.acp.modificationLog.action.allPackageActions{/lang}</option>
 							{foreach from=$availableActions key=actionName item=actionLabel}
 								<option value="{$actionName}"{if $action === $actionName} selected{/if}>{@'&nbsp;'|str_repeat:4}{$actionLabel}</option>
 							{/foreach}

--- a/wcfsetup/install/files/acp/templates/pageAdd.tpl
+++ b/wcfsetup/install/files/acp/templates/pageAdd.tpl
@@ -114,7 +114,7 @@
 							<option value="0">{lang}wcf.acp.page.parentPage.none{/lang}</option>
 
 							{foreach from=$pageNodeList item=pageNode}
-								<option value="{@$pageNode->pageID}"{if $pageNode->pageID == $parentPageID} selected{/if}{if $pageNode->requireObjectID || ($action === 'edit' && $pageNode->pageID == $page->pageID)} disabled{/if}>{if $pageNode->getDepth() > 1}{@"&nbsp;&nbsp;&nbsp;&nbsp;"|str_repeat:($pageNode->getDepth() - 1)}{/if}{$pageNode->name}</option>
+								<option value="{$pageNode->pageID}"{if $pageNode->pageID == $parentPageID} selected{/if}{if $pageNode->requireObjectID || ($action === 'edit' && $pageNode->pageID == $page->pageID)} disabled{/if}>{if $pageNode->getDepth() > 1}{@"&nbsp;&nbsp;&nbsp;&nbsp;"|str_repeat:($pageNode->getDepth() - 1)}{/if}{$pageNode->name}</option>
 							{/foreach}
 						</select>
 						{if $errorField == 'parentPageID'}
@@ -134,7 +134,7 @@
 					<dd>
 						<select name="applicationPackageID" id="applicationPackageID"{if $action == 'edit' && $page->originIsSystem} disabled{/if}>
 							{foreach from=$availableApplications item=availableApplication}
-								<option value="{@$availableApplication->packageID}"{if $availableApplication->packageID == $applicationPackageID} selected{/if}>{$availableApplication->domainName}{$availableApplication->domainPath}</option>
+								<option value="{$availableApplication->packageID}"{if $availableApplication->packageID == $applicationPackageID} selected{/if}>{$availableApplication->domainName}{$availableApplication->domainPath}</option>
 							{/foreach}
 						</select>
 						{if $errorField == 'applicationPackageID'}
@@ -157,7 +157,7 @@
 								{assign var='_overrideApplicationPackageID' value=$overrideApplicationPackageID}
 								{if !$_overrideApplicationPackageID}{assign var='_overrideApplicationPackageID' value=$page->applicationPackageID}{/if}
 								{foreach from=$availableApplications item=availableApplication}
-									<option value="{@$availableApplication->packageID}"{if $availableApplication->packageID == $_overrideApplicationPackageID} selected{/if}>{$availableApplication->domainName}{$availableApplication->domainPath}</option>
+									<option value="{$availableApplication->packageID}"{if $availableApplication->packageID == $_overrideApplicationPackageID} selected{/if}>{$availableApplication->domainName}{$availableApplication->domainPath}</option>
 								{/foreach}
 							</select>
 							{if $errorField == 'overrideApplicationPackageID'}
@@ -275,7 +275,7 @@
 								<option value="0">{lang}wcf.global.noSelection{/lang}</option>
 
 								{foreach from=$menuItemNodeList item=menuItemNode}
-									<option value="{@$menuItemNode->itemID}"{if $menuItemNode->itemID == $parentMenuItemID} selected{/if}>{if $menuItemNode->getDepth() > 1}{@"&nbsp;&nbsp;&nbsp;&nbsp;"|str_repeat:($menuItemNode->getDepth() - 1)}{/if}{$menuItemNode->getTitle()}</option>
+									<option value="{$menuItemNode->itemID}"{if $menuItemNode->itemID == $parentMenuItemID} selected{/if}>{if $menuItemNode->getDepth() > 1}{@"&nbsp;&nbsp;&nbsp;&nbsp;"|str_repeat:($menuItemNode->getDepth() - 1)}{/if}{$menuItemNode->getTitle()}</option>
 								{/foreach}
 							</select>
 							{if $errorField == 'parentMenuItemID'}
@@ -481,7 +481,7 @@
 							{foreach from=$availableBoxes item=availableBox}
 								<li>
 									<label>
-										<input type="checkbox" name="boxIDs[]" value="{@$availableBox->boxID}"{if $availableBox->boxID|in_array:$boxIDs} checked{/if}{if $availableBox->identifier == 'com.woltlab.wcf.MainMenu'} disabled{/if}>
+										<input type="checkbox" name="boxIDs[]" value="{$availableBox->boxID}"{if $availableBox->boxID|in_array:$boxIDs} checked{/if}{if $availableBox->identifier == 'com.woltlab.wcf.MainMenu'} disabled{/if}>
 										{$availableBox->name}
 										{if $availableBox->isDisabled}
 											<span class="jsTooltip" title="{lang}wcf.acp.box.isDisabled{/lang}">
@@ -532,7 +532,7 @@
 
 	<div class="formSubmit">
 		<input type="submit" value="{lang}wcf.global.button.submit{/lang}" accesskey="s">
-		<input type="hidden" name="isMultilingual" value="{@$isMultilingual}">
+		<input type="hidden" name="isMultilingual" value="{$isMultilingual}">
 		<input type="hidden" name="pageType" value="{$pageType}">
 		{csrfToken}
 	</div>

--- a/wcfsetup/install/files/acp/templates/pageList.tpl
+++ b/wcfsetup/install/files/acp/templates/pageList.tpl
@@ -51,7 +51,7 @@
 					<select name="applicationPackageID" id="applicationPackageID">
 						<option value="0">{lang}wcf.acp.page.application{/lang}</option>
 						{foreach from=$availableApplications item=availableApplication}
-							<option value="{@$availableApplication->packageID}"{if $availableApplication->packageID == $applicationPackageID} selected{/if}>{$availableApplication->domainName}{$availableApplication->domainPath}</option>
+							<option value="{$availableApplication->packageID}"{if $availableApplication->packageID == $applicationPackageID} selected{/if}>{$availableApplication->domainName}{$availableApplication->domainPath}</option>
 						{/foreach}
 					</select>
 				</dd>

--- a/wcfsetup/install/files/acp/templates/paidSubscriptionAdd.tpl
+++ b/wcfsetup/install/files/acp/templates/paidSubscriptionAdd.tpl
@@ -94,7 +94,7 @@
 				<dt>{lang}wcf.acp.paidSubscription.excludedSubscriptions{/lang}</dt>
 				<dd>
 					{foreach from=$availableSubscriptions item=availableSubscription}
-						<label><input type="checkbox" name="excludedSubscriptionIDs[]" value="{@$availableSubscription->subscriptionID}"{if $availableSubscription->subscriptionID|in_array:$excludedSubscriptionIDs} checked{/if}> {$availableSubscription->getTitle()}</label>
+						<label><input type="checkbox" name="excludedSubscriptionIDs[]" value="{$availableSubscription->subscriptionID}"{if $availableSubscription->subscriptionID|in_array:$excludedSubscriptionIDs} checked{/if}> {$availableSubscription->getTitle()}</label>
 					{/foreach}
 					<small>{lang}wcf.acp.paidSubscription.excludedSubscriptions.description{/lang}</small>
 				</dd>
@@ -136,7 +136,7 @@
 		<dl id="subscriptionLengthDL"{if $errorField == 'subscriptionLength'} class="formError"{/if}>
 			<dt><label for="subscriptionLength">{lang}wcf.acp.paidSubscription.subscriptionLength{/lang}</label></dt>
 			<dd>
-				<input type="number" id="subscriptionLength" name="subscriptionLength" value="{@$subscriptionLength}" class="tiny"{if !$canChangePaymentOptions} readonly{/if}>
+				<input type="number" id="subscriptionLength" name="subscriptionLength" value="{$subscriptionLength}" class="tiny"{if !$canChangePaymentOptions} readonly{/if}>
 				<select name="subscriptionLengthUnit" id="subscriptionLengthUnit"{if !$canChangePaymentOptions} disabled{/if}>
 					<option value="D"{if $subscriptionLengthUnit == 'D'} selected{/if}>{lang}wcf.acp.paidSubscription.subscriptionLengthUnit.D{/lang}</option>
 					<option value="M"{if $subscriptionLengthUnit == 'M'} selected{/if}>{lang}wcf.acp.paidSubscription.subscriptionLengthUnit.M{/lang}</option>
@@ -166,7 +166,7 @@
 			<dt><label>{lang}wcf.acp.paidSubscription.userGroups{/lang}</label></dt>
 			<dd>
 				{foreach from=$availableUserGroups item=userGroup}
-					<label><input type="checkbox" name="groupIDs[]" value="{@$userGroup->groupID}"{if $userGroup->groupID|in_array:$groupIDs} checked{/if}> {$userGroup->getTitle()}</label>
+					<label><input type="checkbox" name="groupIDs[]" value="{$userGroup->groupID}"{if $userGroup->groupID|in_array:$groupIDs} checked{/if}> {$userGroup->getTitle()}</label>
 				{/foreach}
 				{if $errorField == 'groupIDs'}
 					<small class="innerError">

--- a/wcfsetup/install/files/acp/templates/paidSubscriptionTransactionLogList.tpl
+++ b/wcfsetup/install/files/acp/templates/paidSubscriptionTransactionLogList.tpl
@@ -46,7 +46,7 @@
 						<select name="subscriptionID" id="subscriptionID">
 							<option value="0">{lang}wcf.acp.paidSubscription.subscription{/lang}</option>
 							{foreach from=$availableSubscriptions item=availableSubscription}
-								<option value="{@$availableSubscription->subscriptionID}"{if $availableSubscription->subscriptionID == $subscriptionID} selected{/if}>{$availableSubscription->getTitle()}</option>
+								<option value="{$availableSubscription->subscriptionID}"{if $availableSubscription->subscriptionID == $subscriptionID} selected{/if}>{$availableSubscription->getTitle()}</option>
 							{/foreach}
 						</select>
 					</dd>

--- a/wcfsetup/install/files/acp/templates/paidSubscriptionUserList.tpl
+++ b/wcfsetup/install/files/acp/templates/paidSubscriptionUserList.tpl
@@ -39,7 +39,7 @@
 						<select name="subscriptionID" id="subscriptionID">
 							<option value="0">{lang}wcf.acp.paidSubscription.subscription{/lang}</option>
 							{foreach from=$availableSubscriptions item=availableSubscription}
-								<option value="{@$availableSubscription->subscriptionID}"{if $availableSubscription->subscriptionID == $subscriptionID} selected{/if}>{$availableSubscription->getTitle()}</option>
+								<option value="{$availableSubscription->subscriptionID}"{if $availableSubscription->subscriptionID == $subscriptionID} selected{/if}>{$availableSubscription->getTitle()}</option>
 							{/foreach}
 						</select>
 					</dd>

--- a/wcfsetup/install/files/acp/templates/scrollablePageCheckboxList.tpl
+++ b/wcfsetup/install/files/acp/templates/scrollablePageCheckboxList.tpl
@@ -17,7 +17,7 @@
 <ul class="scrollableCheckboxList" id="{@$pageCheckboxListContainerID}">
 	{foreach from=$pageNodeList item=pageNode}
 		<li{if $pageNode->getDepth() > 1} style="padding-left: {$pageNode->getDepth()*20-20}px"{/if}>
-			<label><input type="checkbox" name="{@$pageCheckboxID}[]" value="{@$pageNode->pageID}" data-identifier="{@$pageNode->identifier}"{if $pageNode->pageID|in_array:$pageIDs} checked{/if}> {$pageNode->name}</label>
+			<label><input type="checkbox" name="{@$pageCheckboxID}[]" value="{$pageNode->pageID}" data-identifier="{@$pageNode->identifier}"{if $pageNode->pageID|in_array:$pageIDs} checked{/if}> {$pageNode->name}</label>
 		</li>
 	{/foreach}
 </ul>

--- a/wcfsetup/install/files/acp/templates/stat.tpl
+++ b/wcfsetup/install/files/acp/templates/stat.tpl
@@ -64,7 +64,7 @@
 			<dt><label>{lang}wcf.acp.stat.category.{@$categoryName}{/lang}</label></dt>
 			<dd>
 				{foreach from=$objectTypes item=objectType}
-					<label><input type="checkbox" name="objectTypeID" value="{@$objectType->objectTypeID}"{if $objectType->default} checked{/if}> {lang}wcf.acp.stat.{@$objectType->objectType}{/lang}</label>
+					<label><input type="checkbox" name="objectTypeID" value="{$objectType->objectTypeID}"{if $objectType->default} checked{/if}> {lang}wcf.acp.stat.{@$objectType->objectType}{/lang}</label>
 				{/foreach}
 			</dd>
 		</dl>

--- a/wcfsetup/install/files/acp/templates/styleAdd.tpl
+++ b/wcfsetup/install/files/acp/templates/styleAdd.tpl
@@ -376,10 +376,10 @@
 				<dl id="fluidLayoutMinWidth">
 					<dt><label for="wcfLayoutMinWidth">{lang}wcf.acp.style.globals.fluidLayoutMinWidth{/lang}</label></dt>
 					<dd>
-						<input type="number" id="wcfLayoutMinWidth" name="wcfLayoutMinWidth" value="{@$variables[wcfLayoutMinWidth]}" class="tiny">
+						<input type="number" id="wcfLayoutMinWidth" name="wcfLayoutMinWidth" value="{$variables[wcfLayoutMinWidth]}" class="tiny">
 						<select name="wcfLayoutMinWidth_unit" class="jsUnitSelect">
 							{foreach from=$availableUnits item=unit}
-								<option value="{@$unit}"{if $variables[wcfLayoutMinWidth_unit] == $unit} selected{/if}>{@$unit}</option>
+								<option value="{$unit}"{if $variables[wcfLayoutMinWidth_unit] == $unit} selected{/if}>{@$unit}</option>
 							{/foreach}
 						</select>
 					</dd>
@@ -387,10 +387,10 @@
 				<dl id="fluidLayoutMaxWidth">
 					<dt><label for="wcfLayoutMaxWidth">{lang}wcf.acp.style.globals.fluidLayoutMaxWidth{/lang}</label></dt>
 					<dd>
-						<input type="number" id="wcfLayoutMaxWidth" name="wcfLayoutMaxWidth" value="{@$variables[wcfLayoutMaxWidth]}" class="tiny">
+						<input type="number" id="wcfLayoutMaxWidth" name="wcfLayoutMaxWidth" value="{$variables[wcfLayoutMaxWidth]}" class="tiny">
 						<select name="wcfLayoutMaxWidth_unit" class="jsUnitSelect">
 							{foreach from=$availableUnits item=unit}
-								<option value="{@$unit}"{if $variables[wcfLayoutMaxWidth_unit] == $unit} selected{/if}>{@$unit}</option>
+								<option value="{$unit}"{if $variables[wcfLayoutMaxWidth_unit] == $unit} selected{/if}>{@$unit}</option>
 							{/foreach}
 						</select>
 					</dd>
@@ -399,10 +399,10 @@
 				<dl id="fixedLayoutVariables">
 					<dt><label for="wcfLayoutFixedWidth">{lang}wcf.acp.style.globals.fixedLayoutWidth{/lang}</label></dt>
 					<dd>
-						<input type="number" id="wcfLayoutFixedWidth" name="wcfLayoutFixedWidth" value="{@$variables[wcfLayoutFixedWidth]}" class="tiny">
+						<input type="number" id="wcfLayoutFixedWidth" name="wcfLayoutFixedWidth" value="{$variables[wcfLayoutFixedWidth]}" class="tiny">
 						<select name="wcfLayoutFixedWidth_unit" class="jsUnitSelect">
 							{foreach from=$availableUnits item=unit}
-								<option value="{@$unit}"{if $variables[wcfLayoutFixedWidth_unit] == $unit} selected{/if}>{@$unit}</option>
+								<option value="{$unit}"{if $variables[wcfLayoutFixedWidth_unit] == $unit} selected{/if}>{@$unit}</option>
 							{/foreach}
 						</select>
 					</dd>
@@ -467,11 +467,11 @@
 				<dl>
 					<dt><label for="wcfFontSizeDefault">{lang}wcf.acp.style.globals.fontSizeDefault{/lang}</label></dt>
 					<dd>
-						<input type="number" id="wcfFontSizeDefault" name="wcfFontSizeDefault" value="{@$variables[wcfFontSizeDefault]}" class="tiny">
+						<input type="number" id="wcfFontSizeDefault" name="wcfFontSizeDefault" value="{$variables[wcfFontSizeDefault]}" class="tiny">
 						<select name="wcfFontSizeDefault_unit" class="jsUnitSelect">
 							{foreach from=$availableUnits item=unit}
 								{if $unit == 'px' || $unit == 'pt'}
-									<option value="{@$unit}"{if $variables[wcfFontSizeDefault_unit] == $unit} selected{/if}>{@$unit}</option>
+									<option value="{$unit}"{if $variables[wcfFontSizeDefault_unit] == $unit} selected{/if}>{@$unit}</option>
 								{/if}
 							{/foreach}
 						</select>
@@ -480,10 +480,10 @@
 				<dl>
 					<dt><label for="wcfFontSizeSmall">{lang}wcf.acp.style.globals.fontSizeSmall{/lang}</label></dt>
 					<dd>
-						<input type="number" id="wcfFontSizeSmall" name="wcfFontSizeSmall" value="{@$variables[wcfFontSizeSmall]}" class="tiny">
+						<input type="number" id="wcfFontSizeSmall" name="wcfFontSizeSmall" value="{$variables[wcfFontSizeSmall]}" class="tiny">
 						<select name="wcfFontSizeSmall_unit" class="jsUnitSelect">
 							{foreach from=$availableUnits item=unit}
-								<option value="{@$unit}"{if $variables[wcfFontSizeSmall_unit] == $unit} selected{/if}>{@$unit}</option>
+								<option value="{$unit}"{if $variables[wcfFontSizeSmall_unit] == $unit} selected{/if}>{@$unit}</option>
 							{/foreach}
 						</select>
 					</dd>
@@ -491,10 +491,10 @@
 				<dl>
 					<dt><label for="wcfFontSizeHeadline">{lang}wcf.acp.style.globals.fontSizeHeadline{/lang}</label></dt>
 					<dd>
-						<input type="number" id="wcfFontSizeHeadline" name="wcfFontSizeHeadline" value="{@$variables[wcfFontSizeHeadline]}" class="tiny">
+						<input type="number" id="wcfFontSizeHeadline" name="wcfFontSizeHeadline" value="{$variables[wcfFontSizeHeadline]}" class="tiny">
 						<select name="wcfFontSizeHeadline_unit" class="jsUnitSelect">
 							{foreach from=$availableUnits item=unit}
-								<option value="{@$unit}"{if $variables[wcfFontSizeHeadline_unit] == $unit} selected{/if}>{@$unit}</option>
+								<option value="{$unit}"{if $variables[wcfFontSizeHeadline_unit] == $unit} selected{/if}>{@$unit}</option>
 							{/foreach}
 						</select>
 					</dd>
@@ -502,10 +502,10 @@
 				<dl>
 					<dt><label for="wcfFontSizeSection">{lang}wcf.acp.style.globals.fontSizeSection{/lang}</label></dt>
 					<dd>
-						<input type="number" id="wcfFontSizeSection" name="wcfFontSizeSection" value="{@$variables[wcfFontSizeSection]}" class="tiny">
+						<input type="number" id="wcfFontSizeSection" name="wcfFontSizeSection" value="{$variables[wcfFontSizeSection]}" class="tiny">
 						<select name="wcfFontSizeSection_unit" class="jsUnitSelect">
 							{foreach from=$availableUnits item=unit}
-								<option value="{@$unit}"{if $variables[wcfFontSizeSection_unit] == $unit} selected{/if}>{@$unit}</option>
+								<option value="{$unit}"{if $variables[wcfFontSizeSection_unit] == $unit} selected{/if}>{@$unit}</option>
 							{/foreach}
 						</select>
 					</dd>
@@ -513,10 +513,10 @@
 				<dl>
 					<dt><label for="wcfFontSizeTitle">{lang}wcf.acp.style.globals.fontSizeTitle{/lang}</label></dt>
 					<dd>
-						<input type="number" id="wcfFontSizeTitle" name="wcfFontSizeTitle" value="{@$variables[wcfFontSizeTitle]}" class="tiny">
+						<input type="number" id="wcfFontSizeTitle" name="wcfFontSizeTitle" value="{$variables[wcfFontSizeTitle]}" class="tiny">
 						<select name="wcfFontSizeTitle_unit" class="jsUnitSelect">
 							{foreach from=$availableUnits item=unit}
-								<option value="{@$unit}"{if $variables[wcfFontSizeTitle_unit] == $unit} selected{/if}>{@$unit}</option>
+								<option value="{$unit}"{if $variables[wcfFontSizeTitle_unit] == $unit} selected{/if}>{@$unit}</option>
 							{/foreach}
 						</select>
 					</dd>

--- a/wcfsetup/install/files/acp/templates/tagAdd.tpl
+++ b/wcfsetup/install/files/acp/templates/tagAdd.tpl
@@ -41,7 +41,7 @@
 					<select id="languageID" name="languageID"{if $action == 'edit'} disabled{/if}>
 						{content}
 							{foreach from=$availableLanguages item=language}
-								<option value="{@$language->languageID}"{if $languageID == $language->languageID} selected{/if}>{$language->languageName} ({$language->languageCode})</option>
+								<option value="{$language->languageID}"{if $languageID == $language->languageID} selected{/if}>{$language->languageName} ({$language->languageCode})</option>
 							{/foreach}
 						{/content}
 					</select>

--- a/wcfsetup/install/files/acp/templates/tagSetAsSynonyms.tpl
+++ b/wcfsetup/install/files/acp/templates/tagSetAsSynonyms.tpl
@@ -3,7 +3,7 @@
 <ul class="containerBoxList">
 	{foreach from=$tags item=tag}
 		<li>
-			<label><input type="radio" name="tagID" value="{@$tag->tagID}"> <span class="badge tag">{$tag->name}</span></label>
+			<label><input type="radio" name="tagID" value="{$tag->tagID}"> <span class="badge tag">{$tag->name}</span></label>
 		</li>
 	{/foreach}
 </ul>

--- a/wcfsetup/install/files/acp/templates/templateAdd.tpl
+++ b/wcfsetup/install/files/acp/templates/templateAdd.tpl
@@ -75,7 +75,7 @@
 		
 		<div class="formSubmit">
 			<input type="submit" value="{lang}wcf.global.button.submit{/lang}" accesskey="s">
-			{if $copy}<input type="hidden" name="copy" value="{@$copy}">{/if}
+			{if $copy}<input type="hidden" name="copy" value="{$copy}">{/if}
 			{csrfToken}
 		</div>
 	</form>

--- a/wcfsetup/install/files/acp/templates/templateDiff.tpl
+++ b/wcfsetup/install/files/acp/templates/templateDiff.tpl
@@ -69,10 +69,10 @@
 							*}{foreach from=$diff item='line'}{*
 								*}{if $line[0] == ' '}{*
 									*}{assign var=removeOffset value=0}{assign var=lineNo value=$lineNo + 1}{*
-									*}<li value="{@$lineNo}" style="margin: 0">{$line[1]}</li>{*
+									*}<li value="{$lineNo}" style="margin: 0">{$line[1]}</li>{*
 								*}{elseif $line[0] == '-'}{*
 									*}{assign var=removeOffset value=$removeOffset + 1}{assign var=lineNo value=$lineNo + 1}{*
-									*}<li value="{@$lineNo}" style="background-color: lightpink;margin: 0">{$line[1]}</li>{*
+									*}<li value="{$lineNo}" style="background-color: lightpink;margin: 0">{$line[1]}</li>{*
 								*}{elseif $line[0] == '+'}{*
 									*}{assign var=removeOffset value=$removeOffset - 1}{*
 									*}{if $removeOffset < 0}<li style="list-style-type: none;margin: 0">&nbsp;</li>{/if}{*
@@ -100,12 +100,12 @@
 										*}{@'<li style="list-style-type: none;margin: 0">&nbsp;</li>'|str_repeat:$removeOffset}{*
 									*}{/if}{*
 									*}{assign var=removeOffset value=0}{assign var=lineNo value=$lineNo + 1}{*
-									*}<li value="{@$lineNo}" style="margin: 0">{$line[1]}</li>{*
+									*}<li value="{$lineNo}" style="margin: 0">{$line[1]}</li>{*
 								*}{elseif $line[0] == '-'}{*
 									*}{assign var=removeOffset value=$removeOffset + 1}{*
 								*}{elseif $line[0] == '+'}{*
 									*}{assign var=removeOffset value=$removeOffset - 1}{assign var=lineNo value=$lineNo + 1}{*
-									*}<li value="{@$lineNo}" style="background-color: lightgreen; margin: 0">{$line[1]}</li>{*
+									*}<li value="{$lineNo}" style="background-color: lightgreen; margin: 0">{$line[1]}</li>{*
 								*}{/if}{*
 							*}{/foreach}{*
 						*}</ol>{*

--- a/wcfsetup/install/files/acp/templates/userAdd.tpl
+++ b/wcfsetup/install/files/acp/templates/userAdd.tpl
@@ -454,7 +454,7 @@
 										</dt>
 										<dd>
 											{foreach from=$availableContentLanguages key=availableLanguageID item=availableLanguage}
-												<label><input type="checkbox" name="visibleLanguages[]" value="{@$availableLanguageID}"{if $availableLanguageID|in_array:$visibleLanguages} checked{/if}> {@$availableLanguage}</label>
+												<label><input type="checkbox" name="visibleLanguages[]" value="{$availableLanguageID}"{if $availableLanguageID|in_array:$visibleLanguages} checked{/if}> {@$availableLanguage}</label>
 											{/foreach}
 										</dd>
 									</dl>
@@ -468,7 +468,7 @@
 										<select id="styleID" name="styleID">
 											<option value="0">{lang}wcf.global.defaultValue{/lang}</option>
 											{foreach from=$availableStyles item=style}
-												<option value="{@$style->styleID}"{if $style->styleID == $styleID} selected{/if}>{$style->styleName}</option>
+												<option value="{$style->styleID}"{if $style->styleID == $styleID} selected{/if}>{$style->styleName}</option>
 											{/foreach}
 										</select>
 										{if $errorField === 'styleID'}
@@ -844,7 +844,7 @@
 {if $action === 'edit' && $ownerGroupID}
 	<script data-relocate="true">
 		(() => {
-			const input = document.querySelector('input[name="groupIDs[]"][value="{@$ownerGroupID}"]');
+			const input = document.querySelector('input[name="groupIDs[]"][value="{$ownerGroupID}"]');
 			if (input) {
 				const icon = document.createElement("span");
 				icon.innerHTML = '<fa-icon name="shield-halved"></fa-icon>';

--- a/wcfsetup/install/files/acp/templates/userGroupAdd.tpl
+++ b/wcfsetup/install/files/acp/templates/userGroupAdd.tpl
@@ -118,7 +118,7 @@
 		<dl{if $errorType.priority|isset} class="formError"{/if}>
 			<dt><label for="priority">{lang}wcf.acp.group.priority{/lang}</label></dt>
 			<dd>
-				<input type="number" id="priority" name="priority" value="{@$priority}" class="tiny" max="8388607">
+				<input type="number" id="priority" name="priority" value="{$priority}" class="tiny" max="8388607">
 				{if $errorType.priority|isset}
 					<small class="innerError">
 						{lang}wcf.acp.group.priority.error.{@$errorType.priority}{/lang}
@@ -225,7 +225,7 @@
 	
 	<div class="formSubmit">
 		<input type="submit" value="{lang}wcf.global.button.submit{/lang}" accesskey="s">
-		<input type="hidden" name="action" value="{@$action}">
+		<input type="hidden" name="action" value="{$action}">
 		{csrfToken}
 	</div>
 </form>
@@ -257,7 +257,7 @@
 					});
 				});
 			{elseif $ownerGroupID}
-				var input = elBySel('input[name="values[admin.user.accessibleGroups][]"][value="{@$ownerGroupID}"]');
+				var input = elBySel('input[name="values[admin.user.accessibleGroups][]"][value="{$ownerGroupID}"]');
 				if (input) {
 					elRemove(input.closest('label'));
 				}

--- a/wcfsetup/install/files/acp/templates/userGroupAssignmentAdd.tpl
+++ b/wcfsetup/install/files/acp/templates/userGroupAssignmentAdd.tpl
@@ -75,7 +75,7 @@
 	
 	<div class="formSubmit">
 		<input type="submit" value="{lang}wcf.global.button.submit{/lang}" accesskey="s">
-		<input type="hidden" name="action" value="{@$action}">
+		<input type="hidden" name="action" value="{$action}">
 		{csrfToken}
 	</div>
 </form>

--- a/wcfsetup/install/files/acp/templates/userMail.tpl
+++ b/wcfsetup/install/files/acp/templates/userMail.tpl
@@ -158,7 +158,7 @@
 	
 	<div class="formSubmit">
 		<input type="submit" value="{lang}wcf.global.button.submit{/lang}" accesskey="s">
-		<input type="hidden" name="action" value="{@$action}">
+		<input type="hidden" name="action" value="{$action}">
 		<input type="hidden" name="userIDs" value="{implode from=$userIDs item=userID glue=','}{@$userID}{/implode}">
 		{csrfToken}
 	</div>

--- a/wcfsetup/install/files/acp/templates/userMerge.tpl
+++ b/wcfsetup/install/files/acp/templates/userMerge.tpl
@@ -38,7 +38,7 @@
 				<select name="destinationUserID" id="destinationUserID">
 					<option value="0">{lang}wcf.global.noSelection{/lang}</option>
 					{foreach from=$users item=user}
-						<option value="{@$user->userID}">{$user->username}</option>
+						<option value="{$user->userID}">{$user->username}</option>
 					{/foreach}
 				</select>
 				

--- a/wcfsetup/install/files/acp/templates/userOptionAdd.tpl
+++ b/wcfsetup/install/files/acp/templates/userOptionAdd.tpl
@@ -83,7 +83,7 @@
 			<dl>
 				<dt><label for="showOrder">{lang}wcf.global.showOrder{/lang}</label></dt>
 				<dd>
-					<input type="number" id="showOrder" name="showOrder" value="{@$showOrder}" class="short">
+					<input type="number" id="showOrder" name="showOrder" value="{$showOrder}" class="short">
 				</dd>
 			</dl>
 			

--- a/wcfsetup/install/files/acp/templates/userOptionCategoryAdd.tpl
+++ b/wcfsetup/install/files/acp/templates/userOptionCategoryAdd.tpl
@@ -39,7 +39,7 @@
 		<dl>
 			<dt><label for="showOrder">{lang}wcf.global.showOrder{/lang}</label></dt>
 			<dd>
-				<input type="number" id="showOrder" name="showOrder" value="{@$showOrder}" class="short">
+				<input type="number" id="showOrder" name="showOrder" value="{$showOrder}" class="short">
 			</dd>
 		</dl>
 		

--- a/wcfsetup/install/files/acp/templates/userRankAdd.tpl
+++ b/wcfsetup/install/files/acp/templates/userRankAdd.tpl
@@ -112,7 +112,7 @@
 		<dl{if $errorField == 'repeatImage'} class="formError"{/if}>
 			<dt><label for="repeatImage">{lang}wcf.acp.user.rank.repeatImage{/lang}</label></dt>
 			<dd>
-				<input type="number" id="repeatImage" name="repeatImage" value="{@$repeatImage}" min="1" class="tiny">
+				<input type="number" id="repeatImage" name="repeatImage" value="{$repeatImage}" min="1" class="tiny">
 				{if $errorField == 'rankImage'}
 					<small class="innerError">
 						{lang}wcf.acp.user.rank.repeatImage.error.{@$errorType}{/lang}
@@ -146,7 +146,7 @@
 			<dd>
 				<select id="groupID" name="groupID">
 					{foreach from=$availableGroups item=group}
-						<option value="{@$group->groupID}"{if $group->groupID == $groupID} selected{/if}>{$group->getTitle()}</option>
+						<option value="{$group->groupID}"{if $group->groupID == $groupID} selected{/if}>{$group->getTitle()}</option>
 					{/foreach}
 				</select>
 				{if $errorField == 'groupID'}
@@ -183,7 +183,7 @@
 		<dl{if $errorField == 'requiredPoints'} class="formError"{/if}>
 			<dt><label for="requiredPoints">{lang}wcf.acp.user.rank.requiredPoints{/lang}</label></dt>
 			<dd>
-				<input type="number" id="requiredPoints" name="requiredPoints" value="{@$requiredPoints}" min="0" class="tiny">
+				<input type="number" id="requiredPoints" name="requiredPoints" value="{$requiredPoints}" min="0" class="tiny">
 				{if $errorField == 'requiredPoints'}
 					<small class="innerError">
 						{lang}wcf.acp.user.rank.requiredPoints.error.{@$errorType}{/lang}

--- a/wcfsetup/install/files/acp/templates/userSearch.tpl
+++ b/wcfsetup/install/files/acp/templates/userSearch.tpl
@@ -75,7 +75,7 @@
 			<dl>
 				<dt><label for="itemsPerPage">{lang}wcf.acp.user.search.display.itemsPerPage{/lang}</label></dt>
 				<dd>
-					<input type="number" id="itemsPerPage" name="itemsPerPage" value="{@$itemsPerPage}" class="tiny">
+					<input type="number" id="itemsPerPage" name="itemsPerPage" value="{$itemsPerPage}" class="tiny">
 				</dd>
 			</dl>
 			

--- a/wcfsetup/install/files/acp/templates/userTrophyAdd.tpl
+++ b/wcfsetup/install/files/acp/templates/userTrophyAdd.tpl
@@ -75,7 +75,7 @@
 							{foreach from=$trophyCategories item=category}
 								<optgroup label="{$category->getTitle()}">
 									{foreach from=$category->getTrophies(true) item=trophy}
-										<option value="{@$trophy->trophyID}"{if $trophy->trophyID == $trophyID} selected{/if}{if $trophy->awardAutomatically} disabled{/if}>{$trophy->getTitle()}</option>
+										<option value="{$trophy->trophyID}"{if $trophy->trophyID == $trophyID} selected{/if}{if $trophy->awardAutomatically} disabled{/if}>{$trophy->getTitle()}</option>
 									{/foreach}
 								</optgroup>
 							{/foreach}

--- a/wcfsetup/install/files/acp/templates/userTrophyList.tpl
+++ b/wcfsetup/install/files/acp/templates/userTrophyList.tpl
@@ -34,7 +34,7 @@
 						{foreach from=$trophyCategories item=category}
 							<optgroup label="{$category->getTitle()}">
 								{foreach from=$category->getTrophies(true) item=trophy}
-									<option value="{@$trophy->trophyID}"{if $trophy->trophyID == $trophyID} selected{/if}>{$trophy->getTitle()}</option>
+									<option value="{$trophy->trophyID}"{if $trophy->trophyID == $trophyID} selected{/if}>{$trophy->getTitle()}</option>
 								{/foreach}
 							</optgroup>
 						{/foreach}

--- a/wcfsetup/install/files/acp/templates/versionTrackerList.tpl
+++ b/wcfsetup/install/files/acp/templates/versionTrackerList.tpl
@@ -126,7 +126,7 @@
 							<button type="button" class="jsRevertButton jsTooltip" title="{lang}wcf.edit.revert{/lang}" data-object-id="{@$edit->versionID}" data-confirm-message="{lang __encode=true}wcf.edit.revert.sure{/lang}">
 								{icon name='arrow-rotate-left'}
 							</button>
-							<input type="radio" name="oldID" value="{@$edit->versionID}"{if $oldID == $edit->versionID} checked{/if}> <input type="radio" name="newID" value="{@$edit->versionID}"{if $newID == $edit->versionID} checked{/if}>
+							<input type="radio" name="oldID" value="{$edit->versionID}"{if $oldID == $edit->versionID} checked{/if}> <input type="radio" name="newID" value="{$edit->versionID}"{if $newID == $edit->versionID} checked{/if}>
 							{event name='rowButtons'}
 						</td>
 						<td class="columnID">{#($tpl[foreach][edit][total] - $tpl[foreach][edit][iteration] + 1)}</td>


### PR DESCRIPTION
There should not be any reason to not HTML escape an HTML attribute value,
because it may not contain any HTML syntax anyway.

see dcf18656ba99b5f8f91312f460407e32d11c40b0
