### PR TITLE
Run the userQuit cronjob every 4 hours

### DIFF
--- a/com.woltlab.wcf/cronjob.xml
+++ b/com.woltlab.wcf/cronjob.xml
@@ -59,7 +59,7 @@
 			<classname>wcf\system\cronjob\UserQuitCronjob</classname>
 			<description>Deletes canceled user accounts</description>
 			<description language="de">Löscht gekündigte Benutzer-Accounts</description>
-			<expression>0 0 * * *</expression>
+			<expression>0 */4 * * *</expression>
 			<canbedisabled>0</canbedisabled>
 		</cronjob>
 		<cronjob name="com.woltlab.wcf.dailyMailNotification">


### PR DESCRIPTION
Users that initiated their quit reported more than once that their user account
was not yet deleted, even though their quit time already expired. This is
especially pronounced if the planned quit time was in the morning, as the
cronjob previously only ran during night.

Run the cronjob every 4 hours, reducing the time window where the quit time
already expired, but the account is not actually deleted yet. A delay of a few
hours is likely reasonable even for layman users.
