### PR TITLE
Improve the behavior of visible scrollbars

### DIFF
--- a/ts/WoltLabSuite/Core/Bootstrap.ts
+++ b/ts/WoltLabSuite/Core/Bootstrap.ts
@@ -141,6 +141,11 @@ export function setup(options: BoostrapOptions): void {
 
   document.querySelectorAll(".pagination").forEach((el: HTMLElement) => UiPageJumpTo.init(el));
 
+  window.requestAnimationFrame(() => {
+    const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth;
+    document.documentElement.style.setProperty("--scrollbar-width", `${scrollbarWidth}px`);
+  });
+
   initA11y();
 
   DomChangeListener.add("WoltLabSuite/Core/Bootstrap", () => initA11y);

--- a/ts/WoltLabSuite/Core/Element/woltlab-core-dialog.ts
+++ b/ts/WoltLabSuite/Core/Element/woltlab-core-dialog.ts
@@ -277,6 +277,8 @@ export class WoltlabCoreDialogElement extends HTMLElement {
         event.preventDefault();
         return;
       }
+
+      this.#detachDialog();
     });
 
     // Close the dialog by clicking on the backdrop.

--- a/ts/WoltLabSuite/Core/Ui/Screen.ts
+++ b/ts/WoltLabSuite/Core/Ui/Screen.ts
@@ -102,8 +102,6 @@ export function scrollDisable(): void {
 
     const pageContainer = document.getElementById("pageContainer")!;
 
-    // iOS does not handle overflow and fixed positioning well, we need to
-    // simulate the scrolling by vertically moving the container.
     if (is("screen-md-down")) {
       pageContainer.style.setProperty("position", "relative", "");
       pageContainer.style.setProperty("top", `-${_scrollTop}px`, "");

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Bootstrap.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Bootstrap.js
@@ -110,6 +110,10 @@ define(["require", "exports", "tslib", "./Core", "./Date/Picker", "./Devtools", 
             }
         }, 20);
         document.querySelectorAll(".pagination").forEach((el) => UiPageJumpTo.init(el));
+        window.requestAnimationFrame(() => {
+            const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth;
+            document.documentElement.style.setProperty("--scrollbar-width", `${scrollbarWidth}px`);
+        });
         initA11y();
         Listener_1.default.add("WoltLabSuite/Core/Bootstrap", () => initA11y);
         if (options.colorScheme === "system") {

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Element/woltlab-core-dialog.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Element/woltlab-core-dialog.js
@@ -211,6 +211,7 @@ define(["require", "exports", "tslib", "../Dom/Util", "../Helper/PageOverlay", "
                     event.preventDefault();
                     return;
                 }
+                this.#detachDialog();
             });
             // Close the dialog by clicking on the backdrop.
             //

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Screen.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Screen.js
@@ -91,8 +91,6 @@ define(["require", "exports", "tslib", "../Core"], function (require, exports, t
                 _scrollOffsetFrom = "documentElement";
             }
             const pageContainer = document.getElementById("pageContainer");
-            // iOS does not handle overflow and fixed positioning well, we need to
-            // simulate the scrolling by vertically moving the container.
             if (is("screen-md-down")) {
                 pageContainer.style.setProperty("position", "relative", "");
                 pageContainer.style.setProperty("top", `-${_scrollTop}px`, "");

--- a/wcfsetup/install/files/style/layout/layout.scss
+++ b/wcfsetup/install/files/style/layout/layout.scss
@@ -29,6 +29,10 @@ body {
 	@include wcfFontDefault;
 }
 
+html {
+	overflow-y: scroll;
+}
+
 body {
 	background-color: var(--wcfContentBackground);
 	color: var(--wcfContentText);

--- a/wcfsetup/install/files/style/layout/layout.scss
+++ b/wcfsetup/install/files/style/layout/layout.scss
@@ -6,6 +6,12 @@ html.disableScrolling {
 	}
 }
 
+@include screen-lg {
+	html.disableScrolling {
+		padding-right: var(--scrollbar-width, 0);
+	}
+}
+
 @include screen-md-down {
 	html.disableScrolling {
 		/* Fix for the gap when using fullscreen dialogs and the navbar collapses.

--- a/wcfsetup/install/files/style/layout/pageHeader.scss
+++ b/wcfsetup/install/files/style/layout/pageHeader.scss
@@ -35,6 +35,12 @@
 	}
 }
 
+@include screen-lg {
+	html.disableScrolling .pageHeaderPanel {
+		right: var(--scrollbar-width, 0);
+	}
+}
+
 .pageHeaderFacade {
 	&:first-child {
 		// page header without user-panel (during setup)

--- a/wcfsetup/install/files/style/ui/dialog.scss
+++ b/wcfsetup/install/files/style/ui/dialog.scss
@@ -312,6 +312,11 @@
 .dialog::backdrop {
 	animation: 0.24s dialogBackdrop;
 	background-color: rgba(0, 0, 0, 0.34);
+	overflow-y: scroll;
+}
+
+html[data-color-scheme="dark"] .dialog::backdrop {
+	color-scheme: dark;
 }
 
 .dialog__document {

--- a/wcfsetup/install/files/style/ui/dialog.scss
+++ b/wcfsetup/install/files/style/ui/dialog.scss
@@ -71,7 +71,7 @@
 		// this causes a blurry text rendering in Chromium.
 		// The offset is calculated using a `ResizeObserver`.
 		left: 50%;
-		transform: translateX(var(--translate-x)) translateY(-50%);
+		transform: translateX(var(--translate-x, 0)) translateY(-50%);
 
 		&[aria-hidden="false"] {
 			animation: wcfDialog 0.24s;

--- a/wcfsetup/install/files/style/ui/pageAction.scss
+++ b/wcfsetup/install/files/style/ui/pageAction.scss
@@ -66,6 +66,12 @@
 	}
 }
 
+@include screen-lg {
+	html.disableScrolling .pageAction {
+		right: calc(10px + var(--scrollbar-width, 0));
+	}
+}
+
 .pageOverlayActive .pageAction {
 	display: none;
 }


### PR DESCRIPTION
The vertical scrollbar is now always visible regardless of any existing overflow. This avoids layout shifts when navigating between pages with and without a visible scrollbar.

Opening a dialog will now emulate a visible scrollbar but without any scrollable distance. The content is slightly offset to account for the emulated scrollbar.

This changes has no impact on devices that do not show a permanent scrollbar, such as mobile devices or macOS.

See https://www.woltlab.com/community/thread/300727-ganze-seite-springt-beim-%C3%B6ffnen-von-dialogen/