### PR TITLE
Fix bad merge in Media/Clipboard.ts

### DIFF
--- a/ts/WoltLabSuite/Core/Media/Clipboard.ts
+++ b/ts/WoltLabSuite/Core/Media/Clipboard.ts
@@ -20,7 +20,7 @@ import { AjaxCallbackObject, AjaxCallbackSetup } from "../Ajax/Data";
 import { DialogCallbackObject, DialogCallbackSetup } from "../Ui/Dialog/Data";
 
 let _mediaManager: MediaManager;
-const _didInit = false;
+let _didInit = false;
 
 class MediaClipboard implements AjaxCallbackObject, DialogCallbackObject {
   public _ajaxSetup(): ReturnType<AjaxCallbackSetup> {
@@ -139,6 +139,8 @@ export function init(pageClassName: string, hasMarkedItems: boolean, mediaManage
     });
 
     EventHandler.add("com.woltlab.wcf.clipboard", "com.woltlab.wcf.media", (data) => clipboardAction(data));
+
+    _didInit = true;
   }
 
   _mediaManager = mediaManager;

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Media/Clipboard.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Media/Clipboard.js
@@ -18,7 +18,7 @@ define(["require", "exports", "tslib", "../Controller/Clipboard", "../Ui/Notific
     Language = tslib_1.__importStar(Language);
     Ajax = tslib_1.__importStar(Ajax);
     let _mediaManager;
-    const _didInit = false;
+    let _didInit = false;
     class MediaClipboard {
         _ajaxSetup() {
             return {
@@ -104,6 +104,7 @@ define(["require", "exports", "tslib", "../Controller/Clipboard", "../Ui/Notific
                 pageClassName: pageClassName,
             });
             EventHandler.add("com.woltlab.wcf.clipboard", "com.woltlab.wcf.media", (data) => clipboardAction(data));
+            _didInit = true;
         }
         _mediaManager = mediaManager;
     }


### PR DESCRIPTION
The `_didInit = true` assignment added in
3510ed70b5abcd0786cca33469812b2781024cc9 got lost during the TypeScript
transformation in b5030e676de80fc60f7619c0149999cfed394499.

Fixes #5341
