### PR TITLE
Entirely hide the search for guests if login is forced

### DIFF
--- a/com.woltlab.wcf/templates/pageHeader.tpl
+++ b/com.woltlab.wcf/templates/pageHeader.tpl
@@ -11,8 +11,6 @@
 		<div id="pageHeaderFacade" class="pageHeaderFacade">
 			<div class="layoutBoundary">
 				{include file='pageHeaderLogo'}
-				
-				{include file='pageHeaderSearch'}
 			</div>
 		</div>
 	</header>

--- a/com.woltlab.wcf/templates/pageHeaderUser.tpl
+++ b/com.woltlab.wcf/templates/pageHeaderUser.tpl
@@ -209,10 +209,14 @@
 			{event name='menuItems'}
 		{/if}
 		
-		<!-- page search -->
-		<li>
-			<a href="{link controller='Search'}{/link}" id="userPanelSearchButton" class="jsTooltip" title="{lang}wcf.global.search{/lang}">{icon size=32 name='magnifying-glass'} <span>{lang}wcf.global.search{/lang}</span></a>
-		</li>
+		{if !(FORCE_LOGIN && !$__wcf->user->userID)}
+			<!-- page search -->
+			<li>
+				<a href="{link controller='Search'}{/link}" id="userPanelSearchButton" class="jsTooltip" title="{lang}wcf.global.search{/lang}">{icon size=32 name='magnifying-glass'} <span>{lang}wcf.global.search{/lang}</span></a>
+
+				{include file='pageHeaderSearch'}
+			</li>
+		{/if}
 	</ul>
 </nav>
 {if $__wcf->user->userID}


### PR DESCRIPTION
I've opted to select 6.0 as the target branch, but the movement of the
`{include}` might not be appropriate for 6.0. Rendering appears to be fine,
though. Please retarget if you're not comfortable with this change at this
point.

--------

The search is non-functional and possibly leaks information about installed
packages by the list of search providers.
