### PR TITLE
Require a `_fk` suffix for explicit FOREIGN KEY names

### DIFF
--- a/wcfsetup/install/files/lib/system/database/table/DatabaseTableChangeProcessor.class.php
+++ b/wcfsetup/install/files/lib/system/database/table/DatabaseTableChangeProcessor.class.php
@@ -1284,6 +1284,16 @@ final class DatabaseTableChangeProcessor
                             'type' => 'unknownTableInForeignKey',
                         ];
                     }
+
+                    if (!\str_ends_with($foreignKey->getName(), '_fk') && !$foreignKey->willBeDropped()) {
+                        $errors[] = [
+                            'name' => $foreignKey->getName(),
+                            'columnNames' => \implode(',', $foreignKey->getColumns()),
+                            'referencedTableName' => $foreignKey->getReferencedTable(),
+                            'tableName' => $table->getName(),
+                            'type' => 'missingFkSuffixInForeignKey',
+                        ];
+                    }
                 }
             }
         }

--- a/wcfsetup/install/lang/de.xml
+++ b/wcfsetup/install/lang/de.xml
@@ -1985,6 +1985,8 @@ Die Datenbestände werden sorgfältig gepflegt, aber es ist nicht ausgeschlossen
 		Der Fremdschlüssel {$error[tableName]} ({$error[columnNames]}) gehört zu einem anderen Paket und kann deshalb nicht gelöscht werden.
 	{else if $error[type] === 'unknownTableInForeignKey'}
 		Der Fremdschlüssel {$error[tableName]} ({$error[columnNames]}) referenziert eine unbekannte Tabelle {$error[referencedTableName]}.
+	{else if $error[type] === 'missingFkSuffixInForeignKey'}
+		Der Name des Fremdschlüssels {$error[name]} hat kein '_fk'-Suffix.
 	{else if $error[type] === 'duplicateColumnInIndex'}
 		Der Index {$error[tableName]} ({$error[columnNames]}) enthält doppelte Spalten.
 	{else if $error[type] === 'primaryNotCalledPrimary'}

--- a/wcfsetup/install/lang/en.xml
+++ b/wcfsetup/install/lang/en.xml
@@ -1968,6 +1968,8 @@ If you have <strong>already bought the licenses for the listed apps</strong>, th
 		The foreign key {$error[tableName]} ({$error[columnNames]}) belongs to a different package and thus cannot be dropped.
 	{else if $error[type] === 'unknownTableInForeignKey'}
 		The foreign key {$error[tableName]} ({$error[columnNames]}) references an unknown table {$error[referencedTableName]}.
+	{else if $error[type] === 'missingFkSuffixInForeignKey'}
+		The name of foreign key {$error[name]} does not have a '_fk' suffix.
 	{else if $error[type] === 'duplicateColumnInIndex'}
 		The index {$error[tableName]} ({$error[columnNames]}) contains duplicate columns.
 	{else if $error[type] === 'primaryNotCalledPrimary'}


### PR DESCRIPTION
This is required to correctly uninstall these FOREIGN KEYs.
