### PR TITLE
Fix links to the ACP in emails

### DIFF
--- a/wcfsetup/install/files/lib/system/request/LinkHandler.class.php
+++ b/wcfsetup/install/files/lib/system/request/LinkHandler.class.php
@@ -105,7 +105,9 @@ final class LinkHandler extends SingletonFactory
         // enforce a certain level of sanitation and protection for links embedded in emails
         if (isset($parameters['isEmail'])) {
             if ((bool)$parameters['isEmail']) {
-                $parameters['forceFrontend'] = true;
+                if (!isset($parameters['isACP']) || !(bool)$parameters['isACP']) {
+                    $parameters['forceFrontend'] = true;
+                }
             }
 
             unset($parameters['isEmail']);


### PR DESCRIPTION
Links in emails always led to the frontend by mistake, even if `isACP` was set.

ref https://www.woltlab.com/community/thread/301368-the-link-to-the-error-log-in-the-emails-shows-the-error-page-not-found/