### PR TITLE
Improve the UX around submitting package installation requests

### DIFF
--- a/wcfsetup/install/files/acp/js/WCF.ACP.js
+++ b/wcfsetup/install/files/acp/js/WCF.ACP.js
@@ -259,7 +259,14 @@ WCF.ACP.Package.Installation = Class.extend({
 	 * Initializes the package installation.
 	 */
 	_init: function() {
-		$('#submitButton').click($.proxy(this.prepareInstallation, this));
+		const button = document.getElementById('submitButton');
+		button.addEventListener(
+			'click',
+			() => {
+				button.disabled = true;
+				this.prepareInstallation();
+			}
+		);
 	},
 	
 	/**

--- a/wcfsetup/install/files/acp/js/WCF.ACP.js
+++ b/wcfsetup/install/files/acp/js/WCF.ACP.js
@@ -317,6 +317,7 @@ WCF.ACP.Package.Installation = Class.extend({
 			document.activeElement.blur();
 		}
 		
+		require(['WoltLabSuite/Core/Ajax/Status'], ({show}) => show());
 		this._proxy.setOption('data', this._getParameters());
 		this._proxy.sendRequest();
 	},
@@ -351,6 +352,7 @@ WCF.ACP.Package.Installation = Class.extend({
 				closable: false,
 				title: WCF.Language.get(this._dialogTitle)
 			});
+			require(['WoltLabSuite/Core/Ajax/Status'], ({hide}) => hide());
 		}
 		
 		this._setIcon('spinner');


### PR DESCRIPTION
- Disable submit button in package installation confirmation after clicking
- Show the regular AJAX status in package installation until the first request goes through
