### PR TITLE
Use correct character for return key in phrases

### DIFF
--- a/wcfsetup/install/lang/de.xml
+++ b/wcfsetup/install/lang/de.xml
@@ -410,7 +410,7 @@
 		<item name="wcf.acp.devtools.project.add"><![CDATA[Projekt hinzufügen]]></item>
 		<item name="wcf.acp.devtools.project.edit"><![CDATA[Projekt bearbeiten]]></item>
 		<item name="wcf.acp.devtools.project.filterByName"><![CDATA[Nach Name filtern]]></item>
-		<item name="wcf.acp.devtools.project.filterByName.description"><![CDATA[Die Auswahl des hervorgehobenen Projekts kann mit <kbd>↑</kbd> und <kbd>↓</kbd> verändert werden. Mit <kbd>⮐</kbd> wird der Daten-Abgleich des hervorgehobenen Projekts geöffnet.]]></item>
+		<item name="wcf.acp.devtools.project.filterByName.description"><![CDATA[Die Auswahl des hervorgehobenen Projekts kann mit <kbd>↑</kbd> und <kbd>↓</kbd> verändert werden. Mit <kbd>⏎</kbd> wird der Daten-Abgleich des hervorgehobenen Projekts geöffnet.]]></item>
 		<item name="wcf.acp.devtools.project.introduction"><![CDATA[Bitte {if LANGUAGE_USE_INFORMAL_VARIANT}beachte{else}beachten Sie{/if} die <a href="https://docs.woltlab.com/latest/getting-started/#developer-tools" class="externalURL">Hinweise zur Benutzung</a> in der Entwickler-Dokumentation.]]></item>
 		<item name="wcf.acp.devtools.project.list"><![CDATA[Projekte]]></item>
 		<item name="wcf.acp.devtools.project.name"><![CDATA[Name]]></item>

--- a/wcfsetup/install/lang/en.xml
+++ b/wcfsetup/install/lang/en.xml
@@ -388,7 +388,7 @@
 		<item name="wcf.acp.devtools.project.add"><![CDATA[Add Project]]></item>
 		<item name="wcf.acp.devtools.project.edit"><![CDATA[Edit Project]]></item>
 		<item name="wcf.acp.devtools.project.filterByName"><![CDATA[Filter by Name]]></item>
-		<item name="wcf.acp.devtools.project.filterByName.description"><![CDATA[Press <kbd>↑</kbd> and <kbd>↓</kbd> to change the highlighted project. Pressing <kbd>⮐</kbd> will navigate to the “Sync Data” of the highlighted project.]]></item>
+		<item name="wcf.acp.devtools.project.filterByName.description"><![CDATA[Press <kbd>↑</kbd> and <kbd>↓</kbd> to change the highlighted project. Pressing <kbd>⏎</kbd> will navigate to the “Sync Data” of the highlighted project.]]></item>
 		<item name="wcf.acp.devtools.project.introduction"><![CDATA[Please read the <a href="https://docs.woltlab.com/latest/getting-started/#developer-tools" class="externalURL">usage instructions</a> in the developer documentation.]]></item>
 		<item name="wcf.acp.devtools.project.list"><![CDATA[Projects]]></item>
 		<item name="wcf.acp.devtools.project.name"><![CDATA[Name]]></item>


### PR DESCRIPTION
Per https://en.wikipedia.org/wiki/Enter_key#Keyboard_symbols:

> The return key symbol is U+23CE ⏎ RETURN SYMBOL, an arrow pointing down and
> leftward;
