### PR TITLE
Refactor `AttachmentBBCode`

### DIFF
--- a/wcfsetup/install/files/lib/system/bbcode/AttachmentBBCode.class.php
+++ b/wcfsetup/install/files/lib/system/bbcode/AttachmentBBCode.class.php
@@ -3,7 +3,6 @@
 namespace wcf\system\bbcode;
 
 use wcf\data\attachment\Attachment;
-use wcf\data\attachment\GroupedAttachmentList;
 use wcf\system\message\embedded\object\MessageEmbeddedObjectManager;
 use wcf\system\request\LinkHandler;
 use wcf\system\style\FontAwesomeIcon;
@@ -13,26 +12,12 @@ use wcf\util\StringUtil;
 /**
  * Parses the [attach] bbcode tag.
  *
- * @author  Marcel Werk
- * @copyright   2001-2019 WoltLab GmbH
+ * @author Alexander Ebert, Marcel Werk
+ * @copyright 2001-2023 WoltLab GmbH
  * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
  */
 final class AttachmentBBCode extends AbstractBBCode
 {
-    /**
-     * list of attachments
-     * @var GroupedAttachmentList
-     * @deprecated
-     */
-    protected static $attachmentList;
-
-    /**
-     * active object id
-     * @var int
-     * @deprecated
-     */
-    protected static $objectID = 0;
-
     /**
      * @inheritDoc
      */
@@ -60,17 +45,6 @@ final class AttachmentBBCode extends AbstractBBCode
             'com.woltlab.wcf.attachment',
             $attachmentID
         );
-        if ($attachment === null) {
-            if (self::$attachmentList !== null) {
-                $attachments = self::$attachmentList->getGroupedObjects(self::$objectID);
-                if (isset($attachments[$attachmentID])) {
-                    $attachment = $attachments[$attachmentID];
-
-                    // mark attachment as embedded
-                    $attachment->markAsEmbedded();
-                }
-            }
-        }
 
         if ($attachment !== null) {
             if ($attachment->showAsImage() && $attachment->canViewPreview() && ($parser->getOutputType() == 'text/html' || $parser->getOutputType() == 'text/simplified-html')) {
@@ -190,27 +164,5 @@ final class AttachmentBBCode extends AbstractBBCode
         return StringUtil::getAnchorTag(LinkHandler::getInstance()->getLink('Attachment', [
             'id' => $attachmentID,
         ]));
-    }
-
-    /**
-     * Sets the attachment list.
-     *
-     * @param GroupedAttachmentList $attachmentList
-     * @deprecated
-     */
-    public static function setAttachmentList(GroupedAttachmentList $attachmentList)
-    {
-        self::$attachmentList = $attachmentList;
-    }
-
-    /**
-     * Sets the active object id.
-     *
-     * @param int $objectID
-     * @deprecated
-     */
-    public static function setObjectID($objectID)
-    {
-        self::$objectID = $objectID;
     }
 }

