### PR TITLE
Add minlength and maxlength elements to option.xsd

### DIFF
--- a/XSD/option.xsd
+++ b/XSD/option.xsd
@@ -72,6 +72,8 @@
 					<xs:element name="suffix" type="xs:string" minOccurs="0" />
 					<xs:element name="minvalue" type="xs:int" minOccurs="0" />
 					<xs:element name="maxvalue" type="xs:int" minOccurs="0" />
+					<xs:element name="minlength" type="xs:int" minOccurs="0" />
+					<xs:element name="maxlength" type="xs:int" minOccurs="0" />
 				</xs:all>
 			</xs:extension>
 		</xs:complexContent>


### PR DESCRIPTION
Please see https://github.com/WoltLab/WCF/issues/5809 aswell. Maybe some more changes can be added to this PR.

Currently, the schema file for the option-pip does not recognize `minlength` and `maxlength` for options of type text, which is probably used quite frequently. Technically, this can be picked for 5.4/5.5/6.0 aswell.

![Nudibranch092](https://github.com/WoltLab/WCF/assets/11349966/f6b5c213-8c23-471d-9268-8a1221f00358)