### PR TITLE
Fix issues when pasting in `LineBreakSeparatedText` input fields

### DIFF
--- a/ts/WoltLabSuite/Core/Ui/ItemList/LineBreakSeparatedText.ts
+++ b/ts/WoltLabSuite/Core/Ui/ItemList/LineBreakSeparatedText.ts
@@ -288,7 +288,13 @@ export class UiItemListLineBreakSeparatedText {
     if (items.length > 1) {
       event.preventDefault();
 
-      items.forEach((item) => this.insertItem(item));
+      items.forEach((item) => {
+        item = item.trim();
+
+        if (item !== "" && !this.items.has(item)) {
+          this.insertItem(item);
+        }
+      });
 
       this.resetInput();
     }

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/ItemList/LineBreakSeparatedText.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/ItemList/LineBreakSeparatedText.js
@@ -236,7 +236,12 @@ define(["require", "exports", "tslib", "../Confirmation", "../../Language", "../
             const items = event.clipboardData.getData("text/plain").split("\n");
             if (items.length > 1) {
                 event.preventDefault();
-                items.forEach((item) => this.insertItem(item));
+                items.forEach((item) => {
+                    item = item.trim();
+                    if (item !== "" && !this.items.has(item)) {
+                        this.insertItem(item);
+                    }
+                });
                 this.resetInput();
             }
         }


### PR DESCRIPTION
Pasting from the clipboard could result in duplicates and empty entries.