### PR TITLE
Fix obsolete 'caret-down' icon in menus

### DIFF
--- a/com.woltlab.wcf/templates/__menu.tpl
+++ b/com.woltlab.wcf/templates/__menu.tpl
@@ -9,7 +9,7 @@
 					{if $menuItemNode->getOutstandingItems() > 0}
 						<span class="boxMenuLinkOutstandingItems badge badgeUpdate" aria-label="{lang}wcf.page.menu.outstandingItems{/lang}">{#$menuItemNode->getOutstandingItems()}</span>
 					{/if}
-					{if $menuItemNode->hasChildren()}
+					{if $menuIdentifier == 'com.woltlab.wcf.MainMenu' && $menuItemNode->hasChildren() && $menuItemNode->getDepth() == 1}
 						{icon name='caret-down' type='solid'}
 					{/if}
 				</a>

--- a/wcfsetup/install/files/lib/data/menu/Menu.class.php
+++ b/wcfsetup/install/files/lib/data/menu/Menu.class.php
@@ -89,6 +89,7 @@ class Menu extends DatabaseObject implements ITitledObject
         WCF::getTPL()->assign([
             'menuItemNodeList' => $this->getMenuItemNodeList(),
             'menuTitle' => $this->getTitle(),
+            'menuIdentifier' => $this->identifier,
         ]);
 
         return WCF::getTPL()->fetch('__menu');


### PR DESCRIPTION
The icon was incorrectly shown in all menus and all levels.