### PR TITLE
Remove FirstTimeSetupForm.class.php on upgrade

### DIFF
--- a/com.woltlab.wcf/acpTemplateDelete.xml
+++ b/com.woltlab.wcf/acpTemplateDelete.xml
@@ -13,6 +13,7 @@
 		<template>dashboardList</template>
 		<template>dashboardOption</template>
 		<template>devtoolsFormBuilderTest</template>
+		<template>firstTimeSetup</template>
 		<template>languageServerAdd</template>
 		<template>languageServerList</template>
 		<template>mainMenu</template>

--- a/com.woltlab.wcf/fileDelete.xml
+++ b/com.woltlab.wcf/fileDelete.xml
@@ -1545,6 +1545,7 @@
 		<file>lib/acp/form/DashboardOptionForm.class.php</file>
 		<file>lib/acp/form/DevtoolsFormBuilderTestForm.class.php</file>
 		<file>lib/acp/form/DevtoolsProjectSyncForm.class.php</file>
+		<file>lib/acp/form/FirstTimeSetupForm.class.php</file>
 		<file>lib/acp/form/LanguageServerAddForm.class.php</file>
 		<file>lib/acp/form/LanguageServerEditForm.class.php</file>
 		<file>lib/acp/form/MasterPasswordForm.class.php</file>


### PR DESCRIPTION
Upon performing a software upgrade, an issue has been identified whereby the user becomes constrained within the previous iteration of the First Time Setup page. Despite the presence of a new version, the user is presented with the outdated version due to the prioritization of the FirstTimeSetupForm over the recently added FirstTimeSetupAction. This issue stems from the oversight of not removing the previous controller and template during the _upgrade_ from version 5.5, resulting in a conflict with the updated software. In order to resolve this issue, it is necessary to remove the outdated components using the *delete-PiPs. Failure to do so may result in users being unable to properly utilize the updated software.