### PR TITLE
Fix descriptions for subscribe buttons

### DIFF
--- a/wcfsetup/install/lang/de.xml
+++ b/wcfsetup/install/lang/de.xml
@@ -5490,7 +5490,7 @@ Benachrichtigungen auf <a href="{link isHtmlEmail=true}{/link}">{PAGE_TITLE|phra
 		<item name="wcf.user.objectWatch.manageSubscription"><![CDATA[Abonnement verwalten]]></item>
 		<item name="wcf.user.objectWatch.button.subscribed"><![CDATA[Abonniert]]></item>
 		<item name="wcf.user.objectWatch.notSubscribed"><![CDATA[Nicht abonniert]]></item>
-		<item name="wcf.user.objectWatch.notSubscribed.description"><![CDATA[Erhalte{if !LANGUAGE_USE_INFORMAL_VARIANT}n Sie{/if} keine Benachrichtigungen über neue Inhalte.]]></item>
+		<item name="wcf.user.objectWatch.notSubscribed.description"><![CDATA[Keine Benachrichtigungen über neue Inhalte erhalten.]]></item>
 		<item name="wcf.user.objectWatch.subscribed"><![CDATA[Abonniert]]></item>
 		<item name="wcf.user.objectWatch.subscribed.description"><![CDATA[Erhalte{if !LANGUAGE_USE_INFORMAL_VARIANT}n Sie{/if} Benachrichtigungen über neue Inhalte.]]></item>
 	</category>

--- a/wcfsetup/install/lang/de.xml
+++ b/wcfsetup/install/lang/de.xml
@@ -5490,9 +5490,9 @@ Benachrichtigungen auf <a href="{link isHtmlEmail=true}{/link}">{PAGE_TITLE|phra
 		<item name="wcf.user.objectWatch.manageSubscription"><![CDATA[Abonnement verwalten]]></item>
 		<item name="wcf.user.objectWatch.button.subscribed"><![CDATA[Abonniert]]></item>
 		<item name="wcf.user.objectWatch.notSubscribed"><![CDATA[Nicht abonniert]]></item>
-		<item name="wcf.user.objectWatch.notSubscribed.description"><![CDATA[Erhalte{if !LANGUAGE_USE_INFORMAL_VARIANT}n Sie{/if} Benachrichtigungen für Erwähnungen, Zitate und Reaktionen.]]></item>
+		<item name="wcf.user.objectWatch.notSubscribed.description"><![CDATA[Erhalte{if !LANGUAGE_USE_INFORMAL_VARIANT}n Sie{/if} keine Benachrichtigungen über neue Inhalte.]]></item>
 		<item name="wcf.user.objectWatch.subscribed"><![CDATA[Abonniert]]></item>
-		<item name="wcf.user.objectWatch.subscribed.description"><![CDATA[Erhalte{if !LANGUAGE_USE_INFORMAL_VARIANT}n Sie{/if} Benachrichtigungen über neue Inhalte, Erwähnungen, Zitate und Reaktionen.]]></item>
+		<item name="wcf.user.objectWatch.subscribed.description"><![CDATA[Erhalte{if !LANGUAGE_USE_INFORMAL_VARIANT}n Sie{/if} Benachrichtigungen über neue Inhalte.]]></item>
 	</category>
 	<category name="wcf.user.option">
 		<item name="wcf.user.option.aboutMe"><![CDATA[Über mich]]></item>

--- a/wcfsetup/install/lang/en.xml
+++ b/wcfsetup/install/lang/en.xml
@@ -5495,9 +5495,9 @@ your notifications on <a href="{link isHtmlEmail=true}{/link}">{PAGE_TITLE|phras
 		<item name="wcf.user.objectWatch.manageSubscription"><![CDATA[Manage Subscription]]></item>
 		<item name="wcf.user.objectWatch.button.subscribed"><![CDATA[Subscribed]]></item>
 		<item name="wcf.user.objectWatch.notSubscribed"><![CDATA[Not subscribed]]></item>
-		<item name="wcf.user.objectWatch.notSubscribed.description"><![CDATA[Receive notifications for mentions, quotes and reactions.]]></item>
+		<item name="wcf.user.objectWatch.notSubscribed.description"><![CDATA[Receive no notifications for new content.]]></item>
 		<item name="wcf.user.objectWatch.subscribed"><![CDATA[Subscribed]]></item>
-		<item name="wcf.user.objectWatch.subscribed.description"><![CDATA[Receive notifications for new content, mentions, quotes and reactions.]]></item>
+		<item name="wcf.user.objectWatch.subscribed.description"><![CDATA[Receive notifications for new content.]]></item>
 	</category>
 	<category name="wcf.user.option">
 		<item name="wcf.user.option.aboutMe"><![CDATA[About Me]]></item>

--- a/wcfsetup/install/lang/en.xml
+++ b/wcfsetup/install/lang/en.xml
@@ -5495,7 +5495,7 @@ your notifications on <a href="{link isHtmlEmail=true}{/link}">{PAGE_TITLE|phras
 		<item name="wcf.user.objectWatch.manageSubscription"><![CDATA[Manage Subscription]]></item>
 		<item name="wcf.user.objectWatch.button.subscribed"><![CDATA[Subscribed]]></item>
 		<item name="wcf.user.objectWatch.notSubscribed"><![CDATA[Not subscribed]]></item>
-		<item name="wcf.user.objectWatch.notSubscribed.description"><![CDATA[Receive no notifications for new content.]]></item>
+		<item name="wcf.user.objectWatch.notSubscribed.description"><![CDATA[Do not receive notifications for new content.]]></item>
 		<item name="wcf.user.objectWatch.subscribed"><![CDATA[Subscribed]]></item>
 		<item name="wcf.user.objectWatch.subscribed.description"><![CDATA[Receive notifications for new content.]]></item>
 	</category>


### PR DESCRIPTION
These are generic language variables that are used in various places. Not all use cases support mentions, quotes, or reactions, so the previous descriptions were misleading.