### PR TITLE
Delete orphaned moderation queue comment notifications

### DIFF
--- a/wcfsetup/install/files/lib/system/user/notification/event/ModerationQueueCommentUserNotificationEvent.class.php
+++ b/wcfsetup/install/files/lib/system/user/notification/event/ModerationQueueCommentUserNotificationEvent.class.php
@@ -55,6 +55,9 @@ class ModerationQueueCommentUserNotificationEvent extends AbstractCommentUserNot
         if (!WCF::getSession()->getPermission('mod.general.canUseModeration')) {
             return false;
         }
+        if (!$this->moderationQueue->queueID) {
+            return false;
+        }
 
         return $this->moderationQueue->canEdit();
     }
@@ -143,6 +146,9 @@ class ModerationQueueCommentUserNotificationEvent extends AbstractCommentUserNot
         $this->moderationQueue = new ViewableModerationQueue(
             new ModerationQueue($this->getUserNotificationObject()->objectID)
         );
+        if (!$this->moderationQueue->queueID) {
+            return;
+        }
 
         /** @var IModerationQueueHandler $moderationHandler */
         $moderationHandler = ObjectTypeCache::getInstance()


### PR DESCRIPTION
See https://www.woltlab.com/community/thread/305204-moderatoren-erhalten-call-to-a-member-function-getprocessor-on-null-fehler/
Closes https://github.com/WoltLab/WCF/issues/5829