### PR TITLE
Optimize IP Address Pruning Process

### DIFF
--- a/wcfsetup/install/files/lib/system/cronjob/PruneIpAddressesCronjob.class.php
+++ b/wcfsetup/install/files/lib/system/cronjob/PruneIpAddressesCronjob.class.php
@@ -43,11 +43,13 @@ class PruneIpAddressesCronjob extends AbstractCronjob
             foreach ($columnData as $ipAddressColumn => $timestampColumn) {
                 $sql = "UPDATE  {$tableName}
                         SET     {$ipAddressColumn} = ?
-                        WHERE   {$timestampColumn} <= ?";
+                        WHERE   {$timestampColumn} <= ?
+                            AND {$ipAddressColumn} <> ?";
                 $statement = WCF::getDB()->prepareStatement($sql);
                 $statement->execute([
                     '',
                     TIME_NOW - 86400 * PRUNE_IP_ADDRESS, // 86400 = 1 day
+                    '',
                 ]);
             }
         }


### PR DESCRIPTION
Currently, when pruning IP addresses, each row within the database tables is examined, including those that have already been processed. This approach can significantly slow down queries in large communities. To enhance efficiency, it is proposed that rows with already processed (empty) IP addresses be excluded from further processing.

This PR optimizes the IP address pruning process by excluding rows where the IP address has already been cleared, thereby reducing unnecessary database query processing.

```json
{
	"table": "wbb1_post",
	"rows":
	[
		{
			"id": 1,
			"select_type": "UPDATE",
			"table": "wbb1_post",
			"partitions": null,
			"type": "index",
			"possible_keys": null,
			"key": "PRIMARY",
			"key_len": "4",
			"ref": null,
			"rows": 8672069,
			"filtered": 100.00,
			"Extra": "Using where"
		}
	]
}
```

vs.

```json
{
	"table": "wbb1_post",
	"rows":
	[
		{
			"id": 1,
			"select_type": "UPDATE",
			"table": "wbb1_post",
			"partitions": null,
			"type": "range",
			"possible_keys": "ipAddress",
			"key": "ipAddress",
			"key_len": "158",
			"ref": "const",
			"rows": 84463,
			"filtered": 100.00,
			"Extra": "Using where; Using temporary"
		}
	]
}
```