### PR TITLE
Add package update safety check with regard to version numbers

### DIFF
--- a/wcfsetup/install/files/lib/system/package/PackageInstallationNodeBuilder.class.php
+++ b/wcfsetup/install/files/lib/system/package/PackageInstallationNodeBuilder.class.php
@@ -90,6 +90,8 @@ class PackageInstallationNodeBuilder
         $package = $this->installation->getPackage();
         switch ($this->installation->getAction()) {
             case 'install':
+                $currentPackageVersion = null;
+
                 $auditLogger->log(
                     <<<EOT
                     Building installation nodes
@@ -134,7 +136,7 @@ class PackageInstallationNodeBuilder
         // required packages
         $this->buildRequirementNodes();
 
-        $this->buildStartMarkerNode();
+        $this->buildStartMarkerNode($currentPackageVersion);
 
         // install package itself
         if ($this->installation->getAction() == 'install') {
@@ -416,7 +418,7 @@ class PackageInstallationNodeBuilder
         ]);
     }
 
-    protected function buildStartMarkerNode()
+    protected function buildStartMarkerNode(?string $currentPackageVersion)
     {
         if (!empty($this->node)) {
             $this->parentNode = $this->node;
@@ -435,7 +437,9 @@ class PackageInstallationNodeBuilder
             $this->node,
             $this->parentNode,
             'start',
-            \serialize([]),
+            \serialize([
+                'currentPackageVersion' => $currentPackageVersion,
+            ]),
         ]);
     }
 


### PR DESCRIPTION
During a multi-package update, e.g. when upgrading to a new major release, the
entire installation plan is built upfront. Do to so the package system needs to
keep track of the to-be-installed packages and package versions to properly
resolve update instructions and dependencies.

This is done using the `PackageInstallationNodeBuilder::$pendingPackages`
variable which needs to be updated at exactly the right locations. Historically
there were a few issues with incorrect versions being stored in that variable
which in turn might cause the installation to use the wrong instructions based
on the wrong assumed version number.

To ensure that such a broken installation plan does not cause havoc, the
assumed version is now stored within the start marker node. When it's time to
actually install the package this assumed version is compared to the actual
version. If there's a mismatch, the update is aborted at a safe point: The
previous package is fully installed. For the current package with the wrongly
selected instructions no actual installation logic was performed yet. The admin
can retry the update and now the installation process will (hopefully) select
correct instructions when starting from a clean state.

see #5409
