### PR TITLE
Bugifx media insert

### DIFF
--- a/com.woltlab.wcf/bbcode.xml
+++ b/com.woltlab.wcf/bbcode.xml
@@ -193,7 +193,7 @@
 					<validationpattern><![CDATA[^(left|right|center|none)$]]></validationpattern>
 				</attribute>
 				<attribute name="3">
-					<validationpattern><![CDATA[^\d+$]]></validationpattern>
+					<validationpattern><![CDATA[^(\d+|auto)$]]></validationpattern>
 				</attribute>
 			</attributes>
 		</bbcode>

--- a/ts/WoltLabSuite/Core/Media/Manager/Editor.ts
+++ b/ts/WoltLabSuite/Core/Media/Manager/Editor.ts
@@ -259,14 +259,7 @@ export class MediaManagerEditor extends MediaManager<MediaManagerEditorOptions> 
         thumbnailSize = "original";
       }
 
-      let link = media.link;
-      if (thumbnailSize !== "original") {
-        link = media[thumbnailSize + "ThumbnailLink"];
-      }
-
-      ckeditor.insertHtml(
-        `<img src="${link}" class="woltlabSuiteMedia" data-media-id="${media.mediaID}" data-media-size="${thumbnailSize}">`,
-      );
+      ckeditor.insertText(`[wsm='${media.mediaID}','${thumbnailSize}'][/wsm]`);
     } else {
       ckeditor.insertText(`[wsm='${media.mediaID}'][/wsm]`);
     }

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Media/Manager/Editor.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Media/Manager/Editor.js
@@ -214,11 +214,7 @@ define(["require", "exports", "tslib", "./Base", "../../Core", "../../Event/Hand
                 if (!thumbnailSize) {
                     thumbnailSize = "original";
                 }
-                let link = media.link;
-                if (thumbnailSize !== "original") {
-                    link = media[thumbnailSize + "ThumbnailLink"];
-                }
-                ckeditor.insertHtml(`<img src="${link}" class="woltlabSuiteMedia" data-media-id="${media.mediaID}" data-media-size="${thumbnailSize}">`);
+                ckeditor.insertText(`[wsm='${media.mediaID}','${thumbnailSize}'][/wsm]`);
             }
             else {
                 ckeditor.insertText(`[wsm='${media.mediaID}'][/wsm]`);

--- a/wcfsetup/install/files/lib/system/html/input/node/HtmlInputNodeImg.class.php
+++ b/wcfsetup/install/files/lib/system/html/input/node/HtmlInputNodeImg.class.php
@@ -75,8 +75,6 @@ class HtmlInputNodeImg extends AbstractHtmlInputNode
             $class = $element->getAttribute('class');
             if (\preg_match('~\bwoltlabAttachment\b~', $class)) {
                 $this->handleAttachment($element, $class);
-            } elseif (\preg_match('~\bwoltlabSuiteMedia\b~', $class)) {
-                $this->handleMedium($element, $class);
             } elseif (\preg_match('~\bsmiley\b~', $class)) {
                 $this->handleSmiley($element);
             }

--- a/wcfsetup/install/files/lib/system/html/input/node/HtmlInputNodeWoltlabMetacodeMarker.class.php
+++ b/wcfsetup/install/files/lib/system/html/input/node/HtmlInputNodeWoltlabMetacodeMarker.class.php
@@ -574,6 +574,14 @@ class HtmlInputNodeWoltlabMetacodeMarker extends AbstractHtmlInputNode
                 /** @var \DOMElement $node */
                 return \in_array($node->getAttribute('data-name'), $this->blockElements);
 
+            case 'a':
+                /** @var \DOMElement $node */
+                $metacodeChild = $node->firstChild;
+                if (!($metacodeChild instanceof \DOMElement)) {
+                    return false;
+                }
+                return $metacodeChild->nodeName === 'woltlab-metacode-marker'
+                    && $metacodeChild->getAttribute('data-name') === 'wsm';
             default:
                 return \in_array($node->nodeName, self::$customBlockElementTagNames);
         }


### PR DESCRIPTION
See: 
- https://www.woltlab.com/community/thread/303949-nach-wie-vor-probleme-mit-dem-neuen-editor-bilder-aus-medien-mobile-anzeige/
- https://github.com/WoltLab/editor/pull/111

No longer insert media as `img` tag
Also fix that the media should have a link as a parent.

After that, media will only be available in the editor as `[wsm...][/wsm]`.