### PR TITLE
Change the order of the buttons in the ckeditor link form dialog box

### DIFF
--- a/wcfsetup/install/files/style/ui/ckeditor.scss
+++ b/wcfsetup/install/files/style/ui/ckeditor.scss
@@ -624,3 +624,17 @@ html.iOS {
 		font-size: 16px;
 	}
 }
+
+.ck-link-form {
+  .ck-labeled-field-view {
+    order: 0;
+  }
+
+  .ck-button-cancel {
+    order: 1;
+  }
+
+  .ck-button-save {
+    order: 2;
+  }
+}


### PR DESCRIPTION
See: https://www.woltlab.com/community/thread/304335-ckeditor-reihenfolge-der-buttons-im-link-dialog-anpassen/