### PR TITLE
Force replace some HTML tags before sending messages to the search index

### DIFF
--- a/wcfsetup/install/files/lib/system/search/SearchIndexManager.class.php
+++ b/wcfsetup/install/files/lib/system/search/SearchIndexManager.class.php
@@ -122,6 +122,24 @@ class SearchIndexManager extends SingletonFactory implements ISearchIndexManager
         $languageID = null,
         $metaData = ''
     ) {
+        // Force replace certain tags with a whitespace to prevent words from adjacent
+        // lines to be glued together.
+        $message = \str_replace([
+            '<br>',
+            '</h1>',
+            '</h2>',
+            '</h3>',
+            '</h4>',
+            '</h5>',
+            '</h6>',
+            '</kbd>',
+            '</li>',
+            '</p>',
+            '</pre>',
+            '</td>',
+            '</woltlab-metacode>',
+        ], ' ', $message);
+
         // strip html; remove whitespace from beginning and end of the message
         $message = StringUtil::trim(StringUtil::stripHTML($message));
 

--- a/wcfsetup/install/files/lib/system/search/SearchIndexManager.class.php
+++ b/wcfsetup/install/files/lib/system/search/SearchIndexManager.class.php
@@ -122,23 +122,9 @@ class SearchIndexManager extends SingletonFactory implements ISearchIndexManager
         $languageID = null,
         $metaData = ''
     ) {
-        // Force replace certain tags with a whitespace to prevent words from adjacent
-        // lines to be glued together.
-        $message = \str_replace([
-            '<br>',
-            '</h1>',
-            '</h2>',
-            '</h3>',
-            '</h4>',
-            '</h5>',
-            '</h6>',
-            '</kbd>',
-            '</li>',
-            '</p>',
-            '</pre>',
-            '</td>',
-            '</woltlab-metacode>',
-        ], ' ', $message);
+        // Inserts a whitespace after certain tags to prevent words from adjacent
+        // lines to be effectively be glued together when the tags are removed.
+        $message = \preg_replace('~(<br>|</(?:h[1-6]|kbd|li|p|pre|td|woltlab-metacode)>)~', '\\1 ', $message);
 
         // strip html; remove whitespace from beginning and end of the message
         $message = StringUtil::trim(StringUtil::stripHTML($message));


### PR DESCRIPTION
Stripping the HTML can cause certain words to be accidentally joined when there is no symbol between them that is recognized by the tokenizer. Inserting a whitespace at tag positions that are known to be prone is a stop-gap solution until we find a more stable replacement strategy.

See #4652 and WoltLab/com.woltlab.wcf.elasticSearch#14