### PR TITLE
Fix media/attachment inside a-tag

### DIFF
--- a/wcfsetup/install/files/lib/system/html/input/node/HtmlInputNodeImg.class.php
+++ b/wcfsetup/install/files/lib/system/html/input/node/HtmlInputNodeImg.class.php
@@ -186,7 +186,7 @@ class HtmlInputNodeImg extends AbstractHtmlInputNode
 
         $replaceElement = $element;
         $parent = $this->getParentFigure($element);
-        if ($parent !== null && $parent->tagName === "figure") {
+        if ($parent !== null) {
             if (\preg_match('~\b(?<float>image-style-side-left|image-style-side)\b~', $parent->getAttribute('class'), $matches)) {
                 $float = ($matches['float'] === 'image-style-side-left') ? 'left' : 'right';
             } else {


### PR DESCRIPTION
Prevent attachments and/or media from being converted to an img-tag and not saved as `woltlab-metacode` .