### PR TITLE
Add support for the UTC timezone

### DIFF
--- a/com.woltlab.wcf/option.xml
+++ b/com.woltlab.wcf/option.xml
@@ -718,7 +718,7 @@ block:wcf.acp.option.blacklist_sfs_action.block]]></selectoptions>
 			<option name="timezone">
 				<categoryname>general.system.date</categoryname>
 				<optiontype>timezone</optiontype>
-				<defaultvalue>Europe/London</defaultvalue>
+				<defaultvalue>UTC</defaultvalue>
 			</option>
 			<!-- /general.system.date -->
 			<!-- general.system.googleMaps -->

--- a/constants.php
+++ b/constants.php
@@ -69,7 +69,7 @@
 \define('RECAPTCHA_PUBLICKEY', '');
 \define('RECAPTCHA_PRIVATEKEY', '');
 \define('RECAPTCHA_PRIVATEKEY_INVISIBLE', '');
-\define('TIMEZONE', 'Europe/London');
+\define('TIMEZONE', 'UTC');
 \define('GOOGLE_MAPS_API_KEY', '');
 \define('GOOGLE_MAPS_ZOOM', '13');
 \define('GOOGLE_MAPS_DEFAULT_LATITUDE', '52.517');

--- a/wcfsetup/install/files/acp/install_com.woltlab.wcf_step1.php
+++ b/wcfsetup/install/files/acp/install_com.woltlab.wcf_step1.php
@@ -11,9 +11,9 @@ use wcf\system\WCF;
 use wcf\util\DateUtil;
 
 // change the priority of the PIPs to "1"
-$sql = "UPDATE  wcf" . WCF_N . "_package_installation_plugin
+$sql = "UPDATE  wcf1_package_installation_plugin
         SET     priority = ?";
-$statement = WCF::getDB()->prepareStatement($sql);
+$statement = WCF::getDB()->prepare($sql);
 $statement->execute([1]);
 
 // Clear any outdated cached data from WCFSetup.
