### PR TITLE
Improve performance of `<wcfNode-*>` identifier generation

### DIFF
--- a/wcfsetup/install/files/lib/system/html/node/AbstractHtmlNodeProcessor.class.php
+++ b/wcfsetup/install/files/lib/system/html/node/AbstractHtmlNodeProcessor.class.php
@@ -347,4 +347,27 @@ abstract class AbstractHtmlNodeProcessor implements IHtmlNodeProcessor
             }
         }
     }
+
+    /**
+     * Returns a randomly generated tagName+identifier pair for <wcfNode-*> tags.
+     *
+     * @return array{0: string, 1: string}
+     */
+    public function getWcfNodeIdentifer(): array
+    {
+        static $engine = null;
+
+        if ($engine === null) {
+            if (\class_exists(\Random\Engine\Xoshiro256StarStar::class, false)) {
+                $randomizer = new \Random\Randomizer(new \Random\Engine\Xoshiro256StarStar());
+                $engine = static fn () => \bin2hex($randomizer->getBytes(16));
+            } else {
+                $engine = static fn () => \bin2hex(\random_bytes(16));
+            }
+        }
+
+        $identifier = $engine();
+
+        return [$identifier, "wcfNode-{$identifier}"];
+    }
 }

--- a/wcfsetup/install/files/lib/system/html/output/node/HtmlOutputNodePre.class.php
+++ b/wcfsetup/install/files/lib/system/html/output/node/HtmlOutputNodePre.class.php
@@ -38,22 +38,22 @@ class HtmlOutputNodePre extends AbstractHtmlOutputNode
         /** @var \DOMElement $element */
         foreach ($elements as $element) {
             if ($element->getAttribute('class') === 'woltlabHtml') {
-                $nodeIdentifier = StringUtil::getRandomID();
+                [$nodeIdentifier, $tagName] = $htmlNodeProcessor->getWcfNodeIdentifer();
                 $htmlNodeProcessor->addNodeData($this, $nodeIdentifier, ['rawHTML' => $element->textContent]);
 
-                $htmlNodeProcessor->renameTag($element, 'wcfNode-' . $nodeIdentifier);
+                $htmlNodeProcessor->renameTag($element, $tagName);
                 continue;
             }
 
             switch ($this->outputType) {
                 case 'text/html':
-                    $nodeIdentifier = StringUtil::getRandomID();
                     $context = $htmlNodeProcessor->getHtmlProcessor()->getContext();
                     $prefix = '';
                     // Create a unique prefix if possible
                     if (isset($context['objectType']) && isset($context['objectID'])) {
                         $prefix = \str_replace('.', '_', $context['objectType']) . '_' . $context['objectID'] . '_';
                     }
+                    [$nodeIdentifier, $tagName] = $htmlNodeProcessor->getWcfNodeIdentifer();
                     $htmlNodeProcessor->addNodeData($this, $nodeIdentifier, [
                         'content' => $element->textContent,
                         'file' => $element->getAttribute('data-file'),
@@ -64,7 +64,7 @@ class HtmlOutputNodePre extends AbstractHtmlOutputNode
                         'isAmp' => ($htmlNodeProcessor instanceof AmpHtmlOutputNodeProcessor),
                     ]);
 
-                    $htmlNodeProcessor->renameTag($element, 'wcfNode-' . $nodeIdentifier);
+                    $htmlNodeProcessor->renameTag($element, $tagName);
                     break;
 
                 case 'text/simplified-html':

--- a/wcfsetup/install/files/lib/system/html/output/node/HtmlOutputNodeWoltlabMetacode.class.php
+++ b/wcfsetup/install/files/lib/system/html/output/node/HtmlOutputNodeWoltlabMetacode.class.php
@@ -31,9 +31,9 @@ class HtmlOutputNodeWoltlabMetacode extends AbstractHtmlOutputNode
             $name = $element->getAttribute('data-name');
             $attributes = $element->getAttribute('data-attributes');
 
-            $nodeIdentifier = StringUtil::getRandomID();
+            [$nodeIdentifier, $tagName] = $htmlNodeProcessor->getWcfNodeIdentifer();
 
-            $element = $htmlNodeProcessor->renameTag($element, 'wcfNode-' . $nodeIdentifier);
+            $element = $htmlNodeProcessor->renameTag($element, $tagName);
 
             $htmlNodeProcessor->addNodeData($this, $nodeIdentifier, [
                 'name' => $name,

--- a/wcfsetup/install/files/lib/system/html/output/node/HtmlOutputNodeWoltlabQuote.class.php
+++ b/wcfsetup/install/files/lib/system/html/output/node/HtmlOutputNodeWoltlabQuote.class.php
@@ -49,14 +49,14 @@ class HtmlOutputNodeWoltlabQuote extends AbstractHtmlOutputNode
                         $link = WCF::getPath() . $link;
                     }
 
-                    $nodeIdentifier = StringUtil::getRandomID();
+                    [$nodeIdentifier, $tagName] = $htmlNodeProcessor->getWcfNodeIdentifer();
                     $htmlNodeProcessor->addNodeData($this, $nodeIdentifier, [
                         'author' => $element->getAttribute('data-author'),
                         'collapse' => $collapse,
                         'url' => $link,
                     ]);
 
-                    $htmlNodeProcessor->renameTag($element, 'wcfNode-' . $nodeIdentifier);
+                    $htmlNodeProcessor->renameTag($element, $tagName);
                     break;
 
                 case 'text/simplified-html':

--- a/wcfsetup/install/files/lib/system/html/output/node/HtmlOutputNodeWoltlabSpoiler.class.php
+++ b/wcfsetup/install/files/lib/system/html/output/node/HtmlOutputNodeWoltlabSpoiler.class.php
@@ -30,14 +30,14 @@ class HtmlOutputNodeWoltlabSpoiler extends AbstractHtmlOutputNode
         /** @var \DOMElement $element */
         foreach ($elements as $element) {
             if ($this->outputType === 'text/html') {
-                $nodeIdentifier = StringUtil::getRandomID();
+                [$nodeIdentifier, $tagName] = $htmlNodeProcessor->getWcfNodeIdentifer();
                 $htmlNodeProcessor->addNodeData(
                     $this,
                     $nodeIdentifier,
                     ['label' => $element->getAttribute('data-label')]
                 );
 
-                $htmlNodeProcessor->renameTag($element, 'wcfNode-' . $nodeIdentifier);
+                $htmlNodeProcessor->renameTag($element, $tagName);
             } elseif ($this->outputType === 'text/simplified-html' || $this->outputType === 'text/plain') {
                 $htmlNodeProcessor->replaceElementWithText(
                     $element,

--- a/wcfsetup/install/files/lib/system/html/output/node/HtmlOutputUnfurlUrlNode.class.php
+++ b/wcfsetup/install/files/lib/system/html/output/node/HtmlOutputUnfurlUrlNode.class.php
@@ -61,13 +61,13 @@ class HtmlOutputUnfurlUrlNode extends AbstractHtmlOutputNode
                     $enableUgc = $processor->enableUgc;
                 }
 
-                $nodeIdentifier = StringUtil::getRandomID();
+                [$nodeIdentifier, $tagName] = $htmlNodeProcessor->getWcfNodeIdentifer();
                 $htmlNodeProcessor->addNodeData($this, $nodeIdentifier, [
                     'urlId' => $attribute,
                     'enableUgc' => $enableUgc,
                 ]);
 
-                $htmlNodeProcessor->renameTag($element, 'wcfNode-' . $nodeIdentifier);
+                $htmlNodeProcessor->renameTag($element, $tagName);
             }
         }
     }


### PR DESCRIPTION
StringUtil::getRandomID() leverages the CSPRNG and constant time encoder to
generate IDs which is the secure, but slow, default choice.

For generation of the identifiers of `<wcfNode-*>` it is not required that the
values are absolutely unguessable, instead uniqueness and reasonable
unpredictability is sufficient, especially as the values are regenerated for
every request.

For content with a large number of BBCodes the overhead of a secure ID
generation can add up:

For a post with 300 BBCodes that is rendered 50 times the old ID generator
resulted in ~3300ms total rendering time, whereas the new ID generator with PHP
8.2 (thus leveraging xoshiro256**) is down to ~2500ms, a 25% reduction. However
even with PHP 8.1 the new generator will be faster, because it does not use the
constant time encoder. It will become even faster if PHP 8.2 is required and
the extra `$engine` closure can be removed.
