### PR TITLE
Stop needlessly invoking the autoloader to `<wcfNode-*>` tags

### DIFF
--- a/wcfsetup/install/files/lib/system/html/node/AbstractHtmlNodeProcessor.class.php
+++ b/wcfsetup/install/files/lib/system/html/node/AbstractHtmlNodeProcessor.class.php
@@ -330,7 +330,10 @@ abstract class AbstractHtmlNodeProcessor implements IHtmlNodeProcessor
         }
 
         foreach ($tags as $tagName) {
-            if (\in_array($tagName, $skipTags)) {
+            if (
+                \in_array($tagName, $skipTags)
+                || \str_starts_with($tagName, 'wcfNode-')
+            ) {
                 continue;
             }
 


### PR DESCRIPTION
These node names are randomly generated and will never match an existing class.
In fact the tag name transformation did not even result in valid classnames in
the majority of cases, because the randomly generated ID might start with a
number, thus including a hyphen in the classname.

Stop needlessly invoking the autoloader, and thus accessing the disk, for these
tags.
