### PR TITLE
Remove the “right to left” smiley aliases

### DIFF
--- a/com.woltlab.wcf/smiley.xml
+++ b/com.woltlab.wcf/smiley.xml
@@ -5,22 +5,19 @@
 			<title>smile</title>
 			<path>images/smilies/emojione/263a.png</path>
 			<path2x>images/smilies/emojione/263a@2x.png</path2x>
-			<aliases><![CDATA[:-)
-(:]]></aliases>
+			<aliases><![CDATA[:-)]]></aliases>
 		</smiley>
 		<smiley name=":(">
 			<title>sad</title>
 			<path>images/smilies/emojione/2639.png</path>
 			<path2x>images/smilies/emojione/2639@2x.png</path2x>
-			<aliases><![CDATA[:-(
-):]]></aliases>
+			<aliases><![CDATA[:-(]]></aliases>
 		</smiley>
 		<smiley name=";)">
 			<title>wink</title>
 			<path>images/smilies/emojione/1f609.png</path>
 			<path2x>images/smilies/emojione/1f609@2x.png</path2x>
-			<aliases><![CDATA[;-)
-(;]]></aliases>
+			<aliases><![CDATA[;-)]]></aliases>
 		</smiley>
 		<smiley name=":P">
 			<title>tongue</title>


### PR DESCRIPTION
Especially the `):` alias is pretty annoying, because it is a reasonable
sequence within a regular text:

    This is an example (to highlight the issue with the alias):

    As we see, the closing parenthesis and the colon match the alias.
