### PR TITLE
Daily notification mail, define backwards compatibility variable

### DIFF
--- a/com.woltlab.wcf/templates/email_dailyNotification.tpl
+++ b/com.woltlab.wcf/templates/email_dailyNotification.tpl
@@ -1,3 +1,6 @@
+{if !$notificationCount|isset}{assign var=notificationCount value=$notifications|count}{/if}
+{if !$maximum|isset}{assign var=maximum value=$notificationCount}{/if}
+{if !$remaining|isset}{assign var=remaining value=0}{/if}
 {if $mimeType === 'text/plain'}
 {capture assign='content'}
 {lang}wcf.user.notification.mail.daily.plaintext.intro{/lang}

--- a/com.woltlab.wcf/templates/email_dailyNotification.tpl
+++ b/com.woltlab.wcf/templates/email_dailyNotification.tpl
@@ -1,3 +1,4 @@
+{* variable definition for full backwards-compatibility *}
 {if !$notificationCount|isset}{assign var=notificationCount value=$notifications|count}{/if}
 {if !$maximum|isset}{assign var=maximum value=$notificationCount}{/if}
 {if !$remaining|isset}{assign var=remaining value=0}{/if}


### PR DESCRIPTION
See 
- https://www.woltlab.com/community/thread/304141-undefined-array-key-notificationcount/
- https://github.com/WoltLab/WCF/commit/bc0e1f3fd2740a696370195e6c6d3ebeb822e14b

If a daily notification was created in 5.5.x but not sent, and then the system is upgraded to 6.0.x, the mail cannot be sent because of the missing variables.