### PR TITLE
Remove possible invalid html code, if bbcode `isBlockElement`

### DIFF
--- a/wcfsetup/install/files/lib/system/html/upcast/node/HtmlUpcastNodeWoltlabMetacode.class.php
+++ b/wcfsetup/install/files/lib/system/html/upcast/node/HtmlUpcastNodeWoltlabMetacode.class.php
@@ -101,9 +101,7 @@ final class HtmlUpcastNodeWoltlabMetacode extends AbstractHtmlUpcastNode
 
                     if ($bbcode->isSourceCode) {
                         $content = $element->ownerDocument->createElement('p');
-                        $content->append(
-                            $element->ownerDocument->createTextNode($element->textContent)
-                        );
+                        $content->append($element->textContent);
                         DomUtil::replaceElement($element, $startParagraph, false);
                         DOMUtil::insertAfter($content, $startParagraph);
                         DomUtil::insertAfter($endParagraph, $content);

--- a/wcfsetup/install/files/lib/system/html/upcast/node/HtmlUpcastNodeWoltlabMetacode.class.php
+++ b/wcfsetup/install/files/lib/system/html/upcast/node/HtmlUpcastNodeWoltlabMetacode.class.php
@@ -93,17 +93,25 @@ final class HtmlUpcastNodeWoltlabMetacode extends AbstractHtmlUpcastNode
                 $bbcode = BBCodeCache::getInstance()->getBBCodeByTag($name);
 
                 if ($bbcode === null || $bbcode->isBlockElement) {
-                    $newElement = $element->ownerDocument->createElement('p');
-                    $newElement->appendChild($element->ownerDocument->createTextNode("[{$name}{$attributes}]"));
+                    $startParagraph = $element->ownerDocument->createElement('p');
+                    $startParagraph->append("[{$name}{$attributes}]");
+
+                    $endParagraph = $element->ownerDocument->createElement('p');
+                    $endParagraph->append("[/{$name}]");
+
                     if ($bbcode->isSourceCode) {
-                        $newElement->appendChild(
+                        $content = $element->ownerDocument->createElement('p');
+                        $content->append(
                             $element->ownerDocument->createTextNode($element->textContent)
                         );
-                        DomUtil::replaceElement($element, $newElement, false);
+                        DomUtil::replaceElement($element, $startParagraph, false);
+                        DOMUtil::insertAfter($content, $startParagraph);
+                        DomUtil::insertAfter($endParagraph, $content);
                     } else {
-                        DomUtil::replaceElement($element, $newElement);
+                        DOMUtil::insertBefore($startParagraph, $element);
+                        DOMUtil::insertAfter($endParagraph, $element);
+                        DOMUtil::removeNode($element, true);
                     }
-                    $newElement->appendChild($element->ownerDocument->createTextNode("[/{$name}]"));
                 } else {
                     $insertNode = $element->parentNode->insertBefore(
                         $element->ownerDocument->createTextNode("[{$name}{$attributes}]"),


### PR DESCRIPTION
Fix when a BB-Code is defined as `isBlockElement` and contains a list or other html code that is not allowed in a `p` element. The browser inserted an additional empty `p` element at the end of the BB-Code.