### PR TITLE
Fix JSON encoding in IconPreFilterTemplatePlugin

### DIFF
--- a/wcfsetup/install/files/lib/system/template/plugin/IconPrefilterTemplatePlugin.class.php
+++ b/wcfsetup/install/files/lib/system/template/plugin/IconPrefilterTemplatePlugin.class.php
@@ -41,7 +41,7 @@ final class IconPrefilterTemplatePlugin implements IPrefilterTemplatePlugin
                     $html = $this->getIcon($type, $name)->toHtml($size);
 
                     if ($encodeJson) {
-                        return JSON::encode($encodeJson);
+                        return JSON::encode($html);
                     }
 
                     return $html;


### PR DESCRIPTION
Instead of the actual HTML code of an icon, the value of `$encodeJson` is returned instead.