--- a/wcfsetup/install/files/lib/system/bbcode/AttachmentBBCode.class.php
+++ b/wcfsetup/install/files/lib/system/bbcode/AttachmentBBCode.class.php
@@ -23,10 +23,56 @@ final class AttachmentBBCode extends AbstractBBCode
      */
     public function getParsedTag(array $openingTag, $content, array $closingTag, BBCodeParser $parser): string
     {
-        // get attachment id
-        $attachmentID = 0;
-        if (isset($openingTag['attributes'][0])) {
-            $attachmentID = $openingTag['attributes'][0];
+        $attachmentID = \intval($openingTag['attributes'][0] ?? 0);
+
+        $attachment = $this->getAttachment($attachmentID);
+        if ($attachment === null) {
+            return StringUtil::getAnchorTag(LinkHandler::getInstance()->getLink('Attachment', [
+                'id' => $attachmentID,
+            ]));
+        }
+
+        $outputType = $parser->getOutputType();
+
+        if ($attachment->showAsImage() && $attachment->canViewPreview() && ($outputType == 'text/html' || $outputType == 'text/simplified-html')) {
+            return $this->renderAsImage($attachment, $outputType, $openingTag['attributes']);
+        } elseif (\substr($attachment->fileType, 0, 6) === 'video/' && $outputType == 'text/html') {
+            return $this->renderAsVideoPlayer($attachment);
+        } elseif (\substr($attachment->fileType, 0, 6) === 'audio/' && $outputType == 'text/html') {
+            return $this->rederAsAudioPlayer($attachment);
+        }
+
+        return StringUtil::getAnchorTag($attachment->getLink(), $attachment->filename);
+    }
+
+    private function renderAsImage(Attachment $attachment, string $outputType, array $attributes): string
+    {
+        // image
+        $alignment = ($attributes[1] ?? '');
+        $thumbnail = ($attributes[2] ?? false);
+
+        // backward compatibility, check if width is larger than thumbnail's width to display full version
+        if (\is_numeric($thumbnail)) {
+            if ($thumbnail == 0) {
+                $thumbnail = true;
+            } else {
+                // true if supplied width is smaller or equal to thumbnail's width
+                $thumbnail = ($attachment->thumbnailWidth >= $thumbnail) ? true : false;
+            }
+        } elseif ($thumbnail === 'false') {
+            $thumbnail = false;
+        } elseif ($thumbnail !== false) {
+            $thumbnail = true;
+        }
+
+        // always use thumbnail in simplified version
+        if ($outputType == 'text/simplified-html') {
+            $thumbnail = true;
+        }
+
+        // Force the use of the thumbnail if the user cannot access the full version.
+        if (!$thumbnail && !$attachment->canDownload()) {
+            $thumbnail = true;
         }
 
         $hasParentLink = false;
@@ -40,55 +86,19 @@ final class AttachmentBBCode extends AbstractBBCode
             }
         }
 
