### PR TITLE
Disable log directory recursion

### DIFF
--- a/wcfsetup/install/files/lib/acp/page/ExceptionLogViewPage.class.php
+++ b/wcfsetup/install/files/lib/acp/page/ExceptionLogViewPage.class.php
@@ -103,7 +103,7 @@ class ExceptionLogViewPage extends MultipleLinkPage
         RegistryHandler::getInstance()->set('com.woltlab.wcf', 'exceptionMailerTimestamp', TIME_NOW);
 
         $fileNameRegex = new Regex('(?:^|/)\d{4}-\d{2}-\d{2}\.txt$');
-        $this->logFiles = DirectoryUtil::getInstance(WCF_DIR . 'log/')->getFiles(\SORT_DESC, $fileNameRegex);
+        $this->logFiles = DirectoryUtil::getInstance(WCF_DIR . 'log/', false)->getFiles(\SORT_DESC, $fileNameRegex);
 
         if ($this->exceptionID) {
             // search the appropriate file


### PR DESCRIPTION
The exception log overview page currently displays all files that follow the same naming scheme, which is appropriate. However, it is possible for other log files with the same or similar naming schemes to be present in the log folder. For instance, in our case, we store log files with the same naming scheme in a subdirectory. This proposal addresses the issue because, at present, these files are included in the overview since the software reads the log directory recursively.