### PR TITLE
Improve usability of the `TaggedPage`

### DIFF
--- a/com.woltlab.wcf/templates/combinedTagged.tpl
+++ b/com.woltlab.wcf/templates/combinedTagged.tpl
@@ -27,7 +27,12 @@
 		<nav class="boxContent">
 			<ul class="boxMenu">
 				{foreach from=$availableObjectTypes item=availableObjectType}
-					<li{if $objectType == $availableObjectType->objectType} class="active"{/if}><a class="boxMenuLink" href="{link controller='CombinedTagged'}{@$linkParameters}&objectType={@$availableObjectType->objectType}{/link}">{lang}wcf.tagging.objectType.{@$availableObjectType->objectType}{/lang}</a></li>
+					<li{if $objectType == $availableObjectType->objectType} class="active"{/if}>
+						<a class="boxMenuLink" href="{link controller='CombinedTagged'}{@$linkParameters}&objectType={@$availableObjectType->objectType}{/link}">
+							<span class="boxMenuLinkTitle">{lang}wcf.tagging.objectType.{@$availableObjectType->objectType}{/lang}</span>
+							<span class="badge">{#$itemsPerType[$availableObjectType->objectType]}</span>
+						</a>
+					</li>
 				{/foreach}
 			</ul>
 		</nav>

--- a/com.woltlab.wcf/templates/tagged.tpl
+++ b/com.woltlab.wcf/templates/tagged.tpl
@@ -19,7 +19,12 @@
 		<nav class="boxContent">
 			<ul class="boxMenu">
 				{foreach from=$availableObjectTypes item=availableObjectType}
-					<li{if $objectType == $availableObjectType->objectType} class="active"{/if}><a class="boxMenuLink" href="{link controller='Tagged' object=$tag}objectType={@$availableObjectType->objectType}{/link}">{lang}wcf.tagging.objectType.{@$availableObjectType->objectType}{/lang}</a></li>
+					<li{if $objectType == $availableObjectType->objectType} class="active"{/if}>
+						<a class="boxMenuLink" href="{link controller='Tagged' object=$tag}objectType={@$availableObjectType->objectType}{/link}">
+							<span class="boxMenuLinkTitle">{lang}wcf.tagging.objectType.{@$availableObjectType->objectType}{/lang}</span>
+							<span class="badge">{#$itemsPerType[$availableObjectType->objectType]}</span>
+						</a>
+					</li>
 				{/foreach}
 			</ul>
 		</nav>


### PR DESCRIPTION
If the page was called without filtering by `objectType`, the first available `objectType` was taken, even if this did not provide any results at all for the respective tag.