### PR TITLE
Remove obsolete extension checks

### DIFF
--- a/wcfsetup/install/files/acp/templates/systemCheck.tpl
+++ b/wcfsetup/install/files/acp/templates/systemCheck.tpl
@@ -109,18 +109,6 @@
 		</dd>
 	</dl>
 	
-	<dl{if !$results[php][sha256]} class="formError"{/if}>
-		<dt>{lang}wcf.acp.systemCheck.php.sha256{/lang}</dt>
-		<dd>
-			{if $results[php][sha256]}
-				{@$statusOk} {lang}wcf.acp.systemCheck.pass{/lang}
-			{else}
-				{@$statusInsufficient} {lang}wcf.acp.systemCheck.notSupported{/lang}
-			{/if}
-			<small>{lang}wcf.acp.systemCheck.php.sha256.description{/lang}</small>
-		</dd>
-	</dl>
-
 	<dl{if $results[php][opcache] === false} class="formError"{/if}>
 		<dt>{lang}wcf.acp.systemCheck.php.opcache{/lang}</dt>
 		<dd>

--- a/wcfsetup/install/files/lib/acp/page/SystemCheckPage.class.php
+++ b/wcfsetup/install/files/lib/acp/page/SystemCheckPage.class.php
@@ -66,12 +66,9 @@ class SystemCheckPage extends AbstractPage
         'dom',
         'exif',
         'gd',
-        'hash',
         'intl',
-        'json',
         'libxml',
         'mbstring',
-        'pcre',
         'pdo_mysql',
         'pdo',
         'zlib',
@@ -146,7 +143,6 @@ class SystemCheckPage extends AbstractPage
                 'result' => false,
                 'value' => '0',
             ],
-            'sha256' => false,
             'opcache' => null,
             'version' => [
                 'result' => 'unsupported',
@@ -318,10 +314,6 @@ class SystemCheckPage extends AbstractPage
             }
         }
 
-        if (\extension_loaded('hash')) {
-            $this->results['php']['sha256'] = \in_array('sha256', \hash_algos());
-        }
-
         try {
             // Attempt to reset ourselves to perform a functional check.
             WCF::resetZendOpcache(__FILE__);
@@ -334,7 +326,6 @@ class SystemCheckPage extends AbstractPage
         }
 
         $this->results['status']['php'] = empty($this->results['php']['extension'])
-            && $this->results['php']['sha256']
             && $this->results['php']['opcache'] !== false;
     }
 

