### PR TITLE
Fix LanguageImportForm

### DIFF
--- a/wcfsetup/install/files/lib/acp/form/LanguageImportForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/LanguageImportForm.class.php
@@ -154,7 +154,7 @@ class LanguageImportForm extends AbstractForm
         LanguageFactory::getInstance()->clearCache();
         LanguageFactory::getInstance()->deleteLanguageCache();
 
-        EventHandler::getInstance()->fire(new LanguageImported($this->language));
+        EventHandler::getInstance()->fire(new LanguageImported(new Language($this->language->languageID)));
 
         $this->saved();
 


### PR DESCRIPTION
The LanguageImported listener was previously receiving an object of type `wcf\data\language\LanguageEditor`, instead of the required `wcf\data\language\Language`. This commit updates the code to ensure that the listener is provided with a Language object, allowing it to function properly.