### PR TITLE
Fix image(attachment and media) width change from editor

### DIFF
--- a/com.woltlab.wcf/bbcode.xml
+++ b/com.woltlab.wcf/bbcode.xml
@@ -192,6 +192,9 @@
 				<attribute name="2">
 					<validationpattern><![CDATA[^(left|right|none)$]]></validationpattern>
 				</attribute>
+				<attribute name="3">
+					<validationpattern><![CDATA[^\d+$]]></validationpattern>
+				</attribute>
 			</attributes>
 		</bbcode>
 		<bbcode name="wsp">

--- a/com.woltlab.wcf/templates/mediaBBCodeTag.tpl
+++ b/com.woltlab.wcf/templates/mediaBBCodeTag.tpl
@@ -1,5 +1,5 @@
 {if !$removeLinks|isset}{assign var='removeLinks' value=false}{/if}
-<span class="mediaBBCode{if $float != 'none'} messageFloatObject{$float|ucfirst}{/if}">
+<span class="mediaBBCode{if $float != 'none'} messageFloatObject{$float|ucfirst}{/if}"{if $width !== 'auto'} style="width: {$width}px; display: inline-flex"{/if}>
 	{if $media->isImage}
 		{if $thumbnailSize != 'original'}
 			{if !$removeLinks}

--- a/wcfsetup/install/files/acp/templates/mediaBBCodeTag.tpl
+++ b/wcfsetup/install/files/acp/templates/mediaBBCodeTag.tpl
@@ -1,5 +1,5 @@
 {if !$removeLinks|isset}{assign var='removeLinks' value=false}{/if}
-<span class="mediaBBCode{if $float != 'none'} messageFloatObject{$float|ucfirst}{/if}">
+<span class="mediaBBCode{if $float != 'none'} messageFloatObject{$float|ucfirst}{/if}"{if $width !== 'auto'} style="width: {$width}px; display: inline-flex"{/if}>
 	{if $media->isImage}
 		{if $thumbnailSize != 'original'}
 			{if !$removeLinks}

--- a/wcfsetup/install/files/lib/system/bbcode/AttachmentBBCode.class.php
+++ b/wcfsetup/install/files/lib/system/bbcode/AttachmentBBCode.class.php
@@ -110,7 +110,7 @@ final class AttachmentBBCode extends AbstractBBCode
         }
 
         return \sprintf(
-            '<span title="%s" class="%s" style="width: %s">%s</span>',
+            '<span title="%s" class="%s" style="width: %s; display: inline-flex;">%s</span>',
             $title,
             $class,
             $width,
@@ -168,7 +168,7 @@ final class AttachmentBBCode extends AbstractBBCode
         }
 
         return \sprintf(
-            '<span class="%s" stlye="width: %s">%s%s</span>',
+            '<span class="%s" style="width: %s; display: inline-flex">%s%s</span>',
             $class,
             $width,
             $imageElement,

--- a/wcfsetup/install/files/lib/system/bbcode/WoltLabSuiteMediaBBCode.class.php
+++ b/wcfsetup/install/files/lib/system/bbcode/WoltLabSuiteMediaBBCode.class.php
@@ -60,6 +60,7 @@ final class WoltLabSuiteMediaBBCode extends AbstractBBCode
                 if ($media->isImage) {
                     $thumbnailSize = (!empty($openingTag['attributes'][1])) ? $openingTag['attributes'][1] : 'original';
                     $float = (!empty($openingTag['attributes'][2])) ? $openingTag['attributes'][2] : 'none';
+                    $width = (!empty($openingTag['attributes'][3])) ? $openingTag['attributes'][3] : 'auto';
 
                     return WCF::getTPL()->fetch('mediaBBCodeTag', 'wcf', [
                         'mediaLink' => $this->getLink($media),
@@ -71,6 +72,7 @@ final class WoltLabSuiteMediaBBCode extends AbstractBBCode
                         'float' => $float,
                         'media' => $media->getLocalizedVersion(MessageEmbeddedObjectManager::getInstance()->getActiveMessageLanguageID()),
                         'thumbnailSize' => $thumbnailSize,
+                        'width' => $width,
                     ]);
                 } elseif ($media->isVideo() || $media->isAudio()) {
                     return WCF::getTPL()->fetch('mediaBBCodeTag', 'wcf', [

--- a/wcfsetup/install/files/lib/system/html/input/node/HtmlInputNodeImg.class.php
+++ b/wcfsetup/install/files/lib/system/html/input/node/HtmlInputNodeImg.class.php
@@ -162,6 +162,12 @@ class HtmlInputNodeImg extends AbstractHtmlInputNode
 
         $float = 'none';
         $thumbnail = 'original';
+        $width = $element->getAttribute("data-width");
+        if (\preg_match('~(?<width>\d+)px$~', $width, $matches)) {
+            $width = (int)$matches['width'];
+        } else {
+            $width = "auto";
+        }
 
         if (
             \preg_match(
@@ -188,6 +194,7 @@ class HtmlInputNodeImg extends AbstractHtmlInputNode
             $mediumID,
             $thumbnail,
             $float,
+            $width,
         ];
 
         $newElement = $element->ownerDocument->createElement('woltlab-metacode');


### PR DESCRIPTION
See: https://www.woltlab.com/community/thread/303398-größenänderung-eingefügter-bilder-dateianhänge-funktioniert-nicht/
- [Update the creditor 5 bundle](https://github.com/WoltLab/editor/pull/107)
- BBCode `wsm` allow now a new attribute `width`
- Add to the style attribute `display: inline-flex`