### PR TITLE
 Remove incorrect modification of `$pendingPackages` in PackageInstallationNodeBuilder::buildRequirementNodes()

### DIFF
--- a/wcfsetup/install/files/lib/system/package/PackageInstallationNodeBuilder.class.php
+++ b/wcfsetup/install/files/lib/system/package/PackageInstallationNodeBuilder.class.php
@@ -626,8 +626,6 @@ class PackageInstallationNodeBuilder
                 'action' => $packageID ? 'update' : 'install',
             ]);
 
-            self::$pendingPackages[$archive->getPackageInfo('name')] = $archive->getPackageInfo('version');
-
             // spawn nodes
             $installation = new PackageInstallationDispatcher($queue);
             $installation->nodeBuilder->setParentNode($this->node);


### PR DESCRIPTION
Previously the `$pendingPackages` were only used to resolve dependencies, thus
the exact position for registering the new version does not really matter.
However with 5df3e65185d4d3f1be7464b1999b949946a5c765 the version is also used
to select the correct update instructions.

Thus the new package version must only be registered after the nodes for the
package in question have actually been built, similarly to the change in
2406351b19c5fac66b8413ba1f6660a376b7e18f.

In fact the registration in `buildRequirementNodes()` is completely redundant
since commit 7ddf2af9528be4c114d4ad83b804c3529769f24c, as the new version will
be registered in `->buildNodes()` a few lines afterwards. The
`$pendingPackages` variable is not read in-between. Thus this will be our fix:
The incorrect line is simply removed without replacement.