### PR TITLE
Accept `float`s in FileUtil::checkMemoryLimit()

### DIFF
--- a/wcfsetup/install/files/lib/util/FileUtil.class.php
+++ b/wcfsetup/install/files/lib/util/FileUtil.class.php
@@ -547,7 +547,7 @@ final class FileUtil
     /**
      * Returns true if the given amount of memory is available.
      */
-    public static function checkMemoryLimit(int $neededMemory): bool
+    public static function checkMemoryLimit(int|float $neededMemory): bool
     {
         return self::getMemoryLimit() == -1 || self::getMemoryLimit() > (\memory_get_usage() + $neededMemory);
     }


### PR DESCRIPTION
While a decimal amount of bytes is not something that exists, it's a common
pattern to approximate the required memory usage of an image operation with the
factor `2.1`, possibly resulting in decimal places. PHP 8.1 emits a warning if
an implicit cast from non-integer float to int happens.

As the input is only used within an inequality expression and not further
processed it is safe to accept arbitrary floats and preferable to slapping
explicit casts onto everything.
