### PR TITLE
Fix `userMenuItemSingleLine` icons

### DIFF
--- a/wcfsetup/install/files/style/ui/userMenu.scss
+++ b/wcfsetup/install/files/style/ui/userMenu.scss
@@ -148,6 +148,10 @@ html:not(.touch) .userMenuButton {
 		.userMenuItemContent {
 			align-self: center;
 		}
+
+		.userMenuItemImage :is(fa-brand, fa-icon) {
+			left: 0;
+		}
 	}
 
 	&.userMenuItemWithUsernames {


### PR DESCRIPTION
See https://www.woltlab.com/community/thread/304949-icons-in-userpanel-kleben-am-rand-seit-version-6-0-9/