### PR TITLE
Add classes to IP addresses

### DIFF
--- a/com.woltlab.wcf/templates/accountSecurity.tpl
+++ b/com.woltlab.wcf/templates/accountSecurity.tpl
@@ -71,7 +71,7 @@
 		{foreach from=$activeSessions item=session}
 			<li class="box64 sessionItem">
 				<div>
-					<span class="icon icon64 fa-{$session->getUserAgent()->getDeviceIcon()}"></span>
+					<span class="userAgent icon icon64 fa-{$session->getUserAgent()->getDeviceIcon()}"></span>
 				</div>
 				
 				<div class="accountSecurityContainer">
@@ -83,7 +83,7 @@
 							<dd>{if $session->isCurrentSession()}{lang}wcf.user.security.currentSession{/lang}{else}{@$session->getLastActivityTime()|time}{/if}</dd>
 							
 							<dt>{lang}wcf.user.security.ipAddress{/lang}</dt>
-							<dd title="{$session->getIpAddress()}">{$session->getIpAddress()->toBulletMasked(16, 48)}</dd>
+							<dd class="ipAddress" title="{$session->getIpAddress()}">{$session->getIpAddress()->toBulletMasked(16, 48)}</dd>
 						</dl>
 					</div>
 					

--- a/com.woltlab.wcf/templates/user.tpl
+++ b/com.woltlab.wcf/templates/user.tpl
@@ -226,7 +226,7 @@
 								{if $user->getCurrentLocation()}<li>{@$user->getCurrentLocation()}</li>{/if}
 							{/if}
 							{if $__wcf->session->getPermission('admin.user.canViewIpAddress') && $user->registrationIpAddress}
-								<li>{lang}wcf.user.registrationIpAddress{/lang}: <span class="userRegistrationIpAddress">{@$user->getRegistrationIpAddress()|ipSearch}</span></li>
+								<li class="ipAddress">{lang}wcf.user.registrationIpAddress{/lang}: <span class="userRegistrationIpAddress">{@$user->getRegistrationIpAddress()|ipSearch}</span></li>
 							{/if}
 						{/content}
 					</ul>

--- a/com.woltlab.wcf/templates/usersOnlineList.tpl
+++ b/com.woltlab.wcf/templates/usersOnlineList.tpl
@@ -90,11 +90,11 @@
 		{if $__wcf->session->getPermission('admin.user.canViewIpAddress')}
 			<dl class="plain inlineDataList small">
 				<dt>{lang}wcf.user.usersOnline.ipAddress{/lang}</dt>
-				<dd title="{$user->getFormattedIPAddress()}">{@$user->getFormattedIPAddress()|ipSearch}</dd>
+				<dd class="ipAddress" title="{$user->getFormattedIPAddress()}">{@$user->getFormattedIPAddress()|ipSearch}</dd>
 				
 				{if !$user->spiderID}
 					<dt>{lang}wcf.user.usersOnline.userAgent{/lang}</dt>
-					<dd title="{$user->userAgent}">{$user->getBrowser()|truncate:30}</dd>
+					<dd class="userAgent" title="{$user->userAgent}">{$user->getBrowser()|truncate:30}</dd>
 				{/if}
 			</dl>
 		{/if}


### PR DESCRIPTION
Working with IP addresses or user agents can be challenging due to the difficulty in efficiently locating them. This pull request addresses this issue by introducing specific classes to the fields where these elements appear, making them readily accessible. For instance, you can now easily manipulate or retrieve these values using JavaScript, streamlining the process and enhancing performance.

Additionally, there are scenarios, such as in the WBB/WSF (postIpAddress template), where applying this change could be beneficial or even necessary. However, for obvious reasons, those suggestions fall outside the scope of what I can propose in this context. :)

This change is relatively minor and carries no risk of causing side effects. Therefore, it should be safe to merge.