-        /** @var Attachment $attachment */
-        $attachment = MessageEmbeddedObjectManager::getInstance()->getObject(
-            'com.woltlab.wcf.attachment',
-            $attachmentID
-        );
+        if (!$thumbnail) {
+            $class = '';
+            if ($alignment == 'left' || $alignment == 'right') {
+                $class = 'messageFloatObject' . \ucfirst($alignment);
+            }
 
-        if ($attachment !== null) {
-            if ($attachment->showAsImage() && $attachment->canViewPreview() && ($parser->getOutputType() == 'text/html' || $parser->getOutputType() == 'text/simplified-html')) {
-                // image
-                $alignment = ($openingTag['attributes'][1] ?? '');
-                $thumbnail = ($openingTag['attributes'][2] ?? false);
+            $source = StringUtil::encodeHTML($attachment->getLink());
+            $title = StringUtil::encodeHTML($attachment->filename);
+            $result = '<img src="' . $source . '" width="' . $attachment->width . '" height="' . $attachment->height . '" alt="">';
 
-                // backward compatibility, check if width is larger than thumbnail's width to display full version
-                if (\is_numeric($thumbnail)) {
-                    if ($thumbnail == 0) {
-                        $thumbnail = true;
-                    } else {
-                        // true if supplied width is smaller or equal to thumbnail's width
-                        $thumbnail = ($attachment->thumbnailWidth >= $thumbnail) ? true : false;
-                    }
-                } elseif ($thumbnail === 'false') {
-                    $thumbnail = false;
-                } elseif ($thumbnail !== false) {
-                    $thumbnail = true;
-                }
-
-                // always use thumbnail in simplified version
-                if ($parser->getOutputType() == 'text/simplified-html') {
-                    $thumbnail = true;
-                }
-
-                // Force the use of the thumbnail if the user cannot access the full version.
-                if (!$thumbnail && !$attachment->canDownload()) {
-                    $thumbnail = true;
-                }
-
-                if (!$thumbnail) {
-                    $class = '';
-                    if ($alignment == 'left' || $alignment == 'right') {
-                        $class = 'messageFloatObject' . \ucfirst($alignment);
-                    }
-
-                    $source = StringUtil::encodeHTML($attachment->getLink());
-                    $title = StringUtil::encodeHTML($attachment->filename);
-                    $result = '<img src="' . $source . '" width="' . $attachment->width . '" height="' . $attachment->height . '" alt="">';
-
-                    if (!$hasParentLink && ($attachment->width > ATTACHMENT_THUMBNAIL_WIDTH || $attachment->height > ATTACHMENT_THUMBNAIL_HEIGHT)) {
-                        $icon = FontAwesomeIcon::fromValues('magnifying-glass')->toHtml(24);
-                        $result = <<<HTML
+            if (!$hasParentLink && ($attachment->width > ATTACHMENT_THUMBNAIL_WIDTH || $attachment->height > ATTACHMENT_THUMBNAIL_HEIGHT)) {
+                $icon = FontAwesomeIcon::fromValues('magnifying-glass')->toHtml(24);
+                $result = <<<HTML
                         <a href="{$source}" title="{$title}" class="embeddedAttachmentLink jsImageViewer {$class}'">
                             {$result}
                             <span class="embeddedAttachmentLinkEnlarge">
@@ -96,73 +106,81 @@ final class AttachmentBBCode extends AbstractBBCode
                             </span>
                         </a>
                         HTML;
-                    } else {
-                        $result = '<span title="' . $title . '"' . ($class ? (' class="' . $class . '"') : '') . '>' . $result . '</span>';
-                    }
-                } else {
-                    $icon = FontAwesomeIcon::fromValues('magnifying-glass')->toHtml(24);
-                    $enlarge = '<span class="embeddedAttachmentLinkEnlarge">' . $icon . '</span>';
+            } else {
+                $result = '<span title="' . $title . '"' . ($class ? (' class="' . $class . '"') : '') . '>' . $result . '</span>';
+            }
+        } else {
+            $icon = FontAwesomeIcon::fromValues('magnifying-glass')->toHtml(24);
+            $enlarge = '<span class="embeddedAttachmentLinkEnlarge">' . $icon . '</span>';
 
-                    $linkParameters = [
-                        'object' => $attachment,
-                    ];
-                    if ($attachment->hasThumbnail()) {
-                        $linkParameters['thumbnail'] = 1;
-                    }
+            $linkParameters = [
+                'object' => $attachment,
+            ];
+            if ($attachment->hasThumbnail()) {
+                $linkParameters['thumbnail'] = 1;
+            }
 
-                    $class = '';
-                    if ($alignment == 'left' || $alignment == 'right') {
-                        $class = 'messageFloatObject' . \ucfirst($alignment);
-                    }
+            $class = '';
+            if ($alignment == 'left' || $alignment == 'right') {
+                $class = 'messageFloatObject' . \ucfirst($alignment);
+            }
 
-                    $imageClasses = '';
-                    if (!$attachment->hasThumbnail()) {
-                        $imageClasses = 'embeddedAttachmentLink jsResizeImage';
-                    }
+            $imageClasses = '';
+            if (!$attachment->hasThumbnail()) {
+                $imageClasses = 'embeddedAttachmentLink jsResizeImage';
+            }
 
-                    if ($class && (!$attachment->hasThumbnail() || !$attachment->canDownload())) {
-                        $imageClasses .= ' ' . $class;
-                    }
+            if ($class && (!$attachment->hasThumbnail() || !$attachment->canDownload())) {
+                $imageClasses .= ' ' . $class;
+            }
 
-                    $result = '<img src="' . StringUtil::encodeHTML(LinkHandler::getInstance()->getLink(
-                        'Attachment',
-                        $linkParameters
-                    )) . '"' . ($imageClasses ? ' class="' . $imageClasses . '"' : '') . ' width="' . ($attachment->hasThumbnail() ? $attachment->thumbnailWidth : $attachment->width) . '" height="' . ($attachment->hasThumbnail() ? $attachment->thumbnailHeight : $attachment->height) . '" alt="" loading="lazy">';
+            $result = '<img src="' . StringUtil::encodeHTML(LinkHandler::getInstance()->getLink(
+                'Attachment',
+                $linkParameters
+            )) . '"' . ($imageClasses ? ' class="' . $imageClasses . '"' : '') . ' width="' . ($attachment->hasThumbnail() ? $attachment->thumbnailWidth : $attachment->width) . '" height="' . ($attachment->hasThumbnail() ? $attachment->thumbnailHeight : $attachment->height) . '" alt="" loading="lazy">';
 
-                    if (!$hasParentLink && $attachment->hasThumbnail() && $attachment->canDownload()) {
-                        $result = '<a href="' . StringUtil::encodeHTML(LinkHandler::getInstance()->getLink(
-                            'Attachment',
-                            ['object' => $attachment]
-                        )) . '" title="' . StringUtil::encodeHTML($attachment->filename) . '" class="embeddedAttachmentLink jsImageViewer' . ($class ? ' ' . $class : '') . '">' . $result . $enlarge . '</a>';
-                    } else {
-                        if (\str_contains($imageClasses, 'embeddedAttachmentLink')) {
-                            $result = $result . $enlarge;
-                        }
-
-                        $result = '<span' . ($class ? (' class="' . $class . '"') : '') . '>' . $result . '</span>';
-                    }
+            if (!$hasParentLink && $attachment->hasThumbnail() && $attachment->canDownload()) {
+                $result = '<a href="' . StringUtil::encodeHTML(LinkHandler::getInstance()->getLink(
+                    'Attachment',
+                    ['object' => $attachment]
+                )) . '" title="' . StringUtil::encodeHTML($attachment->filename) . '" class="embeddedAttachmentLink jsImageViewer' . ($class ? ' ' . $class : '') . '">' . $result . $enlarge . '</a>';
+            } else {
+                if (\str_contains($imageClasses, 'embeddedAttachmentLink')) {
+                    $result = $result . $enlarge;
                 }
 
-                return $result;
-            } elseif (\substr($attachment->fileType, 0, 6) === 'video/' && $parser->getOutputType() == 'text/html') {
-                return WCF::getTPL()->fetch('__videoAttachmentBBCode', 'wcf', [
-                    'attachment' => $attachment,
-                    'attachmentIdentifier' => StringUtil::getRandomID(),
-                ]);
-            } elseif (\substr($attachment->fileType, 0, 6) === 'audio/' && $parser->getOutputType() == 'text/html') {
-                return WCF::getTPL()->fetch('__audioAttachmentBBCode', 'wcf', [
-                    'attachment' => $attachment,
-                    'attachmentIdentifier' => StringUtil::getRandomID(),
-                ]);
-            } else {
-                // file
-                return StringUtil::getAnchorTag($attachment->getLink(), $attachment->filename);
+                $result = '<span' . ($class ? (' class="' . $class . '"') : '') . '>' . $result . '</span>';
             }
         }
 
-        // fallback
-        return StringUtil::getAnchorTag(LinkHandler::getInstance()->getLink('Attachment', [
-            'id' => $attachmentID,
-        ]));
+        return $result;
+    }
+
+    private function renderAsVideoPlayer(Attachment $attachment): string
+    {
+        return WCF::getTPL()->fetch('__videoAttachmentBBCode', 'wcf', [
+            'attachment' => $attachment,
+            'attachmentIdentifier' => StringUtil::getRandomID(),
+        ]);
+    }
+
+    private function rederAsAudioPlayer(Attachment $attachment): string
+    {
+        return WCF::getTPL()->fetch('__audioAttachmentBBCode', 'wcf', [
+            'attachment' => $attachment,
+            'attachmentIdentifier' => StringUtil::getRandomID(),
+        ]);
+    }
+
+    private function getAttachment(int $attachmentID): ?Attachment
+    {
+        if (!$attachmentID) {
+            return null;
+        }
+
+        return MessageEmbeddedObjectManager::getInstance()->getObject(
+            'com.woltlab.wcf.attachment',
+            $attachmentID
+        );
     }
 }

--- a/wcfsetup/install/files/lib/system/bbcode/AttachmentBBCode.class.php
+++ b/wcfsetup/install/files/lib/system/bbcode/AttachmentBBCode.class.php
@@ -70,7 +70,7 @@ final class AttachmentBBCode extends AbstractBBCode
 
             $source = StringUtil::encodeHTML($attachment->getLink());
             $title = StringUtil::encodeHTML($attachment->filename);
-            $image = \sprintf(
+            $imageElement = \sprintf(
                 '<img src="%s" width="%d" height="%d" alt="" loading="lazy">',
                 $source,
                 $attachment->width,
@@ -78,27 +78,35 @@ final class AttachmentBBCode extends AbstractBBCode
             );
 
             if (!$hasParentLink && ($attachment->width > ATTACHMENT_THUMBNAIL_WIDTH || $attachment->height > ATTACHMENT_THUMBNAIL_HEIGHT)) {
-                $icon = FontAwesomeIcon::fromValues('magnifying-glass')->toHtml(24);
-                return <<<HTML
-                    <a href="{$source}" title="{$title}" class="embeddedAttachmentLink jsImageViewer {$class}'">
-                        {$image}
-                        <span class="embeddedAttachmentLinkEnlarge">
-                            {$icon}
-                        </span>
-                    </a>
-                    HTML;
+                return \sprintf(
+                    <<<'HTML'
+                        <a href="%s" title="%s" class="embeddedAttachmentLink jsImageViewer %s">
+                            %s
+                            <span class="embeddedAttachmentLinkEnlarge">
+                                %s
+                            </span>
+                        </a>
+                        HTML,
+                    $source,
+                    $title,
+                    $class,
+                    $imageElement,
+                    FontAwesomeIcon::fromValues('magnifying-glass')->toHtml(24),
+                );
             }
 
             return \sprintf(
                 '<span title="%s" class="%s">%s</span>',
                 $title,
                 $class,
-                $image,
+                $imageElement,
             );
         }
 
-        $icon = FontAwesomeIcon::fromValues('magnifying-glass')->toHtml(24);
-        $enlarge = '<span class="embeddedAttachmentLinkEnlarge">' . $icon . '</span>';
+        $enlargeImageControls = \sprintf(
+            '<span class="embeddedAttachmentLinkEnlarge">%s</span>',
+            FontAwesomeIcon::fromValues('magnifying-glass')->toHtml(24),
+        );
 
         $linkParameters = [
             'object' => $attachment,
@@ -121,7 +129,7 @@ final class AttachmentBBCode extends AbstractBBCode
             $imageClasses .= ' ' . $class;
         }
 
-        $image = \sprintf(
+        $imageElement = \sprintf(
             '<img src="%s" class="%s" width="%d" height="%d" alt="" loading="lazy">',
             StringUtil::encodeHTML(LinkHandler::getInstance()->getLink('Attachment', $linkParameters)),
             $imageClasses,
@@ -135,16 +143,16 @@ final class AttachmentBBCode extends AbstractBBCode
                 StringUtil::encodeHTML(LinkHandler::getInstance()->getLink('Attachment', ['object' => $attachment])),
                 StringUtil::encodeHTML($attachment->filename),
                 $class,
-                $image,
-                $enlarge,
+                $imageElement,
+                $enlargeImageControls,
             );
         }
 
         return \sprintf(
             '<span class="%s">%s%s</span>',
             $class,
-            $image,
-            \str_contains($imageClasses, 'embeddedAttachmentLink') ? $enlarge : '',
+            $imageElement,
+            \str_contains($imageClasses, 'embeddedAttachmentLink') ? $enlargeImageControls : '',
         );
     }
 


### PR DESCRIPTION
The intention is to clean up some long deprecated functions as well as organizing the code a bit. The previous implementation used one large method with heavy nesting of conditions to generate the HTML output.

My main goal was to split up the code path into smaller chunks to make it possible to get to the responsible section depending on the type of attachment being displayed. I also changed the HTML generation from barely readable multiline string concatenation into a series of `\sprintf()` calls.