### PR TITLE
Improve a11y of the widget for embedded content

### DIFF
--- a/com.woltlab.wcf/templates/articleBBCode.tpl
+++ b/com.woltlab.wcf/templates/articleBBCode.tpl
@@ -10,9 +10,9 @@
 
 		<div class="embeddedContentCategory">{lang}wcf.article.bbcode.type{/lang}</div>
 		
-		<div class="embeddedContentTitle" id="{$titleHash}_articleTitle{@$article->articleID}">
+		<h3 class="embeddedContentTitle" id="{$titleHash}_articleTitle{@$article->articleID}">
 			<a href="{@$article->getLink()}" class="embeddedContentTitleLink">{$article->getTitle()}</a>
-		</div>
+		</h3>
 		
 		<div class="embeddedContentDescription">
 			{@$article->getFormattedTeaser()}

--- a/com.woltlab.wcf/templates/articleBBCode.tpl
+++ b/com.woltlab.wcf/templates/articleBBCode.tpl
@@ -8,23 +8,25 @@
 			loading="lazy"
 			alt="">
 
-        <div class="embeddedContentCategory">{lang}wcf.article.bbcode.type{/lang}</div>
+		<div class="embeddedContentCategory">{lang}wcf.article.bbcode.type{/lang}</div>
 		
-		<div class="embeddedContentTitle" id="{$titleHash}_articleTitle{@$article->articleID}">{$article->getTitle()}</div>
+		<div class="embeddedContentTitle" id="{$titleHash}_articleTitle{@$article->articleID}">
+			<a href="{@$article->getLink()}" class="embeddedContentTitleLink">{$article->getTitle()}</a>
+		</div>
 		
 		<div class="embeddedContentDescription">
 			{@$article->getFormattedTeaser()}
 		</div>
-
-		<a href="{@$article->getLink()}" class="embeddedContentLinkShadow"></a>
 	</div>
 	
 	<div class="embeddedContentMeta">
-		{user object=$article->getUserProfile() type='avatar32' class='embeddedContentMetaImage' ariaHidden='true' tabindex='-1'}
+		<div class="embeddedContentMetaImage">
+			{@$article->getUserProfile()->getAvatar()->getImageTag(32)}
+		</div>
 		
 		<div class="embeddedContentMetaContent">
 			<div class="embeddedContentMetaAuthor">
-				{user object=$article->getUserProfile() class='username'}
+				{@$article->getUserProfile()->getFormattedUsername()}
 			</div>
 			
 			<div class="embeddedContentMetaTime">

--- a/wcfsetup/install/files/acp/templates/articleBBCode.tpl
+++ b/wcfsetup/install/files/acp/templates/articleBBCode.tpl
@@ -10,9 +10,9 @@
 
 		<div class="embeddedContentCategory">{lang}wcf.article.bbcode.type{/lang}</div>
 		
-		<div class="embeddedContentTitle" id="{$titleHash}_articleTitle{@$article->articleID}">
+		<h3 class="embeddedContentTitle" id="{$titleHash}_articleTitle{@$article->articleID}">
 			<a href="{@$article->getLink()}" class="embeddedContentTitleLink">{$article->getTitle()}</a>
-		</div>
+		</h3>
 		
 		<div class="embeddedContentDescription">
 			{@$article->getFormattedTeaser()}

--- a/wcfsetup/install/files/acp/templates/articleBBCode.tpl
+++ b/wcfsetup/install/files/acp/templates/articleBBCode.tpl
@@ -8,23 +8,25 @@
 			loading="lazy"
 			alt="">
 
-        <div class="embeddedContentCategory">{lang}wcf.article.bbcode.type{/lang}</div>
+		<div class="embeddedContentCategory">{lang}wcf.article.bbcode.type{/lang}</div>
 		
-		<div class="embeddedContentTitle" id="{$titleHash}_articleTitle{@$article->articleID}">{$article->getTitle()}</div>
+		<div class="embeddedContentTitle" id="{$titleHash}_articleTitle{@$article->articleID}">
+			<a href="{@$article->getLink()}" class="embeddedContentTitleLink">{$article->getTitle()}</a>
+		</div>
 		
 		<div class="embeddedContentDescription">
 			{@$article->getFormattedTeaser()}
 		</div>
-
-		<a href="{@$article->getLink()}" class="embeddedContentLinkShadow"></a>
 	</div>
 	
 	<div class="embeddedContentMeta">
