### PR TITLE
Enforce the selection of a landing page for WoltLab Suite Core in applicationManagement

### DIFF
--- a/wcfsetup/install/files/acp/templates/applicationManagement.tpl
+++ b/wcfsetup/install/files/acp/templates/applicationManagement.tpl
@@ -100,7 +100,7 @@
 							<td class="columnText columnLandingPageID">
 								<select name="landingPageID[{$application->packageID}]" required>
 									<option value="">{lang}wcf.global.noSelection{/lang}</option>
-									<option value="0"{if $application->getAbbreviation() !== 'wcf'}{if $application->landingPageID === null} selected{/if}{else} disabled{/if}>{lang}wcf.acp.application.landingPage.default{/lang}</option>
+									<option value="0"{if $application->getAbbreviation() === 'wcf'} disabled{elseif $application->landingPageID === null} selected{/if}>{lang}wcf.acp.application.landingPage.default{/lang}</option>
 									
 									{foreach from=$pageNodeList item=pageNode}
 										{if !$pageNode->isDisabled && !$pageNode->requireObjectID && !$pageNode->excludeFromLandingPage}

--- a/wcfsetup/install/files/acp/templates/applicationManagement.tpl
+++ b/wcfsetup/install/files/acp/templates/applicationManagement.tpl
@@ -98,8 +98,9 @@
 								<small>{$application->getPageURL()}</small>
 							</td>
 							<td class="columnText columnLandingPageID">
-								<select name="landingPageID[{$application->packageID}]">
-									<option value="0">{lang}wcf.acp.application.landingPage.default{/lang}</option>
+								<select name="landingPageID[{$application->packageID}]" required>
+									<option value="">{lang}wcf.global.noSelection{/lang}</option>
+									<option value="0"{if $application->getAbbreviation() !== 'wcf'}{if $application->landingPageID === null} selected{/if}{else} disabled{/if}>{lang}wcf.acp.application.landingPage.default{/lang}</option>
 									
 									{foreach from=$pageNodeList item=pageNode}
 										{if !$pageNode->isDisabled && !$pageNode->requireObjectID && !$pageNode->excludeFromLandingPage}


### PR DESCRIPTION
This is enforced in the template only, because the PHP logic already needs to
handle a NULL landing page, as the global landing page could be deleted or
uninstalled. It will implicitly fall back to the ArticleList then.

Resolves #4843
