### PR TITLE
Unique background job

### DIFF
--- a/wcfsetup/install/files/acp/database/update_com.woltlab.wcf_6.1.php
+++ b/wcfsetup/install/files/acp/database/update_com.woltlab.wcf_6.1.php
@@ -11,6 +11,7 @@
 use wcf\system\database\table\column\DefaultFalseBooleanDatabaseTableColumn;
 use wcf\system\database\table\column\NotNullInt10DatabaseTableColumn;
 use wcf\system\database\table\column\NotNullVarchar191DatabaseTableColumn;
+use wcf\system\database\table\column\VarcharDatabaseTableColumn;
 use wcf\system\database\table\DatabaseTable;
 use wcf\system\database\table\index\DatabaseTableForeignKey;
 use wcf\system\database\table\index\DatabaseTableIndex;
@@ -41,5 +42,15 @@ return [
             DatabaseTableIndex::create('messageEmbeddedObject')
                 ->type(DatabaseTableIndex::UNIQUE_TYPE)
                 ->columns(['messageObjectTypeID', 'messageID', 'embeddedObjectTypeID', 'embeddedObjectID']),
+        ]),
+    PartialDatabaseTable::create('wcf1_background_job')
+        ->columns([
+            VarcharDatabaseTableColumn::create('identifier')
+                ->length(191)
+                ->defaultValue(null),
+        ])
+        ->indices([
+            DatabaseTableIndex::create('identifier')
+                ->columns(['identifier']),
         ])
 ];

--- a/wcfsetup/install/files/lib/system/background/BackgroundQueueHandler.class.php
+++ b/wcfsetup/install/files/lib/system/background/BackgroundQueueHandler.class.php
@@ -104,9 +104,9 @@ final class BackgroundQueueHandler extends SingletonFactory
                 }
 
                 $statement->execute([
-                \serialize($job),
-                $time,
-                $identifier
+                    \serialize($job),
+                    $time,
+                    $identifier
                 ]);
             }
             WCF::getDB()->commitTransaction();
@@ -239,6 +239,9 @@ final class BackgroundQueueHandler extends SingletonFactory
                     WHERE       jobID = ?";
             $statement = WCF::getDB()->prepare($sql);
             $statement->execute([$row['jobID']]);
+        }
+        if ($job instanceof AbstractUniqueBackgroundJob && $job->queueAgain()) {
+            $this->enqueueIn($job->newInstance(), $job->retryAfter());
         }
 
         return true;

--- a/wcfsetup/install/files/lib/system/background/job/AbstractUniqueBackgroundJob.class.php
+++ b/wcfsetup/install/files/lib/system/background/job/AbstractUniqueBackgroundJob.class.php
@@ -2,8 +2,6 @@
 
 namespace wcf\system\background\job;
 
-use wcf\system\background\BackgroundQueueHandler;
-
 /**
  * @author      Olaf Braun
  * @copyright   2001-2024 WoltLab GmbH
@@ -27,32 +25,35 @@ abstract class AbstractUniqueBackgroundJob extends AbstractBackgroundJob
         return static::class;
     }
 
-    #[\Override]
-    final public function perform()
-    {
-        $this->run();
-        if ($this->requeue()) {
-            BackgroundQueueHandler::getInstance()->enqueueIn($this);
-        }
-    }
-
     /**
-     * Runs the job.
+     * Returns a new instance of this job to be queued again.
+     * This will reset the fail counter.
+     *
+     * @return AbstractUniqueBackgroundJob
      */
-    abstract protected function run(): void;
+    public function newInstance(): AbstractUniqueBackgroundJob
+    {
+        return new static();
+    }
 
     /**
      * Returns whether this job should be queued again because it has more to do.
      *
      * @return bool
      */