-		{user object=$article->getUserProfile() type='avatar32' class='embeddedContentMetaImage' ariaHidden='true' tabindex='-1'}
+		<div class="embeddedContentMetaImage">
+			{@$article->getUserProfile()->getAvatar()->getImageTag(32)}
+		</div>
 		
 		<div class="embeddedContentMetaContent">
 			<div class="embeddedContentMetaAuthor">
-				{user object=$article->getUserProfile() class='username'}
+				{@$article->getUserProfile()->getFormattedUsername()}
 			</div>
 			
 			<div class="embeddedContentMetaTime">

--- a/wcfsetup/install/files/style/ui/embeddedContent.scss
+++ b/wcfsetup/install/files/style/ui/embeddedContent.scss
@@ -1,10 +1,14 @@
 .embeddedContent {
 	background-color: var(--wcfContentBackground);
-	box-shadow: 0 0 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
-	border-radius: 3px;
+	box-shadow: var(--wcfBoxShadowCard);
+	border-radius: var(--wcfBorderRadius);
 	margin: 10px 0;
 	max-width: 400px;
 	overflow: hidden;
+}
+
+html[data-color-scheme="dark"] .embeddedContent {
+	border: 1px solid var(--wcfContentBorderInner);
 }
 
 /* @deprecated 5.4 Use `<img class="embeddedContentImageElement">` instead */
@@ -54,11 +58,8 @@
 
 /* @deprecated 6.0 Use `.embeddedContentTitleLink` instead */
 .embeddedContentLinkShadow {
-	bottom: 0;
-	left: 0;
+	inset: 0;
 	position: absolute;
-	right: 0;
-	top: 0;
 }
 
 .embeddedContentCategory {
@@ -67,10 +68,11 @@
 	@include wcfFontSmall;
 }
 
-.embeddedContentTitle {
+.embeddedContentTitle,
+.messageBody > .messageText .embeddedContentTitle {
 	color: var(--wcfContentHeadlineText);
 	display: -webkit-box;
-	margin-bottom: 5px;
+	margin: 0;
 	overflow: hidden;
 	-webkit-line-clamp: 2;
 	-webkit-box-orient: vertical;
@@ -87,6 +89,7 @@
 
 .embeddedContentDescription {
 	color: var(--wcfContentDimmedText);
+	margin-top: 5px;
 	max-height: calc(5em * #{var(--wcfFontLineHeight)});
 	overflow: hidden;
 	position: relative;

--- a/wcfsetup/install/files/style/ui/embeddedContent.scss
+++ b/wcfsetup/install/files/style/ui/embeddedContent.scss
@@ -40,12 +40,10 @@
 	color: inherit;
 
 	&::before {
-		bottom: 0;
 		content: "";
-		left: 0;
+		inset: 0;
 		position: absolute;
-		right: 0;
-		top: 0;
+		z-index: 1;
 	}
 
 	&:hover,

--- a/wcfsetup/install/files/style/ui/embeddedContent.scss
+++ b/wcfsetup/install/files/style/ui/embeddedContent.scss
@@ -36,6 +36,25 @@
 	position: relative;
 }
 
+.embeddedContentTitleLink {
+	color: inherit;
+
+	&::before {
+		bottom: 0;
+		content: "";
+		left: 0;
+		position: absolute;
+		right: 0;
+		top: 0;
+	}
+
+	&:hover,
+	&:focus {
+		color: inherit;
+	}
+}
+
+/* @deprecated 6.0 Use `.embeddedContentTitleLink` instead */
 .embeddedContentLinkShadow {
 	bottom: 0;
 	left: 0;

--- a/wcfsetup/install/files/style/ui/embeddedContent.scss
+++ b/wcfsetup/install/files/style/ui/embeddedContent.scss
@@ -87,7 +87,7 @@
 
 .embeddedContentDescription {
 	color: var(--wcfContentDimmedText);
-	max-height: calc(5 * #{var(--wcfFontLineHeight)}em);
+	max-height: calc(5em * #{var(--wcfFontLineHeight)});
 	overflow: hidden;
 	position: relative;
 
@@ -99,10 +99,10 @@
 		);
 		content: "";
 		left: 0;
-		height: #{var(--wcfFontLineHeight)}em;
+		height: calc(1em * #{var(--wcfFontLineHeight)});
 		position: absolute;
 		right: 0;
-		top: calc(4 * #{var(--wcfFontLineHeight)}em);
+		top: calc(4em * #{var(--wcfFontLineHeight)});
 	}
 }
 


### PR DESCRIPTION
- [x] Use a real link instead of a shadow link for the main content link
- [x] Reduce total number of links in the widget
- [x] Use a headline tag for the content title (difficult bc CSS selectors inherit)
- [x] Adjusts margins/paddings