### PR TITLE
Make use of `ini_parse_quantity()` in FileUtil::getMemoryLimit()

### DIFF
--- a/wcfsetup/install/files/lib/util/FileUtil.class.php
+++ b/wcfsetup/install/files/lib/util/FileUtil.class.php
@@ -514,29 +514,31 @@ final class FileUtil
             $memoryLimit = \ini_get('memory_limit');
 
             // no limit
-            if ($memoryLimit == -1) {
+            if ($memoryLimit == "-1") {
                 self::$memoryLimit = -1;
-            }
+            } else if (\function_exists('ini_parse_quantity')) {
+                self::$memoryLimit = \ini_parse_quantity($memoryLimit);
+            } else {
+                // completely numeric, PHP assumes byte
+                if (\is_numeric($memoryLimit)) {
+                    self::$memoryLimit = $memoryLimit;
+                }
 
-            // completely numeric, PHP assumes byte
-            if (\is_numeric($memoryLimit)) {
-                self::$memoryLimit = $memoryLimit;
-            }
+                // PHP supports 'K', 'M' and 'G' shorthand notation
+                if (\preg_match('~^(\d+)\s*([KMG])$~i', $memoryLimit, $matches)) {
+                    switch (\strtoupper($matches[2])) {
+                        case 'K':
+                            self::$memoryLimit = $matches[1] * 1024;
+                            break;
 
-            // PHP supports 'K', 'M' and 'G' shorthand notation
-            if (\preg_match('~^(\d+)\s*([KMG])$~i', $memoryLimit, $matches)) {
-                switch (\strtoupper($matches[2])) {
-                    case 'K':
-                        self::$memoryLimit = $matches[1] * 1024;
-                        break;
+                        case 'M':
+                            self::$memoryLimit = $matches[1] * 1024 * 1024;
+                            break;
 
-                    case 'M':
-                        self::$memoryLimit = $matches[1] * 1024 * 1024;
-                        break;
-
-                    case 'G':
-                        self::$memoryLimit = $matches[1] * 1024 * 1024 * 1024;
-                        break;
+                        case 'G':
+                            self::$memoryLimit = $matches[1] * 1024 * 1024 * 1024;
+                            break;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Best reviewed with whitespace changes ignored.

------------

If `ini_parse_quantity()` is available (PHP 8.2+) it will certainly be more
accurate and simpler than our home-grown calculator.
