### PR TITLE
Improve the loading experience of the newsfeed in dark mode

### DIFF
--- a/wcfsetup/install/files/acp/style/layout.scss
+++ b/wcfsetup/install/files/acp/style/layout.scss
@@ -870,24 +870,30 @@ html[data-color-scheme="dark"] {
 	}
 }
 
-.woltlabNewsfeed__loading {
-	text-align: center;
-	width: 600px;
-}
-
-.woltlabNewsfeed.loaded .woltlabNewsfeed__loading {
-	display: none;
-}
-
-.woltlabNewsfeed__iframe {
+.woltlabNewsfeed {
 	border: 1px solid var(--wcfContentBorderInner);
 	border-radius: var(--wcfBorderRadius);
 	height: 100vh;
 	max-width: 100%;
-	visibility: hidden;
+	text-align: center;
 	width: 600px;
 }
 
-.woltlabNewsfeed.loaded .woltlabNewsfeed__iframe {
-	visibility: visible;
+.woltlabNewsfeed .loading-indicator {
+	margin-top: 40px;
+}
+
+.woltlabNewsfeed:not(.woltlabNewsfeed--loading) .loading-indicator {
+	display: none;
+}
+
+.woltlabNewsfeed__iframe {
+	border-radius: var(--wcfBorderRadius);
+	height: 100vh;
+	max-width: 100%;
+	width: 600px;
+}
+
+.woltlabNewsfeed--loading .woltlabNewsfeed__iframe {
+	visibility: hidden;
 }

--- a/wcfsetup/install/files/acp/style/layout.scss
+++ b/wcfsetup/install/files/acp/style/layout.scss
@@ -870,10 +870,24 @@ html[data-color-scheme="dark"] {
 	}
 }
 
-#woltlab_newsfeed {
+.woltlabNewsfeed__loading {
+	text-align: center;
+	width: 600px;
+}
+
+.woltlabNewsfeed.loaded .woltlabNewsfeed__loading {
+	display: none;
+}
+
+.woltlabNewsfeed__iframe {
 	border: 1px solid var(--wcfContentBorderInner);
 	border-radius: var(--wcfBorderRadius);
 	height: 100vh;
 	max-width: 100%;
+	visibility: hidden;
 	width: 600px;
+}
+
+.woltlabNewsfeed.loaded .woltlabNewsfeed__iframe {
+	visibility: visible;
 }

--- a/wcfsetup/install/files/acp/templates/index.tpl
+++ b/wcfsetup/install/files/acp/templates/index.tpl
@@ -56,20 +56,30 @@
 	{if ENABLE_WOLTLAB_NEWS}
 		<div id="news" class="hidden tabMenuContent">
 			<div class="section">
-				<iframe
-					id="woltlab_newsfeed"
-					referrerpolicy="no-referrer"
-					sandbox
-					hidden
-				></iframe>
+				<div class="woltlabNewsfeed">
+					<div class="woltlabNewsfeed__loading">{icon name='spinner' size=64}</div>
+					<iframe
+						class="woltlabNewsfeed__iframe"
+						referrerpolicy="no-referrer"
+						sandbox
+					></iframe>
+				</div>
+
 				<script data-eager="true">
 				{
 					const languageCode = "{if $__wcf->language->languageCode === 'de'}de{else}en{/if}";
 					let colorScheme = document.documentElement.dataset.colorScheme;
-					const iframe = document.getElementById("woltlab_newsfeed");
+					const container = document.querySelector('.woltlabNewsfeed');
+					const iframe = container.querySelector(".woltlabNewsfeed__iframe");
 
 					const updateColorScheme = () => {
+						container.classList.remove('loaded');
 						iframe.src = `https://newsfeed.woltlab.com/${ languageCode }_${ colorScheme }.html`;
+						iframe.addEventListener(
+							'load',
+							() => container.classList.add('loaded'),
+							{ once: true }
+						);
 					};
 
 					const observer = new MutationObserver(() => {
@@ -84,7 +94,6 @@
 					});
 
 					updateColorScheme();
-					iframe.hidden = false;
 				}
 				</script>
 			</div>

--- a/wcfsetup/install/files/acp/templates/index.tpl
+++ b/wcfsetup/install/files/acp/templates/index.tpl
@@ -56,8 +56,8 @@
 	{if ENABLE_WOLTLAB_NEWS}
 		<div id="news" class="hidden tabMenuContent">
 			<div class="section">
-				<div class="woltlabNewsfeed">
-					<div class="woltlabNewsfeed__loading">{icon name='spinner' size=64}</div>
+				<div class="woltlabNewsfeed woltlabNewsfeed--loading">
+					<woltlab-core-loading-indicator size="48"></woltlab-core-loading-indicator>
 					<iframe
 						class="woltlabNewsfeed__iframe"
 						referrerpolicy="no-referrer"
@@ -69,17 +69,17 @@
 				{
 					const languageCode = "{if $__wcf->language->languageCode === 'de'}de{else}en{/if}";
 					let colorScheme = document.documentElement.dataset.colorScheme;
-					const container = document.querySelector('.woltlabNewsfeed');
+					const container = document.querySelector(".woltlabNewsfeed");
 					const iframe = container.querySelector(".woltlabNewsfeed__iframe");
 
 					const updateColorScheme = () => {
-						container.classList.remove('loaded');
-						iframe.src = `https://newsfeed.woltlab.com/${ languageCode }_${ colorScheme }.html`;
+						container.classList.add("woltlabNewsfeed--loading");
 						iframe.addEventListener(
-							'load',
-							() => container.classList.add('loaded'),
+							"load",
+							() => container.classList.remove("woltlabNewsfeed--loading"),
 							{ once: true }
 						);
+						iframe.src = `https://newsfeed.woltlab.com/${ languageCode }_${ colorScheme }.html`;
 					};
 
 					const observer = new MutationObserver(() => {


### PR DESCRIPTION
The default page of an `<iframe>` is `about:blank` which has a light background
color. In case the newsfeed loads slowly or fails to load entirely, there will
be a big white block in a dark mode ACP which looks odd.

Fix this issue by setting the `<iframe>` to be `visibility: hidden` until the
contents are available. Additionally a spinner is shown while the iframe is
hidden.
