### PR TITLE
Add missing `dropdown` class

### DIFF
--- a/ts/WoltLabSuite/Core/Controller/Clipboard.ts
+++ b/ts/WoltLabSuite/Core/Controller/Clipboard.ts
@@ -496,6 +496,7 @@ class ControllerClipboard {
           UiPageAction.show(actionName);
         } else {
           UiPageAction.add(actionName, editor);
+          created = true;
         }
       }
 

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Controller/Clipboard.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Controller/Clipboard.js
@@ -411,6 +411,7 @@ define(["require", "exports", "tslib", "../Ajax", "../Core", "../Dom/Change/List
                     }
                     else {
                         UiPageAction.add(actionName, editor);
+                        created = true;
                     }
                 }
                 if (created) {


### PR DESCRIPTION
See https://www.woltlab.com/community/thread/304725-fehlende-klasse-bei-page-actions/

Make sure the `dropdown` class is added to the button. This was not done when the editor was already created but had zero elements.