### PR TITLE
Apply small stylig optimization

### DIFF
--- a/com.woltlab.wcf/templates/error.tpl
+++ b/com.woltlab.wcf/templates/error.tpl
@@ -20,7 +20,7 @@
 <div class="section">
 	<div class="box64 userException">
 		{icon size=64 name='circle-exclamation'}
-		<p>
+		<p class="userExceptionMessage">
 			{@$message}
 		</p>
 	</div>


### PR DESCRIPTION
Adding the `userExceptionMessage` makes it look better. And what about the inline CSS? Is that intentional? I would prefer to replace it with a proper CSS class as well.