### PR TITLE
Configure a default prefix in Psr15DialogForm

### DIFF
--- a/wcfsetup/install/files/lib/system/form/builder/Psr15DialogForm.class.php
+++ b/wcfsetup/install/files/lib/system/form/builder/Psr15DialogForm.class.php
@@ -26,6 +26,7 @@ final class Psr15DialogForm extends FormDocument
         string $title
     ) {
         $this->id($id);
+        $this->prefix($id);
         $this->title = $title;
 
         $this->ajax = true;


### PR DESCRIPTION
As dialogs are embedded into an existing page, conflicts are likely when using
generic field names such as "title" or "message". Configure the form ID as the
default prefix for all fields. Users may still override the prefix if desired.
