### PR TITLE
Disable implicit delete of attachments for signature

### DIFF
--- a/wcfsetup/install/files/js/WCF.Attachment.js
+++ b/wcfsetup/install/files/js/WCF.Attachment.js
@@ -118,6 +118,11 @@ WCF.Attachment.Upload = WCF.Upload.extend({
 				{ listenToCkeditor },
 			) => {
 				const discardAllAttachments = () => {
+					// Disable the implicit deletion of signature attachments.
+					if (objectType === "com.woltlab.wcf.user.signature") {
+						return;
+					}
+
 					this._fileListSelector[0]
 							.querySelectorAll('li:not(.uploadFailed) .jsObjectAction[data-object-action="delete"]')
 							.forEach((button) => {


### PR DESCRIPTION
See: https://www.woltlab.com/community/thread/304178-signatur-dateianhang-verschwindet-beim-speichern-oder-andere-komische-effekte/