### PR TITLE
Fix the `addEventListener` definition for custom elements

### DIFF
--- a/ts/WoltLabSuite/Core/Element/woltlab-core-dialog-control.ts
+++ b/ts/WoltLabSuite/Core/Element/woltlab-core-dialog-control.ts
@@ -144,19 +144,16 @@ export class WoltlabCoreDialogControlElement extends HTMLElement {
       this.append(this.#extraButton);
     }
   }
+}
 
-  public addEventListener<T extends keyof WoltlabCoreDialogControlEventMap>(
-    type: T,
-    listener: (this: WoltlabCoreDialogControlElement, ev: WoltlabCoreDialogControlEventMap[T]) => any,
-    options?: boolean | AddEventListenerOptions,
-  ): void;
-  public addEventListener(
-    type: string,
-    listener: (this: WoltlabCoreDialogControlElement, ev: Event) => any,
-    options?: boolean | AddEventListenerOptions,
-  ): void {
-    super.addEventListener(type, listener, options);
-  }
+export interface WoltlabCoreDialogControlElement extends HTMLElement {
+  addEventListener: {
+    <T extends keyof WoltlabCoreDialogControlEventMap>(
+      type: T,
+      listener: (this: WoltlabCoreDialogControlElement, ev: WoltlabCoreDialogControlEventMap[T]) => any,
+      options?: boolean | AddEventListenerOptions,
+    ): void;
+  } & HTMLElement["addEventListener"];
 }
 
 window.customElements.define("woltlab-core-dialog-control", WoltlabCoreDialogControlElement);

--- a/ts/WoltLabSuite/Core/Element/woltlab-core-dialog.ts
+++ b/ts/WoltLabSuite/Core/Element/woltlab-core-dialog.ts
@@ -303,19 +303,16 @@ export class WoltlabCoreDialogElement extends HTMLElement {
 
     return event.defaultPrevented === false;
   }
+}
 
-  public addEventListener<T extends keyof WoltlabCoreDialogEventMap>(
-    type: T,
-    listener: (this: WoltlabCoreDialogElement, ev: WoltlabCoreDialogEventMap[T]) => any,
-    options?: boolean | AddEventListenerOptions,
-  ): void;
-  public addEventListener(
-    type: string,
-    listener: (this: WoltlabCoreDialogElement, ev: Event) => any,
-    options?: boolean | AddEventListenerOptions,
-  ): void {
-    super.addEventListener(type, listener, options);
-  }
+export interface WoltlabCoreDialogElement extends HTMLElement {
+  addEventListener: {
+    <T extends keyof WoltlabCoreDialogEventMap>(
+      type: T,
+      listener: (this: WoltlabCoreDialogElement, ev: WoltlabCoreDialogEventMap[T]) => any,
+      options?: boolean | AddEventListenerOptions,
+    ): void;
+  } & HTMLElement["addEventListener"];
 }
 
 window.customElements.define("woltlab-core-dialog", WoltlabCoreDialogElement);

--- a/ts/WoltLabSuite/WebComponent/woltlab-core-pagination.ts
+++ b/ts/WoltLabSuite/WebComponent/woltlab-core-pagination.ts
@@ -297,19 +297,16 @@
       this.setAttribute("url", url);
       this.#render();
     }
+  }
 
-    public addEventListener<T extends keyof WoltlabCorePaginationEventMap>(
-      type: T,
-      listener: (this: WoltlabCorePaginationElement, ev: WoltlabCorePaginationEventMap[T]) => any,
-      options?: boolean | AddEventListenerOptions,
-    ): void;
-    public addEventListener(
-      type: string,
-      listener: (this: WoltlabCorePaginationElement, ev: Event) => any,
-      options?: boolean | AddEventListenerOptions,
-    ): void {
-      super.addEventListener(type, listener, options);
-    }
+  interface WoltlabCorePaginationElement extends HTMLElement {
+    addEventListener: {
+      <T extends keyof WoltlabCorePaginationEventMap>(
+        type: T,
+        listener: (this: WoltlabCorePaginationElement, ev: WoltlabCorePaginationEventMap[T]) => any,
+        options?: boolean | AddEventListenerOptions,
+      ): void;
+    } & HTMLElement["addEventListener"];
   }
 
   window.customElements.define("woltlab-core-pagination", WoltlabCorePaginationElement);

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Element/woltlab-core-dialog-control.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Element/woltlab-core-dialog-control.js
@@ -115,9 +115,6 @@ define(["require", "exports", "tslib", "../Language"], function (require, export
                 this.append(this.#extraButton);
             }
         }
-        addEventListener(type, listener, options) {
-            super.addEventListener(type, listener, options);
-        }
     }
     exports.WoltlabCoreDialogControlElement = WoltlabCoreDialogControlElement;
     window.customElements.define("woltlab-core-dialog-control", WoltlabCoreDialogControlElement);

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Element/woltlab-core-dialog.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Element/woltlab-core-dialog.js
@@ -233,9 +233,6 @@ define(["require", "exports", "tslib", "../Dom/Util", "../Helper/PageOverlay", "
             this.dispatchEvent(event);
             return event.defaultPrevented === false;
         }
-        addEventListener(type, listener, options) {
-            super.addEventListener(type, listener, options);
-        }
     }
     exports.WoltlabCoreDialogElement = WoltlabCoreDialogElement;
     window.customElements.define("woltlab-core-dialog", WoltlabCoreDialogElement);

--- a/wcfsetup/install/files/js/WoltLabSuite/WebComponent.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/WebComponent.js
@@ -1675,9 +1675,6 @@
         this.setAttribute("url", url);
         this.#render();
       }
-      addEventListener(type, listener, options) {
-        super.addEventListener(type, listener, options);
-      }
     }
     window.customElements.define("woltlab-core-pagination", WoltlabCorePaginationElement);
   }


### PR DESCRIPTION
The previous definition violated the liskov substitution principle, because not all valid calls for the parent type `HTMLElement` are valid calls on the custom element. Specifically it was not allowed to e.g. bind a `click` (or any other “standard”) event onto a `woltlab-core-dialog` element.

This error was reported when consuming the `.d.ts` definitions in a TypeScript project with `strict: true`.

Also the `addEventListener` was needlessly emitted as a real function that just delegates to `super.addEventListener()`.

Fix both issues by moving the function signature definition into an `interface` (to avoid the code generation) and by intersecting our more specific definition with the `HTMLElement["addEventListener"]` definition to inherit all signatures from `HTMLElement`.

see microsoft/TypeScript#52916