### PR TITLE
Move replacement of placerholders in mail texts into `UserMailBox`

### DIFF
--- a/com.woltlab.wcf/templates/email_mailWorker.tpl
+++ b/com.woltlab.wcf/templates/email_mailWorker.tpl
@@ -1,4 +1,4 @@
-{assign var='text' value="\x7B\$username\x7D"|str_replace:$mailbox->getUser()->username:$text}{if $mimeType === 'text/plain'}
+{assign var='text' value=$mailbox->getPersonalizedText($text)}{if $mimeType === 'text/plain'}
 {include file='email_plaintext' content=$text}
 {else}
 	{if $enableHTML}

--- a/wcfsetup/install/files/lib/system/email/UserMailbox.class.php
+++ b/wcfsetup/install/files/lib/system/email/UserMailbox.class.php
@@ -47,4 +47,15 @@ class UserMailbox extends Mailbox implements IUserMailbox
 
         return $user;
     }
+
+    /**
+     * Takes the passed text and replaces the placeholders for username and email address with the user's values.
+     */
+    public function getPersonalizedText(string $text): string
+    {
+        $text = \str_replace('{$username}', $this->getUser()->username, $text);
+        $text = \str_replace('{$email}', $this->getUser()->email, $text);
+
+        return $text;
+    }
 }

--- a/wcfsetup/install/files/lib/system/email/UserMailbox.class.php
+++ b/wcfsetup/install/files/lib/system/email/UserMailbox.class.php
@@ -53,9 +53,12 @@ class UserMailbox extends Mailbox implements IUserMailbox
      */
     public function getPersonalizedText(string $text): string
     {
-        $text = \str_replace('{$username}', $this->getUser()->username, $text);
-        $text = \str_replace('{$email}', $this->getUser()->email, $text);
-
-        return $text;
+        return \strtr(
+            $text,
+            [
+                '{$username}' => $this->getUser()->username,
+                '{$email}' => $this->getUser()->email,
+            ]
+        );
     }
 }


### PR DESCRIPTION
Also added support for an `{$email}` placeholder.