@@ -21,11 +21,11 @@ UserStorageHandler::getInstance()->clear();
 
 // get server timezone
 if ($timezone = @\date_default_timezone_get()) {
-    if ($timezone != 'Europe/London' && \in_array($timezone, DateUtil::getAvailableTimezones())) {
-        $sql = "UPDATE  wcf" . WCF_N . "_option
+    if (\in_array($timezone, DateUtil::getAvailableTimezones())) {
+        $sql = "UPDATE  wcf1_option
                 SET     optionValue = ?
                 WHERE   optionName = ?";
-        $statement = WCF::getDB()->prepareStatement($sql);
+        $statement = WCF::getDB()->prepare($sql);
         $statement->execute([
             $timezone,
             'timezone',

--- a/wcfsetup/install/files/lib/system/WCF.class.php
+++ b/wcfsetup/install/files/lib/system/WCF.class.php
@@ -49,7 +49,7 @@ if (($error = \error_get_last()) !== null) {
 
 // fix timezone warning issue
 if (!@\ini_get('date.timezone')) {
-    @\date_default_timezone_set('Europe/London');
+    @\date_default_timezone_set('UTC');
 }
 
 // Force enable the reporting of all errors, no matter what's

--- a/wcfsetup/install/files/lib/util/DateUtil.class.php
+++ b/wcfsetup/install/files/lib/util/DateUtil.class.php
@@ -83,9 +83,9 @@ final class DateUtil
         'Atlantic/South_Georgia', // (UTC-02:00) Mid-Atlantic
         'Atlantic/Azores', // (UTC-01:00) Azores
         'Atlantic/Cape_Verde', // (UTC-01:00) Cape Verde Is.
-        'Africa/Casablanca', // (UTC) Casablanca
-        'Europe/London', // (UTC) Dublin, Lisbon, London
-        'Africa/Monrovia', // (UTC) Monrovia, Reykjavik
+        'Africa/Casablanca', // (UTC+00:00) Casablanca
+        'Europe/London', // (UTC+00:00) Dublin, Lisbon, London
+        'Africa/Monrovia', // (UTC+00:00) Monrovia, Reykjavik
         'Europe/Berlin', // (UTC+01:00) Amsterdam, Berlin, Rome, Stockholm, Vienna
         'Europe/Belgrade', // (UTC+01:00) Belgrade, Bratislava, Budapest, Ljubljana, Prague
         'Europe/Paris', // (UTC+01:00) Brussels, Copenhagen, Madrid, Paris
@@ -146,6 +146,8 @@ final class DateUtil
         'Pacific/Fiji', // (UTC+12:00) Fiji
         'Pacific/Tongatapu', // (UTC+13:00) Nukualofa
         'Pacific/Apia', // (UTC+13:00) Samoa
+
+        'UTC',
     ];
 
     /**

--- a/wcfsetup/install/files/options.inc.php
+++ b/wcfsetup/install/files/options.inc.php
@@ -21,7 +21,7 @@ if (\file_exists(WCF_DIR . 'cookiePrefix.txt')) {
 
 \define('CACHE_SOURCE_TYPE', 'disk');
 \define('IMAGE_ADAPTER_TYPE', 'gd');
-\define('TIMEZONE', 'Europe/Berlin');
+\define('TIMEZONE', 'UTC');
 
 \define('ENABLE_DEBUG_MODE', 1);
 \define('ENABLE_PRODUCTION_DEBUG_MODE', 1);

--- a/wcfsetup/install/lang/de.xml
+++ b/wcfsetup/install/lang/de.xml
@@ -3638,9 +3638,9 @@ Dateianhänge:
 		<item name="wcf.date.timezone.atlantic.south_georgia"><![CDATA[(UTC-02:00) Mittelatlantik]]></item>
 		<item name="wcf.date.timezone.atlantic.azores"><![CDATA[(UTC-01:00) Azoren]]></item>
 		<item name="wcf.date.timezone.atlantic.cape_verde"><![CDATA[(UTC-01:00) Kap Verde]]></item>
-		<item name="wcf.date.timezone.africa.casablanca"><![CDATA[(UTC) Casablanca]]></item>
-		<item name="wcf.date.timezone.europe.london"><![CDATA[(UTC) Dublin, Edinburgh, Lissabon, London]]></item>
-		<item name="wcf.date.timezone.africa.monrovia"><![CDATA[(UTC) Monrovia, Reykjavík]]></item>
+		<item name="wcf.date.timezone.africa.casablanca"><![CDATA[(UTC+00:00) Casablanca]]></item>
+		<item name="wcf.date.timezone.europe.london"><![CDATA[(UTC+00:00) Dublin, Edinburgh, Lissabon, London]]></item>
+		<item name="wcf.date.timezone.africa.monrovia"><![CDATA[(UTC+00:00) Monrovia, Reykjavík]]></item>
 		<item name="wcf.date.timezone.europe.berlin"><![CDATA[(UTC+01:00) Amsterdam, Berlin, Bern, Rom, Stockholm, Wien]]></item>
 		<item name="wcf.date.timezone.europe.belgrade"><![CDATA[(UTC+01:00) Belgrad, Bratislava, Budapest, Ljubljana, Prag]]></item>
 		<item name="wcf.date.timezone.europe.paris"><![CDATA[(UTC+01:00) Brüssel, Kopenhagen, Madrid, Paris]]></item>
@@ -3701,6 +3701,7 @@ Dateianhänge:
 		<item name="wcf.date.timezone.pacific.fiji"><![CDATA[(UTC+12:00) Fidschi]]></item>
 		<item name="wcf.date.timezone.pacific.tongatapu"><![CDATA[(UTC+13:00) Nuku'alofa]]></item>
 		<item name="wcf.date.timezone.pacific.apia"><![CDATA[(UTC+13:00) Samoa]]></item>
+		<item name="wcf.date.timezone.utc"><![CDATA[UTC]]></item>
 		<item name="wcf.date.period.start"><![CDATA[von]]></item>
 		<item name="wcf.date.period.end"><![CDATA[bis]]></item>
 		<item name="wcf.date.firstDayOfTheWeek"><![CDATA[1]]></item>

--- a/wcfsetup/install/lang/en.xml
+++ b/wcfsetup/install/lang/en.xml
@@ -3587,9 +3587,9 @@ Attachments:
 		<item name="wcf.date.timezone.atlantic.south_georgia"><![CDATA[(UTC-02:00) South Georgia and the South Sandwich Islands]]></item>
 		<item name="wcf.date.timezone.atlantic.azores"><![CDATA[(UTC-01:00) Azores]]></item>
 		<item name="wcf.date.timezone.atlantic.cape_verde"><![CDATA[(UTC-01:00) Cape Verde]]></item>
-		<item name="wcf.date.timezone.africa.casablanca"><![CDATA[(UTC) Casablanca]]></item>
-		<item name="wcf.date.timezone.europe.london"><![CDATA[(UTC) Dublin, Edinburgh, Lisbon, London]]></item>
-		<item name="wcf.date.timezone.africa.monrovia"><![CDATA[(UTC) Monrovia, Reykjavík]]></item>
+		<item name="wcf.date.timezone.africa.casablanca"><![CDATA[(UTC+00:00) Casablanca]]></item>
+		<item name="wcf.date.timezone.europe.london"><![CDATA[(UTC+00:00) Dublin, Edinburgh, Lisbon, London]]></item>
+		<item name="wcf.date.timezone.africa.monrovia"><![CDATA[(UTC+00:00) Monrovia, Reykjavík]]></item>
 		<item name="wcf.date.timezone.europe.berlin"><![CDATA[(UTC+01:00) Amsterdam, Berlin, Bern, Rome, Stockholm, Vienna]]></item>
 		<item name="wcf.date.timezone.europe.belgrade"><![CDATA[(UTC+01:00) Belgrade, Bratislava, Budapest, Ljubljana, Prague]]></item>
 		<item name="wcf.date.timezone.europe.paris"><![CDATA[(UTC+01:00) Brussels, Copenhagen, Madrid, Paris]]></item>
@@ -3650,6 +3650,7 @@ Attachments:
 		<item name="wcf.date.timezone.pacific.fiji"><![CDATA[(UTC+12:00) Fiji]]></item>
 		<item name="wcf.date.timezone.pacific.tongatapu"><![CDATA[(UTC+13:00) Nukuʻalofa]]></item>
 		<item name="wcf.date.timezone.pacific.apia"><![CDATA[(UTC+13:00) Samoa]]></item>
+		<item name="wcf.date.timezone.utc"><![CDATA[UTC]]></item>
 		<item name="wcf.date.period.start"><![CDATA[from]]></item>
 		<item name="wcf.date.period.end"><![CDATA[to]]></item>
 		<item name="wcf.date.firstDayOfTheWeek"><![CDATA[0]]></item>


### PR DESCRIPTION
This adds explicit support for the UTC timezone. None of the existing timezones
are a suitable replacement for UTC purposes, because they might be affected by
DST shenanigans. Specifically Europe/London looks more or less fine in winter,
but differs from UTC in summer.

UTC is also an obvious unopinionated (or at least less opinionated :-) )default
choice, because everything else is based off it. It is also useful having UTC
for the calendar for global virtual events (e.g. some event in a video game)
that are announced based on UTC time.

The UTC selection appears at the button of the dropdown to not be in the way
for users that want to set their real timezone, but is also easily findable for
the calendar purposes.

The name used is not "Etc/UTC", but "UTC". It's supported both by PHP and
JavaScript and the recommended choice with PHP.
