### PR TITLE
Use session variable to store login redirect URL

### DIFF
--- a/com.woltlab.wcf/templates/multifactorAuthentication.tpl
+++ b/com.woltlab.wcf/templates/multifactorAuthentication.tpl
@@ -16,7 +16,7 @@
 			{if $setup->getId() != $method->getId()}
 				<li>
 					<a
-						href="{link controller='MultifactorAuthentication' object=$method url=$redirectUrl}{/link}"
+						href="{link controller='MultifactorAuthentication' object=$method}{/link}"
 						class="button authOtherOptionButtons__button"
 					>
 						{if $method->getObjectType()->icon}

--- a/wcfsetup/install/files/acp/templates/login.tpl
+++ b/wcfsetup/install/files/acp/templates/login.tpl
@@ -12,7 +12,7 @@
 	{include file='formError'}
 {/if}
 
-<form id="loginForm" method="post" action="{link controller='Login' url=$url}{/link}">
+<form id="loginForm" method="post" action="{$loginController}">
 	<dl{if $errorField == 'username'} class="formError"{/if}>
 		<dt>
 			<label for="username">{lang}wcf.user.usernameOrEmail{/lang}</label> <span class="formFieldRequired">*</span>

--- a/wcfsetup/install/files/acp/templates/multifactorAuthentication.tpl
+++ b/wcfsetup/install/files/acp/templates/multifactorAuthentication.tpl
@@ -21,7 +21,7 @@
 			{if $setup->getId() != $method->getId()}
 				<li>
 					<a
-						href="{link controller='MultifactorAuthentication' object=$method url=$redirectUrl}{/link}"
+						href="{link controller='MultifactorAuthentication' object=$method}{/link}"
 						class="button authOtherOptionButtons__button"
 					>
 						{if $method->getObjectType()->icon}

--- a/wcfsetup/install/files/lib/action/FacebookAuthAction.class.php
+++ b/wcfsetup/install/files/lib/action/FacebookAuthAction.class.php
@@ -12,6 +12,7 @@ use wcf\system\event\EventHandler;
 use wcf\system\exception\NamedUserException;
 use wcf\system\request\LinkHandler;
 use wcf\system\user\authentication\event\UserLoggedIn;
+use wcf\system\user\authentication\LoginRedirect;
 use wcf\system\user\authentication\oauth\User as OauthUser;
 use wcf\system\WCF;
 use wcf\util\JSON;
@@ -141,7 +142,7 @@ final class FacebookAuthAction extends AbstractOauth2Action
                 );
 
                 return new RedirectResponse(
-                    LinkHandler::getInstance()->getLink()
+                    LoginRedirect::getUrl()
                 );
             }
         } else {

--- a/wcfsetup/install/files/lib/action/GithubAuthAction.class.php
+++ b/wcfsetup/install/files/lib/action/GithubAuthAction.class.php
@@ -13,6 +13,7 @@ use wcf\system\event\EventHandler;
 use wcf\system\exception\NamedUserException;
 use wcf\system\request\LinkHandler;
 use wcf\system\user\authentication\event\UserLoggedIn;
+use wcf\system\user\authentication\LoginRedirect;
 use wcf\system\user\authentication\oauth\User as OauthUser;
 use wcf\system\WCF;
 use wcf\util\JSON;
@@ -133,7 +134,7 @@ final class GithubAuthAction extends AbstractOauth2Action
                 );
 
                 return new RedirectResponse(
-                    LinkHandler::getInstance()->getLink()
+                    LoginRedirect::getUrl()
                 );
             }
         } else {

--- a/wcfsetup/install/files/lib/action/GoogleAuthAction.class.php
+++ b/wcfsetup/install/files/lib/action/GoogleAuthAction.class.php
@@ -12,6 +12,7 @@ use wcf\system\event\EventHandler;
 use wcf\system\exception\NamedUserException;
 use wcf\system\request\LinkHandler;
 use wcf\system\user\authentication\event\UserLoggedIn;
+use wcf\system\user\authentication\LoginRedirect;
 use wcf\system\user\authentication\oauth\User as OauthUser;
 use wcf\system\WCF;
 use wcf\util\JSON;
@@ -155,7 +156,7 @@ final class GoogleAuthAction extends AbstractOauth2Action
                 );
 
                 return new RedirectResponse(
-                    LinkHandler::getInstance()->getLink()
+                    LoginRedirect::getUrl()
                 );
             }
         } else {

--- a/wcfsetup/install/files/lib/action/TwitterAuthAction.class.php
+++ b/wcfsetup/install/files/lib/action/TwitterAuthAction.class.php
@@ -17,6 +17,7 @@ use wcf\system\exception\PermissionDeniedException;
 use wcf\system\io\HttpFactory;
 use wcf\system\request\LinkHandler;
 use wcf\system\user\authentication\event\UserLoggedIn;
+use wcf\system\user\authentication\LoginRedirect;
 use wcf\system\user\authentication\oauth\exception\StateValidationException;
 use wcf\system\user\authentication\oauth\User as OauthUser;
 use wcf\system\WCF;
@@ -126,7 +127,7 @@ final class TwitterAuthAction extends AbstractAction
                 );
 
                 return new RedirectResponse(
-                    LinkHandler::getInstance()->getLink()
+                    LoginRedirect::getUrl()
                 );
             }
         } else {

--- a/wcfsetup/install/files/lib/bootstrap/com.woltlab.wcf.php
+++ b/wcfsetup/install/files/lib/bootstrap/com.woltlab.wcf.php
@@ -18,7 +18,9 @@ use wcf\system\package\event\PackageInstallationPluginSynced;
 use wcf\system\package\event\PackageListChanged;
 use wcf\system\package\event\PackageUpdateListChanged;
 use wcf\system\package\license\LicenseApi;
+use wcf\system\session\event\PreserveVariablesCollecting;
 use wcf\system\user\authentication\event\UserLoggedIn;
+use wcf\system\user\authentication\LoginRedirect;
 use wcf\system\user\event\UsernameValidating;
 use wcf\system\WCF;
 use wcf\system\worker\event\RebuildWorkerCollecting;
@@ -32,6 +34,9 @@ return static function (): void {
     );
 
     $eventHandler->register(UserLoggedIn::class, UserLoginCancelLostPasswordListener::class);
+    $eventHandler->register(PreserveVariablesCollecting::class, static function (PreserveVariablesCollecting $event) {
+        $event->keys[] = LoginRedirect::SESSION_VAR_KEY;
+    });
 
     $eventHandler->register(UsernameValidating::class, UsernameValidatingCheckCharactersListener::class);
 

--- a/wcfsetup/install/files/lib/form/LoginForm.class.php
+++ b/wcfsetup/install/files/lib/form/LoginForm.class.php
@@ -3,7 +3,6 @@
 namespace wcf\form;
 
 use wcf\system\event\EventHandler;
-use wcf\system\request\LinkHandler;
 use wcf\system\user\authentication\event\UserLoggedIn;
 use wcf\system\WCF;
 
@@ -40,9 +39,6 @@ class LoginForm extends \wcf\acp\form\LoginForm
 
         $this->saved();
 
-        // redirect to url
-        WCF::getTPL()->assign('__hideUserMenu', true);
-
         $this->performRedirect($needsMultifactor);
     }
 
