### PR TITLE
Stop supporting importing unnamed cronjobs via cronjob.xml

### DIFF
--- a/wcfsetup/install/files/lib/data/cronjob/Cronjob.class.php
+++ b/wcfsetup/install/files/lib/data/cronjob/Cronjob.class.php
@@ -59,13 +59,6 @@ class Cronjob extends DatabaseObject
     const MAX_FAIL_COUNT = 3;
 
     /**
-     * prefix of automatically created cronjob names
-     * @var string
-     * @deprecated  will be removed once cronjob names are mandatory
-     */
-    const AUTOMATIC_NAME_PREFIX = 'com.woltlab.wcf.cronjob';
-
-    /**
      * Returns timestamp of next execution.
      *
      * @param int $timeBase

--- a/wcfsetup/install/files/lib/system/package/plugin/CronjobPackageInstallationPlugin.class.php
+++ b/wcfsetup/install/files/lib/system/package/plugin/CronjobPackageInstallationPlugin.class.php
@@ -106,7 +106,7 @@ class CronjobPackageInstallationPlugin extends AbstractXMLPackageInstallationPlu
         return [
             'canBeDisabled' => isset($data['elements']['canbedisabled']) ? \intval($data['elements']['canbedisabled']) : 1,
             'canBeEdited' => isset($data['elements']['canbeedited']) ? \intval($data['elements']['canbeedited']) : 1,
-            'className' => $data['elements']['classname'] ?? '',
+            'className' => $data['elements']['classname'],
             'cronjobName' => $data['attributes']['name'],
             'description' => $data['elements']['description'] ?? '',
             'isDisabled' => isset($data['elements']['isdisabled']) ? \intval($data['elements']['isdisabled']) : 0,

--- a/wcfsetup/install/files/lib/system/package/plugin/CronjobPackageInstallationPlugin.class.php
+++ b/wcfsetup/install/files/lib/system/package/plugin/CronjobPackageInstallationPlugin.class.php
@@ -4,7 +4,6 @@ namespace wcf\system\package\plugin;
 
 use Cron\CronExpression;
 use Cron\FieldFactory;
-use wcf\data\cronjob\Cronjob;
 use wcf\data\cronjob\CronjobEditor;
 use wcf\data\cronjob\CronjobList;
 use wcf\system\cronjob\ICronjob;
@@ -108,7 +107,7 @@ class CronjobPackageInstallationPlugin extends AbstractXMLPackageInstallationPlu
             'canBeDisabled' => isset($data['elements']['canbedisabled']) ? \intval($data['elements']['canbedisabled']) : 1,
             'canBeEdited' => isset($data['elements']['canbeedited']) ? \intval($data['elements']['canbeedited']) : 1,
             'className' => $data['elements']['classname'] ?? '',
-            'cronjobName' => $data['attributes']['name'] ?? '',
+            'cronjobName' => $data['attributes']['name'],
             'description' => $data['elements']['description'] ?? '',
             'isDisabled' => isset($data['elements']['isdisabled']) ? \intval($data['elements']['isdisabled']) : 0,
             'options' => isset($data['elements']['options']) ? StringUtil::normalizeCsv($data['elements']['options']) : '',
@@ -147,39 +146,8 @@ class CronjobPackageInstallationPlugin extends AbstractXMLPackageInstallationPlu
     /**
      * @inheritDoc
      */
-    protected function import(array $row, array $data)
-    {
-        // if a cronjob is updated without a name given, keep the old automatically
-        // assigned name
-        if (!empty($row) && !$data['cronjobName']) {
-            unset($data['cronjobName']);
-        }
-
-        /** @var Cronjob $cronjob */
-        $cronjob = parent::import($row, $data);
-
-        // update cronjob name
-        if (!$cronjob->cronjobName) {
-            $cronjobEditor = new CronjobEditor($cronjob);
-            $cronjobEditor->update([
-                'cronjobName' => Cronjob::AUTOMATIC_NAME_PREFIX . $cronjob->cronjobID,
-            ]);
-
-            $cronjob = new Cronjob($cronjob->cronjobID);
-        }
-
-        return $cronjob;
-    }
-
-    /**
-     * @inheritDoc
-     */
     protected function findExistingItem(array $data)
     {
-        if (!$data['cronjobName']) {
-            return;
-        }
-
         $sql = "SELECT  *
                 FROM    wcf" . WCF_N . "_" . $this->tableName . "
                 WHERE   packageID = ?


### PR DESCRIPTION
- Stop supporting importing unnamed cronjobs via cronjob.xml
- Require the `classname` element in cronjob PIP
