### PR TITLE
Drop misleading “deprecated” note in `wcf.acp.option.http_send_x_frame_options`

### DIFF
--- a/wcfsetup/install/lang/de.xml
+++ b/wcfsetup/install/lang/de.xml
@@ -1333,7 +1333,7 @@ ACHTUNG: Die oben genannten Meldungen sind stark gekürzt. Sie können Details z
 		<item name="wcf.acp.option.error.tooLow"><![CDATA[Der angegebene Wert ist zu gering.{if $option->minvalue !== null} Der minimale Wert ist {#$option->minvalue}.{/if}]]></item>
 		<item name="wcf.acp.option.error.tooLong"><![CDATA[Der eingegebene Text ist zu lang.]]></item>
 		<item name="wcf.acp.option.error.tooShort"><![CDATA[Der eingegebene Text ist zu kurz.]]></item>
-		<item name="wcf.acp.option.http_send_x_frame_options"><![CDATA[Einbindung in einem Frame verhindern (veraltet / nicht empfohlen)]]></item>
+		<item name="wcf.acp.option.http_send_x_frame_options"><![CDATA[Einbindung in einem Frame verhindern]]></item>
 		<item name="wcf.acp.option.http_send_x_frame_options.description"><![CDATA[Die Option zur Kontrolle der Einbindung in einem Frame ist veraltet, wird in einer zukünftigen Version entfernt und die Einbindung generell unterbunden. Die Einbindung in einem Frame reduziert die Sicherheit, da <a href="https://de.wikipedia.org/wiki/Clickjacking" class="externalURL">Clickjacking-Angriffe</a> ermöglicht werden. Darüber hinaus können bestimmte Sicherheitsmerkmale von Cookies in Frames nicht verwendet werden.]]></item>
 		<item name="wcf.acp.option.image_adapter_type"><![CDATA[Grafik-Bibliothek]]></item>
 		<item name="wcf.acp.option.image_adapter_type.gd"><![CDATA[GD Graphics Library (Standard)]]></item>

--- a/wcfsetup/install/lang/en.xml
+++ b/wcfsetup/install/lang/en.xml
@@ -1312,7 +1312,7 @@ ATTENTION: The messages listed above are greatly shortened. You can view details
 		<item name="wcf.acp.option.error.tooLow"><![CDATA[Under the minimum value{if $option->minvalue !== null} of {#$option->minvalue}{/if}.]]></item>
 		<item name="wcf.acp.option.error.tooLong"><![CDATA[The entered text is too long.]]></item>
 		<item name="wcf.acp.option.error.tooShort"><![CDATA[The entered text is too short.]]></item>
-		<item name="wcf.acp.option.http_send_x_frame_options"><![CDATA[Disallow embedding in a frame (deprecated)]]></item>
+		<item name="wcf.acp.option.http_send_x_frame_options"><![CDATA[Disallow embedding in a frame]]></item>
 		<item name="wcf.acp.option.http_send_x_frame_options.description"><![CDATA[The option to control embedding within a frame is deprecated, will be removed in a future version and embedding will be prevented in all cases. Allowing embedding reduces security by allowing <a href="https://en.wikipedia.org/wiki/Clickjacking" class="externalURL">Clickjacking attacks</a> to happen. In addition certain security features for cookies are not available within frames.]]></item>
 		<item name="wcf.acp.option.image_adapter_type"><![CDATA[Graphics Library]]></item>
 		<item name="wcf.acp.option.image_adapter_type.gd"><![CDATA[Use GD Graphics Library (default)]]></item>


### PR DESCRIPTION
Not the “disallowing of frame embeds” is deprecated, but the disabling of the
disallowing. This becomes clear when reading the description, but not when just
reading the option name + parenthesis.

Drop the parenthesis entirely, the description is quite clear and the ACP index
page will also show a warning if the option still is enabled.

see https://www.woltlab.com/community/thread/299182-einbindung-in-einem-frame-verhindern-veraltet-nicht-empfohlen/
