### PR TITLE
Better detect for standalone links

### DIFF
--- a/wcfsetup/install/files/lib/system/html/input/node/HtmlInputNodeProcessor.class.php
+++ b/wcfsetup/install/files/lib/system/html/input/node/HtmlInputNodeProcessor.class.php
@@ -825,11 +825,8 @@ class HtmlInputNodeProcessor extends AbstractHtmlNodeProcessor
                     // <p>…<br><a href="https://example.com">https://example.com</a><br>…</p>
                     // <p>…<br><u><b><a href="https://example.com">https://example.com</a></b></u><br>…</p>
                     if (
-                        $previousSibling === null && $nextSibling === null
-                        || (
-                            $previousSibling !== null && $nextSibling !== null
-                            && $previousSibling->nodeName === 'br' && $nextSibling->nodeName === 'br'
-                        )
+                        $previousSibling !== null && $nextSibling !== null
+                        && $previousSibling->nodeName === 'br' && $nextSibling->nodeName === 'br'
                     ) {
                         $this->plainLinks[] = $plainLink->setIsStandalone($parent, false);
                         continue;

--- a/wcfsetup/install/files/lib/system/html/input/node/HtmlInputNodeProcessor.class.php
+++ b/wcfsetup/install/files/lib/system/html/input/node/HtmlInputNodeProcessor.class.php
@@ -815,8 +815,8 @@ class HtmlInputNodeProcessor extends AbstractHtmlNodeProcessor
                     //<p><a href="https://example.com">https://example.com</a><br>…</p>
                     //<p>…<br><a href="https://example.com">https://example.com</a></p>
                     if (
-                        ($nextSibling === null && $previousSibling !== null && $previousSibling->nodeName === 'br') ||
-                        ($previousSibling === null && $nextSibling !== null && $nextSibling->nodeName === 'br')
+                        ($nextSibling === null && $previousSibling !== null && $previousSibling->nodeName === 'br')
+                        || ($previousSibling === null && $nextSibling !== null && $nextSibling->nodeName === 'br')
                     ) {
                         $this->plainLinks[] = $plainLink->setIsStandalone($parent, false);
                         continue;
@@ -825,10 +825,10 @@ class HtmlInputNodeProcessor extends AbstractHtmlNodeProcessor
                     //<p>…<br><a href="https://example.com">https://example.com</a><br>…</p>
                     //<p>…<br><u><b><a href="https://example.com">https://example.com</a></b></u><br>…</p>
                     if (
-                        $previousSibling === null && $nextSibling === null ||
-                        (
-                            $previousSibling !== null && $nextSibling !== null &&
-                            $previousSibling->nodeName === 'br' && $nextSibling->nodeName === 'br'
+                        $previousSibling === null && $nextSibling === null
+                        || (
+                            $previousSibling !== null && $nextSibling !== null
+                            && $previousSibling->nodeName === 'br' && $nextSibling->nodeName === 'br'
                         )
                     ) {
                         $this->plainLinks[] = $plainLink->setIsStandalone($parent, false);
@@ -890,6 +890,7 @@ class HtmlInputNodeProcessor extends AbstractHtmlNodeProcessor
             default:
                 return true;
         }
+
         return false;
     }
 }

--- a/wcfsetup/install/files/lib/system/html/input/node/HtmlInputNodeProcessor.class.php
+++ b/wcfsetup/install/files/lib/system/html/input/node/HtmlInputNodeProcessor.class.php
@@ -807,8 +807,8 @@ class HtmlInputNodeProcessor extends AbstractHtmlNodeProcessor
                 }
 
                 if (!$mayContainOtherContent) {
-                    $nextSibling = $this->getNoneEmptyNode($link, 'nextSibling');
-                    $previousSibling = $this->getNoneEmptyNode($link, 'previousSibling');
+                    $nextSibling = $this->getNoneEmptyNode($parentLinkElement, 'nextSibling');
+                    $previousSibling = $this->getNoneEmptyNode($parentLinkElement, 'previousSibling');
 
                     // Check whether the link is at the beginning or end of the paragraph
                     // and whether the next or previous sibling is a line break.

--- a/wcfsetup/install/files/lib/system/html/input/node/HtmlInputNodeProcessor.class.php
+++ b/wcfsetup/install/files/lib/system/html/input/node/HtmlInputNodeProcessor.class.php
@@ -810,10 +810,10 @@ class HtmlInputNodeProcessor extends AbstractHtmlNodeProcessor
                     $nextSibling = $this->getNoneEmptyNode($link, 'nextSibling');
                     $previousSibling = $this->getNoneEmptyNode($link, 'previousSibling');
 
-                    //Check whether the link is at the beginning or end of the paragraph
-                    //and whether the next or previous sibling is a line break.
-                    //<p><a href="https://example.com">https://example.com</a><br>…</p>
-                    //<p>…<br><a href="https://example.com">https://example.com</a></p>
+                    // Check whether the link is at the beginning or end of the paragraph
+                    // and whether the next or previous sibling is a line break.
+                    // <p><a href="https://example.com">https://example.com</a><br>…</p>
+                    // <p>…<br><a href="https://example.com">https://example.com</a></p>
                     if (
                         ($nextSibling === null && $previousSibling !== null && $previousSibling->nodeName === 'br')
                         || ($previousSibling === null && $nextSibling !== null && $nextSibling->nodeName === 'br')
@@ -821,9 +821,9 @@ class HtmlInputNodeProcessor extends AbstractHtmlNodeProcessor
                         $this->plainLinks[] = $plainLink->setIsStandalone($parent, false);
                         continue;
                     }
-                    //If not, the previous and next sibling may be a line break.
-                    //<p>…<br><a href="https://example.com">https://example.com</a><br>…</p>
-                    //<p>…<br><u><b><a href="https://example.com">https://example.com</a></b></u><br>…</p>
+                    // If not, the previous and next sibling may be a line break.
+                    // <p>…<br><a href="https://example.com">https://example.com</a><br>…</p>
+                    // <p>…<br><u><b><a href="https://example.com">https://example.com</a></b></u><br>…</p>
                     if (
                         $previousSibling === null && $nextSibling === null
                         || (

--- a/wcfsetup/install/files/lib/system/html/node/HtmlNodePlainLink.class.php
+++ b/wcfsetup/install/files/lib/system/html/node/HtmlNodePlainLink.class.php
@@ -77,10 +77,10 @@ class HtmlNodePlainLink
     /**
      * Marks the link as standalone, which means that it is the only content in a line.
      *
-     * @param \DOMElement $topLevelParent
+     * @param \DOMElement|null $topLevelParent
      * @return $this
      */
-    public function setIsStandalone(\DOMElement $topLevelParent)
+    public function setIsStandalone(?\DOMElement $topLevelParent = null)
     {
         $this->standalone = true;
         $this->topLevelParent = $topLevelParent;
@@ -171,9 +171,11 @@ class HtmlNodePlainLink
                 throw new \LogicException('Cannot inject a block bbcode in an inline context.');
             }
 
-            // Replace the top level parent with the link itself, which will be replaced with the bbcode afterwards.
-            $this->topLevelParent->parentNode->insertBefore($this->link, $this->topLevelParent);
-            DOMUtil::removeNode($this->topLevelParent);
+            if ($this->topLevelParent !== null) {
+                // Replace the top level parent with the link itself, which will be replaced with the bbcode afterwards.
+                $this->topLevelParent->parentNode->insertBefore($this->link, $this->topLevelParent);
+                DOMUtil::removeNode($this->topLevelParent);
+            }
         }
 
         DOMUtil::replaceElement($this->link, $metacodeElement, false);

--- a/wcfsetup/install/files/lib/system/html/node/HtmlNodePlainLink.class.php
+++ b/wcfsetup/install/files/lib/system/html/node/HtmlNodePlainLink.class.php
@@ -185,7 +185,7 @@ class HtmlNodePlainLink
                 $parent = $this->link;
                 $next = $this->findBr($this->link, 'nextSibling');
                 $previous = $this->findBr($this->link, 'previousSibling');
-                //link inside other elements(u, i, b, …)
+                // Link inside other elements(u, i, b, …)
                 while ($next === null && $previous === null && $parent !== $this->topLevelParent) {
                     $parent = $parent->parentElement;
                     $next = $this->findBr($parent, 'nextSibling');
@@ -207,7 +207,7 @@ class HtmlNodePlainLink
                 }
                 \assert($replaceNode instanceof \DOMElement);
 
-                //remove <br> from start and end of the new block elements
+                // Remove <br> from start and end of the new block elements
                 if ($next !== null) {
                     DOMUtil::removeNode($next);
                 }

--- a/wcfsetup/install/files/lib/system/html/node/HtmlNodeUnfurlLink.class.php
+++ b/wcfsetup/install/files/lib/system/html/node/HtmlNodeUnfurlLink.class.php
@@ -57,6 +57,9 @@ class HtmlNodeUnfurlLink extends HtmlNodePlainLink
 
     private static function removeStyling(HtmlNodePlainLink $element): void
     {
+        if ($element->topLevelParent == null) {
+            return;
+        }
         foreach ($element->topLevelParent->childNodes as $child) {
             DOMUtil::removeNode($child);
         }

--- a/wcfsetup/install/files/lib/system/html/node/HtmlNodeUnfurlLink.class.php
+++ b/wcfsetup/install/files/lib/system/html/node/HtmlNodeUnfurlLink.class.php
@@ -57,7 +57,7 @@ class HtmlNodeUnfurlLink extends HtmlNodePlainLink
 
     private static function removeStyling(HtmlNodePlainLink $element): void
     {
-        if ($element->topLevelParent == null) {
+        if (!$element->aloneInParagraph) {
             return;
         }
         foreach ($element->topLevelParent->childNodes as $child) {


### PR DESCRIPTION
See https://www.woltlab.com/community/thread/304256-unterschiedliche-anzeige-von-thread-verlinkungen-2/

This can handle links that are not inserted in a separate paragraph, but on a line of text with no other content.
For example, this one:
```
<p><a href="https://example.com">https://example.com</a><br>…</p>
<p>…<br><a href="https://example.com">https://example.com</a></p>
<p>…<br><a href="https://example.com">https://example.com</a><br>…</p>
<p>…<br><u><b><a href="https://example.com">https://example.com</a></b></u><br>…</p>
```