### PR TITLE
Simplify install.sql

### DIFF
--- a/wcfsetup/install/files/acp/install_com.woltlab.wcf_step2.php
+++ b/wcfsetup/install/files/acp/install_com.woltlab.wcf_step2.php
@@ -3,6 +3,7 @@
 use wcf\data\category\CategoryEditor;
 use wcf\data\object\type\ObjectTypeCache;
 use wcf\data\reaction\type\ReactionTypeEditor;
+use wcf\data\user\rank\UserRankEditor;
 use wcf\data\user\UserEditor;
 use wcf\data\user\UserProfileAction;
 use wcf\system\image\adapter\ImagickImageAdapter;
@@ -22,6 +23,25 @@ $statement->execute([
     'com.woltlab.wcf.Dashboard',
     1,
 ]);
+
+// install default user ranks
+foreach ([
+    [4, 0, 'wcf.user.rank.administrator', 'blue'],
+    [5, 0, 'wcf.user.rank.moderator', 'blue'],
+    [3, 0, 'wcf.user.rank.user0', ''],
+    [3, 300, 'wcf.user.rank.user1', ''],
+    [3, 900, 'wcf.user.rank.user2', ''],
+    [3, 3000, 'wcf.user.rank.user3', ''],
+    [3, 9000, 'wcf.user.rank.user4', ''],
+    [3, 15000, 'wcf.user.rank.user5', ''],
+] as [$groupID, $requiredPoints, $rankTitle, $cssClassName]) {
+    UserRankEditor::create([
+        'groupID' => $groupID,
+        'requiredPoints' => $requiredPoints,
+        'rankTitle' => $rankTitle,
+        'cssClassName' => $cssClassName,
+    ]);
+}
 
 // update administrator user rank and user online marking
 $editor = new UserEditor(WCF::getUser());

--- a/wcfsetup/install/files/acp/install_com.woltlab.wcf_step2.php
+++ b/wcfsetup/install/files/acp/install_com.woltlab.wcf_step2.php
@@ -2,6 +2,7 @@
 
 use wcf\data\category\CategoryEditor;
 use wcf\data\object\type\ObjectTypeCache;
+use wcf\data\reaction\type\ReactionTypeEditor;
 use wcf\data\user\UserEditor;
 use wcf\data\user\UserProfileAction;
 use wcf\system\image\adapter\ImagickImageAdapter;
@@ -28,6 +29,22 @@ $action = new UserProfileAction([$editor], 'updateUserRank');
 $action->executeAction();
 $action = new UserProfileAction([$editor], 'updateUserOnlineMarking');
 $action->executeAction();
