### PR TITLE
Insert extraPlugins as empty array

### DIFF
--- a/ts/WoltLabSuite/Core/Component/Ckeditor/Configuration.ts
+++ b/ts/WoltLabSuite/Core/Component/Ckeditor/Configuration.ts
@@ -360,6 +360,7 @@ class ConfigurationBuilder {
         },
       },
       woltlabToolbarGroup: this.#toolbarGroups,
+      extraPlugins: [],
     };
   }
 }

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Component/Ckeditor/Configuration.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Component/Ckeditor/Configuration.js
@@ -321,6 +321,7 @@ define(["require", "exports", "../../Language"], function (require, exports, Lan
                     },
                 },
                 woltlabToolbarGroup: this.#toolbarGroups,
+                extraPlugins: [],
             };
         }
     }


### PR DESCRIPTION
Should prevent new CKEditor5 plugins from having to check whether this variable `extraPlugins` exists or not and then create an empty array as it.