### PR TITLE
Triggering the `cancel` event when the close button is clicked.

### DIFF
--- a/ts/WoltLabSuite/Core/Element/woltlab-core-dialog.ts
+++ b/ts/WoltLabSuite/Core/Element/woltlab-core-dialog.ts
@@ -261,6 +261,9 @@ export class WoltlabCoreDialogElement extends HTMLElement {
       closeButton.title = Language.get("wcf.dialog.button.close");
       closeButton.addEventListener("click", () => {
         if (this.#shouldClose()) {
+          const evt = new CustomEvent("cancel", { cancelable: false });
+          this.dispatchEvent(evt);
+
           this.close();
         }
       });

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Element/woltlab-core-dialog.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Element/woltlab-core-dialog.js
@@ -200,6 +200,8 @@ define(["require", "exports", "tslib", "../Dom/Util", "../Helper/PageOverlay", "
                 closeButton.title = Language.get("wcf.dialog.button.close");
                 closeButton.addEventListener("click", () => {
                     if (this.#shouldClose()) {
+                        const evt = new CustomEvent("cancel", { cancelable: false });
+                        this.dispatchEvent(evt);
                         this.close();
                     }
                 });


### PR DESCRIPTION
If the close button is pressed, the `cancel` event is not triggered. The `close` event cannot be used as it is also triggered by a `primary` event.
This `cancel` event does not need to be cancelable, as the `close` event can already be canceled earlier.

See https://www.woltlab.com/community/thread/306214-the-loading-indicator-does-not-disappear-after-closing-the-guest-comment-dialog/