### PR TITLE
Remove unused userOption `editorPastePreserveFormatting`

### DIFF
--- a/com.woltlab.wcf/userOption.xml
+++ b/com.woltlab.wcf/userOption.xml
@@ -176,12 +176,6 @@ dark:wcf.style.setColorScheme.dark</selectoptions>
 				<options>module_user_signature</options>
 				<editable>3</editable>
 			</option>
-			<option name="editorPastePreserveFormatting">
-				<categoryname>settings.general.interface</categoryname>
-				<optiontype>boolean</optiontype>
-				<defaultvalue>1</defaultvalue>
-				<editable>3</editable>
-			</option>
 			<!-- settings.privacy.content -->
 			<option name="canViewOnlineStatus">
 				<categoryname>settings.privacy.content</categoryname>
@@ -254,4 +248,7 @@ dark:wcf.style.setColorScheme.dark</selectoptions>
 			</option>
 		</options>
 	</import>
+	<delete>
+		<option name="editorPastePreserveFormatting"/>
+	</delete>
 </data>

--- a/wcfsetup/install/lang/de.xml
+++ b/wcfsetup/install/lang/de.xml
@@ -5521,8 +5521,6 @@ Benachrichtigungen auf <a href="{link isHtmlEmail=true}{/link}">{PAGE_TITLE|phra
 		<item name="wcf.user.option.facebook"><![CDATA[Facebook]]></item>
 		<item name="wcf.user.option.twitter"><![CDATA[X]]></item>
 		<item name="wcf.user.option.canWriteProfileComments"><![CDATA[Kann Pinnwand-Kommentare schreiben]]></item>
-		<item name="wcf.user.option.editorPastePreserveFormatting"><![CDATA[Text-Formatierung beim Einfügen in den Editor übernehmen]]></item>
-		<item name="wcf.user.option.editorPastePreserveFormatting.description"><![CDATA[Die Deaktivierung dieser Option erzwingt das Einfügen aus der Zwischenablage in reiner Textform, Formatierungen werden dabei entfernt.]]></item>
 		<item name="wcf.user.option.searchRadioButtonOption"><![CDATA[Auswahl des Benutzers bei „{$option->getTitle()}“:]]></item>
 		<item name="wcf.user.option.searchTextOption"><![CDATA[„{$option->getTitle()}“ enthält:]]></item>
 		<item name="wcf.user.option.searchBooleanOption"><![CDATA[Auswahl des Benutzers bei „{$option->getTitle()}“:]]></item>
@@ -7554,5 +7552,7 @@ Benachrichtigungen auf <a href="{link isHtmlEmail=true}{/link}">{PAGE_TITLE|phra
 	<item name="wcf.user.objectWatch.enableNotification.com.woltlab.wcf.article.category"/>
 	<item name="wcf.user.objectWatch.unsubscribe.com.woltlab.wcf.article.category"/>
 	<item name="wcf.editor.button.group.block"/>
+	<item name="wcf.user.option.editorPastePreserveFormatting"/>
+	<item name="wcf.user.option.editorPastePreserveFormatting.description"/>
 </delete>
 </language>

--- a/wcfsetup/install/lang/en.xml
+++ b/wcfsetup/install/lang/en.xml
@@ -5525,8 +5525,6 @@ your notifications on <a href="{link isHtmlEmail=true}{/link}">{PAGE_TITLE|phras
 		<item name="wcf.user.option.facebook"><![CDATA[Facebook]]></item>
 		<item name="wcf.user.option.twitter"><![CDATA[X]]></item>
 		<item name="wcf.user.option.canWriteProfileComments"><![CDATA[Can Write Comments on My Wall]]></item>
-		<item name="wcf.user.option.editorPastePreserveFormatting"><![CDATA[Preserve text formatting when pasting into the editor]]></item>
-		<item name="wcf.user.option.editorPastePreserveFormatting.description"><![CDATA[Disabling this option will force any content to be pasted from clipboard as plain text, stripping all formatting.]]></item>
 		<item name="wcf.user.option.searchRadioButtonOption"><![CDATA[User’s selection for “{$option->getTitle()}”:]]></item>
 		<item name="wcf.user.option.searchTextOption"><![CDATA[“{$option->getTitle()}” contains:]]></item>
 		<item name="wcf.user.option.searchBooleanOption"><![CDATA[User’s selection for “{$option->getTitle()}”:]]></item>
@@ -7447,5 +7445,7 @@ your notifications on <a href="{link isHtmlEmail=true}{/link}">{PAGE_TITLE|phras
 	<item name="wcf.user.objectWatch.enableNotification.com.woltlab.wcf.article.category"/>
 	<item name="wcf.user.objectWatch.unsubscribe.com.woltlab.wcf.article.category"/>
 	<item name="wcf.editor.button.group.block"/>
+	<item name="wcf.user.option.editorPastePreserveFormatting"/>
+	<item name="wcf.user.option.editorPastePreserveFormatting.description"/>
 </delete>
 </language>


### PR DESCRIPTION
See https://www.woltlab.com/community/thread/303877-text-formatierung-beim-einfügen-in-den-editor-übernehmen/
The CKEditor can do this by default with a [key combination](https://ckeditor.com/docs/ckeditor5/latest/features/pasting/paste-plain-text.html)