### PR TITLE
Fix min/max image height compare

### DIFF
--- a/wcfsetup/install/files/lib/system/form/builder/field/UploadFormField.class.php
+++ b/wcfsetup/install/files/lib/system/form/builder/field/UploadFormField.class.php
@@ -696,7 +696,7 @@ class UploadFormField extends AbstractFormField
             }
 
             $minimumImageWidth = $this->getMinimumImageWidth();
-            if ($maximumImageWidth !== null && $minimumImageWidth > $maximumImageWidth) {
+            if ($minimumImageWidth !== null && $minimumImageWidth > $maximumImageWidth) {
                 throw new \InvalidArgumentException(
                     "Maximum image width ({$maximumImageWidth}) cannot be smaller than minimum image width ({$minimumImageWidth}) for field '{$this->getId()}'."
                 );


### PR DESCRIPTION
This will fix the min/max image height compare for the UploadFormField.

With the following code example the system gives an error message
```PHP
UploadFormField::create('preview')
	->maximum(1)
	->minimum(0)
	->imageOnly()
	->allowSvgImage()
	->minimumImageWidth(100)
	->maximumImageWidth(500)
	->minimumImageHeight(100)
	->maximumImageHeight(500)
```

> Maximum image height (500) cannot be smaller than minimum image height (100) for field 'preview'.