### PR TITLE
Always load object data for immutable form fields

### DIFF
--- a/wcfsetup/install/files/lib/system/form/builder/container/SuffixFormFieldContainer.class.php
+++ b/wcfsetup/install/files/lib/system/form/builder/container/SuffixFormFieldContainer.class.php
@@ -178,15 +178,17 @@ class SuffixFormFieldContainer extends FormContainer
      */
     public function suffixHasSelectableOptions()
     {
-        if ($this->getSuffixField() === null) {
+        $suffixField = $this->getSuffixField();
+
+        if ($suffixField === null) {
             return false;
         }
 
-        if ($this->getSuffixField() instanceof IImmutableFormField && $this->getSuffixField()->isImmutable()) {
+        if ($suffixField instanceof IImmutableFormField && $suffixField->isImmutable()) {
             return false;
         }
 
-        foreach ($this->getSuffixField()->getNestedOptions() as $option) {
+        foreach ($suffixField->getNestedOptions() as $option) {
             if ($option['isSelectable']) {
                 return true;
             }

--- a/wcfsetup/install/files/lib/system/form/builder/field/AbstractFormField.class.php
+++ b/wcfsetup/install/files/lib/system/form/builder/field/AbstractFormField.class.php
@@ -218,6 +218,10 @@ abstract class AbstractFormField implements IFormField
      */
     public function updatedObject(array $data, IStorableObject $object, $loadValues = true)
     {
+        if ($this instanceof IImmutableFormField && $this->isImmutable()) {
+            $loadValues = true;
+        }
+
         if ($loadValues && isset($data[$this->getObjectProperty()])) {
             $this->value($data[$this->getObjectProperty()]);
         }

--- a/wcfsetup/install/files/lib/system/form/builder/field/TI18nFormField.class.php
+++ b/wcfsetup/install/files/lib/system/form/builder/field/TI18nFormField.class.php
@@ -278,6 +278,10 @@ trait TI18nFormField
      */
     public function updatedObject(array $data, IStorableObject $object, $loadValues = true)
     {
+        if ($this instanceof IImmutableFormField && $this->isImmutable()) {
+            $loadValues = true;
+        }
+
         if ($loadValues && isset($data[$this->getObjectProperty()])) {
             $value = $data[$this->getObjectProperty()];
 


### PR DESCRIPTION
When reading the input values in immutable form fields are (correctly) skipped,
thus leaving whatever value was there in place. However when an existing object
is provided, the values will not be read from that object, thus resulting in
the default value (which is likely some empty value).

This is confusing and will actually result in bugs, because when validating
saving that default value will then be used.

Fix this by checking whether the field is immutable and then forcing the load
of the object data, even if loading is not requested (i.e. when the input is
non-empty).

I've opted to implement the check within the fields themselves, but it might
make more sense to implement it in FormDocument::updatedObject() directly,
possibly avoiding issues if some immutable field overrides updatedObject and
forgets the check.

There is an existing asymmetry anyway, because the loading of input values is
done in TFormParentNode::readValues() which is pulled into the FormDocument via
the trait, but the loading of object data is directly implemented in
FormDocument. The result of this is that nodes have deeper access to input
loading, compared to object loading. The readValues() method should likely be
removed from the trait and implemented in the document directly, like the
object loading. The method does not really belong on the nodes. This should be
evaluated in a follow-up issue and possibly the immutability check for object
loading then be moved into the FormDocument as well, as suggested above.

see https://www.woltlab.com/community/thread/294841-formbuilder-fehlverhalten-bei-nutzung-von-immutable/
Resolves #4725