-    abstract protected function requeue(): bool;
+    abstract public function queueAgain(): bool;
 
     #[\Override]
     final public function onFinalFailure()
     {
-        if ($this->requeue()) {
-            BackgroundQueueHandler::getInstance()->enqueueIn($this, $this->retryAfter());
-        }
+        // onFailure() and onFinalFailure() are called at the same time.
+        // Do your stuff in onFailure().
+    }
+
+    #[\Override]
+    public function retryAfter()
+    {
+        // change the default value to 60 seconds
+        return 60;
     }
 }

--- a/wcfsetup/install/files/lib/system/background/job/AbstractUniqueBackgroundJob.class.php
+++ b/wcfsetup/install/files/lib/system/background/job/AbstractUniqueBackgroundJob.class.php
@@ -15,7 +15,7 @@ abstract class AbstractUniqueBackgroundJob extends AbstractBackgroundJob
     /**
      * @inheritDoc
      */
-    final public const MAX_FAILURES = 1;
+    final public const MAX_FAILURES = 0;
 
     /**
      * Returns a unique identifier for this job.

--- a/wcfsetup/install/files/lib/system/background/job/AbstractUniqueBackgroundJob.class.php
+++ b/wcfsetup/install/files/lib/system/background/job/AbstractUniqueBackgroundJob.class.php
@@ -31,10 +31,8 @@ abstract class AbstractUniqueBackgroundJob extends AbstractBackgroundJob
     /**
      * Returns a new instance of this job to be queued again.
      * This will reset the fail counter.
-     *
-     * @return AbstractUniqueBackgroundJob
      */
-    public function newInstance(): AbstractUniqueBackgroundJob
+    public function newInstance(): static
     {
         return new static();
     }

--- a/wcfsetup/install/files/lib/system/background/job/AbstractUniqueBackgroundJob.class.php
+++ b/wcfsetup/install/files/lib/system/background/job/AbstractUniqueBackgroundJob.class.php
@@ -37,8 +37,6 @@ abstract class AbstractUniqueBackgroundJob extends AbstractBackgroundJob
 
     /**
      * Returns whether this job should be queued again because it has more to do.
-     *
-     * @return bool
      */
     abstract public function queueAgain(): bool;
 

--- a/wcfsetup/install/files/lib/system/background/job/AbstractUniqueBackgroundJob.class.php
+++ b/wcfsetup/install/files/lib/system/background/job/AbstractUniqueBackgroundJob.class.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace wcf\system\background\job;
+
+use wcf\system\background\BackgroundQueueHandler;
+
+/**
+ * @author      Olaf Braun
+ * @copyright   2001-2024 WoltLab GmbH
+ * @license     GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @since       6.1
+ */
+abstract class AbstractUniqueBackgroundJob extends AbstractBackgroundJob
+{
+    /**
+     * @inheritDoc
+     */
+    final public const MAX_FAILURES = 1;
+
+    /**
+     * Returns a unique identifier for this job.
+     *
+     * @return string
+     */
+    public function identifier(): string
+    {
+        return static::class;
+    }
+
+    #[\Override]
+    final public function perform()
+    {
+        $this->run();
+        if ($this->requeue()) {
+            BackgroundQueueHandler::getInstance()->enqueueIn($this);
+        }
+    }
+
+    /**
+     * Runs the job.
+     */
+    abstract protected function run(): void;
+
+    /**
+     * Returns whether this job should be queued again because it has more to do.
+     *
+     * @return bool
+     */
+    abstract protected function requeue(): bool;
+
+    #[\Override]
+    final public function onFinalFailure()
+    {
+        if ($this->requeue()) {
+            BackgroundQueueHandler::getInstance()->enqueueIn($this, $this->retryAfter());
+        }
+    }
+}

