### PR TITLE
Show the “pollIsPublic” setting when editing polls

### DIFF
--- a/com.woltlab.wcf/templates/__messageFormPoll.tpl
+++ b/com.woltlab.wcf/templates/__messageFormPoll.tpl
@@ -74,9 +74,9 @@
 			<dd>
 				<label><input type="checkbox" name="pollIsChangeable" value="1"{if $pollIsChangeable} checked{/if}> {lang}wcf.poll.isChangeable{/lang}</label>
 			</dd>
-			{if !$pollID && $__wcf->getPollManager()->canStartPublicPoll()}
+			{if $pollID || $__wcf->getPollManager()->canStartPublicPoll()}
 				<dd>
-					<label><input type="checkbox" name="pollIsPublic" value="1"{if $pollIsPublic} checked{/if}> {lang}wcf.poll.isPublic{/lang}</label>
+					<label><input type="checkbox" name="pollIsPublic" value="1"{if $pollIsPublic} checked{/if} {if $pollID}disabled{/if}> {lang}wcf.poll.isPublic{/lang}</label>
 				</dd>
 			{/if}
 			<dd>

--- a/com.woltlab.wcf/templates/__messageFormPollInline.tpl
+++ b/com.woltlab.wcf/templates/__messageFormPollInline.tpl
@@ -55,9 +55,9 @@
 			<dd>
 				<label><input type="checkbox" name="pollIsChangeable" id="{$wysiwygSelector}Poll_isChangeable" value="1"{if $pollIsChangeable} checked{/if}> {lang}wcf.poll.isChangeable{/lang}</label>
 			</dd>
-			{if !$pollID && $__wcf->getPollManager()->canStartPublicPoll()}
+			{if $pollID || $__wcf->getPollManager()->canStartPublicPoll()}
 				<dd>
-					<label><input type="checkbox" name="pollIsPublic" id="{$wysiwygSelector}Poll_isPublic" value="1"{if $pollIsPublic} checked{/if}> {lang}wcf.poll.isPublic{/lang}</label>
+					<label><input type="checkbox" name="pollIsPublic" id="{$wysiwygSelector}Poll_isPublic" value="1"{if $pollIsPublic} checked{/if} {if $pollID}disabled{/if}> {lang}wcf.poll.isPublic{/lang}</label>
 				</dd>
 			{/if}
 			<dd>


### PR DESCRIPTION
The checkbox is marked as disabled, as the setting may not be changed after the
fact.
