### PR TITLE
Introduce `Helper::mapRequestParameters()` to reduce boiler plating

### DIFF
--- a/wcfsetup/install/files/lib/action/ModerationQueueAssignUserAction.class.php
+++ b/wcfsetup/install/files/lib/action/ModerationQueueAssignUserAction.class.php
@@ -2,9 +2,6 @@
 
 namespace wcf\action;
 
-use CuyZ\Valinor\Mapper\Source\Source;
-use CuyZ\Valinor\Mapper\TreeMapper;
-use CuyZ\Valinor\MapperBuilder;
 use Laminas\Diactoros\Response\JsonResponse;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -12,6 +9,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 use wcf\data\moderation\queue\ModerationQueue;
 use wcf\data\object\type\ObjectTypeCache;
 use wcf\data\user\User;
+use wcf\http\Helper;
 use wcf\system\exception\IllegalLinkException;
 use wcf\system\exception\PermissionDeniedException;
 use wcf\system\form\builder\field\dependency\ValueFormFieldDependency;
@@ -26,30 +24,18 @@ use wcf\system\WCF;
 /**
  * Assigns a user to a moderation queue entry.
  *
- * @author  Tim Duesterhus
- * @copyright   2001-2022 WoltLab GmbH
+ * @author Tim Duesterhus
+ * @copyright 2001-2022 WoltLab GmbH
  * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @since 6.0
  */
 final class ModerationQueueAssignUserAction implements RequestHandlerInterface
 {
-    private const PARAMETERS = <<<'EOT'
-        array {
-            id: positive-int
-        }
-        EOT;
-
-    private TreeMapper $mapper;
-
     private readonly ObjectTypeCache $objectTypeCache;
 
     public function __construct()
     {
         $this->objectTypeCache = ObjectTypeCache::getInstance();
-
-        $this->mapper = (new MapperBuilder())
-            ->allowSuperfluousKeys()
-            ->enableFlexibleCasting()
-            ->mapper();
     }
 
     /**
@@ -57,9 +43,13 @@ final class ModerationQueueAssignUserAction implements RequestHandlerInterface
      */
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $parameters = $this->mapper->map(
-            self::PARAMETERS,
-            Source::array($request->getQueryParams())
+        $parameters = Helper::mapRequestParameters(
+            $request->getQueryParams(),
+            <<<'EOT'
+                array {
+                    id: positive-int
+                }
+                EOT
         );
 
         $moderationQueue = new ModerationQueue($parameters['id']);

--- a/wcfsetup/install/files/lib/action/ModerationQueueAssignUserAction.class.php
+++ b/wcfsetup/install/files/lib/action/ModerationQueueAssignUserAction.class.php
@@ -43,7 +43,7 @@ final class ModerationQueueAssignUserAction implements RequestHandlerInterface
      */
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $parameters = Helper::mapRequestParameters(
+        $parameters = Helper::mapQueryString(
             $request->getQueryParams(),
             <<<'EOT'
                 array {

--- a/wcfsetup/install/files/lib/action/ModerationQueueAssignUserAction.class.php
+++ b/wcfsetup/install/files/lib/action/ModerationQueueAssignUserAction.class.php
@@ -43,7 +43,7 @@ final class ModerationQueueAssignUserAction implements RequestHandlerInterface
      */
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $parameters = Helper::mapQueryString(
+        $parameters = Helper::mapQueryParameters(
             $request->getQueryParams(),
             <<<'EOT'
                 array {

--- a/wcfsetup/install/files/lib/http/Helper.class.php
+++ b/wcfsetup/install/files/lib/http/Helper.class.php
@@ -27,7 +27,7 @@ final class Helper
     }
 
     /**
-     * Validates source parameters against the provided schema. Unknown
+     * Validates query parameters against the provided schema. Unknown
      * keys are skipped and values are gracefully converted into the
      * requested types.
      *
@@ -37,7 +37,7 @@ final class Helper
      *
      * @throws MappingError
      */
-    public static function mapQueryString(array $sourceParameters, string $schema): mixed
+    public static function mapQueryParameters(array $queryParameters, string $schema): mixed
     {
         $mapper = (new MapperBuilder())
             ->allowSuperfluousKeys()
@@ -46,7 +46,7 @@ final class Helper
 
         return $mapper->map(
             $schema,
-            Source::array($sourceParameters)
+            Source::array($queryParameters)
         );
     }
 

--- a/wcfsetup/install/files/lib/http/Helper.class.php
+++ b/wcfsetup/install/files/lib/http/Helper.class.php
@@ -37,7 +37,7 @@ final class Helper
      *
      * @throws MappingError
      */
-    public static function mapRequestParameters(array $sourceParameters, string $schema): mixed
+    public static function mapQueryString(array $sourceParameters, string $schema): mixed
     {
         $mapper = (new MapperBuilder())
             ->allowSuperfluousKeys()

--- a/wcfsetup/install/files/lib/http/Helper.class.php
+++ b/wcfsetup/install/files/lib/http/Helper.class.php
@@ -2,6 +2,9 @@
 
 namespace wcf\http;
 
+use CuyZ\Valinor\Mapper\MappingError;
+use CuyZ\Valinor\Mapper\Source\Source;
+use CuyZ\Valinor\MapperBuilder;
 use Psr\Http\Message\ServerRequestInterface;
 
 /**
@@ -21,6 +24,30 @@ final class Helper
     public static function isAjaxRequest(ServerRequestInterface $request): bool
     {
         return $request->getHeaderLine('x-requested-with') === 'XMLHttpRequest';
+    }
+
+    /**
+     * Validates source parameters against the provided schema. Unknown
+     * keys are skipped and values are gracefully converted into the
+     * requested types.
+     *
+     * The returned array will contain only the values specified in the
+     * schema. Missing parameters or values that cannot be casted to the
+     * requested type will yield a `MappingError`.
+     *
+     * @throws MappingError
+     */
+    public static function mapRequestParameters(array $sourceParameters, string $schema): mixed
+    {
+        $mapper = (new MapperBuilder())
+            ->allowSuperfluousKeys()
+            ->enableFlexibleCasting()
+            ->mapper();
+
+        return $mapper->map(
+            $schema,
+            Source::array($sourceParameters)
+        );
     }
 
     /**


### PR DESCRIPTION
The Valinor handling is pretty much the same for all PSR controllers and is pretty verbose when implemented correctly in a controller.

Using a helper method also reduces the risk of developers unintentionally misusing the API, for example, disallowing superfluous URL parameters. Simple patterns like cache busters would cause a strict parameter validation to fail, but this is not something a developer might take into consideration when implementing an API. It does make debugging a bit more painful, but in reality you only have to go through this once during development, whereas cache buster parameters are ubiquitous.