### PR TITLE
Modify `confirmationFactory().withReason()` to allow the reason to be mandatory

### DIFF
--- a/ts/WoltLabSuite/Core/Component/Confirmation.ts
+++ b/ts/WoltLabSuite/Core/Component/Confirmation.ts
@@ -121,7 +121,6 @@ class ConfirmationPrefab {
   async withReason(question: string, isOptional: boolean): Promise<ResultConfirmationWithReason> {
     const dialog = dialogFactory().withoutContent().asConfirmation();
 
-    let reason: HTMLTextAreaElement | undefined = undefined;
     const id = DomUtil.getUniqueId();
     const label = getPhrase(isOptional ? "wcf.dialog.confirmation.reason.optional" : "wcf.dialog.confirmation.reason");
 
@@ -130,7 +129,7 @@ class ConfirmationPrefab {
       <dt><label for="${id}">${label}</label></dt>
       <dd><textarea id="${id}" cols="40" rows="3"></textarea></dd>
     `;
-    reason = dl.querySelector("textarea")!;
+    const reason = dl.querySelector("textarea")!;
 
     dialog.content.append(dl);
 
@@ -140,7 +139,7 @@ class ConfirmationPrefab {
       dialog.addEventListener("primary", () => {
         resolve({
           result: true,
-          reason: reason!.value.trim(),
+          reason: reason.value.trim(),
         });
       });
 

--- a/ts/WoltLabSuite/Core/Component/Confirmation.ts
+++ b/ts/WoltLabSuite/Core/Component/Confirmation.ts
@@ -127,28 +127,20 @@ class ConfirmationPrefab {
 
     const dl = document.createElement("dl");
     dl.innerHTML = `
-        <dt><label for="${id}">${label}</label></dt>
-        <dd><textarea id="${id}" cols="40" rows="3"></textarea></dd>
-      `;
+      <dt><label for="${id}">${label}</label></dt>
+      <dd><textarea id="${id}" cols="40" rows="3"></textarea></dd>
+    `;
     reason = dl.querySelector("textarea")!;
 
     dialog.content.append(dl);
 
     dialog.show(question);
 
-    if (!isOptional) {
-      dialog.addEventListener("validate", (event) => {
-        if (reason!.value.trim() === "") {
-          event.preventDefault();
-        }
-      });
-    }
-
     return new Promise<ResultConfirmationWithReason>((resolve) => {
       dialog.addEventListener("primary", () => {
         resolve({
           result: true,
-          reason: reason ? reason.value.trim() : "",
+          reason: reason!.value.trim(),
         });
       });
 

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Component/Confirmation.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Component/Confirmation.js
@@ -99,24 +99,17 @@ define(["require", "exports", "tslib", "./Dialog", "../Language", "../Dom/Util",
             const label = (0, Language_1.getPhrase)(isOptional ? "wcf.dialog.confirmation.reason.optional" : "wcf.dialog.confirmation.reason");
             const dl = document.createElement("dl");
             dl.innerHTML = `
-        <dt><label for="${id}">${label}</label></dt>
-        <dd><textarea id="${id}" cols="40" rows="3"></textarea></dd>
-      `;
+      <dt><label for="${id}">${label}</label></dt>
+      <dd><textarea id="${id}" cols="40" rows="3"></textarea></dd>
+    `;
             reason = dl.querySelector("textarea");
             dialog.content.append(dl);
             dialog.show(question);
-            if (!isOptional) {
-                dialog.addEventListener("validate", (event) => {
-                    if (reason.value.trim() === "") {
-                        event.preventDefault();
-                    }
-                });
-            }
             return new Promise((resolve) => {
                 dialog.addEventListener("primary", () => {
                     resolve({
                         result: true,
-                        reason: reason ? reason.value.trim() : "",
+                        reason: reason.value.trim(),
                     });
                 });
                 dialog.addEventListener("cancel", () => {

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Component/Confirmation.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Component/Confirmation.js
@@ -94,7 +94,6 @@ define(["require", "exports", "tslib", "./Dialog", "../Language", "../Dom/Util",
         }
         async withReason(question, isOptional) {
             const dialog = (0, Dialog_1.dialogFactory)().withoutContent().asConfirmation();
-            let reason = undefined;
             const id = DomUtil.getUniqueId();
             const label = (0, Language_1.getPhrase)(isOptional ? "wcf.dialog.confirmation.reason.optional" : "wcf.dialog.confirmation.reason");
             const dl = document.createElement("dl");
@@ -102,7 +101,7 @@ define(["require", "exports", "tslib", "./Dialog", "../Language", "../Dom/Util",
       <dt><label for="${id}">${label}</label></dt>
       <dd><textarea id="${id}" cols="40" rows="3"></textarea></dd>
     `;
-            reason = dl.querySelector("textarea");
+            const reason = dl.querySelector("textarea");
             dialog.content.append(dl);
             dialog.show(question);
             return new Promise((resolve) => {

--- a/wcfsetup/install/files/lib/system/event/listener/PreloadPhrasesCollectingListener.class.php
+++ b/wcfsetup/install/files/lib/system/event/listener/PreloadPhrasesCollectingListener.class.php
@@ -46,7 +46,6 @@ final class PreloadPhrasesCollectingListener
         $event->preload('wcf.dialog.confirmation.delete.indeterminate');
         $event->preload('wcf.dialog.confirmation.softDelete');
         $event->preload('wcf.dialog.confirmation.softDelete.indeterminate');
-        $event->preload('wcf.dialog.confirmation.reason');
         $event->preload('wcf.dialog.confirmation.restore');
         $event->preload('wcf.dialog.confirmation.restore.indeterminate');
 
@@ -98,6 +97,7 @@ final class PreloadPhrasesCollectingListener
         $event->preload('wcf.global.page.pagination');
         $event->preload('wcf.global.page.previous');
         $event->preload('wcf.global.reason');
+        $event->preload('wcf.global.reason.optional');
         $event->preload('wcf.global.scrollUp');
         $event->preload('wcf.global.select');
         $event->preload('wcf.global.success');

--- a/wcfsetup/install/lang/de.xml
+++ b/wcfsetup/install/lang/de.xml
@@ -3729,7 +3729,6 @@ Dateianhänge:
 		<item name="wcf.dialog.confirmation.delete.indeterminate"><![CDATA[{if LANGUAGE_USE_INFORMAL_VARIANT}Willst du{else}Wollen Sie{/if} dies wirklich löschen?]]></item>
 		<item name="wcf.dialog.confirmation.softDelete"><![CDATA[{if LANGUAGE_USE_INFORMAL_VARIANT}Möchtest du{else}Möchten Sie{/if} „{$title}“ in den Papierkorb verschieben?]]></item>
 		<item name="wcf.dialog.confirmation.softDelete.indeterminate"><![CDATA[{if LANGUAGE_USE_INFORMAL_VARIANT}Möchtest du{else}Möchten Sie{/if} dies in den Papierkorb verschieben?]]></item>
-		<item name="wcf.dialog.confirmation.reason"><![CDATA[Begründung (optional)]]></item>
 		<item name="wcf.dialog.confirmation.restore"><![CDATA[{if LANGUAGE_USE_INFORMAL_VARIANT}Möchtest du{else}Möchten Sie{/if} „{$title}“ wiederherstellen?]]></item>
 		<item name="wcf.dialog.confirmation.restore.indeterminate"><![CDATA[{if LANGUAGE_USE_INFORMAL_VARIANT}Möchtest du{else}Möchten Sie{/if} dies wiederherstellen?]]></item>
 	</category>
@@ -3942,6 +3941,7 @@ Dateianhänge:
 		<item name="wcf.global.noItems"><![CDATA[Es wurden keine Einträge gefunden.]]></item>
 		<item name="wcf.global.button.showAll"><![CDATA[Alle anzeigen]]></item>
 		<item name="wcf.global.reason"><![CDATA[Begründung]]></item>
+		<item name="wcf.global.reason.optional"><![CDATA[Begründung (optional)]]></item>
 		<item name="wcf.global.settings"><![CDATA[Einstellungen]]></item>
 		<item name="wcf.global.bulkProcessing.warning"><![CDATA[Die Massenbearbeitung führt die unten ausgewählte Aktion <strong>ohne zusätzliche Sicherheitsabfrage</strong> aus!]]></item>
 		<item name="wcf.global.search"><![CDATA[Suche]]></item>
@@ -7519,5 +7519,6 @@ Benachrichtigungen auf <a href="{link isHtmlEmail=true}{/link}">{PAGE_TITLE|phra
 	<item name="wcf.comment.description"/>
 	<item name="wcf.comment.response.add"/>
 	<item name="wcf.dialog.confirmation.softDelete.reason"/>
+	<item name="wcf.dialog.confirmation.reason"/>
 </delete>
 </language>

--- a/wcfsetup/install/lang/en.xml
+++ b/wcfsetup/install/lang/en.xml
@@ -3678,7 +3678,6 @@ Attachments:
 		<item name="wcf.dialog.confirmation.delete.indeterminate"><![CDATA[Are you sure you want to delete this?]]></item>
 		<item name="wcf.dialog.confirmation.softDelete"><![CDATA[Do you want to move “{$title}” to the trash bin?]]></item>
 		<item name="wcf.dialog.confirmation.softDelete.indeterminate"><![CDATA[Do you want to move this to the trash bin?]]></item>
-		<item name="wcf.dialog.confirmation.reason"><![CDATA[Reason (optional)]]></item>
 		<item name="wcf.dialog.confirmation.restore"><![CDATA[Do you want to restore “{$title}”?]]></item>
 		<item name="wcf.dialog.confirmation.restore.indeterminate"><![CDATA[Do you want to restore this?]]></item>
 	</category>
@@ -3891,6 +3890,7 @@ Attachments:
 		<item name="wcf.global.noItems"><![CDATA[There are no items at the moment.]]></item>
 		<item name="wcf.global.button.showAll"><![CDATA[Display All]]></item>
 		<item name="wcf.global.reason"><![CDATA[Reason]]></item>
+		<item name="wcf.global.reason.optional"><![CDATA[Reason (optional)]]></item>
 		<item name="wcf.global.settings"><![CDATA[Settings]]></item>
 		<item name="wcf.global.bulkProcessing.warning"><![CDATA[Warning! The bulk processing will be processed <strong>without further confirmation</strong> for all items matching your criteria.]]></item>
 		<item name="wcf.global.search"><![CDATA[Search]]></item>
@@ -7409,5 +7409,6 @@ your notifications on <a href="{link isHtmlEmail=true}{/link}">{PAGE_TITLE|phras
 	<item name="wcf.comment.description"/>
 	<item name="wcf.comment.response.add"/>
 	<item name="wcf.dialog.confirmation.softDelete.reason"/>
+	<item name="wcf.dialog.confirmation.reason"/>
 </delete>
 </language>


### PR DESCRIPTION
This is a follow-up for https://github.com/WoltLab/WCF/commit/75c922056f57ebf5e011217ad348a52bf3096dbe#r99945184 which implemented this incorrectly. The reason can now be both optional and mandatory, plus it relies on a global phrase instead to reduce duplication.

Function overloads for `softDelete()` have been added to improve type safety.