### PR TITLE
Unify the cache management permissions to `admin.management.canRebuildData`

### DIFF
--- a/com.woltlab.wcf/acpMenu.xml
+++ b/com.woltlab.wcf/acpMenu.xml
@@ -715,7 +715,7 @@
 		<acpmenuitem name="wcf.acp.menu.link.maintenance.cache">
 			<controller>wcf\acp\page\CacheListPage</controller>
 			<parent>wcf.acp.menu.link.maintenance</parent>
-			<permissions>admin.configuration.canManageApplication</permissions>
+			<permissions>admin.management.canRebuildData</permissions>
 		</acpmenuitem>
 		<acpmenuitem name="wcf.acp.menu.link.maintenance.rebuildData">
 			<controller>wcf\acp\page\RebuildDataPage</controller>

--- a/wcfsetup/install/files/lib/acp/action/CacheClearAction.class.php
+++ b/wcfsetup/install/files/lib/acp/action/CacheClearAction.class.php
@@ -21,7 +21,7 @@ final class CacheClearAction extends AbstractSecureAction
     /**
      * @inheritDoc
      */
-    public $neededPermissions = ['admin.management.canViewLog'];
+    public $neededPermissions = ['admin.management.canRebuildData'];
 
     /**
      * @inheritDoc

--- a/wcfsetup/install/files/lib/acp/page/CacheListPage.class.php
+++ b/wcfsetup/install/files/lib/acp/page/CacheListPage.class.php
@@ -27,7 +27,7 @@ class CacheListPage extends AbstractPage
     /**
      * @inheritDoc
      */
-    public $neededPermissions = ['admin.configuration.canManageApplication'];
+    public $neededPermissions = ['admin.management.canRebuildData'];
 
     /**
      * indicates if cache was cleared


### PR DESCRIPTION
Previously CacheListPage and CacheClearAction used differing permissions, which
is not useful at all. Especially since the template didn't check the differing
permissions.

Unify them to “can rebuild data”, because it's the most related one, clearing
the cache effectively rebuilds some data.
