### PR TITLE
Improvements to the dev tools

### DIFF
--- a/ts/WoltLabSuite/Core/Acp/Form/Builder/Field/Devtools/Project/Instructions.ts
+++ b/ts/WoltLabSuite/Core/Acp/Form/Builder/Field/Devtools/Project/Instructions.ts
@@ -312,9 +312,15 @@ class Instructions {
       .getElementById(`${this.formFieldId}_instructions${instructionsId}_pip`)!
       .addEventListener("change", (ev) => this.changeInstructionPip(ev));
 
-    document
-      .getElementById(`${this.formFieldId}_instructions${instructionsId}_value`)!
-      .addEventListener("keypress", (ev) => this.instructionKeyPress(ev));
+    const value = document.getElementById(
+      `${this.formFieldId}_instructions${instructionsId}_value`,
+    ) as HTMLInputElement;
+    value.addEventListener("keypress", (ev) => this.instructionKeyPress(ev));
+
+    const application = document.getElementById(
+      `${this.formFieldId}_instructions${instructionsId}_application`,
+    ) as HTMLSelectElement;
+    application.addEventListener("focus", () => this.#deriveApplicationFromPipName(application, value));
 
     document
       .getElementById(`${this.formFieldId}_instructions${instructionsId}_addButton`)!
@@ -324,6 +330,20 @@ class Instructions {
       instructionsData.instructions.forEach((instruction) => {
         this.addInstructionByData(instructionsId, instruction);
       });
+    }
+  }
+
+  #deriveApplicationFromPipName(application: HTMLSelectElement, value: HTMLInputElement): void {
+    if (application.value !== "") {
+      return;
+    }
+
+    const matches = value.value.trim().match(/_([a-z]+).tar$/);
+    if (matches !== null) {
+      const isValid = Array.from(application.options).some((option) => option.value === matches[1]);
+      if (isValid) {
+        application.value = matches[1];
+      }
     }
   }
 

--- a/ts/WoltLabSuite/Core/Acp/Form/Builder/Field/Devtools/Project/Instructions.ts
+++ b/ts/WoltLabSuite/Core/Acp/Form/Builder/Field/Devtools/Project/Instructions.ts
@@ -368,6 +368,9 @@ class Instructions {
 
     // toggle application selector
     this.toggleApplicationFormField(instructionsId);
+
+    const value = document.getElementById(`${this.formFieldId}_instructions${instructionsId}_value`)!;
+    value.focus();
   }
 
   /**

--- a/ts/WoltLabSuite/Core/Acp/Ui/Devtools/Project/FilterByName.ts
+++ b/ts/WoltLabSuite/Core/Acp/Ui/Devtools/Project/FilterByName.ts
@@ -19,23 +19,104 @@ function filterProjects(): void {
     return;
   }
 
+  let firstProject: HTMLTableRowElement | undefined = undefined;
   projects.forEach((row, name) => {
     if (name.includes(value)) {
       row.hidden = false;
+
+      if (!firstProject) {
+        firstProject = row;
+      }
     } else {
       row.hidden = true;
     }
   });
+
+  if (firstProject) {
+    highlightProject(firstProject);
+  }
 }
 
 function resetFilter(): void {
   filterByName.value = "";
-  projects.forEach((row) => (row.hidden = false));
+  projects.forEach((row) => {
+    row.hidden = false;
+    row.classList.remove("devtoolsProject--highlighted");
+  });
+}
+
+function highlightProject(target: HTMLTableRowElement): void {
+  projects.forEach((row) => {
+    if (row === target) {
+      row.classList.add("devtoolsProject--highlighted");
+    } else {
+      row.classList.remove("devtoolsProject--highlighted");
+    }
+  });
+}
+
+function syncHighlightedProject(): void {
+  const row = getHighlightedProject();
+
+  if (row) {
+    const button = row.querySelector(".devtoolsProjectSync") as HTMLAnchorElement;
+    button.click();
+  }
+}
+
+function highlightPreviousProject(): void {
+  const projects = getVisibleProjects();
+  const current = getHighlightedProject();
+  if (!current) {
+    return;
+  }
+
+  let index = projects.indexOf(current) - 1;
+  if (index < 0) {
+    index = projects.length - 1;
+  }
+
+  highlightProject(projects[index]);
+}
+
+function highlightNextProject(): void {
+  const projects = getVisibleProjects();
+  const current = getHighlightedProject();
+  if (!current) {
+    return;
+  }
+
+  let index = projects.indexOf(current) + 1;
+  if (index >= projects.length) {
+    index = 0;
+  }
+
+  highlightProject(projects[index]);
+}
+
+function getVisibleProjects(): HTMLTableRowElement[] {
+  return Array.from(projects.values()).filter((project) => project.hidden === false);
+}
+
+function getHighlightedProject(): HTMLTableRowElement | undefined {
+  return Array.from(projects.values()).find((project) => project.classList.contains("devtoolsProject--highlighted"));
 }
 
 export function setup(): void {
   filterByName.addEventListener("input", () => filterProjects());
-  filterByName.addEventListener("keyup", (event) => {
+  filterByName.addEventListener("keydown", (event) => {
+    if (event.key === "ArrowDown") {
+      highlightNextProject();
+    }
+
+    if (event.key === "ArrowUp") {
+      highlightPreviousProject();
+    }
+
+    if (event.key === "Enter") {
+      syncHighlightedProject();
+    }
+
     if (event.key === "Escape") {
       resetFilter();
     }

--- a/ts/WoltLabSuite/Core/Acp/Ui/Devtools/Project/FilterByName.ts
+++ b/ts/WoltLabSuite/Core/Acp/Ui/Devtools/Project/FilterByName.ts
@@ -114,18 +114,26 @@ export function setup(): void {
   filterByName.addEventListener("input", () => filterProjects());
   filterByName.addEventListener("keydown", (event) => {
     if (event.key === "ArrowDown") {
+      event.preventDefault();
+
       highlightNextProject();
     }
 
     if (event.key === "ArrowUp") {
+      event.preventDefault();
+
       highlightPreviousProject();
     }
 
     if (event.key === "Enter") {
+      event.preventDefault();
+
       syncHighlightedProject();
     }
 
     if (event.key === "Escape") {
+      event.preventDefault();
+
       resetFilter();
     }
   });

--- a/ts/WoltLabSuite/Core/Acp/Ui/Devtools/Project/FilterByName.ts
+++ b/ts/WoltLabSuite/Core/Acp/Ui/Devtools/Project/FilterByName.ts
@@ -1,0 +1,53 @@
+/**
+ * Provides a filter input to narrow down the list of projects.
+ *
+ * @author Alexander Ebert
+ * @copyright 2001-2023 WoltLab GmbH
+ * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @since 6.0
+ */
+
+import { touch as isTouch } from "WoltLabSuite/Core/Environment";
+
+const filterByName = document.getElementById("filterByName") as HTMLInputElement;
+const projects: Map<string, HTMLTableRowElement> = new Map();
+
+function filterProjects(): void {
+  const value = filterByName.value.trim().toLowerCase();
+  if (value === "") {
+    resetFilter();
+    return;
+  }
+
+  projects.forEach((row, name) => {
+    if (name.includes(value)) {
+      row.hidden = false;
+    } else {
+      row.hidden = true;
+    }
+  });
+}
+
+function resetFilter(): void {
+  filterByName.value = "";
+  projects.forEach((row) => (row.hidden = false));
+}
+
+export function setup(): void {
+  filterByName.addEventListener("input", () => filterProjects());
+  filterByName.addEventListener("keyup", (event) => {
+    if (event.key === "Escape") {
+      resetFilter();
+    }
+  });
+
+  const table = document.getElementById("devtoolsProjectList") as HTMLTableElement;
+  table.querySelectorAll<HTMLTableRowElement>(".devtoolsProject").forEach((row) => {
+    const name = row.dataset.name!.toLowerCase();
+    projects.set(name, row);
+  });
+
+  if (!isTouch()) {
+    filterByName.focus();
+  }
+}

