### PR TITLE
Add a check that `variables_order` has `ENV` active

### DIFF
--- a/wcfsetup/install/files/lib/system/cli/command/WorkerCLICommand.class.php
+++ b/wcfsetup/install/files/lib/system/cli/command/WorkerCLICommand.class.php
@@ -137,6 +137,12 @@ class WorkerCLICommand implements ICLICommand
 
                 return;
             }
+            if (!\str_contains(\ini_get('variables_order'), 'E')) {
+                CLIWCF::getReader()->println(CLIWCF::getLanguage()->get('wcf.cli.worker.threads.variables_order'));
+
+                return;
+            }
+
             $this->spawnController($worker, $threads);
 
             return;

--- a/wcfsetup/install/lang/de.xml
+++ b/wcfsetup/install/lang/de.xml
@@ -3439,6 +3439,7 @@ Erlaubte Dateiendungen: {', '|implode:$attachmentHandler->getFormattedAllowedExt
 		<item name="wcf.cli.worker.list"><![CDATA[Listet alle Worker auf.]]></item>
 		<item name="wcf.cli.worker.threads"><![CDATA[Gewünschte Anzahl von parallelen Prozessen.]]></item>
 		<item name="wcf.cli.worker.threads.windows"><![CDATA[Die parallele Verarbeitung mittels --threads steht unter Windows nicht zur Verfügung.]]></item>
+		<item name="wcf.cli.worker.threads.variables_order"><![CDATA[Für die parallele Verarbeitung mittels --threads wird in der php.ini für "variables_order" der Wert "EGPCS" benötigt.]]></item>
 		<item name="wcf.cli.worker.threadId"><![CDATA[Gibt die Thread-ID während einer parallelen Verarbeitung an. Wird intern genutzt, wenn --threads gesetzt ist.]]></item>
 		<item name="wcf.cli.worker.threadId.invalid"><![CDATA[Die angegebene Thread-ID ist ungültig.]]></item>
 		<item name="wcf.cli.error.command.notFound"><![CDATA[Der Befehl "{$command}" konnte nicht gefunden werden.]]></item>

--- a/wcfsetup/install/lang/en.xml
+++ b/wcfsetup/install/lang/en.xml
@@ -3364,6 +3364,7 @@ Allowed extensions: {', '|implode:$attachmentHandler->getFormattedAllowedExtensi
 		<item name="wcf.cli.worker.list"><![CDATA[Lists all workers.]]></item>
 		<item name="wcf.cli.worker.threads"><![CDATA[Requested number of parallel processes.]]></item>
 		<item name="wcf.cli.worker.threads.windows"><![CDATA[Parallel processing using --threads is not available on Windows.]]></item>
+		<item name="wcf.cli.worker.threads.variables_order"><![CDATA[For parallel processing using --threads, the value "EGPCS" is required for "variables_order" in php.ini.]]></item>
 		<item name="wcf.cli.worker.threadId"><![CDATA[Specifies the thread id when processing in parallel. Used internally when --threads is given.]]></item>
 		<item name="wcf.cli.worker.threadId.invalid"><![CDATA[The entered thread id is not valid.]]></item>
 		<item name="wcf.cli.error.command.notFound"><![CDATA[The command "{$command}" could not be found.]]></item>


### PR DESCRIPTION
See https://www.woltlab.com/community/thread/304558-worker-threads-sterben-direkt/