### PR TITLE
Update Spotify media provider

### DIFF
--- a/com.woltlab.wcf/mediaProvider.xml
+++ b/com.woltlab.wcf/mediaProvider.xml
@@ -51,9 +51,9 @@ https?://open.spotify.com/user/(?<USER>[0-9a-zA-Z]+)/playlist/(?<ID>[0-9a-zA-Z]+
 		</provider>
 		<provider name="spotify">
 			<title>Spotify</title>
-			<regex><![CDATA[https?://play.spotify.com/(?<TYPE>[a-zA-Z]+)/(?<ID>[0-9a-zA-Z]+)
-https?://open.spotify.com/(?<TYPE>[a-zA-Z]+)/(?<ID>[0-9a-zA-Z]+)]]></regex>
 			<html><![CDATA[<iframe width="300" height="380" src="https://embed.spotify.com/?uri=spotify:{$TYPE}:{$ID}" frameborder="0" allowtransparency="true"></iframe>]]></html>
+			<regex><![CDATA[https?://play.spotify.com/(.*/|)(?<TYPE>[a-zA-Z]+)/(?<ID>[0-9a-zA-Z]+)
+https?://open.spotify.com/(.*/|)(?<TYPE>[a-zA-Z]+)/(?<ID>[0-9a-zA-Z]+)]]></regex>
 		</provider>
 		<provider name="twitch">
 			<title>Twitch</title>

--- a/com.woltlab.wcf/mediaProvider.xml
+++ b/com.woltlab.wcf/mediaProvider.xml
@@ -51,9 +51,9 @@ https?://open.spotify.com/user/(?<USER>[0-9a-zA-Z]+)/playlist/(?<ID>[0-9a-zA-Z]+
 		</provider>
 		<provider name="spotify">
 			<title>Spotify</title>
-			<html><![CDATA[<iframe width="300" height="380" src="https://embed.spotify.com/?uri=spotify:{$TYPE}:{$ID}" frameborder="0" allowtransparency="true"></iframe>]]></html>
 			<regex><![CDATA[https?://play.spotify.com/(.*/|)(?<TYPE>[a-zA-Z]+)/(?<ID>[0-9a-zA-Z]+)
 https?://open.spotify.com/(.*/|)(?<TYPE>[a-zA-Z]+)/(?<ID>[0-9a-zA-Z]+)]]></regex>
+			<html><![CDATA[<iframe style="border-radius:12px" src="https://open.spotify.com/embed/{$TYPE}/{$ID}" width="100%" height="352" frameBorder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>]]></html>
 		</provider>
 		<provider name="twitch">
 			<title>Twitch</title>


### PR DESCRIPTION
I split this change into separate commits on purpose.

First, when sharing a spotify url, the link can include an additional path which renders the current expression useless.

Examples (parameters stripped):
https://open.spotify.com/intl-de/track/1ULdASrNy5rurl1TZfFaMP
https://open.spotify.com/playlist/37i9dQZF1DXbSWYCNwaARB

Second, I have updated the embedded iframe to the interactive audio player that Spotify suggests by default. If you don't want to use this embed, just pick the first commit.

I have not touched the "spotify-playlist" media provider at all, because I believe it can be removed. However, this is not something that I should decide or have investigated thoroughly 😅 The media provider hasn't changed since 2017 and at least, when sharing my own playlists, it has the same structure caught by the previous provider:

https://open.spotify.com/playlist/6j7MGcuVZjLwbdqQ7lwyOc

I have also not dropped `play.spotify` urls, because I don't know where they come (or came) from.
Also, I am happy to reduce the height from 352px to the compact variation with 152px.