### PR TITLE
Fix catastrophic backtracking in FileUtil::LINK_REGEX

### DIFF
--- a/wcfsetup/install/files/lib/system/html/input/node/HtmlInputNodeTextParser.class.php
+++ b/wcfsetup/install/files/lib/system/html/input/node/HtmlInputNodeTextParser.class.php
@@ -233,7 +233,7 @@ class HtmlInputNodeTextParser
      * @param string $value node value
      * @param string[] $usernames list of already found usernames
      */
-    protected function detectMention(\DOMText $text, $value, array &$usernames)
+    protected function detectMention(\DOMText $text, string $value, array &$usernames)
     {
         if (!\str_contains($value, '@')) {
             return;
@@ -363,7 +363,7 @@ class HtmlInputNodeTextParser
      * @param string[] $groups list of group names by group id
      * @return      string          modified node value with replacement placeholders
      */
-    protected function parseMention(\DOMText $text, $value, array $users, array $groups)
+    protected function parseMention(\DOMText $text, string $value, array $users, array $groups)
     {
         if (!\str_contains($value, '@')) {
             return $value;
@@ -419,7 +419,7 @@ class HtmlInputNodeTextParser
      * @param bool $allowMedia media bbcode is allowed
      * @return      string          modified node value with replacement placeholders
      */
-    protected function parseURL(\DOMText $text, $value, $allowURL, $allowMedia)
+    protected function parseURL(\DOMText $text, string $value, bool $allowURL, bool $allowMedia)
     {
         return \preg_replace_callback(
             FileUtil::LINK_REGEX,
@@ -455,7 +455,7 @@ class HtmlInputNodeTextParser
      * @param string $value node value
      * @return      string          modified node value with replacement placeholders
      */
-    protected function parseEmail(\DOMText $text, $value)
+    protected function parseEmail(\DOMText $text, string $value)
     {
         if (!\str_contains($value, '@')) {
             return $value;
@@ -489,7 +489,7 @@ class HtmlInputNodeTextParser
      * @param string $value node value
      * @return      string          modified node value with replacement placeholders
      */
-    protected function parseSmiley(\DOMText $text, $value)
+    protected function parseSmiley(\DOMText $text, string $value)
     {
         static $smileyPatterns = null;
         if ($smileyPatterns === null) {

--- a/wcfsetup/install/files/lib/util/FileUtil.class.php
+++ b/wcfsetup/install/files/lib/util/FileUtil.class.php
@@ -35,7 +35,7 @@ final class FileUtil
     /**
      * A regular expression that allows to detect links within text.
      */
-    public const LINK_REGEX = "#(?i)\\b((?:https?://|www\\d{0,3}[.]|(?:[a-z0-9\\-]+[.])+[a-z]{2,4}/)(?:[^\\s()<>]+|\\((?:[^\\s()<>])*\\))+(?:\\((?:[^\\s()<>])*\\)|[^\\s`!()\\[\\]{};:'\".,<>?«»“”‘’]))#iS";
+    public const LINK_REGEX = "#(?i)\\b((?:https?://|www\\d{0,3}[.]|(?:[a-z0-9\\-]+[.])+[a-z]{2,4}/)(?:[^\\s()<>]+|\\([^\\s()<>]*\\))+(?:\\([^\\s()<>]*\\)|[^\\s`!()\\[\\]{};:'\".,<>?«»“”‘’]))#iS";
 
     /**
      * Prepares the temporary folder and returns its path.

--- a/wcfsetup/install/files/lib/util/FileUtil.class.php
+++ b/wcfsetup/install/files/lib/util/FileUtil.class.php
@@ -35,7 +35,7 @@ final class FileUtil
     /**
      * A regular expression that allows to detect links within text.
      */
-    public const LINK_REGEX = "#(?i)\\b((?:https?://|www\\d{0,3}[.]|[a-z0-9.\\-]+[.][a-z]{2,4}/)(?:[^\\s()<>]+|\\(([^\\s()<>]+|(\\([^\\s()<>]+\\)))*\\))+(?:\\(([^\\s()<>]+|(\\([^\\s()<>]+\\)))*\\)|[^\\s`!()\\[\\]{};:'\".,<>?«»“”‘’]))#iS";
+    public const LINK_REGEX = "#(?i)\\b((?:https?://|www\\d{0,3}[.]|(?:[a-z0-9\\-]+[.])+[a-z]{2,4}/)(?:[^\\s()<>]+|\\(([^\\s()<>]+|(\\([^\\s()<>]+\\)))*\\))+(?:\\(([^\\s()<>]+|(\\([^\\s()<>]+\\)))*\\)|[^\\s`!()\\[\\]{};:'\".,<>?«»“”‘’]))#iS";
 
     /**
      * Prepares the temporary folder and returns its path.

--- a/wcfsetup/install/files/lib/util/FileUtil.class.php
+++ b/wcfsetup/install/files/lib/util/FileUtil.class.php
@@ -35,7 +35,7 @@ final class FileUtil
     /**
      * A regular expression that allows to detect links within text.
      */
-    public const LINK_REGEX = "#(?i)\\b((?:https?://|www\\d{0,3}[.]|(?:[a-z0-9\\-]+[.])+[a-z]{2,4}/)(?:[^\\s()<>]+|\\((?:[^\\s()<>]+)*\\))+(?:\\((?:[^\\s()<>]+)*\\)|[^\\s`!()\\[\\]{};:'\".,<>?«»“”‘’]))#iS";
+    public const LINK_REGEX = "#(?i)\\b((?:https?://|www\\d{0,3}[.]|(?:[a-z0-9\\-]+[.])+[a-z]{2,4}/)(?:[^\\s()<>]+|\\((?:[^\\s()<>])*\\))+(?:\\((?:[^\\s()<>])*\\)|[^\\s`!()\\[\\]{};:'\".,<>?«»“”‘’]))#iS";
 
     /**
      * Prepares the temporary folder and returns its path.

--- a/wcfsetup/install/files/lib/util/FileUtil.class.php
+++ b/wcfsetup/install/files/lib/util/FileUtil.class.php
@@ -35,7 +35,7 @@ final class FileUtil
     /**
      * A regular expression that allows to detect links within text.
      */
-    public const LINK_REGEX = "#(?i)\\b((?:https?://|www\\d{0,3}[.]|(?:[a-z0-9\\-]+[.])+[a-z]{2,4}/)(?:[^\\s()<>]+|\\((?:[^\\s()<>]+|(?:\\([^\\s()<>]+\\)))*\\))+(?:\\((?:[^\\s()<>]+|(?:\\([^\\s()<>]+\\)))*\\)|[^\\s`!()\\[\\]{};:'\".,<>?«»“”‘’]))#iS";
+    public const LINK_REGEX = "#(?i)\\b((?:https?://|www\\d{0,3}[.]|(?:[a-z0-9\\-]+[.])+[a-z]{2,4}/)(?:[^\\s()<>]+|\\((?:[^\\s()<>]+)*\\))+(?:\\((?:[^\\s()<>]+)*\\)|[^\\s`!()\\[\\]{};:'\".,<>?«»“”‘’]))#iS";
 
     /**
      * Prepares the temporary folder and returns its path.

--- a/wcfsetup/install/files/lib/util/FileUtil.class.php
+++ b/wcfsetup/install/files/lib/util/FileUtil.class.php
@@ -35,7 +35,7 @@ final class FileUtil
     /**
      * A regular expression that allows to detect links within text.
      */
-    public const LINK_REGEX = "#(?i)\\b((?:https?://|www\\d{0,3}[.]|(?:[a-z0-9\\-]+[.])+[a-z]{2,4}/)(?:[^\\s()<>]+|\\(([^\\s()<>]+|(\\([^\\s()<>]+\\)))*\\))+(?:\\(([^\\s()<>]+|(\\([^\\s()<>]+\\)))*\\)|[^\\s`!()\\[\\]{};:'\".,<>?«»“”‘’]))#iS";
+    public const LINK_REGEX = "#(?i)\\b((?:https?://|www\\d{0,3}[.]|(?:[a-z0-9\\-]+[.])+[a-z]{2,4}/)(?:[^\\s()<>]+|\\((?:[^\\s()<>]+|(?:\\([^\\s()<>]+\\)))*\\))+(?:\\((?:[^\\s()<>]+|(?:\\([^\\s()<>]+\\)))*\\)|[^\\s`!()\\[\\]{};:'\".,<>?«»“”‘’]))#iS";
 
     /**
      * Prepares the temporary folder and returns its path.


### PR DESCRIPTION
The most meaningful change is the removal of the support for nested
parentheses, as this drastically simplified the expression, allowing to easily
detect any consecutive repetation operators that resulted in combinatorial
explosion.

----------

see https://www.woltlab.com/community/thread/301492-fehler-beim-aktualisieren-der-beitr%C3%A4ge/

