### PR TITLE
Align the styling of CKEditor 5 with the regular style

### DIFF
--- a/wcfsetup/install/files/style/ui/ckeditor.scss
+++ b/wcfsetup/install/files/style/ui/ckeditor.scss
@@ -167,6 +167,10 @@
 	--ck-color-labeled-field-label-background: var(--ck-color-base-background);
 }
 
+.ck-insert-table-dropdown__grid .ck-button {
+	border-radius: 0 !important;
+}
+
 html[data-color-scheme="dark"] {
 	.ck.ck-editor,
 	.ck.ck-body {

--- a/wcfsetup/install/files/style/ui/ckeditor.scss
+++ b/wcfsetup/install/files/style/ui/ckeditor.scss
@@ -14,10 +14,10 @@
 .ck.ck-editor,
 .ck.ck-body {
 	--ck-color-base-background: var(--wcfContentContainerBackground);
-
 	--ck-border-radius: var(--wcfBorderRadius);
 	--ck-color-base-border: var(--wcfContentBorderInner);
 	--ck-color-text: var(--wcfContentText);
+
 	--ck-color-toolbar-border: var(--wcfContentBorderInner);
 	--ck-color-toolbar-background: var(--wcfContentContainerBackground);
 
@@ -72,11 +72,6 @@
 	}
 }
 
-/* TODO: DEV ONLY */
-.ck.ck-dropdown .ck-dropdown__panel {
-	display: block !important;
-}
-
 .ck.ck-reset.ck-dropdown__panel,
 .ck.ck-balloon-panel {
 	border-color: transparent;
@@ -95,8 +90,15 @@
 	cursor: pointer;
 }
 
+.ck.ck-editor__editable.ck-focused:not(.ck-editor__nested-editable),
+.ck .ck-editor__nested-editable.ck-editor__nested-editable_focused,
+.ck .ck-editor__nested-editable:focus {
+	border-color: var(--wcfInputBorderActive) !important;
+}
+
 .ck.ck-form__row .ck-button,
-.ck.ck-vertical-form .ck-button {
+.ck.ck-vertical-form .ck-button,
+.ck.ck-body .ck-button {
 	--ck-color-text: var(--wcfButtonText);
 
 	background-color: var(--wcfButtonBackground);
@@ -116,16 +118,6 @@
 	.ck-button {
 		flex: 0 0 auto !important;
 		margin: 0 !important;
-
-		&:not(.ck-disabled) {
-			cursor: pointer;
-		}
-
-		&.ck-disabled {
-			--ck-color-text: var(--wcfButtonDisabledText) !important;
-
-			background-color: var(--wcfButtonDisabledBackground) !important;
-		}
 	}
 
 	.ck-button[type="button"] {
@@ -134,6 +126,20 @@
 
 	.ck-button[type="submit"] {
 		order: 2;
+	}
+}
+
+.ck.ck-form__row,
+.ck.ck-body {
+	.ck-button:not(.ck-disabled) {
+		color: var(--ck-color-text);
+		cursor: pointer;
+	}
+
+	.ck-button.ck-disabled {
+		--ck-color-text: var(--wcfButtonDisabledText) !important;
+
+		background-color: var(--wcfButtonDisabledBackground) !important;
 	}
 
 	.ck-button[type="button"]:not(.ck-disabled):hover {
@@ -155,7 +161,22 @@
 	}
 }
 
+.ck.ck-labeled-field-view > .ck.ck-labeled-field-view__input-wrapper > .ck.ck-label {
+	--ck-color-labeled-field-label-background: var(--ck-color-base-background);
+}
+
 html[data-color-scheme="dark"] {
+	.ck.ck-editor,
+	.ck.ck-body {
+		--ck-color-focus-outer-shadow: #0a2c66;
+		--ck-focus-outer-shadow: var(--ck-focus-outer-shadow-geometry) var(--ck-color-focus-outer-shadow);
+
+		--ck-color-widget-hover-border: #124f81;
+		--ck-color-widget-editable-focus-background: var(--ck-color-base-background);
+		--ck-color-widget-drag-handler-icon-color: var(--ck-color-base-background);
+		--ck-color-widget-type-around-button-hover: var(--ck-color-widget-hover-border);
+	}
+
 	.ck.ck-reset.ck-dropdown__panel,
 	.ck.ck-balloon-panel {
 		border-color: var(--wcfDropdownBorderInner);

--- a/wcfsetup/install/files/style/ui/ckeditor.scss
+++ b/wcfsetup/install/files/style/ui/ckeditor.scss
@@ -11,11 +11,34 @@
 	vertical-align: middle;
 }
 
-.ck.ck-editor {
+.ck.ck-editor,
+.ck.ck-body {
+	--ck-color-base-background: var(--wcfContentContainerBackground);
+
 	--ck-border-radius: var(--wcfBorderRadius);
 	--ck-color-base-border: var(--wcfContentBorderInner);
 	--ck-color-text: var(--wcfContentText);
 	--ck-color-toolbar-border: var(--wcfContentBorderInner);
+	--ck-color-toolbar-background: var(--wcfContentContainerBackground);
+
+	--ck-color-dropdown-panel-background: var(--wcfDropdownBackground);
+	--ck-color-dropdown-panel-border: var(--wcfDropdownBorderInner);
+	--ck-color-panel-background: var(--wcfDropdownBackground);
+	--ck-color-panel-border: var(--wcfDropdownBorderInner);
+
+	--ck-color-input-background: var(--wcfInputBackground);
+	--ck-color-input-border: var(--wcfInputBorder);
+	--ck-color-input-error-border: var(--ck-color-base-error);
+	--ck-color-input-text: var(--wcfInputText);
+	--ck-color-input-disabled-background: var(--wcfInputDisabledBackground);
+	--ck-color-input-disabled-border: var(--wcfInputDisabledBorder);
+	--ck-color-input-disabled-text: var(--wcfInputDisabledText);
+
+	--ck-color-list-background: var(--wcfDropdownBackground);
+	--ck-color-list-button-hover-background: var(--wcfDropdownBackgroundActive);
+	--ck-color-list-button-on-background: var(--wcfDropdownBackgroundActive);
+	--ck-color-list-button-on-background-focus: var(--wcfDropdownBackgroundActive);
+	--ck-color-list-button-on-text: var(--wcfDropdownLink);
 }
 
 .ck.ck-content {
@@ -49,119 +72,93 @@
 	}
 }
 
+/* TODO: DEV ONLY */
+.ck.ck-dropdown .ck-dropdown__panel {
+	display: block !important;
+}
+
+.ck.ck-reset.ck-dropdown__panel,
+.ck.ck-balloon-panel {
+	border-color: transparent;
+	box-shadow: var(--wcfBoxShadow);
+}
+
+.ck.ck-editor
+	.ck.ck-labeled-field-view.ck-labeled-field-view_empty:not(.ck-labeled-field-view_focused)
+	> .ck.ck-labeled-field-view__input-wrapper
+	> .ck.ck-label {
+	color: var(--wcfInputPlaceholder);
+}
+
+.ck.ck-list .ck-list__item .ck-button:not(.ck-disabled):hover {
+	color: var(--wcfDropdownLink);
+	cursor: pointer;
+}
+
+.ck.ck-form__row .ck-button,
+.ck.ck-vertical-form .ck-button {
+	--ck-color-text: var(--wcfButtonText);
+
+	background-color: var(--wcfButtonBackground);
+	border-color: transparent;
+	font-size: var(--wcfFontSizeSmall);
+	padding: 4px 12px !important;
+}
+
+.ck.ck-form__row {
+	column-gap: 10px;
+	justify-content: flex-end !important;
+
+	.ck-button__icon {
+		display: none;
+	}
+
+	.ck-button {
+		flex: 0 0 auto !important;
+		margin: 0 !important;
+
+		&:not(.ck-disabled) {
+			cursor: pointer;
+		}
+
+		&.ck-disabled {
+			--ck-color-text: var(--wcfButtonDisabledText) !important;
+
+			background-color: var(--wcfButtonDisabledBackground) !important;
+		}
+	}
+
+	.ck-button[type="button"] {
+		order: 1;
+	}
+
+	.ck-button[type="submit"] {
+		order: 2;
+	}
+
+	.ck-button[type="button"]:not(.ck-disabled):hover {
+		--ck-color-text: var(--wcfButtonTextActive);
+
+		background-color: var(--wcfButtonBackgroundActive);
+	}
+
+	.ck-button[type="submit"]:not(.ck-disabled) {
+		--ck-color-text: var(--wcfButtonPrimaryText);
+
+		background-color: var(--wcfButtonPrimaryBackground);
+
+		&:hover {
+			--ck-color-text: var(--wcfButtonPrimaryTextActive);
+
+			background-color: var(--wcfButtonPrimaryBackgroundActive);
+		}
+	}
+}
+
 html[data-color-scheme="dark"] {
-	/*
-    Override some of the color values of the built-in “Lark” theme.
-    https://ckeditor.com/docs/ckeditor5/latest/framework/guides/deep-dive/ui/theme-customization.html
-    */
-	.ck.ck-editor {
-		/* Helper variables to avoid duplication in the colors. */
-		--ck-custom-background: hsl(270, 1%, 29%);
-		--ck-custom-foreground: hsl(255, 3%, 18%);
-		--ck-custom-border: hsl(300, 1%, 22%);
-		--ck-custom-white: hsl(0, 0%, 100%);
-
-		/* -- Overrides generic colors. ------------------------------------------------------------- */
-
-		--ck-color-base-foreground: var(--ck-custom-background);
-		--ck-color-focus-border: hsl(208, 90%, 62%);
-		--ck-color-text: hsl(0, 0%, 98%);
-		--ck-color-shadow-drop: hsla(0, 0%, 0%, 0.2);
-		--ck-color-shadow-inner: hsla(0, 0%, 0%, 0.1);
-
-		/* -- Overrides the default .ck-button class colors. ---------------------------------------- */
-
-		--ck-color-button-default-background: var(--ck-custom-background);
-		--ck-color-button-default-hover-background: hsl(270, 1%, 22%);
-		--ck-color-button-default-active-background: hsl(270, 2%, 20%);
-		--ck-color-button-default-active-shadow: hsl(270, 2%, 23%);
-		--ck-color-button-default-disabled-background: var(--ck-custom-background);
-
-		--ck-color-button-on-background: var(--ck-custom-foreground);
-		--ck-color-button-on-hover-background: hsl(255, 4%, 16%);
-		--ck-color-button-on-active-background: hsl(255, 4%, 14%);
-		--ck-color-button-on-active-shadow: hsl(240, 3%, 19%);
-		--ck-color-button-on-disabled-background: var(--ck-custom-foreground);
-
-		--ck-color-button-action-background: hsl(168, 76%, 42%);
-		--ck-color-button-action-hover-background: hsl(168, 76%, 38%);
-		--ck-color-button-action-active-background: hsl(168, 76%, 36%);
-		--ck-color-button-action-active-shadow: hsl(168, 75%, 34%);
-		--ck-color-button-action-disabled-background: hsl(168, 76%, 42%);
-		--ck-color-button-action-text: var(--ck-custom-white);
-
-		--ck-color-button-save: hsl(120, 100%, 46%);
-		--ck-color-button-cancel: hsl(15, 100%, 56%);
-
-		/* -- Overrides the default .ck-dropdown class colors. -------------------------------------- */
-
-		--ck-color-dropdown-panel-background: var(--ck-custom-background);
-		--ck-color-dropdown-panel-border: var(--ck-custom-foreground);
-
-		/* -- Overrides the default .ck-splitbutton class colors. ----------------------------------- */
-
-		--ck-color-split-button-hover-background: var(--ck-color-button-default-hover-background);
-		--ck-color-split-button-hover-border: var(--ck-custom-foreground);
-
-		/* -- Overrides the default .ck-input class colors. ----------------------------------------- */
-
-		--ck-color-input-background: var(--ck-custom-background);
-		--ck-color-input-border: hsl(257, 3%, 43%);
-		--ck-color-input-text: hsl(0, 0%, 98%);
-		--ck-color-input-disabled-background: hsl(255, 4%, 21%);
-		--ck-color-input-disabled-border: hsl(250, 3%, 38%);
-		--ck-color-input-disabled-text: hsl(0, 0%, 78%);
-
-		/* -- Overrides the default .ck-labeled-field-view class colors. ---------------------------- */
-
-		--ck-color-labeled-field-label-background: var(--ck-custom-background);
-
-		/* -- Overrides the default .ck-list class colors. ------------------------------------------ */
-
-		--ck-color-list-background: var(--ck-custom-background);
-		--ck-color-list-button-hover-background: var(--ck-color-base-foreground);
-		--ck-color-list-button-on-background: var(--ck-color-base-active);
-		--ck-color-list-button-on-background-focus: var(--ck-color-base-active-focus);
-		--ck-color-list-button-on-text: var(--ck-color-base-background);
-
-		/* -- Overrides the default .ck-balloon-panel class colors. --------------------------------- */
-
-		--ck-color-panel-background: var(--ck-custom-background);
-		--ck-color-panel-border: var(--ck-custom-border);
-
-		/* -- Overrides the default .ck-toolbar class colors. --------------------------------------- */
-
-		--ck-color-toolbar-background: var(--ck-custom-background);
-		--ck-color-toolbar-border: var(--ck-custom-border);
-
-		/* -- Overrides the default .ck-tooltip class colors. --------------------------------------- */
-
-		--ck-color-tooltip-background: hsl(252, 7%, 14%);
-		--ck-color-tooltip-text: hsl(0, 0%, 93%);
-
-		/* -- Overrides the default colors used by the ckeditor5-image package. --------------------- */
-
-		--ck-color-image-caption-background: hsl(0, 0%, 97%);
-		--ck-color-image-caption-text: hsl(0, 0%, 20%);
-
-		/* -- Overrides the default colors used by the ckeditor5-widget package. -------------------- */
-
-		--ck-color-widget-blurred-border: hsl(0, 0%, 87%);
-		--ck-color-widget-hover-border: hsl(43, 100%, 68%);
-		--ck-color-widget-editable-focus-background: var(--ck-custom-white);
-
-		/* -- Overrides the default colors used by the ckeditor5-link package. ---------------------- */
-
-		--ck-color-link-default: hsl(190, 100%, 75%);
-	}
-
-	/* WoltLab overrides */
-	.ck.ck-editor {
-		--ck-color-base-background: var(--wcfContentContainerBackground);
-		--ck-custom-border: #808080;
-	}
-	.ck.ck-editor .ck.ck-editor__main > .ck-editor__editable:not(.ck-focused) {
-		border-color: var(--ck-custom-border);
+	.ck.ck-reset.ck-dropdown__panel,
+	.ck.ck-balloon-panel {
+		border-color: var(--wcfDropdownBorderInner);
 	}
 }
 

--- a/wcfsetup/install/files/style/ui/ckeditor.scss
+++ b/wcfsetup/install/files/style/ui/ckeditor.scss
@@ -13,6 +13,40 @@
 
 .ck.ck-editor {
 	--ck-border-radius: var(--wcfBorderRadius);
+	--ck-color-base-border: var(--wcfContentBorderInner);
+	--ck-color-text: var(--wcfContentText);
+	--ck-color-toolbar-border: var(--wcfContentBorderInner);
+}
+
+.ck.ck-content {
+	/* The content area must not contain a border radius at all, because it is
+	   difficult to detect if there is an adjacent message tab menu. */
+	border-radius: 0 !important;
+}
+
+.ck.ck-toolbar__items {
+	--ck-color-button-default-hover-background: var(--wcfEditorButtonBackground);
+	--ck-color-button-default-active-background: var(--wcfEditorButtonBackground);
+
+	--ck-color-button-on-background: var(--wcfEditorButtonBackgroundActive);
+	--ck-color-button-on-hover-background: var(--wcfEditorButtonBackgroundActive);
+	--ck-color-button-on-active-background: var(--wcfEditorButtonBackgroundActive);
+	--ck-color-button-on-disabled-background: transparent;
+	--ck-color-button-on-color: var(--wcfEditorButtonTextActive);
+
+	--ck-color-split-button-hover-background: var(--wcfEditorButtonBackground);
+	--ck-color-split-button-hover-border: var(--wcfEditorButtonText);
+
+	fa-icon {
+		color: inherit;
+	}
+
+	.ck-button:not(.ck-disabled):hover,
+	.ck-splitbutton:hover .ck-button:not(.ck-disabled):not(:hover),
+	.ck-splitbutton_open .ck-button:not(.ck-disabled):not(:hover) {
+		/* The editor does not support a separate text color on hover. */
+		color: var(--wcfEditorButtonText);
+	}
 }
 
 html[data-color-scheme="dark"] {

--- a/wcfsetup/install/files/style/ui/ckeditor.scss
+++ b/wcfsetup/install/files/style/ui/ckeditor.scss
@@ -47,6 +47,10 @@
 	border-radius: 0 !important;
 }
 
+.ck.ck-button.ck-button:not(.ck-disabled) {
+	cursor: pointer;
+}
+
 .ck.ck-toolbar__items {
 	--ck-color-button-default-hover-background: var(--wcfEditorButtonBackground);
 	--ck-color-button-default-active-background: var(--wcfEditorButtonBackground);
@@ -87,7 +91,6 @@
 
 .ck.ck-list .ck-list__item .ck-button:not(.ck-disabled):hover {
 	color: var(--wcfDropdownLink);
-	cursor: pointer;
 }
 
 .ck.ck-editor__editable.ck-focused:not(.ck-editor__nested-editable),
@@ -133,7 +136,6 @@
 .ck.ck-body {
 	.ck-button:not(.ck-disabled) {
 		color: var(--ck-color-text);
-		cursor: pointer;
 	}
 
 	.ck-button.ck-disabled {

--- a/wcfsetup/install/files/style/ui/ckeditor.scss
+++ b/wcfsetup/install/files/style/ui/ckeditor.scss
@@ -179,6 +179,7 @@ html[data-color-scheme="dark"] {
 
 .ckeditor5__restoreDraft__dialog {
 	background-color: var(--wcfContentBackground);
+	border: 1px solid transparent;
 	border-radius: 8px;
 	box-shadow: rgb(0 0 0 / 20%) 0 12px 28px 0, rgb(0 0 0 / 10%) 0 2px 4px 0;
 	color: var(--wcfContentText);
@@ -197,6 +198,12 @@ html[data-color-scheme="dark"] {
 	display: flex;
 	flex-direction: row-reverse;
 	margin-top: 20px;
+}
+
+html[data-color-scheme="dark"] {
+	.ckeditor5__restoreDraft__dialog {
+		border-color: var(--wcfContentBorderInner);
+	}
 }
 
 /* Styling of inline errors for the editor. */


### PR DESCRIPTION
The builtin styling diverges too much from our style guide and especially the dark mode variant looked a lot like a foreign object. The CSS has been adjusted to replicate a “good enough” integration that looks familiar without diverging too much.