### PR TITLE
(Un)Escape apostrophe

### DIFF
--- a/ts/WoltLabSuite/Core/StringUtil.ts
+++ b/ts/WoltLabSuite/Core/StringUtil.ts
@@ -26,7 +26,7 @@ export function addThousandsSeparator(number: number): string {
  * Escapes special HTML-characters within a string
  */
 export function escapeHTML(string: string): string {
-  return String(string).replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  return String(string).replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/'/g, "&#039;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
 /**
@@ -76,6 +76,7 @@ export function unescapeHTML(string: string): string {
   return String(string)
     .replace(/&amp;/g, "&")
     .replace(/&quot;/g, '"')
+    .replace(/&#039;/g, "'")
     .replace(/&lt;/g, "<")
     .replace(/&gt;/g, ">");
 }

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/StringUtil.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/StringUtil.js
@@ -27,7 +27,7 @@ define(["require", "exports", "tslib", "./NumberUtil"], function (require, expor
      * Escapes special HTML-characters within a string
      */
     function escapeHTML(string) {
-        return String(string).replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+        return String(string).replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/'/g, "&#039;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
     }
     exports.escapeHTML = escapeHTML;
     /**
@@ -74,6 +74,7 @@ define(["require", "exports", "tslib", "./NumberUtil"], function (require, expor
         return String(string)
             .replace(/&amp;/g, "&")
             .replace(/&quot;/g, '"')
+            .replace(/&#039;/g, "'")
             .replace(/&lt;/g, "<")
             .replace(/&gt;/g, ">");
     }


### PR DESCRIPTION
If you use the `wcf\system\form\builder\field\MultilineTextFormField` with `->i18n()` and save the example value
```
That's a test
```
As soon as the form is opened again, the text will be displayed as follows:
```
That&#039;s a test
```

However, the storage in the database is done correctly