### PR TITLE
Fix reading boolean field values in form builder dialogs

### DIFF
--- a/wcfsetup/install/files/lib/system/form/builder/field/BooleanFormField.class.php
+++ b/wcfsetup/install/files/lib/system/form/builder/field/BooleanFormField.class.php
@@ -48,7 +48,7 @@ class BooleanFormField extends AbstractFormField implements
     public function readValue()
     {
         if ($this->getDocument()->hasRequestData($this->getPrefixedId())) {
-            $this->value = $this->getDocument()->getRequestData($this->getPrefixedId()) === '1';
+            $this->value = \intval($this->getDocument()->getRequestData($this->getPrefixedId())) === 1;
         }
 
         return $this;


### PR DESCRIPTION
For normal forms, the value of `BooleanFormField` is passed as a string. In form builder dialogs, however, it is passed as an int.