### PR TITLE
Use intl Collator to sort groups in EditorGetMentionSuggestionsAction

### DIFF
--- a/wcfsetup/install/files/lib/action/EditorGetMentionSuggestionsAction.class.php
+++ b/wcfsetup/install/files/lib/action/EditorGetMentionSuggestionsAction.class.php
@@ -10,6 +10,7 @@ use wcf\data\user\group\UserGroup;
 use wcf\data\user\UserProfile;
 use wcf\data\user\UserProfileList;
 use wcf\http\Helper;
+use wcf\system\WCF;
 
 /**
  * Suggests users that may be mentioned.
@@ -91,9 +92,11 @@ final class EditorGetMentionSuggestionsAction implements RequestHandlerInterface
             return \str_starts_with(\mb_strtolower($userGroup->getName()), $query);
         });
 
-        \usort($userGroups, static function (UserGroup $a, UserGroup $b) {
-            return \mb_strtolower($a->getName()) <=> \mb_strtolower($b->getName());
-        });
+        $c = new \Collator(WCF::getLanguage()->getLocale());
+        \usort(
+            $userGroups,
+            static fn (UserGroup $a, UserGroup $b) => $c->compare($a->getName(), $b->getName())
+        );
 
         return $userGroups;
     }


### PR DESCRIPTION
This PR likely adds to the inconsistency that #4672 already remarked and it is
not *necessarily* meant for a merge for this reason. However I'm putting it up
for review, because this is new code and so that we have something real to look
at.

Ideally the collator would have an operation for prefix matches as well,
because that would enable interesting capabilities, such as matching accent
characters by their base characters using a reduced Collator *strength*,
unfortunately there isn't such a thing. It could possibly be emulated by
truncating the haystack string to the length of the needle string and then
calling `->compare()` and checking for `0`.

--------

The Collator is able to correctly handle accented characters, as it does not
sort based on the byte values of the UTF-8 representation.

One example would be Latin Capital Letter A with Grave (U+00C0) and Latin
Capital Letter A with Acute (U+00C1). The acute is correctly ordered before the
Grave, but the unicode number of the letter with the acute is the higher one.

see #4672
see 3db0f431b8db3aebb11ec9ac3d69a6199143b738