+
+// install default reactions
+foreach ([
+    [1, 1, 'like.svg'],
+    [2, 2, 'thanks.svg'],
+    [3, 3, 'haha.svg'],
+    [4, 4, 'confused.svg'],
+    [5, 5, 'sad.svg'],
+] as [$reactionTypeID, $showOrder, $iconFile]) {
+    ReactionTypeEditor::create([
+        'reactionTypeID' => $reactionTypeID,
+        'title' => "wcf.reactionType.title{$reactionTypeID}",
+        'showOrder' => $showOrder,
+        'iconFile' => $iconFile,
+    ]);
+}
 
 // add default article category
 CategoryEditor::create([

--- a/wcfsetup/setup/db/install.sql
+++ b/wcfsetup/setup/db/install.sql
@@ -2475,17 +2475,6 @@ INSERT INTO wcf1_style_variable (variableName, defaultValue) VALUES ('wcfUserMen
 -- Email template group
 INSERT INTO wcf1_template_group (parentTemplateGroupID, templateGroupName, templateGroupFolderName) VALUES (NULL, 'wcf.acp.template.group.email', '_wcf_email/');
 
--- default ranks
-INSERT INTO wcf1_user_rank (groupID, requiredPoints, rankTitle, cssClassName) VALUES
-	(4, 0, 'wcf.user.rank.administrator', 'blue'),
-	(5, 0, 'wcf.user.rank.moderator', 'blue'),
-	(3, 0, 'wcf.user.rank.user0', ''),
-	(3, 300, 'wcf.user.rank.user1', ''),
-	(3, 900, 'wcf.user.rank.user2', ''),
-	(3, 3000, 'wcf.user.rank.user3', ''),
-	(3, 9000, 'wcf.user.rank.user4', ''),
-	(3, 15000, 'wcf.user.rank.user5', '');
-
 -- default options: subject and message
 INSERT INTO wcf1_contact_option (optionID, optionTitle, optionDescription, optionType, required, showOrder, originIsSystem) VALUES (1, 'wcf.contact.option1', 'wcf.contact.optionDescription1', 'text', 1, 1, 1);
 INSERT INTO wcf1_contact_option (optionID, optionTitle, optionDescription, optionType, required, showOrder, originIsSystem) VALUES (2, 'wcf.contact.option2', '', 'textarea', 1, 1, 1);

--- a/wcfsetup/setup/db/install.sql
+++ b/wcfsetup/setup/db/install.sql
@@ -2500,10 +2500,3 @@ INSERT INTO wcf1_contact_option (optionID, optionTitle, optionDescription, optio
 
 -- default recipient: site administrator
 INSERT INTO wcf1_contact_recipient (recipientID, name, email, isAdministrator, originIsSystem) VALUES (1, 'wcf.contact.recipient.name1', '', 1, 1);
-
--- default reaction type
-INSERT INTO wcf1_reaction_type (reactionTypeID, title, showOrder, iconFile) VALUES (1, 'wcf.reactionType.title1', 1, 'like.svg');
-INSERT INTO wcf1_reaction_type (reactionTypeID, title, showOrder, iconFile) VALUES (2, 'wcf.reactionType.title2', 2, 'thanks.svg');
-INSERT INTO wcf1_reaction_type (reactionTypeID, title, showOrder, iconFile) VALUES (3, 'wcf.reactionType.title3', 3, 'haha.svg');
-INSERT INTO wcf1_reaction_type (reactionTypeID, title, showOrder, iconFile) VALUES (4, 'wcf.reactionType.title4', 4, 'confused.svg');
-INSERT INTO wcf1_reaction_type (reactionTypeID, title, showOrder, iconFile) VALUES (5, 'wcf.reactionType.title5', 5, 'sad.svg');

--- a/wcfsetup/setup/db/install.sql
+++ b/wcfsetup/setup/db/install.sql
@@ -2295,8 +2295,8 @@ ALTER TABLE wcf1_notice_dismissed ADD FOREIGN KEY (userID) REFERENCES wcf1_user 
 INSERT INTO wcf1_user_group (groupID, groupName, groupDescription, groupType) VALUES (1, 'wcf.acp.group.group1', '', 1); -- Everyone
 INSERT INTO wcf1_user_group (groupID, groupName, groupDescription, groupType) VALUES (2, 'wcf.acp.group.group2', '', 2); -- Guests
 INSERT INTO wcf1_user_group (groupID, groupName, groupDescription, groupType, priority) VALUES (3, 'wcf.acp.group.group3', '', 3, 10); -- Registered Users
-INSERT INTO wcf1_user_group (groupID, groupName, groupDescription, groupType, priority) VALUES (4, 'wcf.acp.group.group4', '', 9, 1000); -- Administrators
-INSERT INTO wcf1_user_group (groupID, groupName, groupDescription, groupType, priority) VALUES (5, 'wcf.acp.group.group5', '', 4, 100); -- Moderators
+INSERT INTO wcf1_user_group (groupID, groupName, groupDescription, groupType, priority, showOnTeamPage) VALUES (4, 'wcf.acp.group.group4', '', 9, 1000, 1); -- Administrators
+INSERT INTO wcf1_user_group (groupID, groupName, groupDescription, groupType, priority, showOnTeamPage) VALUES (5, 'wcf.acp.group.group5', '', 4, 100, 1); -- Moderators
 
 -- default user group options
 INSERT INTO wcf1_user_group_option (packageID, optionID, optionName, categoryName, optionType, defaultValue, showOrder, usersOnly) VALUES (1, 1, 'admin.general.canUseAcp', 'admin.general', 'boolean', '0', 1, 1);
@@ -2474,9 +2474,6 @@ INSERT INTO wcf1_style_variable (variableName, defaultValue) VALUES ('wcfUserMen
 
 -- Email template group
 INSERT INTO wcf1_template_group (parentTemplateGroupID, templateGroupName, templateGroupFolderName) VALUES (NULL, 'wcf.acp.template.group.email', '_wcf_email/');
-
--- default 'showOnTeamPage' setting
-UPDATE wcf1_user_group SET showOnTeamPage = 1 WHERE groupID IN (4, 5);
 
 -- default ranks
 INSERT INTO wcf1_user_rank (groupID, requiredPoints, rankTitle, cssClassName) VALUES

--- a/wcfsetup/setup/db/install.sql
+++ b/wcfsetup/setup/db/install.sql
@@ -2294,9 +2294,9 @@ ALTER TABLE wcf1_notice_dismissed ADD FOREIGN KEY (userID) REFERENCES wcf1_user 
 -- default user groups
 INSERT INTO wcf1_user_group (groupID, groupName, groupDescription, groupType) VALUES (1, 'wcf.acp.group.group1', '', 1); -- Everyone
 INSERT INTO wcf1_user_group (groupID, groupName, groupDescription, groupType) VALUES (2, 'wcf.acp.group.group2', '', 2); -- Guests
-INSERT INTO wcf1_user_group (groupID, groupName, groupDescription, groupType) VALUES (3, 'wcf.acp.group.group3', '', 3); -- Registered Users
-INSERT INTO wcf1_user_group (groupID, groupName, groupDescription, groupType) VALUES (4, 'wcf.acp.group.group4', '', 9); -- Administrators
-INSERT INTO wcf1_user_group (groupID, groupName, groupDescription, groupType) VALUES (5, 'wcf.acp.group.group5', '', 4); -- Moderators
+INSERT INTO wcf1_user_group (groupID, groupName, groupDescription, groupType, priority) VALUES (3, 'wcf.acp.group.group3', '', 3, 10); -- Registered Users
+INSERT INTO wcf1_user_group (groupID, groupName, groupDescription, groupType, priority) VALUES (4, 'wcf.acp.group.group4', '', 9, 1000); -- Administrators
+INSERT INTO wcf1_user_group (groupID, groupName, groupDescription, groupType, priority) VALUES (5, 'wcf.acp.group.group5', '', 4, 100); -- Moderators
 
 -- default user group options
 INSERT INTO wcf1_user_group_option (packageID, optionID, optionName, categoryName, optionType, defaultValue, showOrder, usersOnly) VALUES (1, 1, 'admin.general.canUseAcp', 'admin.general', 'boolean', '0', 1, 1);
@@ -2474,11 +2474,6 @@ INSERT INTO wcf1_style_variable (variableName, defaultValue) VALUES ('wcfUserMen
 
 -- Email template group
 INSERT INTO wcf1_template_group (parentTemplateGroupID, templateGroupName, templateGroupFolderName) VALUES (NULL, 'wcf.acp.template.group.email', '_wcf_email/');
-
--- default priorities
-UPDATE wcf1_user_group SET priority = 10 WHERE groupID = 3;
-UPDATE wcf1_user_group SET priority = 1000 WHERE groupID = 4;
-UPDATE wcf1_user_group SET priority = 100 WHERE groupID = 5;
 
 -- default 'showOnTeamPage' setting
 UPDATE wcf1_user_group SET showOnTeamPage = 1 WHERE groupID IN (4, 5);


### PR DESCRIPTION
This moves some inserts from install.sql into the regular update script. By
running them within the update script, the regular package installation
environment is available. WCFSetup should only do the minimally required stuff.
