### PR TITLE
Add `userBBCodeTag` to the shared templates

### DIFF
--- a/syncTemplates.json
+++ b/syncTemplates.json
@@ -95,6 +95,7 @@
     "trophyImage",
     "unfurlUrl",
     "uploadFieldComponent",
+    "userBBCodeTag",
     "userConditions",
     "userOptionsCondition",
     "worker",

--- a/wcfsetup/install/files/acp/templates/userBBCodeTag.tpl
+++ b/wcfsetup/install/files/acp/templates/userBBCodeTag.tpl
@@ -1,0 +1,6 @@
+{if $userProfile === null}
+	{* user no longer exists, use plain output rather than using a broken link *}
+	@{$username}{* no newline after the tag
+*}{else}
+	<a href="{link controller='User' object=$userProfile->getDecoratedObject()}{/link}" class="userMention userLink" data-object-id="{@$userProfile->userID}">{@$userProfile->getFormattedUsername()}</a>{* no newline after the tag
+*}{/if}


### PR DESCRIPTION
The missing acp template `userBBCodeTag` may lead to exceptions.