### PR TITLE
Fix Article::canEdit() permission for article contributors

### DIFF
--- a/wcfsetup/install/files/lib/data/article/Article.class.php
+++ b/wcfsetup/install/files/lib/data/article/Article.class.php
@@ -147,7 +147,7 @@ class Article extends DatabaseObject implements ILinkableObject, IUserContent
 
         if ($this->publicationStatus != self::PUBLISHED) {
             if (WCF::getSession()->getPermission('admin.content.article.canContributeArticle') && $this->userID == WCF::getUser()->userID) {
-                return false;
+                return true;
             }
         }
 


### PR DESCRIPTION
The previous return value was non-sense, because `false` is already the
default. Users that may contribute articles may edit their own articles until
they are published, thus this must `return true`.
