### PR TITLE
Improve error reporting for `value=null` in `{plural}` template function

### DIFF
--- a/wcfsetup/install/files/lib/system/template/plugin/PluralFunctionTemplatePlugin.class.php
+++ b/wcfsetup/install/files/lib/system/template/plugin/PluralFunctionTemplatePlugin.class.php
@@ -41,7 +41,11 @@ final class PluralFunctionTemplatePlugin implements IFunctionTemplatePlugin
     public function execute($tagArgs, TemplateEngine $tplObj)
     {
         if (!isset($tagArgs['value'])) {
-            throw new SystemException("Missing attribute 'value'");
+            if (!\array_key_exists('value', $tagArgs)) {
+                throw new SystemException("Missing attribute 'value'");
+            } else {
+                throw new SystemException("Attribute 'value' must not be null");
+            }
         }
         if (!isset($tagArgs['other'])) {
             throw new SystemException("Missing attribute 'other'");


### PR DESCRIPTION
Accidental `null`s are a common issue when dealing with database objects,
explicitly detect a `null` to not misleadingly report that the `value`
attribute is missing.

see https://www.woltlab.com/community/thread/299515-fatal-error-nach-update-missing-attribute-value/
