### PR TITLE
Prevent concurrent `click` event while the callback is still loading

### DIFF
--- a/ts/WoltLabSuite/Core/Controller/Moderation/AssignUser.ts
+++ b/ts/WoltLabSuite/Core/Controller/Moderation/AssignUser.ts
@@ -7,6 +7,7 @@
  * @since 6.0
  */
 
+import { clickGuard } from "WoltLabSuite/Core/Helper/ClickGuard";
 import { dialogFactory } from "../../Component/Dialog";
 import { getPhrase } from "../../Language";
 import { show as showNotification } from "../../Ui/Notification";
@@ -54,7 +55,5 @@ function updateStatus(status: string): void {
 }
 
 export function setup(button: HTMLElement): void {
-  button.addEventListener("click", () => {
-    void showDialog(button.dataset.url!);
-  });
+  clickGuard(button, () => showDialog(button.dataset.url!));
 }

--- a/ts/WoltLabSuite/Core/Helper/ClickGuard.ts
+++ b/ts/WoltLabSuite/Core/Helper/ClickGuard.ts
@@ -1,0 +1,38 @@
+/**
+ * Prevents concurrent runs of the event handler for the click event by blocking
+ * the event while a previous call is still running.
+ *
+ * @author Alexander Ebert
+ * @copyright 2001-2023 WoltLab GmbH
+ * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @since 6.0
+ */
+
+export function clickGuard(element: HTMLElement, eventHandler: (event: MouseEvent) => Promise<void>): void {
+  let pending = false;
+
+  element.addEventListener("click", (event) => {
+    if (pending) {
+      event.preventDefault();
+
+      return;
+    }
+
+    pending = true;
+
+    void eventHandler(event)
+      .then(
+        () => {
+          pending = false;
+        },
+        () => {
+          pending = false;
+        },
+      )
+      .catch((reason) => {
+        pending = false;
+
+        throw reason;
+      });
+  });
+}

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Controller/Moderation/AssignUser.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Controller/Moderation/AssignUser.js
@@ -6,7 +6,7 @@
  * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
  * @since 6.0
  */
-define(["require", "exports", "../../Component/Dialog", "../../Language", "../../Ui/Notification"], function (require, exports, Dialog_1, Language_1, Notification_1) {
+define(["require", "exports", "WoltLabSuite/Core/Helper/ClickGuard", "../../Component/Dialog", "../../Language", "../../Ui/Notification"], function (require, exports, ClickGuard_1, Dialog_1, Language_1, Notification_1) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.setup = void 0;
@@ -37,9 +37,7 @@ define(["require", "exports", "../../Component/Dialog", "../../Language", "../..
         document.getElementById("moderationQueueStatus").textContent = status;
     }
     function setup(button) {
-        button.addEventListener("click", () => {
-            void showDialog(button.dataset.url);
-        });
+        (0, ClickGuard_1.clickGuard)(button, () => showDialog(button.dataset.url));
     }
     exports.setup = setup;
 });

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Helper/ClickGuard.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Helper/ClickGuard.js
@@ -1,0 +1,35 @@
+/**
+ * Prevents concurrent runs of the event handler for the click event by blocking
+ * the event while a previous call is still running.
+ *
+ * @author Alexander Ebert
+ * @copyright 2001-2023 WoltLab GmbH
+ * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @since 6.0
+ */
+define(["require", "exports"], function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.clickGuard = void 0;
+    function clickGuard(element, eventHandler) {
+        let pending = false;
+        element.addEventListener("click", (event) => {
+            if (pending) {
+                event.preventDefault();
+                return;
+            }
+            pending = true;
+            void eventHandler(event)
+                .then(() => {
+                pending = false;
+            }, () => {
+                pending = false;
+            })
+                .catch((reason) => {
+                pending = false;
+                throw reason;
+            });
+        });
+    }
+    exports.clickGuard = clickGuard;
+});


### PR DESCRIPTION
This is primarily motivated by https://www.woltlab.com/community/thread/301446-unexpected-behaviour-when-double-clicking-on-create-album-in-the-gallery/ which uses a double click to trigger concurrent requests while the first request is still in flight. This issue can be reproduced with a throttled network link, for example, being on a slow 3G network.

The intention is to provide a simple to use wrapper that prevents multiple clicks, either by mistake or by a lack of response from the UI due to a high network latency or a slow server response. It relies on a promise being passed in and is intended to be combined with things like the `dialogFactory()` and the form builder.

The `AssignUser` action in the moderation queue has been updated to use this helper as a proof of concept.