### PR TITLE
Add a dedicated form field for plain select fields

### DIFF
--- a/com.woltlab.wcf/templates/__selectFormField.tpl
+++ b/com.woltlab.wcf/templates/__selectFormField.tpl
@@ -1,0 +1,15 @@
+<select
+	id="{$field->getPrefixedId()}"
+	name="{$field->getPrefixedId()}"
+	{if !$field->getFieldClasses()|empty} class="{implode from=$field->getFieldClasses() item='class' glue=' '}{$class}{/implode}"{/if}
+	{if $field->isRequired()} required{/if}
+>
+	<option value="">{lang}wcf.global.noSelection{/lang}</option>
+	{foreach from=$field->getNestedOptions() item=__fieldNestedOption}
+		<option
+			value="{$__fieldNestedOption[value]}"
+			{if $field->getValue() == $__fieldNestedOption[value] && $__fieldNestedOption[isSelectable]} selected{/if}
+			{if $field->isImmutable() || !$__fieldNestedOption[isSelectable]} disabled{/if}
+		>{@'&nbsp;'|str_repeat:$__fieldNestedOption[depth] * 4}{@$__fieldNestedOption[label]}</option>
+	{/foreach}
+</select>

--- a/syncTemplates.json
+++ b/syncTemplates.json
@@ -39,6 +39,7 @@
     "__ratingFormField",
     "__rowFormContainer",
     "__rowFormFieldContainer",
+    "__selectFormField",
     "__singleMediaSelectionFormField",
     "__singleSelectionFormField",
     "__sourceCodeFormField",

--- a/wcfsetup/install/files/acp/templates/__selectFormField.tpl
+++ b/wcfsetup/install/files/acp/templates/__selectFormField.tpl
@@ -1,0 +1,15 @@
+<select
+	id="{$field->getPrefixedId()}"
+	name="{$field->getPrefixedId()}"
+	{if !$field->getFieldClasses()|empty} class="{implode from=$field->getFieldClasses() item='class' glue=' '}{$class}{/implode}"{/if}
+	{if $field->isRequired()} required{/if}
+>
+	<option value="">{lang}wcf.global.noSelection{/lang}</option>
+	{foreach from=$field->getNestedOptions() item=__fieldNestedOption}
+		<option
+			value="{$__fieldNestedOption[value]}"
+			{if $field->getValue() == $__fieldNestedOption[value] && $__fieldNestedOption[isSelectable]} selected{/if}
+			{if $field->isImmutable() || !$__fieldNestedOption[isSelectable]} disabled{/if}
+		>{@'&nbsp;'|str_repeat:$__fieldNestedOption[depth] * 4}{@$__fieldNestedOption[label]}</option>
+	{/foreach}
+</select>

--- a/wcfsetup/install/files/lib/system/form/builder/field/SelectFormField.class.php
+++ b/wcfsetup/install/files/lib/system/form/builder/field/SelectFormField.class.php
@@ -33,25 +33,13 @@ final class SelectFormField extends AbstractFormField implements
     /**
      * @inheritDoc
      */
