### PR TITLE
Fix updating the search index if the index manager does not support contexts

### DIFF
--- a/wcfsetup/install/files/lib/system/search/SearchIndexManager.class.php
+++ b/wcfsetup/install/files/lib/system/search/SearchIndexManager.class.php
@@ -165,7 +165,7 @@ class SearchIndexManager extends SingletonFactory implements IContextAwareSearch
                 $metaData
             );
         } else {
-            $searchIndexManager
+            $this
                 ->set($objectType, $objectID, $message, $subject, $time, $userID, $username, $languageID, $metaData);
         }
     }


### PR DESCRIPTION
With the current logic `SearchIndexManager::setWithContext()` needs to delegate
to `$this->set()` instead of `$searchIndexManager->set()` for the HTML
stripping to work correctly.

see db5d43f179789e908febb24418c91260005bbd07