@@ -54,27 +50,7 @@ class LoginForm extends \wcf\acp\form\LoginForm
         parent::assignVariables();
 
         WCF::getTPL()->assign([
-            'loginController' => LinkHandler::getInstance()->getLink('Login', [
-                'url' => $this->url,
-            ]),
             'forceLoginRedirect' => (FORCE_LOGIN && WCF::getSession()->getVar('__wsc_forceLoginRedirect') !== null),
         ]);
-    }
-
-    /**
-     * @inheritDoc
-     */
-    protected function performRedirect(bool $needsMultifactor = false)
-    {
-        if (
-            empty($this->url) || \mb_stripos($this->url, '?login/') !== false || \mb_stripos(
-                $this->url,
-                '/login/'
-            ) !== false
-        ) {
-            $this->url = LinkHandler::getInstance()->getLink();
-        }
-
-        parent::performRedirect($needsMultifactor);
     }
 }

--- a/wcfsetup/install/files/lib/form/MultifactorAuthenticationForm.class.php
+++ b/wcfsetup/install/files/lib/form/MultifactorAuthenticationForm.class.php
@@ -4,14 +4,13 @@ namespace wcf\form;
 
 use wcf\data\object\type\ObjectType;
 use wcf\data\user\User;
-use wcf\system\application\ApplicationHandler;
 use wcf\system\cache\runtime\UserProfileRuntimeCache;
 use wcf\system\event\EventHandler;
 use wcf\system\exception\IllegalLinkException;
 use wcf\system\exception\NamedUserException;
-use wcf\system\form\builder\TemplateFormNode;
 use wcf\system\request\LinkHandler;
 use wcf\system\user\authentication\event\UserLoggedIn;
+use wcf\system\user\authentication\LoginRedirect;
 use wcf\system\user\multifactor\IMultifactorMethod;
 use wcf\system\user\multifactor\Setup;
 use wcf\system\WCF;
