### PR TITLE
Allow time function to be used without timestamps

### DIFF
--- a/wcfsetup/install/files/lib/system/template/plugin/TimeFunctionTemplatePlugin.class.php
+++ b/wcfsetup/install/files/lib/system/template/plugin/TimeFunctionTemplatePlugin.class.php
@@ -13,6 +13,7 @@ use wcf\system\WCF;
  * output types.
  *
  * Usage:
+ *  {time}
  *  {time time=$timestamp}
  *  {time time=$timestamp type='plainTime'}
  *  {time time=$timestamp type='plainDate'}
@@ -28,7 +29,7 @@ final class TimeFunctionTemplatePlugin implements IFunctionTemplatePlugin
 {
     public function execute($tagArgs, TemplateEngine $tplObj): string
     {
-        $time = $tagArgs['time'];
+        $time = $tagArgs['time'] ?? TIME_NOW;
         $type = $tagArgs['type'] ?? 'interactive';
 
         if ($time instanceof \DateTimeImmutable) {


### PR DESCRIPTION
As of now, there's always a time property required. So calling this function without a timestamp results in an exception message.

With this PR, a timestamp is optional. When omitted, it uses TIME_NOW instead.