### PR TITLE
assign `controllerName|controllerApplication` to tpl in `AbstractPage`

### DIFF
--- a/wcfsetup/install/files/lib/page/AbstractPage.class.php
+++ b/wcfsetup/install/files/lib/page/AbstractPage.class.php
@@ -199,11 +199,17 @@ abstract class AbstractPage implements IPage
         // call assignVariables event
         EventHandler::getInstance()->fireAction($this, 'assignVariables');
 
+        $classParts = \explode('\\', static::class);
+        $controllerName = \preg_replace('~(Form|Page)$~', '', \array_pop($classParts));
+        $controllerApplication = \array_shift($classParts);
+
         // assign parameters
         WCF::getTPL()->assign([
             'action' => $this->action,
             'templateName' => $this->templateName,
             'templateNameApplication' => $this->templateNameApplication,
+            'controllerName' => $controllerName,
+            'controllerApplication' => $controllerApplication,
             'canonicalURL' => $this->canonicalURL,
         ]);
     }


### PR DESCRIPTION
This makes using ´form´-tags with actions to the same controller and using the new web component for pagination much easier and more generic:
`<woltlab-core-pagination page="1" count="10" url="{link application=$controllerAplication controller=$controllerName}{/link}"></woltlab-core-pagination>`