### PR TITLE
Do not write an updated style file in StyleEditor::setVariables()

### DIFF
--- a/wcfsetup/install/files/lib/data/style/StyleEditor.class.php
+++ b/wcfsetup/install/files/lib/data/style/StyleEditor.class.php
@@ -1231,7 +1231,7 @@ class StyleEditor extends DatabaseObjectEditor implements IEditableCachedObject
             }
         }
 
-        $this->writeStyleFile();
+        StyleHandler::getInstance()->resetStylesheet($this->getDecoratedObject());
     }
 
     /**


### PR DESCRIPTION
If the style variables have already been loaded, which happens during style
import where the existing and to-be-updated style is currently taken from the
cache, the style will be rewritten with the old variables, effectively
resulting in a noop, making it a useless operation.

However if the existing variables are broken, e.g. because they contain a
syntax error, updating a broken style with a fixed one during package
installation will be impossible (without manually clearing the cache), because
the package installation aborts during compilation of the old SCSS, despite the
new SCSS already been written.

Fixes #5333
