### PR TITLE
Remove the "New Notification:" prefix from notification e-mails

### DIFF
--- a/wcfsetup/install/files/lib/system/user/notification/TestableUserNotificationEventHandler.class.php
+++ b/wcfsetup/install/files/lib/system/user/notification/TestableUserNotificationEventHandler.class.php
@@ -106,9 +106,7 @@ class TestableUserNotificationEventHandler extends SingletonFactory
     public function getEmailBody(ITestableUserNotificationEvent $event, $notificationType)
     {
         $email = new Email();
-        $email->setSubject($event->getLanguage()->getDynamicVariable('wcf.user.notification.mail.subject', [
-            'title' => $event->getEmailTitle(),
-        ]));
+        $email->setSubject($event->getEmailTitle());
         $mailbox = new UserMailbox($this->getRecipient($event->getLanguage())->getDecoratedObject());
         $email->addRecipient($mailbox);
 

--- a/wcfsetup/install/files/lib/system/user/notification/UserNotificationHandler.class.php
+++ b/wcfsetup/install/files/lib/system/user/notification/UserNotificationHandler.class.php
@@ -749,9 +749,7 @@ class UserNotificationHandler extends SingletonFactory
         }
 
         $email = new Email();
-        $email->setSubject($user->getLanguage()->getDynamicVariable('wcf.user.notification.mail.subject', [
-            'title' => $event->getEmailTitle(),
-        ]));
+        $email->setSubject($event->getEmailTitle());
         $email->addRecipient(new UserMailbox($user));
         $humanReadableListId = $user
             ->getLanguage()

--- a/wcfsetup/install/lang/de.xml
+++ b/wcfsetup/install/lang/de.xml
@@ -5308,7 +5308,6 @@ Die E-Mail-Adresse des neuen Benutzers lautet: {@$user->email}.
 		<item name="wcf.user.notification.mailNotificationType.daily"><![CDATA[Tägliche E-Mail-Benachrichtigung]]></item>
 		<item name="wcf.user.notification.mailNotificationType.notSupported"><![CDATA[E-Mail-Benachrichtigungen werden nicht unterstützt.]]></item>
 		<!-- Email Wrapper -->
-		<item name="wcf.user.notification.mail.subject"><![CDATA[Neue Benachrichtigung: {@$title}]]></item>
 		<item name="wcf.user.notification.mail.plaintext.intro"><![CDATA[Hallo {@$mailbox->getUser()->username},]]></item>
 		<item name="wcf.user.notification.mail.plaintext.outro"><![CDATA[Diese E-Mail ist eine automatische Benachrichtigung. BITTE {if LANGUAGE_USE_INFORMAL_VARIANT}ANTWORTE{else}ANTWORTEN SIE{/if} NICHT AUF DIESE E-MAIL.
 

--- a/wcfsetup/install/lang/en.xml
+++ b/wcfsetup/install/lang/en.xml
@@ -5307,7 +5307,6 @@ You also received a list of emergency codes to use when your second factor becom
 		<item name="wcf.user.notification.mailNotificationType.daily"><![CDATA[Daily Email Notification]]></item>
 		<item name="wcf.user.notification.mailNotificationType.notSupported"><![CDATA[Email Notifications are not supported.]]></item>
 		<!-- Email Wrapper -->
-		<item name="wcf.user.notification.mail.subject"><![CDATA[New Notification: {@$title}]]></item>
 		<item name="wcf.user.notification.mail.plaintext.intro"><![CDATA[Dear {@$mailbox->getUser()->username},]]></item>
 		<item name="wcf.user.notification.mail.plaintext.outro"><![CDATA[This is an automatic notification, PLEASE DO NOT REPLY TO THIS EMAIL!
 


### PR DESCRIPTION
The prefix had little use and caused that in many e-mail clients little of the actual subject of the e-mails was immediately visible.