### PR TITLE
Fix inconsistent event handling in `woltlab-core-dialog.ts`

### DIFF
--- a/ts/WoltLabSuite/Core/Element/woltlab-core-dialog.ts
+++ b/ts/WoltLabSuite/Core/Element/woltlab-core-dialog.ts
@@ -173,8 +173,10 @@ export class WoltlabCoreDialogElement extends HTMLElement {
       });
       this.dispatchEvent(evt);
 
+      // Canceling this event is interpreted as a form validation failure.
       if (evt.defaultPrevented) {
         event.preventDefault();
+        return;
       }
 
       if (evt.detail.length > 0) {
@@ -203,8 +205,9 @@ export class WoltlabCoreDialogElement extends HTMLElement {
           }
         });
       }
-
-      if (!this.#shouldClose()) {
+      // There were no validation handlers to process, so validation has passed.
+      // By default the browser will close the dialog unless the submit event’s default action gets prevented.
+      else if (!this.#shouldClose()) {
         // Prevent the browser from closing the dialog
         event.preventDefault();
         // but dispatch the `primary` event
@@ -298,8 +301,7 @@ export class WoltlabCoreDialogElement extends HTMLElement {
 
       if (this.#shouldClose()) {
         this.#detachDialog();
-      }
-      else {
+      } else {
         // Prevent the browser from closing the dialog.
         event.preventDefault();
       }

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Element/woltlab-core-dialog.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Element/woltlab-core-dialog.js
@@ -143,9 +143,17 @@ define(["require", "exports", "tslib", "../Dom/Util", "../Helper/PageOverlay", "
                             // has completed. Triggering the submit again would cause
                             // `validate` to run again, causing an infinite loop.
                             this.#dispatchPrimaryEvent();
-                            this.close();
+                            if (this.#shouldClose()) {
+                                this.close();
+                            }
                         }
                     });
+                }
+                if (!this.#shouldClose()) {
+                    // Prevent the browser from closing the dialog
+                    event.preventDefault();
+                    // but dispatch the `primary` event
+                    this.#dispatchPrimaryEvent();
                 }
             });
             this.#dialog.addEventListener("close", () => {
@@ -160,7 +168,7 @@ define(["require", "exports", "tslib", "../Dom/Util", "../Helper/PageOverlay", "
             formControl.addEventListener("cancel", () => {
                 const event = new CustomEvent("cancel", { cancelable: true });
                 this.dispatchEvent(event);
-                if (!event.defaultPrevented) {
+                if (!event.defaultPrevented && this.#shouldClose()) {
                     this.close();
                 }
             });
@@ -187,7 +195,9 @@ define(["require", "exports", "tslib", "../Dom/Util", "../Helper/PageOverlay", "
                 closeButton.classList.add("dialog__closeButton", "jsTooltip");
                 closeButton.title = Language.get("wcf.dialog.button.close");
                 closeButton.addEventListener("click", () => {
-                    this.close();
+                    if (this.#shouldClose()) {
+                        this.close();
+                    }
                 });
             }
             const header = document.createElement("div");
@@ -211,10 +221,20 @@ define(["require", "exports", "tslib", "../Dom/Util", "../Helper/PageOverlay", "
             this.#dialog.append(doc);
             this.#dialog.classList.add("dialog");
             this.#dialog.setAttribute("aria-labelledby", Util_1.default.identify(this.#title));
-            this.#dialog.addEventListener("cancel", () => {
-                const event = new CustomEvent("cancel");
-                this.dispatchEvent(event);
-                this.#detachDialog();
+            this.#dialog.addEventListener("cancel", (event) => {
+                const evt = new CustomEvent("cancel", { cancelable: true });
+                this.dispatchEvent(evt);
+                if (evt.defaultPrevented) {
+                    event.preventDefault();
+                    return;
+                }
+                if (this.#shouldClose()) {
+                    this.#detachDialog();
+                }
+                else {
+                    // Prevent the browser from closing the dialog.
+                    event.preventDefault();
+                }
             });
             // Close the dialog by clicking on the backdrop.
             //
@@ -223,9 +243,9 @@ define(["require", "exports", "tslib", "../Dom/Util", "../Helper/PageOverlay", "
             // dialog and then releasing it on the backdrop.
             this.#dialog.addEventListener("mousedown", (event) => {
                 if (event.target === this.#dialog) {
-                    const event = new CustomEvent("backdrop", { cancelable: true });
-                    this.dispatchEvent(event);
-                    if (event.defaultPrevented) {
+                    const evt = new CustomEvent("backdrop", { cancelable: true });
+                    this.dispatchEvent(evt);
+                    if (evt.defaultPrevented) {
                         return;
                     }
                     if (this.#shouldClose()) {
@@ -236,7 +256,7 @@ define(["require", "exports", "tslib", "../Dom/Util", "../Helper/PageOverlay", "
             this.append(this.#dialog);
         }
         #shouldClose() {
-            const event = new CustomEvent("close");
+            const event = new CustomEvent("close", { cancelable: true });
             this.dispatchEvent(event);
             return event.defaultPrevented === false;
         }

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Element/woltlab-core-dialog.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Element/woltlab-core-dialog.js
@@ -124,8 +124,10 @@ define(["require", "exports", "tslib", "../Dom/Util", "../Helper/PageOverlay", "
                     detail: callbacks,
                 });
                 this.dispatchEvent(evt);
+                // Canceling this event is interpreted as a form validation failure.
                 if (evt.defaultPrevented) {
                     event.preventDefault();
+                    return;
                 }
                 if (evt.detail.length > 0) {
                     // DOM events cannot wait for async functions. We must
@@ -149,7 +151,9 @@ define(["require", "exports", "tslib", "../Dom/Util", "../Helper/PageOverlay", "
                         }
                     });
                 }
-                if (!this.#shouldClose()) {
+                // There were no validation handlers to process, so validation has passed.
+                // By default the browser will close the dialog unless the submit event’s default action gets prevented.
+                else if (!this.#shouldClose()) {
                     // Prevent the browser from closing the dialog
                     event.preventDefault();
                     // but dispatch the `primary` event


### PR DESCRIPTION
Previously some events that should have been cancelable were not.
The [documentation](https://docs.woltlab.com/6.0/javascript/components_dialog/#event-access) says that `close`, `cancel` and `validate` can be canceled. (the documentation also misses the cancelable `backdrop` event)

I hope I tested all the event combinations / dialog options, but it’s possible I missed some edge cases. :worried: 

Summary of the changes:
- if `validate` failed it unconditionally closed the dialog, not emitting the `close` event, now it does and checks the event state
- if `validate` has no callbacks attached the `close` event gets emitted and if the dialog should not be closed the `primary` event is emitted manually
- the `cancel` form button did not emit the `close` event, now it does and checks the event state
- the `closeButton` unconditionally closed the dialog, not emitting the `close` event, now it does and checks the event state
- the dialog’s native `cancel` event (emitted for example when a user presses the `Escape` key or clicks on the backdrop) unconditionally closed the dialog while emitting a non-cancelable `cancel` event. Now the custom `cancel` event is cancelable, like the `cancel` form button event, and the event state is being checked.
- the custom `close` event used to check whether the dialog should be closed by checking the `event.defaultPrevented` property was in fact not cancelable, now it is

Note: The `backdrop` event is cancelable but does not have any effect in Firefox and Chromium. `event.preventDefault()` and `event.stopPropagation()` on the `mousedown` event did not have any effect and the browser still emitted the `cancel` event on the native dialog element.