--- a/ts/WoltLabSuite/Core/Acp/Ui/Devtools/Project/FilterByName.ts
+++ b/ts/WoltLabSuite/Core/Acp/Ui/Devtools/Project/FilterByName.ts
@@ -32,6 +32,14 @@ function filterProjects(): void {
     }
   });
 
+  // Prefer exact matches when selecting packages.
+  for (const [name, project] of projects) {
+    if (name === value) {
+      firstProject = project;
+      break;
+    }
+  }
+
   if (firstProject) {
     highlightProject(firstProject);
   }

--- a/ts/WoltLabSuite/Core/Acp/Ui/Devtools/Project/Sync.ts
+++ b/ts/WoltLabSuite/Core/Acp/Ui/Devtools/Project/Sync.ts
@@ -32,7 +32,7 @@ interface RequestData {
 class AcpUiDevtoolsProjectSync {
   private readonly buttons = new Map<string, HTMLButtonElement>();
   private readonly buttonStatus = new Map<string, HTMLElement>();
-  private buttonSyncAll?: HTMLAnchorElement = undefined;
+  private readonly buttonSyncAll: HTMLButtonElement = document.getElementById("devtoolsSyncAll") as HTMLButtonElement;
   private readonly container = document.getElementById("syncPipMatches")!;
   private readonly pips: PipData[] = [];
   private readonly projectId: number;
@@ -140,15 +140,7 @@ class AcpUiDevtoolsProjectSync {
       }
     }
 
-    const syncAll = document.createElement("li");
-    syncAll.innerHTML = `<a href="#" class="button"><fa-icon name="arrows-rotate" solid></fa-icon> ${Language.get(
-      "wcf.acp.devtools.sync.syncAll",
-    )}</a>`;
-    this.buttonSyncAll = syncAll.children[0] as HTMLAnchorElement;
-    this.buttonSyncAll.addEventListener("click", this.syncAll.bind(this));
-
-    const list = document.querySelector(".contentHeaderNavigation > ul") as HTMLUListElement;
-    list.insertAdjacentElement("afterbegin", syncAll);
+    this.buttonSyncAll.addEventListener("click", () => this.syncAll());
   }
 
   private sync(pluginName: string, target: string): void {
@@ -164,14 +156,12 @@ class AcpUiDevtoolsProjectSync {
     });
   }
 