@@ -60,20 +59,11 @@ class MultifactorAuthenticationForm extends AbstractFormBuilderForm
     private $setup;
 
     /**
-     * @var string
-     */
-    public $redirectUrl;
-
-    /**
      * @inheritDoc
      */
     public function readParameters()
     {
         parent::readParameters();
-
-        if (!empty($_GET['url']) && ApplicationHandler::getInstance()->isInternalURL($_GET['url'])) {
-            $this->redirectUrl = $_GET['url'];
-        }
 
         if (WCF::getUser()->userID) {
             $this->performRedirect();
@@ -158,15 +148,11 @@ class MultifactorAuthenticationForm extends AbstractFormBuilderForm
     }
 
     /**
-     * Returns to the redirectUrl if given and to the landing page otherwise.
+     * Returns to the redirect url if given and to the landing page otherwise.
      */
     protected function performRedirect()
     {
-        if ($this->redirectUrl) {
-            HeaderUtil::redirect($this->redirectUrl);
-        } else {
-            HeaderUtil::redirect(LinkHandler::getInstance()->getLink());
-        }
+        HeaderUtil::redirect(LoginRedirect::getUrl());
 
         exit;
     }
@@ -178,7 +164,6 @@ class MultifactorAuthenticationForm extends AbstractFormBuilderForm
     {
         $this->form->action(LinkHandler::getInstance()->getControllerLink(static::class, [
             'object' => $this->setup,
-            'url' => $this->redirectUrl,
         ]));
     }
 
@@ -194,7 +179,6 @@ class MultifactorAuthenticationForm extends AbstractFormBuilderForm
             'user' => $this->user,
             'userProfile' => UserProfileRuntimeCache::getInstance()->getObject($this->user->userID),
             'setup' => $this->setup,
-            'redirectUrl' => $this->redirectUrl,
         ]);
     }
 }

--- a/wcfsetup/install/files/lib/form/RegisterForm.class.php
+++ b/wcfsetup/install/files/lib/form/RegisterForm.class.php
@@ -23,6 +23,7 @@ use wcf\system\exception\SystemException;
 use wcf\system\exception\UserInputException;
 use wcf\system\option\user\UserOptionHandler;
 use wcf\system\request\LinkHandler;
+use wcf\system\user\authentication\LoginRedirect;
 use wcf\system\user\group\assignment\UserGroupAssignmentHandler;
 use wcf\system\user\notification\object\UserRegistrationUserNotificationObject;
 use wcf\system\user\notification\UserNotificationHandler;
@@ -113,6 +114,10 @@ class RegisterForm extends UserAddForm
     public function readParameters()
     {
         parent::readParameters();
+
+        if (!empty($_REQUEST['url'])) {
+            LoginRedirect::setUrl(StringUtil::trim($_REQUEST['url']));
+        }
 
         // user is already registered
         if (WCF::getUser()->userID) {
@@ -479,7 +484,7 @@ class RegisterForm extends UserAddForm
 
         // forward to index page
         HeaderUtil::delayedRedirect(
-            LinkHandler::getInstance()->getLink(),
+            LoginRedirect::getUrl(),
             WCF::getLanguage()->getDynamicVariable($this->message, ['user' => $user]),
             15,
             'success',

--- a/wcfsetup/install/files/lib/system/session/event/PreserveVariablesCollecting.class.php
+++ b/wcfsetup/install/files/lib/system/session/event/PreserveVariablesCollecting.class.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace wcf\system\session\event;
+
+use wcf\system\event\IEvent;
+
+/**
+ * This event allows the configuration of session variables that are to be preserved when the user changes.
+ *
+ * @author      Marcel Werk
+ * @copyright   2001-2023 WoltLab GmbH
+ * @license     GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @since       6.1
+ */
+final class PreserveVariablesCollecting implements IEvent
+{
+    /**
+     * @var string[]
+     */
+    public array $keys = [];
+}

--- a/wcfsetup/install/files/lib/system/user/authentication/LoginRedirect.class.php
+++ b/wcfsetup/install/files/lib/system/user/authentication/LoginRedirect.class.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace wcf\system\user\authentication;
+
+use wcf\system\application\ApplicationHandler;
+use wcf\system\request\LinkHandler;
+use wcf\system\request\RequestHandler;
+use wcf\system\WCF;
+
+/**
+ * Manages the URL to which the user should be redirected after login.
+ *
+ * @author      Marcel Werk
+ * @copyright   2001-2023 WoltLab GmbH
+ * @license     GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @since       6.1
+ */
+final class LoginRedirect
+{
+    public const SESSION_VAR_KEY = 'login__redirect__url';
+
+    public static function setUrl(string $url): void
+    {
+        // Discard URL if it is not an absolute URL of local content.
+        if (!ApplicationHandler::getInstance()->isInternalURL($url)) {
+            return;
+        }
+
+        WCF::getSession()->register(self::SESSION_VAR_KEY, $url);
+    }
+
+    public static function getUrl(): string
+    {
+        $url = WCF::getSession()->getVar(self::SESSION_VAR_KEY);
+        if (!$url) {
+            if (RequestHandler::getInstance()->isACPRequest()) {
+                $application = ApplicationHandler::getInstance()->getActiveApplication();
+
+                return $application->getPageURL() . 'acp/';
+            }
+
+            return LinkHandler::getInstance()->getLink();
+        }
+
+        WCF::getSession()->unregister(self::SESSION_VAR_KEY);
+
+        return $url;
+    }
+}


### PR DESCRIPTION
The goal of this PR is to make the redirection after login reliable by saving the URL in the session. This means that the redirection is also available after registration or after logging in via a third-party provider.