### PR TITLE
Adjust format of the license file

### DIFF
--- a/wcfsetup/install/files/lib/system/package/license/LicenseApi.class.php
+++ b/wcfsetup/install/files/lib/system/package/license/LicenseApi.class.php
@@ -29,15 +29,8 @@ final class LicenseApi
     public function updateLicenseFile(?LicenseData $data): void
     {
         $writer = new AtomicWriter(self::LICENSE_FILE);
-        $writer->write(\sprintf(
-            <<<'EOT'
-                <?php
-                /* GENERATED AT %s -- DO NOT EDIT */
-                return unserialize(%s);
-                EOT,
-            \gmdate('r', \TIME_NOW),
-            \var_export(\serialize($data), true),
-        ));
+        $writer->write("<?php /* {$data->creationDate->format('c')} */\n\n");
+        $writer->write(\sprintf("return unserialize(%s);\n", \var_export(\serialize($data), true)));
         $writer->flush();
 
         WCF::resetZendOpcache(self::LICENSE_FILE);


### PR DESCRIPTION
- Use a format that is consistent with `lib/bootstrap.php`.
- Ensure a trailing newline.
- Use the `creationDate` from the LicenseData object as the more accurate date.