--- a/wcfsetup/install/files/lib/system/background/job/AbstractUniqueBackgroundJob.class.php
+++ b/wcfsetup/install/files/lib/system/background/job/AbstractUniqueBackgroundJob.class.php
@@ -20,8 +20,6 @@ abstract class AbstractUniqueBackgroundJob extends AbstractBackgroundJob
 
     /**
      * Returns a unique identifier for this job.
-     *
-     * @return string
      */
     public function identifier(): string
     {

--- a/wcfsetup/install/files/lib/system/background/job/AbstractUniqueBackgroundJob.class.php
+++ b/wcfsetup/install/files/lib/system/background/job/AbstractUniqueBackgroundJob.class.php
@@ -3,6 +3,9 @@
 namespace wcf\system\background\job;
 
 /**
+ * This background job is only queued once
+ * and is requeued when it has more work to do.
+ *
  * @author      Olaf Braun
  * @copyright   2001-2024 WoltLab GmbH
  * @license     GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>

--- a/wcfsetup/install/files/lib/system/cronjob/BackgroundQueueCleanUpCronjob.class.php
+++ b/wcfsetup/install/files/lib/system/cronjob/BackgroundQueueCleanUpCronjob.class.php
@@ -52,6 +52,8 @@ class BackgroundQueueCleanUpCronjob extends AbstractCronjob
 
                         if ($job->getFailures() <= $job::MAX_FAILURES) {
                             BackgroundQueueHandler::getInstance()->enqueueIn($job, $job->retryAfter());
+                        } else {
+                            $job->onFinalFailure();
                         }
                     }
                 } catch (\Exception $e) {

--- a/wcfsetup/install/files/lib/system/cronjob/BackgroundQueueCleanUpCronjob.class.php
+++ b/wcfsetup/install/files/lib/system/cronjob/BackgroundQueueCleanUpCronjob.class.php
@@ -4,6 +4,7 @@ namespace wcf\system\cronjob;
 
 use wcf\data\cronjob\Cronjob;
 use wcf\system\background\BackgroundQueueHandler;
+use wcf\system\background\job\AbstractUniqueBackgroundJob;
 use wcf\system\database\util\PreparedStatementConditionBuilder;
 use wcf\system\WCF;
 
@@ -27,6 +28,8 @@ class BackgroundQueueCleanUpCronjob extends AbstractCronjob
         WCF::getDB()->beginTransaction();
         /** @noinspection PhpUnusedLocalVariableInspection */
         $committed = false;
+        /** @var AbstractUniqueBackgroundJob[] $uniqueJobs */
+        $uniqueJobs = [];
         try {
             $sql = "SELECT      jobID, job
                     FROM        wcf" . WCF_N . "_background_job
@@ -54,6 +57,10 @@ class BackgroundQueueCleanUpCronjob extends AbstractCronjob
                             BackgroundQueueHandler::getInstance()->enqueueIn($job, $job->retryAfter());
                         } else {
                             $job->onFinalFailure();
+
+                            if ($job instanceof AbstractUniqueBackgroundJob) {
+                                $uniqueJobs[] = $job;
+                            }
                         }
                     }
                 } catch (\Exception $e) {
@@ -82,6 +89,13 @@ class BackgroundQueueCleanUpCronjob extends AbstractCronjob
         } finally {
             if (!$committed) {
                 WCF::getDB()->rollBackTransaction();
+            }
+        }
+
+        // Requeue unique jobs if needed
+        foreach ($uniqueJobs as $job) {
+            if ($job->queueAgain()) {
+                BackgroundQueueHandler::getInstance()->enqueueIn($job->newInstance(), $job->retryAfter());
             }
         }
     }

--- a/wcfsetup/setup/db/install.sql
+++ b/wcfsetup/setup/db/install.sql
@@ -234,6 +234,9 @@ CREATE TABLE wcf1_background_job (
 	job MEDIUMBLOB NOT NULL,
 	status ENUM('ready', 'processing') NOT NULL DEFAULT 'ready',
 	time INT(10) NOT NULL,
+	identifier VARCHAR(191) NULL,
+
+	KEY identifier (identifier),
 	KEY (status, time)
 );
 


### PR DESCRIPTION
Background jobs can be marked as "unique".
These background jobs can only exist once in the database to avoid blocking the background queue with too many jobs.

These jobs are automatically requeued when there is more work to do.