--- a/wcfsetup/install/lang/de.xml
+++ b/wcfsetup/install/lang/de.xml
@@ -2758,8 +2758,6 @@ Abschnitte dürfen nicht leer sein und nur folgende Zeichen enthalten: <kbd>[a-z
 		<item name="wcf.acp.systemCheck.php.extension.description"><![CDATA[Die offiziellen Erweiterungen von PHP stellen zusätzliche Funktionen bereit, die für den Betrieb der Software notwendig sind.]]></item>
 		<item name="wcf.acp.systemCheck.php.memoryLimit"><![CDATA[Verfügbarer Arbeitsspeicher („memory_limit“)]]></item>
 		<item name="wcf.acp.systemCheck.php.memoryLimit.description"><![CDATA[Einige Prozesse benötigen in Spitzenzeiten eine große Menge Arbeitsspeicher, für den einwandfreien Betrieb werden mindestens {$phpMemoryLimit} MB benötigt.]]></item>
-		<item name="wcf.acp.systemCheck.php.sha256"><![CDATA[Unterstützung für SHA-256]]></item>
-		<item name="wcf.acp.systemCheck.php.sha256.description"><![CDATA[Die kryptographische Funktion SHA-256 wird für den sicheren Betrieb der Software benötigt.]]></item>
 		<item name="wcf.acp.systemCheck.php.x64"><![CDATA[64-Bit-Unterstützung]]></item>
 		<item name="wcf.acp.systemCheck.php.x64.description"><![CDATA[Die eingesetzte PHP-Version muss die Verarbeitung von 64-Bit-Ganzzahlen unterstützen, um Zahlwerte größer als etwa 2,1 Milliarden korrekt zu verarbeiten.]]></item>
 		<item name="wcf.acp.systemCheck.mysql.mysqlnd"><![CDATA[MySQL Native Driver verwendet]]></item>

--- a/wcfsetup/install/lang/en.xml
+++ b/wcfsetup/install/lang/en.xml
@@ -2690,8 +2690,6 @@ If you have <strong>already bought the licenses for the listed apps</strong>, th
 		<item name="wcf.acp.systemCheck.php.extension.description"><![CDATA[The official PHP extensions provide additional capabilities and features that are required for the software to work.]]></item>
 		<item name="wcf.acp.systemCheck.php.memoryLimit"><![CDATA[Available Memory (“memory_limit”)]]></item>
 		<item name="wcf.acp.systemCheck.php.memoryLimit.description"><![CDATA[Processes may require large amounts of memory at peak, requiring a limit of at least {$phpMemoryLimit} MB.]]></item>
-		<item name="wcf.acp.systemCheck.php.sha256"><![CDATA[Support for SHA-256]]></item>
-		<item name="wcf.acp.systemCheck.php.sha256.description"><![CDATA[The cryptographic function SHA-256 is required for a safe and secure operation of the software.]]></item>
 		<item name="wcf.acp.systemCheck.php.x64"><![CDATA[64-bit Support]]></item>
 		<item name="wcf.acp.systemCheck.php.x64.description"><![CDATA[The PHP version must support 64-bit integers to correctly process numbers larger than ~2.1 billion.]]></item>
 		<item name="wcf.acp.systemCheck.mysql.mysqlnd"><![CDATA[MySQL Native Driver used]]></item>

--- a/wcfsetup/test.php
+++ b/wcfsetup/test.php
@@ -215,12 +215,9 @@ $requiredExtensions = [
 	'ctype',
 	'dom',
 	'exif',
-	'json',
-	'hash',
 	'intl',
 	'libxml',
 	'mbstring',
-	'pcre',
 	'pdo',
 	'pdo_mysql',
 	'zlib',
@@ -254,14 +251,6 @@ $phrases = [
 	'php_extension_gd_or_imagick_webp_failure' => [
 		'de' => 'Unterstützung für WebP-Grafiken in %s fehlt',
 		'en' => 'Support for WebP images in %s missing',
-	],
-	'php_sha256_success' => [
-		'de' => 'Unterstützung für SHA-256-Hashfunktion vorhanden',
-		'en' => 'Support for SHA-256 algorithm available',
-	],
-	'php_sha256_failure' => [
-		'de' => 'Unterstützung für SHA-256-Hashfunktion fehlt',
-		'en' => 'Support for SHA-256 algorithm missing',
 	],
 	'php_memory_limit_success' => [
 		'de' => 'Arbeitsspeicher-Limit %s',
@@ -349,13 +338,10 @@ function checkMemoryLimit() {
 	
 	return false;
 }
-function checkHashAlgorithms() {
-	return extension_loaded('hash') && in_array('sha256', hash_algos());
-}
 function checkResult() {
 	global $requiredExtensions;
 	
-	if (!checkPHPVersion() || !checkHashAlgorithms() || !checkMemoryLimit() || !checkOpcache()) return false;
+	if (!checkPHPVersion() || !checkMemoryLimit() || !checkOpcache()) return false;
 	
 	foreach ($requiredExtensions as $extension) {
 		if (!extension_loaded($extension)) return false;
@@ -418,12 +404,6 @@ function checkOpcache() {
 				<?php } ?>
 			<?php } else { ?>	
 				<li class="failure"><?=getPhrase('php_extension_gd_or_imagick_failure')?></li>
-			<?php } ?>
-			
-			<?php if (checkHashAlgorithms()) { ?>
-				<li class="success"><?=getPhrase('php_sha256_success')?></li>
-			<?php } else { ?>
-				<li class="failure"><?=getPhrase('php_sha256_failure')?></li>
 			<?php } ?>
 			
 			<?php if (checkMemoryLimit()) { ?>


### PR DESCRIPTION
All these extensions are guaranteed to be enabled in PHP 8.1, unless the build
is FUBAR, thus there is no need to check them any longer. This allows us to get
rid of the special SHA-256 check in SystemCheckPage as well.
