### PR TITLE
Fix the use of Google Fonts

### DIFF
--- a/wcfsetup/install/files/lib/system/style/StyleCompiler.class.php
+++ b/wcfsetup/install/files/lib/system/style/StyleCompiler.class.php
@@ -635,11 +635,11 @@ final class StyleCompiler extends SingletonFactory
         }
 
         if (!empty($variables['wcfFontFamilyGoogle'])) {
-            // The SCSS parser attempts to evaluate the variables, causing issues with font names that
-            // include logical operators such as "And" or "Or".
-            $variables['wcfFontFamilyGoogle'] = '"' . $variables['wcfFontFamilyGoogle'] . '"';
-
-            $variables['wcfFontFamily'] = $variables['wcfFontFamilyGoogle'] . ', ' . $variables['wcfFontFamily'];
+            $variables['wcfFontFamily'] = \sprintf(
+                '"%s", %s',
+                $variables['wcfFontFamilyGoogle'],
+                $variables['wcfFontFamily']
+            );
         }
 
         // add options as SCSS variables


### PR DESCRIPTION
Due to the move to proper CSS variables, instead of just SCSS variables, the
variables need to be available during `->bootstrap()` and thus they are
prepared early in the compilation process. This preparation included quoting
the Google Font. Later in the bootstrap, when loading the CSS for the Google
Font, the corresponding CSS file could not be found due to this quoting.

It appears that the quoting of the variable itself is no longer be necessary.
The previous comment stated that font names with 'and' or 'or' in their name
cause issues. While the current list of fonts does not include any font with
'or' in its name, I successfully tested the `Black And White Picture` font.

The SCSS compiled just fine, possibly due to an upgrade of the SCSS compiler
that fixed a limitation. So this is going to be the bugfix.

Fixes #5400
