### PR TITLE
Migrate user mail form to formbuilder form

### DIFF
--- a/wcfsetup/install/files/acp/templates/userMail.tpl
+++ b/wcfsetup/install/files/acp/templates/userMail.tpl
@@ -10,15 +10,15 @@
 
 {if $mailID|isset}
 	<script data-relocate="true">
-		require(['Language', 'WoltLabSuite/Core/Acp/Ui/Worker'], function (Language, AcpUiWorker) {
-			Language.add('wcf.acp.worker.abort.confirmMessage', '{jslang}wcf.acp.worker.abort.confirmMessage{/jslang}');
+		require(['WoltLabSuite/Core/Acp/Ui/Worker'], (AcpUiWorker) => {
+			{jsphrase name='wcf.acp.worker.abort.confirmMessage'}
 			
 			new AcpUiWorker({
 				dialogId: 'mail',
 				dialogTitle: '{jslang}{$pageTitle}{/jslang}',
 				className: 'wcf\\system\\worker\\MailWorker',
 				parameters: {
-					mailID: {@$mailID},
+					mailID: {$mailID},
 				},
 			});
 		});
@@ -27,141 +27,10 @@
 
 <header class="contentHeader">
 	<div class="contentHeaderTitle">
-		<h1 class="contentTitle">{lang}{@$pageTitle}{/lang}</h1>
+		<h1 class="contentTitle">{lang}{$pageTitle}{/lang}</h1>
 	</div>
-	
-	<nav class="contentHeaderNavigation">
-		<ul>
-			<li><a href="{link controller='UserList'}{/link}" class="button">{icon name='list'} <span>{lang}wcf.acp.menu.link.user.list{/lang}</span></a></li>
-			<li><a href="{link controller='UserSearch'}{/link}" class="button">{icon name='magnifying-glass'} <span>{lang}wcf.acp.user.search{/lang}</span></a></li>
-			
-			{event name='contentHeaderNavigation'}
-		</ul>
-	</nav>
 </header>
 
-{include file='shared_formError'}
-
-<form method="post" action="{link controller='UserMail'}{/link}">
-	{if $action == ''}
-		<section class="section">
-			<h2 class="sectionTitle">{lang}wcf.acp.user.sendMail.markedUsers{/lang}</h2>
-			
-			<div>
-				{implode from=$userList item=$user}<a href="{link controller='UserEdit' id=$user->userID}{/link}">{$user}</a>{/implode}
-			</div>
-			
-			{event name='markedUserFields'}
-		</section>
-	{/if}
-	
-	{if $action == 'group'}
-		<section class="section">
-			<h2 class="sectionTitle">{lang}wcf.acp.user.sendMail.groups{/lang}</h2>
-			
-			<dl{if $errorField == 'groupIDs'} class="formError"{/if}>
-				<dd>
-					{htmlCheckboxes options=$groups name=groupIDs selected=$groupIDs}
-					{if $errorField == 'groupIDs'}
-						<small class="innerError">
-							{if $errorType == 'empty'}
-								{lang}wcf.global.form.error.empty{/lang}
-							{else}
-								{lang}wcf.acp.user.sendMail.groups.error.{@$errorType}{/lang}
-							{/if}
-						</small>
-					{/if}
-				</dd>
-			</dl>
-			
-			{event name='userGroupFields'}
-		</section>
-	{/if}
-	
-	<section class="section">
-		<h2 class="sectionTitle">{lang}wcf.acp.user.sendMail.mail{/lang}</h2>
-		
-		<dl{if $errorField == 'subject'} class="formError"{/if}>
-			<dt><label for="subject">{lang}wcf.acp.user.sendMail.subject{/lang}</label></dt>
-			<dd>
-				<input type="text" id="subject" name="subject" value="{$subject}" autofocus class="long">
-				{if $errorField == 'subject'}
-					<small class="innerError">
-						{if $errorType == 'empty'}
-							{lang}wcf.global.form.error.empty{/lang}
-						{else}
-							{lang}wcf.acp.user.sendMail.subject.error.{@$errorType}{/lang}
-						{/if}
-					</small>
-				{/if}
-			</dd>
-		</dl>
-		
-		<dl{if $errorField == 'fromName'} class="formError"{/if}>
-			<dt><label for="fromName">{lang}wcf.acp.user.sendMail.fromName{/lang}</label></dt>
-			<dd>
-				<input type="text" id="fromName" name="fromName" value="{$fromName}" class="long">
-				{if $errorField == 'fromName'}
-					<small class="innerError">
-						{lang}wcf.acp.user.sendMail.subject.fromName.{@$errorType}{/lang}
-					</small>
-				{/if}
-			</dd>
-		</dl>
-		
-		<dl{if $errorField == 'from'} class="formError"{/if}>
-			<dt><label for="from">{lang}wcf.acp.user.sendMail.from{/lang}</label></dt>
-			<dd>
-				<input type="text" id="from" name="from" value="{$from}" class="long">
-				{if $errorField == 'from'}
-					<small class="innerError">
-						{if $errorType == 'empty'}
-							{lang}wcf.global.form.error.empty{/lang}
-						{elseif $errorType == 'invalid'}
-							{lang}wcf.user.email.error.invalid{/lang}
-						{else}
-							{lang}wcf.acp.user.sendMail.subject.from.{@$errorType}{/lang}
-						{/if}
-					</small>
-				{/if}
-				<small>{lang}wcf.acp.user.sendMail.from.description{/lang}</small>
-			</dd>
-		</dl>
-		
-		<dl{if $errorField == 'text'} class="formError"{/if}>
-			<dt><label for="text">{lang}wcf.acp.user.sendMail.text{/lang}</label></dt>
-			<dd>
-				<textarea id="text" name="text" rows="15" cols="40" class="long">{$text}</textarea>
-				{if $errorField == 'text'}
-					<small class="innerError">
-						{if $errorType == 'empty'}
-							{lang}wcf.global.form.error.empty{/lang}
-						{else}
-							{lang}wcf.acp.user.sendMail.text.error.{@$errorType}{/lang}
-						{/if}
-					</small>
-				{/if}
-			</dd>
-		</dl>
-		
-		<dl>
-			<dt></dt>
-			<dd>
-				<label><input type="checkbox" id="enableHTML" name="enableHTML" {if $enableHTML == 1}checked {/if}value="1"> {lang}wcf.acp.user.sendMail.enableHTML{/lang}</label>
-			</dd>
-		</dl>
-		
-		{event name='mailFields'}
-	</section>
-	
-	{event name='sections'}
-	
-	<div class="formSubmit">
-		<input type="submit" value="{lang}wcf.global.button.submit{/lang}" accesskey="s">
-		<input type="hidden" name="action" value="{$action}">
-		<input type="hidden" name="userIDs" value="{implode from=$userIDs item=userID glue=','}{@$userID}{/implode}">
-		{csrfToken}
-	</div>
-</form>
+{unsafe:$form->getHtml()}
 
 {include file='footer'}

--- a/wcfsetup/install/files/lib/acp/form/UserMailForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/UserMailForm.class.php
@@ -3,172 +3,82 @@
 namespace wcf\acp\form;
 
 use wcf\data\user\group\UserGroup;
-use wcf\data\user\UserList;
 use wcf\form\AbstractForm;
+use wcf\form\AbstractFormBuilderForm;
 use wcf\system\clipboard\ClipboardHandler;
 use wcf\system\exception\IllegalLinkException;
-use wcf\system\exception\SystemException;
-use wcf\system\exception\UserInputException;
+use wcf\system\form\builder\field\BooleanFormField;
+use wcf\system\form\builder\field\HiddenFormField;
+use wcf\system\form\builder\field\MultilineTextFormField;
+use wcf\system\form\builder\field\MultipleSelectionFormField;
+use wcf\system\form\builder\field\TextFormField;
+use wcf\system\form\builder\field\user\UserFormField;
 use wcf\system\WCF;
-use wcf\util\ArrayUtil;
-use wcf\util\StringUtil;
-use wcf\util\UserUtil;
 
 /**
  * Shows the user mail form.
  *
- * @author  Marcel Werk
- * @copyright   2001-2019 WoltLab GmbH
- * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @author      Marcel Werk
+ * @copyright   2001-2024 WoltLab GmbH
+ * @license     GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
  */
-class UserMailForm extends AbstractForm
+class UserMailForm extends AbstractFormBuilderForm
 {
-    /**
-     * enable html for message body
-     * @var bool
-     */
-    public $enableHTML = false;
-
-    /**
-     * sender address
-     * @var string
-     */
-    public $from = '';
-
-    /**
-     * sender name
-     * @var string
-     */
-    public $fromName = '';
-
-    /**
-     * list of group ids
-     * @var int[]
-     */
-    public $groupIDs = [];
-
-    /**
-     * list of groups
-     * @var UserGroup[]
-     */
-    public $groups = [];
-
-    /**
-     * @inheritDoc
-     */
-    public $neededPermissions = ['admin.user.canMailUser'];
-
-    /**
-     * message subject
-     * @var string
-     */
-    public $subject = '';
-
-    /**
-     * message body
-     * @var string
-     */
-    public $text = '';
-
-    /**
-     * single user id
-     * @var int
-     */
-    public $userID = 0;
-
-    /**
-     * list of user ids
-     * @var int[]
-     */
-    public $userIDs = [];
-
-    /**
-     * list of users
-     * @var UserList
-     */
-    public $userList;
-
-    /**
-     * @inheritDoc
-     */
-    public function readParameters()
+    #[\Override]
+    public function readParameters(): void
     {
         parent::readParameters();
 
-        if (isset($_GET['id'])) {
-            $this->userID = \intval($_GET['id']);
-        }
-
-        $this->activeMenuItem = ($this->action == 'all' ? 'wcf.acp.menu.link.user.mail' : ($this->action == 'group' ? 'wcf.acp.menu.link.group.mail' : 'wcf.acp.menu.link.user.list'));
+        $this->activeMenuItem = match ($this->action) {
+            'all' => 'wcf.acp.menu.link.user.mail',
+            'group' => 'wcf.acp.menu.link.group.mail',
+            default => 'wcf.acp.menu.link.user.list',
+        };
     }
 
-    /**
-     * @inheritDoc
-     */
-    public function readFormParameters()
+    #[\Override]
+    protected function createForm(): void
     {
-        parent::readFormParameters();
+        parent::createForm();
 
-        if (isset($_POST['userIDs'])) {
-            $this->userIDs = ArrayUtil::toIntegerArray(\explode(',', $_POST['userIDs']));
+        if ($this->action == 'group') {
+            $this->form->appendChild($this->getGroupFormField());
         }
-        if (isset($_POST['groupIDs']) && \is_array($_POST['groupIDs'])) {
-            $this->groupIDs = ArrayUtil::toIntegerArray($_POST['groupIDs']);
+
+        if ($this->action == '') {
+            $this->form->appendChild($this->getUserFormField());
         }
-        if (isset($_POST['subject'])) {
-            $this->subject = StringUtil::trim($_POST['subject']);
-        }
-        if (isset($_POST['text'])) {
-            $this->text = StringUtil::trim($_POST['text']);
-        }
-        if (isset($_POST['from'])) {
-            $this->from = StringUtil::trim($_POST['from']);
-        }
-        if (isset($_POST['fromName'])) {
-            $this->fromName = StringUtil::trim($_POST['fromName']);
-        }
-        if (isset($_POST['enableHTML'])) {
-            $this->enableHTML = true;
-        }
+
+        $this->form->appendChildren([
+            TextFormField::create('subject')
+                ->label('wcf.acp.user.sendMail.subject')
+                ->required(),
+            MultilineTextFormField::create('text')
+                ->label('wcf.acp.user.sendMail.text')
+                ->required(),
+            BooleanFormField::create('enableHTML')
+                ->label('wcf.acp.user.sendMail.enableHTML'),
+            HiddenFormField::create('action')
+                ->value($this->action),
+        ]);
     }
 
-    /**
-     * @inheritDoc
-     */
-    public function validate()
+    #[\Override]
+    public function assignVariables()
     {
-        parent::validate();
+        parent::assignVariables();
 
-        if ($this->action == 'group' && empty($this->groupIDs)) {
-            throw new UserInputException('groupIDs');
-        }
-        if ($this->action == '' && empty($this->userIDs)) {
-            throw new IllegalLinkException();
-        }
-
-        if (empty($this->subject)) {
-            throw new UserInputException('subject');
-        }
-
-        if (empty($this->text)) {
-            throw new UserInputException('text');
-        }
-
-        if (empty($this->from)) {
-            throw new UserInputException('from');
-        } elseif (!UserUtil::isValidEmail($this->from)) {
-            throw new UserInputException('from', 'invalid');
-        }
+        WCF::getTPL()->assign([
+            'action' => $this->action,
+        ]);
     }
 
-    /**
-     * @inheritDoc
-     */
+    #[\Override]
     public function save()
     {
-        parent::save();
+        AbstractForm::save();
 
-        // save config in session
+        $formData = $this->form->getData();
         $userMailData = WCF::getSession()->getVar('userMailData');
         if ($userMailData === null) {
             $userMailData = [];
@@ -176,13 +86,13 @@ class UserMailForm extends AbstractForm
         $mailID = \count($userMailData);
         $userMailData[$mailID] = [
             'action' => $this->action,
-            'userIDs' => $this->userIDs,
-            'groupIDs' => $this->groupIDs,
-            'subject' => $this->subject,
-            'text' => $this->text,
-            'from' => $this->from,
-            'fromName' => $this->fromName,
-            'enableHTML' => $this->enableHTML,
+            'userIDs' => $formData['userIDs'] ?? [],
+            'groupIDs' => $formData['groupIDs'] ?? [],
+            'subject' => $formData['data']['subject'],
+            'text' => $formData['data']['text'],
+            'enableHTML' => $formData['data']['enableHTML'],
+            'from' => \MAIL_FROM_ADDRESS,
+            'fromName' => \MAIL_FROM_NAME,
         ];
         WCF::getSession()->register('userMailData', $userMailData);
         $this->saved();
@@ -190,68 +100,38 @@ class UserMailForm extends AbstractForm
         WCF::getTPL()->assign('mailID', $mailID);
     }
 
-    /**
-     * @inheritDoc
-     */
-    public function readData()
+    private function getGroupFormField(): MultipleSelectionFormField
     {
-        parent::readData();
-
-        if (empty($_POST)) {
-            // get marked user ids
-            if (empty($this->action)) {
-                if ($this->userID) {
-                    // single user mail form
-                    $this->userIDs = [$this->userID];
-                } else {
-                    // get type id
-                    $objectTypeID = ClipboardHandler::getInstance()->getObjectTypeID('com.woltlab.wcf.user');
-                    if ($objectTypeID === null) {
-                        throw new SystemException("Unknown clipboard item type 'com.woltlab.wcf.user'");
-                    }
-
-                    // get user ids
-                    $users = ClipboardHandler::getInstance()->getMarkedItems($objectTypeID);
-                    if (empty($users)) {
-                        throw new IllegalLinkException();
-                    }
-
-                    // load users
-                    $this->userIDs = \array_keys($users);
-                }
-            }
-
-            $this->from = MAIL_FROM_ADDRESS;
-            $this->fromName = MAIL_FROM_NAME;
-        }
-
-        if (!empty($this->userIDs)) {
-            $this->userList = new UserList();
-            $this->userList->getConditionBuilder()->add("user_table.userID IN (?)", [$this->userIDs]);
-            $this->userList->sqlOrderBy = "user_table.username ASC";
-            $this->userList->readObjects();
-        }
-
-        $this->groups = UserGroup::getSortedAccessibleGroups([], [UserGroup::GUESTS, UserGroup::EVERYONE]);
+        return MultipleSelectionFormField::create('groupIDs')
+            ->label('wcf.acp.user.sendMail.groups')
+            ->required()
+            ->options(
+                UserGroup::getSortedAccessibleGroups([], [UserGroup::GUESTS, UserGroup::EVERYONE]),
+                false,
+                false
+            );
     }
 
-    /**
-     * @inheritDoc
-     */
-    public function assignVariables()
+    private function getUserFormField(): UserFormField
     {
-        parent::assignVariables();
+        $formField = UserFormField::create('userIDs')
+            ->label('wcf.acp.user.sendMail.markedUsers')
+            ->required()
+            ->multiple();
 
-        WCF::getTPL()->assign([
-            'enableHTML' => $this->enableHTML,
-            'from' => $this->from,
-            'fromName' => $this->fromName,
-            'groupIDs' => $this->groupIDs,
-            'groups' => $this->groups,
-            'subject' => $this->subject,
-            'text' => $this->text,
-            'userIDs' => $this->userIDs,
-            'userList' => $this->userList,
-        ]);
+        if (!count($_POST)) {
+            if (!empty($_GET['id'])) {
+                $formField->value([\intval($_GET['id'])]);
+            } else {
+                $objectTypeID = ClipboardHandler::getInstance()->getObjectTypeID('com.woltlab.wcf.user');
+                $users = ClipboardHandler::getInstance()->getMarkedItems($objectTypeID);
+                if ($users === []) {
+                    throw new IllegalLinkException();
+                }
+                $formField->value(\array_keys($users));
+            }
+        }
+
+        return $formField;
     }
 }

--- a/wcfsetup/install/lang/de.xml
+++ b/wcfsetup/install/lang/de.xml
@@ -3102,13 +3102,8 @@ Abschnitte dürfen nicht leer sein und nur folgende Zeichen enthalten: <kbd>[a-z
 		<item name="wcf.acp.user.sendMail"><![CDATA[E-Mail an Benutzer senden]]></item>
 		<item name="wcf.acp.user.sendMail.all"><![CDATA[E-Mail an alle Benutzer senden]]></item>
 		<item name="wcf.acp.user.sendMail.enableHTML"><![CDATA[E-Mail als HTML versenden]]></item>
-		<item name="wcf.acp.user.sendMail.from"><![CDATA[Absender]]></item>
-		<item name="wcf.acp.user.sendMail.from.description"><![CDATA[Hier {if LANGUAGE_USE_INFORMAL_VARIANT}kannst du{else}können Sie{/if} die E-Mail-Adresse des Absenders definieren.<br>
-Wenn {if LANGUAGE_USE_INFORMAL_VARIANT}du{else}Sie{/if} unter „Konfiguration » Optionen » Allgemein » E-Mails“ alles ausgefüllt {if LANGUAGE_USE_INFORMAL_VARIANT}hast{else}haben{/if}, wird dieses Feld automatisch ausgefüllt. {if LANGUAGE_USE_INFORMAL_VARIANT}Solltest du{else}Sollten Sie{/if} E-Mails per SMTP senden, so {if LANGUAGE_USE_INFORMAL_VARIANT}achte{else}achten Sie{/if} darauf, dass die E-Mail-Adresse des Absenders auch vom Server akzeptiert werden muss.]]></item>
-		<item name="wcf.acp.user.sendMail.fromName"><![CDATA[Absender-Name]]></item>
 		<item name="wcf.acp.user.sendMail.group"><![CDATA[E-Mail an Gruppenmitglieder senden]]></item>
 		<item name="wcf.acp.user.sendMail.groups"><![CDATA[E-Mail an die Mitglieder folgender Benutzergruppen senden]]></item>
-		<item name="wcf.acp.user.sendMail.mail"><![CDATA[E-Mail]]></item>
 		<item name="wcf.acp.user.sendMail.markedUsers"><![CDATA[E-Mail an folgende Benutzer senden]]></item>
 		<item name="wcf.acp.user.sendMail.subject"><![CDATA[Betreff]]></item>
 		<item name="wcf.acp.user.sendMail.text"><![CDATA[Nachricht]]></item>

--- a/wcfsetup/install/lang/en.xml
+++ b/wcfsetup/install/lang/en.xml
@@ -3031,13 +3031,8 @@ If you have <strong>already bought the licenses for the listed apps</strong>, th
 		<item name="wcf.acp.user.sendMail"><![CDATA[Send Email to Users]]></item>
 		<item name="wcf.acp.user.sendMail.all"><![CDATA[Email All Users]]></item>
 		<item name="wcf.acp.user.sendMail.enableHTML"><![CDATA[Enable HTML code in email message]]></item>
-		<item name="wcf.acp.user.sendMail.from"><![CDATA[Sender’s Email]]></item>
-		<item name="wcf.acp.user.sendMail.from.description"><![CDATA[Specify the sender’s email address.<br>
-You can define the default sender in “Configuration » Options » General » Emails”. The sender’s email must be known to the server if using SMTP, otherwise it would be rejected.]]></item>
-		<item name="wcf.acp.user.sendMail.fromName"><![CDATA[Sender’s Name]]></item>
 		<item name="wcf.acp.user.sendMail.group"><![CDATA[Email User Group]]></item>
 		<item name="wcf.acp.user.sendMail.groups"><![CDATA[Send email to members of the following user groups]]></item>
-		<item name="wcf.acp.user.sendMail.mail"><![CDATA[Email]]></item>
 		<item name="wcf.acp.user.sendMail.markedUsers"><![CDATA[Send email to following users]]></item>
 		<item name="wcf.acp.user.sendMail.subject"><![CDATA[Email Subject]]></item>
 		<item name="wcf.acp.user.sendMail.text"><![CDATA[Email Message]]></item>


### PR DESCRIPTION
This PR also removes the strange option of using a different sender for the emails. Because it is not recommended to use a sender that does not match the email configuration.