### PR TITLE
Implement a helper to prevent the parallel execution of callbacks

### DIFF
--- a/ts/WoltLabSuite/Core/Controller/Moderation/AssignUser.ts
+++ b/ts/WoltLabSuite/Core/Controller/Moderation/AssignUser.ts
@@ -7,6 +7,7 @@
  * @since 6.0
  */
 
+import { promiseMutex } from "WoltLabSuite/Core/Helper/PromiseMutex";
 import { dialogFactory } from "../../Component/Dialog";
 import { getPhrase } from "../../Language";
 import { show as showNotification } from "../../Ui/Notification";
@@ -54,7 +55,8 @@ function updateStatus(status: string): void {
 }
 
 export function setup(button: HTMLElement): void {
-  button.addEventListener("click", () => {
-    void showDialog(button.dataset.url!);
-  });
+  button.addEventListener(
+    "click",
+    promiseMutex(() => showDialog(button.dataset.url!)),
+  );
 }

--- a/ts/WoltLabSuite/Core/Helper/PromiseMutex.ts
+++ b/ts/WoltLabSuite/Core/Helper/PromiseMutex.ts
@@ -1,0 +1,29 @@
+/**
+ * Prevents concurrent runs of the callback promise by blocking subsequent calls
+ * while the previous promise has not been resolved or rejected.
+ *
+ * @author Tim Düsterhus
+ * @copyright 2001-2023 WoltLab GmbH
+ * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @since 6.0
+ */
+
+export function promiseMutex<T extends (...args: any[]) => Promise<unknown>>(
+  promise: T,
+): (...args: Parameters<T>) => boolean {
+  let pending = false;
+
+  return function (...args: Parameters<T>): boolean {
+    if (pending) {
+      return false;
+    }
+
+    pending = true;
+
+    void promise(...args).finally(() => {
+      pending = false;
+    });
+
+    return true;
+  };
+}

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Controller/Moderation/AssignUser.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Controller/Moderation/AssignUser.js
@@ -6,7 +6,7 @@
  * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
  * @since 6.0
  */
-define(["require", "exports", "../../Component/Dialog", "../../Language", "../../Ui/Notification"], function (require, exports, Dialog_1, Language_1, Notification_1) {
+define(["require", "exports", "WoltLabSuite/Core/Helper/PromiseMutex", "../../Component/Dialog", "../../Language", "../../Ui/Notification"], function (require, exports, PromiseMutex_1, Dialog_1, Language_1, Notification_1) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.setup = void 0;
@@ -37,9 +37,7 @@ define(["require", "exports", "../../Component/Dialog", "../../Language", "../..
         document.getElementById("moderationQueueStatus").textContent = status;
     }
     function setup(button) {
-        button.addEventListener("click", () => {
-            void showDialog(button.dataset.url);
-        });
+        button.addEventListener("click", (0, PromiseMutex_1.promiseMutex)(() => showDialog(button.dataset.url)));
     }
     exports.setup = setup;
 });

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Helper/PromiseMutex.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Helper/PromiseMutex.js
@@ -1,0 +1,28 @@
+/**
+ * Prevents concurrent runs of the callback promise by blocking subsequent calls
+ * while the previous promise has not been resolved or rejected.
+ *
+ * @author Tim Düsterhus
+ * @copyright 2001-2023 WoltLab GmbH
+ * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @since 6.0
+ */
+define(["require", "exports"], function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.promiseMutex = void 0;
+    function promiseMutex(promise) {
+        let pending = false;
+        return function (...args) {
+            if (pending) {
+                return false;
+            }
+            pending = true;
+            void promise(...args).finally(() => {
+                pending = false;
+            });
+            return true;
+        };
+    }
+    exports.promiseMutex = promiseMutex;
+});


### PR DESCRIPTION
This is primarily motivated by https://www.woltlab.com/community/thread/301446-unexpected-behaviour-when-double-clicking-on-create-album-in-the-gallery/ which uses a double click to trigger concurrent requests while the first request is still in flight. This issue can be reproduced with a throttled network link, for example, being on a slow 3G network.

The intention is to provide a simple to use wrapper that prevents certain callbacks from being executed in parallel, either by mistake or by a lack of response from the UI due to a high network latency or a slow server response. It relies on a promise being passed in which will release the mutex when it resolves or is being rejected.

The `AssignUser` action in the moderation queue has been updated to use this helper as a proof of concept.

Closes #5640 