### PR TITLE
Use “standard” order for alignment options in CKEditor toolbar

### DIFF
--- a/ts/WoltLabSuite/Core/Component/Ckeditor/Configuration.ts
+++ b/ts/WoltLabSuite/Core/Component/Ckeditor/Configuration.ts
@@ -303,10 +303,10 @@ class ConfigurationBuilder {
     return {
       alignment: {
         options: [
-          { name: "center", className: "text-center" },
           { name: "left", className: "text-left" },
-          { name: "justify", className: "text-justify" },
+          { name: "center", className: "text-center" },
           { name: "right", className: "text-right" },
+          { name: "justify", className: "text-justify" },
         ],
       },
       highlight: {

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Component/Ckeditor/Configuration.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Component/Ckeditor/Configuration.js
@@ -260,10 +260,10 @@ define(["require", "exports", "../../Language"], function (require, exports, Lan
             return {
                 alignment: {
                     options: [
-                        { name: "center", className: "text-center" },
                         { name: "left", className: "text-left" },
-                        { name: "justify", className: "text-justify" },
+                        { name: "center", className: "text-center" },
                         { name: "right", className: "text-right" },
+                        { name: "justify", className: "text-justify" },
                     ],
                 },
                 highlight: {


### PR DESCRIPTION
It might be arguable whether it should be "left, center, right, justify" or
"left, right, center, justify", but in no case "center" should come first.

"left, center, right, justify" is used by Google Docs and LibreOffice Writer.
