### PR TITLE
Add `machine` output type to `{time}`

### DIFF
--- a/wcfsetup/install/files/lib/system/template/plugin/TimeFunctionTemplatePlugin.class.php
+++ b/wcfsetup/install/files/lib/system/template/plugin/TimeFunctionTemplatePlugin.class.php
@@ -16,6 +16,7 @@ use wcf\system\WCF;
  *  {time time=$timestamp}
  *  {time time=$timestamp type='plainTime'}
  *  {time time=$timestamp type='plainDate'}
+ *  {time time=$timestamp type='machine'}
  *  {time time=$timestamp type='custom' format='Y-m-d'}
  *
  * @author Tim Duesterhus, Marcel Werk
@@ -82,6 +83,8 @@ final class TimeFunctionTemplatePlugin implements IFunctionTemplatePlugin
                     ],
                     $locale
                 );
+            case 'machine':
+                return $dateTime->format(\DateTimeInterface::ATOM);
             case 'custom':
                 return $dateTime->format($tagArgs['format']);
             default:


### PR DESCRIPTION
This will output a machine-readable version of the datetime, i.e. the ISO-8601
format.

This is intended as a replacement for `{$foo|date:'c'}`.