-  private syncAll(event: MouseEvent): void {
-    event.preventDefault();
-
-    if (this.buttonSyncAll!.classList.contains("disabled")) {
+  private syncAll(): void {
+    if (this.buttonSyncAll.classList.contains("disabled")) {
       return;
     }
 
-    this.buttonSyncAll!.classList.add("disabled");
+    this.buttonSyncAll.classList.add("disabled");
 
     this.queue = [];
     this.pips.forEach((pip) => {
@@ -184,7 +174,7 @@ class AcpUiDevtoolsProjectSync {
 
   private syncNext(): void {
     if (this.queue.length === 0) {
-      this.buttonSyncAll!.classList.remove("disabled");
+      this.buttonSyncAll.classList.remove("disabled");
 
       UiNotification.show();
 
@@ -238,7 +228,7 @@ class AcpUiDevtoolsProjectSync {
       }
     });
 
-    this.buttonSyncAll!.classList.remove("disabled");
+    this.buttonSyncAll.classList.remove("disabled");
 
     return true;
   }

--- a/wcfsetup/install/files/acp/templates/__devtoolsProjectPathPasteHelper.tpl
+++ b/wcfsetup/install/files/acp/templates/__devtoolsProjectPathPasteHelper.tpl
@@ -7,12 +7,11 @@
             return;
         }
 
-        let value = event.clipboardData.getData("text/plain").trim();
-        if (value.match(/.+[/\\]([^/\\]+)[/\\]?$/)) {
-            value = RegExp.$1;
-            if (value.includes(".")) {
-                name.value = value;
-            }
+        const value = event.clipboardData.getData("text/plain").trim();
+
+        const matches = value.match(/.+[/\\]([^/\\]+)[/\\]?$/);
+        if (matches !== null && matches[1].includes(".")) {
+            name.value = matches[1];
         }
     });
 }

--- a/wcfsetup/install/files/acp/templates/__devtoolsProjectPathPasteHelper.tpl
+++ b/wcfsetup/install/files/acp/templates/__devtoolsProjectPathPasteHelper.tpl
@@ -1,0 +1,19 @@
+<script data-relocate="true">
+{
+    const name = document.getElementById("name");
+    const path = document.getElementById("path");
+    path.addEventListener("paste", (event) => {
+        if (name.value.trim() !== "") {
+            return;
+        }
+
+        let value = event.clipboardData.getData("text/plain").trim();
+        if (value.match(/.+[/\\]([^/\\]+)[/\\]?$/)) {
+            value = RegExp.$1;
+            if (value.includes(".")) {
+                name.value = value;
+            }
+        }
+    });
+}
+</script>

--- a/wcfsetup/install/files/acp/templates/devtoolsProjectList.tpl
+++ b/wcfsetup/install/files/acp/templates/devtoolsProjectList.tpl
@@ -1,9 +1,10 @@
 {include file='header' pageTitle='wcf.acp.devtools.project.list'}
 
 <script data-relocate="true">
-	require(['WoltLabSuite/Core/Acp/Ui/Devtools/Project/QuickSetup', 'Language'], function(AcpUiDevtoolsProjectQuickSetup, Language) {
+	require(['WoltLabSuite/Core/Acp/Ui/Devtools/Project/FilterByName', 'WoltLabSuite/Core/Acp/Ui/Devtools/Project/QuickSetup', 'Language'], function({ setup: setupFilterByName }, AcpUiDevtoolsProjectQuickSetup, Language) {
 		Language.add('wcf.acp.devtools.project.quickSetup', '{jslang}wcf.acp.devtools.project.quickSetup{/jslang}');
 		
+		setupFilterByName();
 		AcpUiDevtoolsProjectQuickSetup.init();
 	});
 </script>
@@ -26,8 +27,19 @@
 <p class="info">{lang}wcf.acp.devtools.project.introduction{/lang}</p>
 
 {hascontent}
+	<div class="section">
+		<dl>
+			<dt>
+				<label for="filterByName">{lang}wcf.acp.devtools.project.filterByName{/lang}</label>
+			</dt>
+			<dd>
+				<input type="text" id="filterByName" class="long">
+			</dd>
+		</dl>
+	</div>
+
 	<div class="section tabularBox">
-		<table class="table jsObjectActionContainer" data-object-action-class-name="wcf\data\devtools\project\DevtoolsProjectAction">
+		<table class="table jsObjectActionContainer" data-object-action-class-name="wcf\data\devtools\project\DevtoolsProjectAction" id="devtoolsProjectList">
 			<thead>
 				<tr>
 					<th class="columnID{if $sortField === 'projectID'} active {@$sortOrder}{/if}" colspan="3"><a href="{link controller='DevtoolsProjectList'}sortField=projectID&sortOrder={if $sortField === 'projectID' && $sortOrder === 'ASC'}DESC{else}ASC{/if}{/link}">{lang}wcf.global.objectID{/lang}</a></th>
@@ -41,7 +53,7 @@
 			<tbody>
 				{content}
 					{foreach from=$objects item=object}
-						<tr class="jsObjectRow jsObjectActionObject" data-object-id="{@$object->getObjectID()}">
+						<tr class="jsObjectRow jsObjectActionObject devtoolsProject" data-object-id="{$object->getObjectID()}" data-name="{$object->name}">
 							<td class="columnIcon">
 								<a href="{link controller='DevtoolsProjectSync' id=$object->getObjectID()}{/link}" class="button small">{lang}wcf.acp.devtools.project.sync{/lang}</a>
 								<a href="{link controller='DevtoolsProjectPipList' id=$object->getObjectID()}{/link}" class="button small">{lang}wcf.acp.devtools.project.pips{/lang}</a>

--- a/wcfsetup/install/files/acp/templates/devtoolsProjectList.tpl
+++ b/wcfsetup/install/files/acp/templates/devtoolsProjectList.tpl
@@ -28,49 +28,51 @@
 
 {hascontent}
 	<div class="section">
-		<dl>
-			<dt>
-				<label for="filterByName">{lang}wcf.acp.devtools.project.filterByName{/lang}</label>
-			</dt>
-			<dd>
-				<input type="text" id="filterByName" class="long">
-				<small>{lang}wcf.acp.devtools.project.filterByName.description{/lang}</small>
-			</dd>
-		</dl>
-	</div>
+		<div class="section">
+			<dl>
+				<dt>
+					<label for="filterByName">{lang}wcf.acp.devtools.project.filterByName{/lang}</label>
+				</dt>
+				<dd>
+					<input type="text" id="filterByName" class="long">
+					<small>{lang}wcf.acp.devtools.project.filterByName.description{/lang}</small>
+				</dd>
+			</dl>
+		</div>
 
-	<div class="section tabularBox">
-		<table class="table jsObjectActionContainer" data-object-action-class-name="wcf\data\devtools\project\DevtoolsProjectAction" id="devtoolsProjectList">
-			<thead>
-				<tr>
-					<th class="columnID{if $sortField === 'projectID'} active {@$sortOrder}{/if}" colspan="3"><a href="{link controller='DevtoolsProjectList'}sortField=projectID&sortOrder={if $sortField === 'projectID' && $sortOrder === 'ASC'}DESC{else}ASC{/if}{/link}">{lang}wcf.global.objectID{/lang}</a></th>
-					<th class="columnText{if $sortField === 'name'} active {@$sortOrder}{/if}"><a href="{link controller='DevtoolsProjectList'}sortField=name&sortOrder={if $sortField === 'name' && $sortOrder === 'ASC'}DESC{else}ASC{/if}{/link}">{lang}wcf.acp.devtools.project.name{/lang}</a></th>
-					<th class="columnText{if $sortField === 'path'} active {@$sortOrder}{/if}"><a href="{link controller='DevtoolsProjectList'}sortField=path&sortOrder={if $sortField === 'path' && $sortOrder === 'ASC'}DESC{else}ASC{/if}{/link}">{lang}wcf.acp.devtools.project.path{/lang}</a></th>
-					
-					{event name='columnHeads'}
-				</tr>
-			</thead>
-			
-			<tbody>
-				{content}
-					{foreach from=$objects item=object}
-						<tr class="jsObjectRow jsObjectActionObject devtoolsProject" data-object-id="{$object->getObjectID()}" data-name="{$object->name}">
-							<td class="columnIcon">
-								<a href="{link controller='DevtoolsProjectSync' id=$object->getObjectID()}{/link}" class="button small devtoolsProjectSync">{lang}wcf.acp.devtools.project.sync{/lang}</a>
-								<a href="{link controller='DevtoolsProjectPipList' id=$object->getObjectID()}{/link}" class="button small">{lang}wcf.acp.devtools.project.pips{/lang}</a>
-							</td>
-							<td class="columnIcon">
-								<a href="{link controller='DevtoolsProjectEdit' id=$object->getObjectID()}{/link}" title="{lang}wcf.global.button.edit{/lang}" class="jsTooltip">{icon name='pencil'}</a>
-								{objectAction action="delete" objectTitle=$object->name}
-							</td>
-							<td class="columnID">{@$object->getObjectID()}</td>
-							<td class="columnText"><a href="{link controller='DevtoolsProjectEdit' id=$object->getObjectID()}{/link}">{$object->name}</a></td>
-							<td class="columnText"><small>{$object->path}</small></td>
-						</tr>
-					{/foreach}
-				{/content}
-			</tbody>
-		</table>
+		<div class="section tabularBox">
+			<table class="table jsObjectActionContainer" data-object-action-class-name="wcf\data\devtools\project\DevtoolsProjectAction" id="devtoolsProjectList">
+				<thead>
+					<tr>
+						<th class="columnID{if $sortField === 'projectID'} active {@$sortOrder}{/if}" colspan="3"><a href="{link controller='DevtoolsProjectList'}sortField=projectID&sortOrder={if $sortField === 'projectID' && $sortOrder === 'ASC'}DESC{else}ASC{/if}{/link}">{lang}wcf.global.objectID{/lang}</a></th>
+						<th class="columnText{if $sortField === 'name'} active {@$sortOrder}{/if}"><a href="{link controller='DevtoolsProjectList'}sortField=name&sortOrder={if $sortField === 'name' && $sortOrder === 'ASC'}DESC{else}ASC{/if}{/link}">{lang}wcf.acp.devtools.project.name{/lang}</a></th>
+						<th class="columnText{if $sortField === 'path'} active {@$sortOrder}{/if}"><a href="{link controller='DevtoolsProjectList'}sortField=path&sortOrder={if $sortField === 'path' && $sortOrder === 'ASC'}DESC{else}ASC{/if}{/link}">{lang}wcf.acp.devtools.project.path{/lang}</a></th>
+						
+						{event name='columnHeads'}
+					</tr>
+				</thead>
+				
+				<tbody>
+					{content}
+						{foreach from=$objects item=object}
+							<tr class="jsObjectRow jsObjectActionObject devtoolsProject" data-object-id="{$object->getObjectID()}" data-name="{$object->name}">
+								<td class="columnIcon">
+									<a href="{link controller='DevtoolsProjectSync' id=$object->getObjectID()}{/link}" class="button small devtoolsProjectSync">{lang}wcf.acp.devtools.project.sync{/lang}</a>
+									<a href="{link controller='DevtoolsProjectPipList' id=$object->getObjectID()}{/link}" class="button small">{lang}wcf.acp.devtools.project.pips{/lang}</a>
+								</td>
+								<td class="columnIcon">
+									<a href="{link controller='DevtoolsProjectEdit' id=$object->getObjectID()}{/link}" title="{lang}wcf.global.button.edit{/lang}" class="jsTooltip">{icon name='pencil'}</a>
+									{objectAction action="delete" objectTitle=$object->name}
+								</td>
+								<td class="columnID">{@$object->getObjectID()}</td>
+								<td class="columnText"><a href="{link controller='DevtoolsProjectEdit' id=$object->getObjectID()}{/link}">{$object->name}</a></td>
+								<td class="columnText"><small>{$object->path}</small></td>
+							</tr>
+						{/foreach}
+					{/content}
+				</tbody>
+			</table>
+		</div>
 	</div>
 {hascontentelse}
 	<p class="info">{lang}wcf.global.noItems{/lang}</p>

--- a/wcfsetup/install/files/acp/templates/devtoolsProjectList.tpl
+++ b/wcfsetup/install/files/acp/templates/devtoolsProjectList.tpl
@@ -34,6 +34,7 @@
 			</dt>
 			<dd>
 				<input type="text" id="filterByName" class="long">
+				<small>{lang}wcf.acp.devtools.project.filterByName.description{/lang}</small>
 			</dd>
 		</dl>
 	</div>
@@ -55,7 +56,7 @@
 					{foreach from=$objects item=object}
 						<tr class="jsObjectRow jsObjectActionObject devtoolsProject" data-object-id="{$object->getObjectID()}" data-name="{$object->name}">
 							<td class="columnIcon">
-								<a href="{link controller='DevtoolsProjectSync' id=$object->getObjectID()}{/link}" class="button small">{lang}wcf.acp.devtools.project.sync{/lang}</a>
+								<a href="{link controller='DevtoolsProjectSync' id=$object->getObjectID()}{/link}" class="button small devtoolsProjectSync">{lang}wcf.acp.devtools.project.sync{/lang}</a>
 								<a href="{link controller='DevtoolsProjectPipList' id=$object->getObjectID()}{/link}" class="button small">{lang}wcf.acp.devtools.project.pips{/lang}</a>
 							</td>
 							<td class="columnIcon">
@@ -98,5 +99,11 @@
 		<button type="button" id="projectQuickSetupSubmit" class="button buttonPrimary">{lang}wcf.global.button.submit{/lang}</button>
 	</div>
 </div>
+
+<style>
+.devtoolsProject.devtoolsProject--highlighted td {
+	background-color: var(--wcfTabularBoxBackgroundActive);
+}
+</style>
 
 {include file='footer'}

--- a/wcfsetup/install/files/acp/templates/devtoolsProjectPipEntryList.tpl
+++ b/wcfsetup/install/files/acp/templates/devtoolsProjectPipEntryList.tpl
@@ -8,6 +8,9 @@
 	
 	<nav class="contentHeaderNavigation">
 		<ul>
+			{if $project->validate() === ''}
+				<li><a href="{link controller='DevtoolsProjectSync' id=$project->getObjectID()}{/link}" class="button">{icon name='arrows-rotate'} <span>{lang}wcf.acp.devtools.project.sync{/lang}</span></a></li>
+			{/if}
 			<li class="dropdown">
 				<a class="button dropdownToggle">{icon name='list'} <span>{lang}wcf.acp.devtools.project.pip.list{/lang}</span></a>
 				<div class="dropdownMenu">

--- a/wcfsetup/install/files/acp/templates/devtoolsProjectSync.tpl
+++ b/wcfsetup/install/files/acp/templates/devtoolsProjectSync.tpl
@@ -9,6 +9,12 @@
 	<nav class="contentHeaderNavigation">
 		<ul>
 			{if $object->validate() === ''}
+				<li>
+					<button class="button" id="devtoolsSyncAll">
+						{icon name='arrows-rotate' type='solid'}
+						{lang}wcf.acp.devtools.sync.syncAll{/lang}
+					</button>
+				</li>
 				<li><a href="{link controller='DevtoolsProjectPipList' id=$object->getObjectID()}{/link}" class="button">{icon name='list'} <span>{lang}wcf.acp.devtools.project.pips{/lang}</span></a></li>
 			{/if}
 			<li><a href="{link controller='DevtoolsProjectEdit' id=$object->getObjectID()}{/link}" class="button">{icon name='pencil'} <span>{lang}wcf.acp.devtools.project.edit{/lang}</span></a></li>

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Acp/Form/Builder/Field/Devtools/Project/Instructions.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Acp/Form/Builder/Field/Devtools/Project/Instructions.js
@@ -220,9 +220,10 @@ define(["require", "exports", "tslib", "../../../../../../Core", "../../../../..
             document
                 .getElementById(`${this.formFieldId}_instructions${instructionsId}_pip`)
                 .addEventListener("change", (ev) => this.changeInstructionPip(ev));
-            document
-                .getElementById(`${this.formFieldId}_instructions${instructionsId}_value`)
-                .addEventListener("keypress", (ev) => this.instructionKeyPress(ev));
+            const value = document.getElementById(`${this.formFieldId}_instructions${instructionsId}_value`);
+            value.addEventListener("keypress", (ev) => this.instructionKeyPress(ev));
+            const application = document.getElementById(`${this.formFieldId}_instructions${instructionsId}_application`);
+            application.addEventListener("focus", () => this.#deriveApplicationFromPipName(application, value));
             document
                 .getElementById(`${this.formFieldId}_instructions${instructionsId}_addButton`)
                 .addEventListener("click", (ev) => this.addInstruction(ev));
@@ -230,6 +231,18 @@ define(["require", "exports", "tslib", "../../../../../../Core", "../../../../..
                 instructionsData.instructions.forEach((instruction) => {
                     this.addInstructionByData(instructionsId, instruction);
                 });
+            }
+        }
+        #deriveApplicationFromPipName(application, value) {
+            if (application.value !== "") {
+                return;
+            }
+            const matches = value.value.trim().match(/_([a-z]+).tar$/);
+            if (matches !== null) {
+                const isValid = Array.from(application.options).some((option) => option.value === matches[1]);
+                if (isValid) {
+                    application.value = matches[1];
+                }
             }
         }
         /**

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Acp/Form/Builder/Field/Devtools/Project/Instructions.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Acp/Form/Builder/Field/Devtools/Project/Instructions.js
@@ -264,6 +264,8 @@ define(["require", "exports", "tslib", "../../../../../../Core", "../../../../..
             }
             // toggle application selector
             this.toggleApplicationFormField(instructionsId);
+            const value = document.getElementById(`${this.formFieldId}_instructions${instructionsId}_value`);
+            value.focus();
         }
         /**
          * Opens a dialog to edit an existing instruction.

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Acp/Ui/Devtools/Project/FilterByName.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Acp/Ui/Devtools/Project/FilterByName.js
@@ -30,6 +30,13 @@ define(["require", "exports", "WoltLabSuite/Core/Environment"], function (requir
                 row.hidden = true;
             }
         });
+        // Prefer exact matches when selecting packages.
+        for (const [name, project] of projects) {
+            if (name === value) {
+                firstProject = project;
+                break;
+            }
+        }
         if (firstProject) {
             highlightProject(firstProject);
         }

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Acp/Ui/Devtools/Project/FilterByName.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Acp/Ui/Devtools/Project/FilterByName.js
@@ -18,22 +18,88 @@ define(["require", "exports", "WoltLabSuite/Core/Environment"], function (requir
             resetFilter();
             return;
         }
+        let firstProject = undefined;
         projects.forEach((row, name) => {
             if (name.includes(value)) {
                 row.hidden = false;
+                if (!firstProject) {
+                    firstProject = row;
+                }
             }
             else {
                 row.hidden = true;
             }
         });
+        if (firstProject) {
+            highlightProject(firstProject);
+        }
     }
     function resetFilter() {
         filterByName.value = "";
-        projects.forEach((row) => (row.hidden = false));
+        projects.forEach((row) => {
+            row.hidden = false;
+            row.classList.remove("devtoolsProject--highlighted");
+        });
+    }
+    function highlightProject(target) {
+        projects.forEach((row) => {
+            if (row === target) {
+                row.classList.add("devtoolsProject--highlighted");
+            }
+            else {
+                row.classList.remove("devtoolsProject--highlighted");
+            }
+        });
+    }
+    function syncHighlightedProject() {
+        const row = getHighlightedProject();
+        if (row) {
+            const button = row.querySelector(".devtoolsProjectSync");
+            button.click();
+        }
+    }
+    function highlightPreviousProject() {
+        const projects = getVisibleProjects();
+        const current = getHighlightedProject();
+        if (!current) {
+            return;
+        }
+        let index = projects.indexOf(current) - 1;
+        if (index < 0) {
+            index = projects.length - 1;
+        }
+        highlightProject(projects[index]);
+    }
+    function highlightNextProject() {
+        const projects = getVisibleProjects();
+        const current = getHighlightedProject();
+        if (!current) {
+            return;
+        }
+        let index = projects.indexOf(current) + 1;
+        if (index >= projects.length) {
+            index = 0;
+        }
+        highlightProject(projects[index]);
+    }
+    function getVisibleProjects() {
+        return Array.from(projects.values()).filter((project) => project.hidden === false);
+    }
+    function getHighlightedProject() {
+        return Array.from(projects.values()).find((project) => project.classList.contains("devtoolsProject--highlighted"));
     }
     function setup() {
         filterByName.addEventListener("input", () => filterProjects());
-        filterByName.addEventListener("keyup", (event) => {
+        filterByName.addEventListener("keydown", (event) => {
+            if (event.key === "ArrowDown") {
+                highlightNextProject();
+            }
+            if (event.key === "ArrowUp") {
+                highlightPreviousProject();
+            }
+            if (event.key === "Enter") {
+                syncHighlightedProject();
+            }
             if (event.key === "Escape") {
                 resetFilter();
             }

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Acp/Ui/Devtools/Project/FilterByName.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Acp/Ui/Devtools/Project/FilterByName.js
@@ -99,15 +99,19 @@ define(["require", "exports", "WoltLabSuite/Core/Environment"], function (requir
         filterByName.addEventListener("input", () => filterProjects());
         filterByName.addEventListener("keydown", (event) => {
             if (event.key === "ArrowDown") {
+                event.preventDefault();
                 highlightNextProject();
             }
             if (event.key === "ArrowUp") {
+                event.preventDefault();
                 highlightPreviousProject();
             }
             if (event.key === "Enter") {
+                event.preventDefault();
                 syncHighlightedProject();
             }
             if (event.key === "Escape") {
+                event.preventDefault();
                 resetFilter();
             }
         });

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Acp/Ui/Devtools/Project/FilterByName.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Acp/Ui/Devtools/Project/FilterByName.js
@@ -1,0 +1,51 @@
+/**
+ * Provides a filter input to narrow down the list of projects.
+ *
+ * @author Alexander Ebert
+ * @copyright 2001-2023 WoltLab GmbH
+ * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @since 6.0
+ */
+define(["require", "exports", "WoltLabSuite/Core/Environment"], function (require, exports, Environment_1) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.setup = void 0;
+    const filterByName = document.getElementById("filterByName");
+    const projects = new Map();
+    function filterProjects() {
+        const value = filterByName.value.trim().toLowerCase();
+        if (value === "") {
+            resetFilter();
+            return;
+        }
+        projects.forEach((row, name) => {
+            if (name.includes(value)) {
+                row.hidden = false;
+            }
+            else {
+                row.hidden = true;
+            }
+        });
+    }
+    function resetFilter() {
+        filterByName.value = "";
+        projects.forEach((row) => (row.hidden = false));
+    }
+    function setup() {
+        filterByName.addEventListener("input", () => filterProjects());
+        filterByName.addEventListener("keyup", (event) => {
+            if (event.key === "Escape") {
+                resetFilter();
+            }
+        });
+        const table = document.getElementById("devtoolsProjectList");
+        table.querySelectorAll(".devtoolsProject").forEach((row) => {
+            const name = row.dataset.name.toLowerCase();
+            projects.set(name, row);
+        });
+        if (!(0, Environment_1.touch)()) {
+            filterByName.focus();
+        }
+    }
+    exports.setup = setup;
+});

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Acp/Ui/Devtools/Project/Sync.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Acp/Ui/Devtools/Project/Sync.js
@@ -8,7 +8,7 @@ define(["require", "exports", "tslib", "../../../../Ajax", "../../../../Language
     class AcpUiDevtoolsProjectSync {
         buttons = new Map();
         buttonStatus = new Map();
-        buttonSyncAll = undefined;
+        buttonSyncAll = document.getElementById("devtoolsSyncAll");
         container = document.getElementById("syncPipMatches");
         pips = [];
         projectId;
@@ -91,12 +91,7 @@ define(["require", "exports", "tslib", "../../../../Ajax", "../../../../Language
                     break;
                 }
             }
-            const syncAll = document.createElement("li");
-            syncAll.innerHTML = `<a href="#" class="button"><fa-icon name="arrows-rotate" solid></fa-icon> ${Language.get("wcf.acp.devtools.sync.syncAll")}</a>`;
-            this.buttonSyncAll = syncAll.children[0];
-            this.buttonSyncAll.addEventListener("click", this.syncAll.bind(this));
-            const list = document.querySelector(".contentHeaderNavigation > ul");
-            list.insertAdjacentElement("afterbegin", syncAll);
+            this.buttonSyncAll.addEventListener("click", () => this.syncAll());
         }
         sync(pluginName, target) {
             const identifier = this.getButtonIdentifier(pluginName, target);
@@ -109,8 +104,7 @@ define(["require", "exports", "tslib", "../../../../Ajax", "../../../../Language
                 },
             });
         }
-        syncAll(event) {
-            event.preventDefault();
+        syncAll() {
             if (this.buttonSyncAll.classList.contains("disabled")) {
                 return;
             }

--- a/wcfsetup/install/files/lib/acp/form/DevtoolsProjectAddForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/DevtoolsProjectAddForm.class.php
@@ -29,6 +29,7 @@ use wcf\system\form\builder\field\UrlFormField;
 use wcf\system\form\builder\field\validation\FormFieldValidationError;
 use wcf\system\form\builder\field\validation\FormFieldValidator;
 use wcf\system\form\builder\field\validation\FormFieldValidatorUtil;
+use wcf\system\form\builder\TemplateFormNode;
 use wcf\system\package\plugin\AbstractXMLPackageInstallationPlugin;
 use wcf\system\Regex;
 use wcf\system\WCF;
@@ -229,6 +230,9 @@ class DevtoolsProjectAddForm extends AbstractFormBuilderForm
                             }
                         }
                     })),
+                TemplateFormNode::create('pathPasteHelper')
+                    ->application('wcf')
+                    ->templateName('__devtoolsProjectPathPasteHelper')
             ]);
         $dataTab->appendChild($dataContainer);
 

--- a/wcfsetup/install/lang/de.xml
+++ b/wcfsetup/install/lang/de.xml
@@ -410,6 +410,7 @@
 		<item name="wcf.acp.devtools.project.add"><![CDATA[Projekt hinzufügen]]></item>
 		<item name="wcf.acp.devtools.project.edit"><![CDATA[Projekt bearbeiten]]></item>
 		<item name="wcf.acp.devtools.project.filterByName"><![CDATA[Nach Name filtern]]></item>
+		<item name="wcf.acp.devtools.project.filterByName.description"><![CDATA[Die Auswahl des hervorgehobenen Projekts kann mit <kbd>↑</kbd> und <kbd>↓</kbd> verändert werden. Mit <kbd>⮐</kbd> wird der Daten-Abgleich des hervorgehobenen Projekts geöffnet.]]></item>
 		<item name="wcf.acp.devtools.project.introduction"><![CDATA[Bitte {if LANGUAGE_USE_INFORMAL_VARIANT}beachte{else}beachten Sie{/if} die <a href="https://docs.woltlab.com/latest/getting-started/#developer-tools" class="externalURL">Hinweise zur Benutzung</a> in der Entwickler-Dokumentation.]]></item>
 		<item name="wcf.acp.devtools.project.list"><![CDATA[Projekte]]></item>
 		<item name="wcf.acp.devtools.project.name"><![CDATA[Name]]></item>

--- a/wcfsetup/install/lang/de.xml
+++ b/wcfsetup/install/lang/de.xml
@@ -409,6 +409,7 @@
 	<category name="wcf.acp.devtools">
 		<item name="wcf.acp.devtools.project.add"><![CDATA[Projekt hinzufügen]]></item>
 		<item name="wcf.acp.devtools.project.edit"><![CDATA[Projekt bearbeiten]]></item>
+		<item name="wcf.acp.devtools.project.filterByName"><![CDATA[Nach Name filtern]]></item>
 		<item name="wcf.acp.devtools.project.introduction"><![CDATA[Bitte {if LANGUAGE_USE_INFORMAL_VARIANT}beachte{else}beachten Sie{/if} die <a href="https://docs.woltlab.com/latest/getting-started/#developer-tools" class="externalURL">Hinweise zur Benutzung</a> in der Entwickler-Dokumentation.]]></item>
 		<item name="wcf.acp.devtools.project.list"><![CDATA[Projekte]]></item>
 		<item name="wcf.acp.devtools.project.name"><![CDATA[Name]]></item>

--- a/wcfsetup/install/lang/en.xml
+++ b/wcfsetup/install/lang/en.xml
@@ -387,6 +387,7 @@
 	<category name="wcf.acp.devtools">
 		<item name="wcf.acp.devtools.project.add"><![CDATA[Add Project]]></item>
 		<item name="wcf.acp.devtools.project.edit"><![CDATA[Edit Project]]></item>
+		<item name="wcf.acp.devtools.project.filterByName"><![CDATA[Filter by Name]]></item>
 		<item name="wcf.acp.devtools.project.introduction"><![CDATA[Please read the <a href="https://docs.woltlab.com/latest/getting-started/#developer-tools" class="externalURL">usage instructions</a> in the developer documentation.]]></item>
 		<item name="wcf.acp.devtools.project.list"><![CDATA[Projects]]></item>
 		<item name="wcf.acp.devtools.project.name"><![CDATA[Name]]></item>

--- a/wcfsetup/install/lang/en.xml
+++ b/wcfsetup/install/lang/en.xml
@@ -388,6 +388,7 @@
 		<item name="wcf.acp.devtools.project.add"><![CDATA[Add Project]]></item>
 		<item name="wcf.acp.devtools.project.edit"><![CDATA[Edit Project]]></item>
 		<item name="wcf.acp.devtools.project.filterByName"><![CDATA[Filter by Name]]></item>
+		<item name="wcf.acp.devtools.project.filterByName.description"><![CDATA[Press <kbd>↑</kbd> and <kbd>↓</kbd> to change the highlighted project. Pressing <kbd>⮐</kbd> will navigate to the “Sync Data” of the highlighted project.]]></item>
 		<item name="wcf.acp.devtools.project.introduction"><![CDATA[Please read the <a href="https://docs.woltlab.com/latest/getting-started/#developer-tools" class="externalURL">usage instructions</a> in the developer documentation.]]></item>
 		<item name="wcf.acp.devtools.project.list"><![CDATA[Projects]]></item>
 		<item name="wcf.acp.devtools.project.name"><![CDATA[Name]]></item>


### PR DESCRIPTION
This PR adds a few improvements to the developer tools that should ease the day-to-day work.

* New project
  * When the name is empty and a path is pasted into the path input whose last component looks like a package name then this component is copied to the project name field.
* Adding instructions
  * Selecting the PIP will move the focus to the value field.
  * For PIPs with an application, the value is attempted to be guessed from the value, for example, the value `files_wbb.tar` will default to the `wbb` application.
* List of a project’s PIPs
  * Added a button to access the sync page of the project.
* List of projects
  * Added a new input field to filter the list of projects by their name.
  * The arrow up an down can be used to highlight a project.
  * Hitting return on the highlighted project will navigate to the “Sync Data” page.