### PR TITLE
Add reusable phrases

### DIFF
--- a/wcfsetup/install/lang/de.xml
+++ b/wcfsetup/install/lang/de.xml
@@ -3758,6 +3758,7 @@ Dateianhänge:
 		<item name="wcf.date.datePicker.year"><![CDATA[Jahr]]></item>
 		<item name="wcf.date.datePicker.hour"><![CDATA[Stunde]]></item>
 		<item name="wcf.date.datePicker.minute"><![CDATA[Minute]]></item>
+		<item name="wcf.date.pointInTime"><![CDATA[Zeitpunkt]]></item>
 	</category>
 	<category name="wcf.dialog">
 		<item name="wcf.dialog.button.cancel"><![CDATA[Abbrechen]]></item>

--- a/wcfsetup/install/lang/de.xml
+++ b/wcfsetup/install/lang/de.xml
@@ -4592,6 +4592,7 @@ Dateianhänge:
 		<item name="wcf.user.username.error.invalid"><![CDATA[{if LANGUAGE_USE_INFORMAL_VARIANT}Du hast{else}Sie haben{/if} einen ungültigen Benutzernamen eingegeben.]]></item>
 		<item name="wcf.user.userNote"><![CDATA[{$__wcf->user->username}]]></item>
 		<item name="wcf.user.group"><![CDATA[Benutzergruppe]]></item>
+		<item name="wcf.user.group.groupName"><![CDATA[Gruppenname]]></item>
 		<item name="wcf.user.option.error.tooLong"><![CDATA[Der eingegebene Text ist zu lang.]]></item>
 		<item name="wcf.user.option.error.tooShort"><![CDATA[Der eingegebene Text ist zu kurz.]]></item>
 		<item name="wcf.user.option.error.tooHigh"><![CDATA[Der angegebene Wert ist zu hoch.{if $option->maxvalue !== null} Der maximale Wert ist {#$option->maxvalue}.{/if}]]></item>

--- a/wcfsetup/install/lang/en.xml
+++ b/wcfsetup/install/lang/en.xml
@@ -3705,6 +3705,7 @@ Attachments:
 		<item name="wcf.date.datePicker.year"><![CDATA[Year]]></item>
 		<item name="wcf.date.datePicker.hour"><![CDATA[Hour]]></item>
 		<item name="wcf.date.datePicker.minute"><![CDATA[Minute]]></item>
+		<item name="wcf.date.pointInTime"><![CDATA[Time]]></item>
 	</category>
 	<category name="wcf.dialog">
 		<item name="wcf.dialog.button.cancel"><![CDATA[Cancel]]></item>

--- a/wcfsetup/install/lang/en.xml
+++ b/wcfsetup/install/lang/en.xml
@@ -4598,6 +4598,7 @@ Attachments:
 		<item name="wcf.user.username.error.invalid"><![CDATA[The username is invalid.]]></item>
 		<item name="wcf.user.userNote"><![CDATA[{$__wcf->user->username}]]></item>
 		<item name="wcf.user.group"><![CDATA[User Group]]></item>
+		<item name="wcf.user.group.groupName"><![CDATA[Group Name]]></item>
 		<item name="wcf.user.option.error.tooLong"><![CDATA[The entered text is too long.]]></item>
 		<item name="wcf.user.option.error.tooShort"><![CDATA[The entered text is too short.]]></item>
 		<item name="wcf.user.option.error.tooHigh"><![CDATA[The set value is too high.{if $option->maxvalue !== null} The maximum value is {#$option->maxvalue}.{/if}]]></item>


### PR DESCRIPTION
Another phrase that is commonly used for “Zeitpunkt” is “Datum”, but that is
not always fitting. The “Datum” phrase is also not available generically.

I'm not sure if these phrases are a value-add after all, but the issue still
existed, so I'm putting this proposal up for discussion. If you don't think
these should be added, then that's fine.

Resolves #4899
