### PR TITLE
Error correction in DateFormField for invalid values

### DIFF
--- a/wcfsetup/install/files/lib/system/form/builder/field/DateFormField.class.php
+++ b/wcfsetup/install/files/lib/system/form/builder/field/DateFormField.class.php
@@ -299,7 +299,7 @@ class DateFormField extends AbstractFormField implements
             } elseif ($this->getValueDateTimeObject() === null) {
                 try {
                     $this->value($value);
-                } catch (\InvalidArgumentException $e) {
+                } catch (\InvalidArgumentException) {
                     $this->value = null;
                 }
             }

--- a/wcfsetup/install/files/lib/system/form/builder/field/DateFormField.class.php
+++ b/wcfsetup/install/files/lib/system/form/builder/field/DateFormField.class.php
@@ -291,10 +291,17 @@ class DateFormField extends AbstractFormField implements
             $this->getDocument()->hasRequestData($this->getPrefixedId())
             && \is_string($this->getDocument()->getRequestData($this->getPrefixedId()))
         ) {
-            $this->value = $this->getDocument()->getRequestData($this->getPrefixedId());
+            $value = $this->getDocument()->getRequestData($this->getPrefixedId());
+            $this->value = $value;
 
             if ($this->value === '') {
                 $this->value = null;
+            } elseif ($this->getValueDateTimeObject() === null) {
+                try {
+                    $this->value($value);
+                } catch (\InvalidArgumentException $e) {
+                    $this->value = null;
+                }
             }
         }
 


### PR DESCRIPTION
Fixes an error in the `DateFormField`  that occurs when numeric or invalid values that cannot be converted to a date are passed.