### PR TITLE
Clean up “is login” handling in ACP templates

### DIFF
--- a/wcfsetup/install/files/acp/style/layout.scss
+++ b/wcfsetup/install/files/acp/style/layout.scss
@@ -287,11 +287,11 @@ html {
 	.pageHeader {
 		grid-template-areas: "logo woltlab jumpToPage search user menu";
 		grid-template-columns: auto repeat(5, max-content);
+	}
 
-		.pageHeaderContainerIsLogin & {
-			grid-template-areas: "logo";
-			grid-template-columns: auto;
-		}
+	.pageHeaderContainerIsLogin .pageHeader {
+		grid-template-areas: "logo";
+		grid-template-columns: auto;
 	}
 
 	.pageHeaderPanel > .layoutBoundary {

--- a/wcfsetup/install/files/acp/style/layout.scss
+++ b/wcfsetup/install/files/acp/style/layout.scss
@@ -288,7 +288,7 @@ html {
 		grid-template-areas: "logo woltlab jumpToPage search user menu";
 		grid-template-columns: auto repeat(5, max-content);
 
-		&[data-is-login="true"] {
+		.pageHeaderContainerIsLogin & {
 			grid-template-areas: "logo";
 			grid-template-columns: auto;
 		}

--- a/wcfsetup/install/files/acp/templates/pageHeader.tpl
+++ b/wcfsetup/install/files/acp/templates/pageHeader.tpl
@@ -1,5 +1,5 @@
 <div class="pageHeaderContainer{if !$__isLogin|empty} pageHeaderContainerIsLogin{/if}">
-	<header id="pageHeader" class="pageHeader" data-is-login="{if !$__wcfAcpIsLogin|empty}true{else}false{/if}">
+	<header id="pageHeader" class="pageHeader" data-is-login="{if !$__isLogin|empty}true{else}false{/if}">
 		<div id="pageHeaderPanel" class="pageHeaderPanel">
 			<div class="layoutBoundary">
 				{include file='pageHeaderLogo'}

--- a/wcfsetup/install/files/acp/templates/pageHeader.tpl
+++ b/wcfsetup/install/files/acp/templates/pageHeader.tpl
@@ -1,5 +1,5 @@
 <div class="pageHeaderContainer{if !$__isLogin|empty} pageHeaderContainerIsLogin{/if}">
-	<header id="pageHeader" class="pageHeader" data-is-login="{if !$__isLogin|empty}true{else}false{/if}">
+	<header id="pageHeader" class="pageHeader">
 		<div id="pageHeaderPanel" class="pageHeaderPanel">
 			<div class="layoutBoundary">
 				{include file='pageHeaderLogo'}

--- a/wcfsetup/install/files/lib/acp/form/LoginForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/LoginForm.class.php
@@ -62,7 +62,6 @@ class LoginForm extends AbstractCaptchaForm
     public function __run()
     {
         WCF::getTPL()->assign([
-            '__wcfAcpIsLogin' => true,
             '__isLogin' => true,
         ]);
 

--- a/wcfsetup/install/files/lib/acp/form/ReauthenticationForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/ReauthenticationForm.class.php
@@ -17,7 +17,6 @@ class ReauthenticationForm extends \wcf\form\ReauthenticationForm
     public function __run()
     {
         WCF::getTPL()->assign([
-            '__wcfAcpIsLogin' => true,
             '__isLogin' => true,
         ]);
 

--- a/wcfsetup/install/files/lib/acp/form/RescueModeForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/RescueModeForm.class.php
@@ -83,7 +83,6 @@ final class RescueModeForm extends AbstractForm
         }
 
         WCF::getTPL()->assign([
-            '__wcfAcpIsLogin' => true,
             '__isLogin' => true,
         ]);
 


### PR DESCRIPTION
I'm reasonably sure that these are correct, but possibly there is a deeper
reason why it worked like this, so please have a careful look.