-    public function getSaveValue()
-    {
-        if ($this->getValue() === '') {
-            return;
-        }
-
-        return parent::getSaveValue();
-    }
-
-    /**
-     * @inheritDoc
-     */
     public function readValue()
     {
         if ($this->getDocument()->hasRequestData($this->getPrefixedId())) {
             $value = $this->getDocument()->getRequestData($this->getPrefixedId());
 
             if (\is_string($value)) {
-                $this->value = $value;
+                $this->value = $value !== '' ? $value : null;
             }
         }
 
@@ -63,7 +51,7 @@ final class SelectFormField extends AbstractFormField implements
      */
     public function validate()
     {
-        if ($this->getValue() === '') {
+        if ($this->getValue() === null) {
             if ($this->isRequired()) {
                 $this->addValidationError(new FormFieldValidationError('empty'));
             }
@@ -82,14 +70,10 @@ final class SelectFormField extends AbstractFormField implements
      */
     public function value($value)
     {
-        // ignore `null` as value which can be passed either for nullable
-        // fields or as value if no options are available
-        if ($value === null) {
-            return $this;
-        }
-
-        if (!isset($this->getOptions()[$value])) {
-            throw new \InvalidArgumentException("Unknown value '{$value}' for field '{$this->getId()}'.");
+        if ($value !== null) {
+            if (!isset($this->getOptions()[$value])) {
+                throw new \InvalidArgumentException("Unknown value '{$value}' for field '{$this->getId()}'.");
+            }
         }
 
         return parent::value($value);

--- a/wcfsetup/install/files/lib/system/form/builder/field/SelectFormField.class.php
+++ b/wcfsetup/install/files/lib/system/form/builder/field/SelectFormField.class.php
@@ -55,11 +55,13 @@ final class SelectFormField extends AbstractFormField implements
             if ($this->isRequired()) {
                 $this->addValidationError(new FormFieldValidationError('empty'));
             }
-        } else if (!isset($this->getOptions()[$this->getValue()])) {
-            $this->addValidationError(new FormFieldValidationError(
-                'invalidValue',
-                'wcf.global.form.error.noValidSelection'
-            ));
+        } else {
+            if (!isset($this->getOptions()[$this->getValue()])) {
+                $this->addValidationError(new FormFieldValidationError(
+                    'invalidValue',
+                    'wcf.global.form.error.noValidSelection'
+                ));
+            }
         }
 
         parent::validate();

--- a/wcfsetup/install/files/lib/system/form/builder/field/SelectFormField.class.php
+++ b/wcfsetup/install/files/lib/system/form/builder/field/SelectFormField.class.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace wcf\system\form\builder\field;
+
+use wcf\system\form\builder\field\validation\FormFieldValidationError;
+
+/**
+ * Implementation of a form field for selecting a single value.
+ *
+ * @author  Matthias Schmidt, Marcel Werk
+ * @copyright   2001-2023 WoltLab GmbH
+ * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @since   6.0
+ */
+final class SelectFormField extends AbstractFormField implements
+    ICssClassFormField,
+    IImmutableFormField
+{
+    use TCssClassFormField;
+    use TImmutableFormField;
+    use TSelectionFormField;
+
+    /**
+     * @inheritDoc
+     */
+    protected $javaScriptDataHandlerModule = 'WoltLabSuite/Core/Form/Builder/Field/Value';
+
+    /**
+     * @inheritDoc
+     */
+    protected $templateName = '__selectFormField';
+
+    /**
+     * @inheritDoc
+     */
+    public function getSaveValue()
+    {
+        if ($this->getValue() === '') {
+            return;
+        }
+
+        return parent::getSaveValue();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function readValue()
+    {
+        if ($this->getDocument()->hasRequestData($this->getPrefixedId())) {
+            $value = $this->getDocument()->getRequestData($this->getPrefixedId());
+
+            if (\is_string($value)) {
+                $this->value = $value;
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function validate()
+    {
+        if ($this->getValue() === '') {
+            if ($this->isRequired()) {
+                $this->addValidationError(new FormFieldValidationError('empty'));
+            }
+        } else if (!isset($this->getOptions()[$this->getValue()])) {
+            $this->addValidationError(new FormFieldValidationError(
+                'invalidValue',
+                'wcf.global.form.error.noValidSelection'
+            ));
+        }
+
+        parent::validate();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function value($value)
+    {
+        // ignore `null` as value which can be passed either for nullable
+        // fields or as value if no options are available
+        if ($value === null) {
+            return $this;
+        }
+
+        if (!isset($this->getOptions()[$value])) {
+            throw new \InvalidArgumentException("Unknown value '{$value}' for field '{$this->getId()}'.");
+        }
+
+        return parent::value($value);
+    }
+}


### PR DESCRIPTION
The existing `SingleSelectionFormField` has multiple design flaws that are difficult to solve in a backward compatible way. The main issue with the existing implementation is that it tries to solve too many problems at once, creating an API that is inconsistent and difficult to use / easy to misuse.

This is the first implementation with more to follow that will eventually allow us to phase out the `SingleSelectionFormField`.

Closes #5265
Closes #4789