### PR TITLE
Inline the `woltlab_environment` type in XSDs

### DIFF
--- a/XSD/eventListener.xsd
+++ b/XSD/eventListener.xsd
@@ -49,7 +49,15 @@
 				</xs:simpleType>
 			</xs:element>
 			<xs:element name="inherit" type="woltlab_boolean" minOccurs="0" />
-			<xs:element name="environment" type="woltlab_environment" minOccurs="0" />
+			<xs:element name="environment" minOccurs="0">
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:enumeration value="user" />
+						<xs:enumeration value="admin" />
+						<xs:enumeration value="all" />
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
 			<xs:element name="nice" minOccurs="0">
 				<xs:simpleType>
 					<xs:restriction base="xs:integer">

--- a/XSD/templateListener.xsd
+++ b/XSD/templateListener.xsd
@@ -31,7 +31,14 @@
 	<!-- deleted template listeners -->
 	<xs:complexType name="templatelistener_delete">
 		<xs:all>
-			<xs:element name="environment" type="woltlab_environment" />
+			<xs:element name="environment">
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:enumeration value="user" />
+						<xs:enumeration value="admin" />
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
 			<xs:element name="templatename" type="xs:string" />
 			<xs:element name="eventname" type="xs:string" />
 		</xs:all>
@@ -41,7 +48,14 @@
 	<!-- imported/updated template listeners -->
 	<xs:complexType name="templatelistener_import">
 		<xs:all>
-			<xs:element name="environment" type="woltlab_environment" />
+			<xs:element name="environment">
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:enumeration value="user" />
+						<xs:enumeration value="admin" />
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
 			<xs:element name="templatename" type="xs:string" />
 			<xs:element name="eventname" type="xs:string" />
 			<xs:element name="templatecode" type="xs:string" />

--- a/XSD/types.xsd
+++ b/XSD/types.xsd
@@ -23,13 +23,4 @@
 			<xs:maxInclusive value="1" />
 		</xs:restriction>
 	</xs:simpleType>
-	
-	<!-- user/admin environment type which only accepts 'user' or 'admin' -->
-	<xs:simpleType name="woltlab_environment">
-		<xs:restriction base="xs:string">
-			<xs:enumeration value="user" />
-			<xs:enumeration value="admin" />
-			<xs:enumeration value="all" />
-		</xs:restriction>
-	</xs:simpleType>
 </xs:schema>


### PR DESCRIPTION
Not all PIPs support the “all” environment, notably the templateListener PIP.
Thus the legal list of environments is now inlined to make it explicit and also
improve the readability of the XSDs.

Supporting the “all” environment for the templateListener PIP is not really
useful, as template names are rarely shared between frontend and ACP. It's
simple enough to register an explicit listener for each environment in the rare
case all of (templateName, eventName, templateCode) match up.

Fixes #5619
