### PR TITLE
Introduce the `unsafe` keyword for the raw output of variables

### DIFF
--- a/wcfsetup/install/files/lib/system/template/TemplateScriptingCompiler.class.php
+++ b/wcfsetup/install/files/lib/system/template/TemplateScriptingCompiler.class.php
@@ -1352,6 +1352,8 @@ class TemplateScriptingCompiler
         $formatNumeric = false;
         if ($tag[0] == '@') {
             $tag = \mb_substr($tag, 1);
+        } elseif (\str_starts_with($tag, 'unsafe:')) {
+            $tag = \mb_substr($tag, 7);
         } elseif ($tag[0] == '#') {
             $tag = \mb_substr($tag, 1);
             $formatNumeric = true;
@@ -1901,7 +1903,7 @@ class TemplateScriptingCompiler
         $this->quotePattern = '(?:' . $this->doubleQuotePattern . '|' . $this->singleQuotePattern . ')';
         $this->numericPattern = '(?i)(?:(?:\-?\d+(?:\.\d+)?)|true|false|null)';
         $this->simpleVarPattern = '(?:\$(' . $this->validVarnamePattern . '))';
-        $this->outputPattern = '(?:(?:@|#)?(?:' . $this->constantPattern . '|' . $this->quotePattern . '|' . $this->numericPattern . '|' . $this->simpleVarPattern . '|\())';
+        $this->outputPattern = '(?:(?:@|#|unsafe:)?(?:' . $this->constantPattern . '|' . $this->quotePattern . '|' . $this->numericPattern . '|' . $this->simpleVarPattern . '|\())';
     }
 
     /**


### PR DESCRIPTION
The new syntax should make it clearer that the raw output is potentially dangerous and should only be used with caution.