### PR TITLE
Fix visuals in devtoolsProjectSync if the first non-important PIP has no target

### DIFF
--- a/wcfsetup/install/files/acp/templates/devtoolsProjectSync.tpl
+++ b/wcfsetup/install/files/acp/templates/devtoolsProjectSync.tpl
@@ -131,6 +131,10 @@
 			border-top: 4px solid #e0e0e0;
 		}
 		
+		#syncPipMatches.jsShowOnlyMatches tr[data-is-important="true"] ~ tr[data-is-important="false"].jsHasPipTargets:not(:is(tr[data-is-important="false"].jsHasPipTargets ~ tr)) td {
+			border-top: 4px solid #e0e0e0;
+		}
+		
 		.syncStatusContainer {
 			overflow: hidden;
 		}


### PR DESCRIPTION
The thicker border was missing, because the element having the border was
visually hidden.
