### PR TITLE
Allow PHP 8.3 in CheckSystemEnvironment for testing purposes

### DIFF
--- a/wcfsetup/install/files/lib/http/middleware/CheckSystemEnvironment.class.php
+++ b/wcfsetup/install/files/lib/http/middleware/CheckSystemEnvironment.class.php
@@ -27,7 +27,7 @@ final class CheckSystemEnvironment implements MiddlewareInterface
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         if (!RequestHandler::getInstance()->isACPRequest()) {
-            if (!(80100 <= \PHP_VERSION_ID && \PHP_VERSION_ID <= 80299)) {
+            if (!(80100 <= \PHP_VERSION_ID && \PHP_VERSION_ID <= 80300)) {
                 return new HtmlResponse(
                     (new HtmlErrorRenderer())->render(
                         WCF::getLanguage()->getDynamicVariable('wcf.global.error.title'),


### PR DESCRIPTION
With the first Alpha of PHP 8.3 now released, compatibility testing can begin
and this requires that the frontend is actually available.
