### PR TITLE
Force set `__isLogin` in ACP’s LoginForm, ReauthenticationForm and RescueModeForm

### DIFF
--- a/wcfsetup/install/files/acp/templates/login.tpl
+++ b/wcfsetup/install/files/acp/templates/login.tpl
@@ -1,4 +1,4 @@
-{include file='header' pageTitle='wcf.user.login' __isLogin=true}
+{include file='header' pageTitle='wcf.user.login'}
 
 <div id="login" class="acpLoginForm" style="display: none">
 	<form method="post" action="{link controller='Login'}{/link}">

--- a/wcfsetup/install/files/acp/templates/reauthentication.tpl
+++ b/wcfsetup/install/files/acp/templates/reauthentication.tpl
@@ -1,4 +1,4 @@
-{include file='header' pageTitle='wcf.user.reauthentication' __isLogin=true}
+{include file='header' pageTitle='wcf.user.reauthentication'}
 
 {*
 <header class="contentHeader">

--- a/wcfsetup/install/files/lib/acp/form/LoginForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/LoginForm.class.php
@@ -59,6 +59,16 @@ class LoginForm extends AbstractCaptchaForm
      */
     public $useCaptcha = false;
 
+    public function __run()
+    {
+        WCF::getTPL()->assign([
+            '__wcfAcpIsLogin' => true,
+            '__isLogin' => true,
+        ]);
+
+        parent::__run();
+    }
+
     /**
      * @inheritDoc
      */
@@ -270,7 +280,6 @@ class LoginForm extends AbstractCaptchaForm
             'username' => $this->username,
             'password' => $this->password,
             'url' => $this->url,
-            '__wcfAcpIsLogin' => true,
         ]);
     }
 }

--- a/wcfsetup/install/files/lib/acp/form/ReauthenticationForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/ReauthenticationForm.class.php
@@ -14,10 +14,13 @@ use wcf\system\WCF;
  */
 class ReauthenticationForm extends \wcf\form\ReauthenticationForm
 {
-    public function assignVariables()
+    public function __run()
     {
-        parent::assignVariables();
+        WCF::getTPL()->assign([
+            '__wcfAcpIsLogin' => true,
+            '__isLogin' => true,
+        ]);
 
-        WCF::getTPL()->assign(['__wcfAcpIsLogin' => true]);
+        parent::__run();
     }
 }

--- a/wcfsetup/install/files/lib/acp/form/RescueModeForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/RescueModeForm.class.php
@@ -80,6 +80,11 @@ final class RescueModeForm extends AbstractCaptchaForm
             );
         }
 
+        WCF::getTPL()->assign([
+            '__wcfAcpIsLogin' => true,
+            '__isLogin' => true,
+        ]);
+
         return parent::__run();
     }
 


### PR DESCRIPTION
Otherwise this leaks the ACP header when a NamedUserException is thrown.

----------

Which target branch should this be? It's technically a small information leak.
