### PR TITLE
Bugfix with WysiwygAttachmentFormField and FileProcessor

### DIFF
--- a/com.woltlab.wcf/templates/shared_wysiwygAttachmentFormField.tpl
+++ b/com.woltlab.wcf/templates/shared_wysiwygAttachmentFormField.tpl
@@ -11,7 +11,7 @@
 		<dt></dt>
 		<dd>
 			<div data-max-size="{$field->getAttachmentHandler()->getMaxSize()}"></div>
-			<small>{lang}wcf.attachment.upload.limits{/lang}</small>
+			<small>{lang attachmentHandler=$field->getAttachmentHandler()}wcf.attachment.upload.limits{/lang}</small>
 		</dd>
 	</dl>
 

--- a/wcfsetup/install/files/lib/system/attachment/AttachmentHandler.class.php
+++ b/wcfsetup/install/files/lib/system/attachment/AttachmentHandler.class.php
@@ -331,7 +331,7 @@ class AttachmentHandler implements \Countable
     {
         return $this->getFileProcessor()->toHtmlElement(
             $this->objectType->objectType,
-            $this->objectID,
+            $this->objectID ?? 0,
             \implode(',', $this->tmpHash),
             $this->parentObjectID
         );


### PR DESCRIPTION
Fixes the problem that when using the WysiwygFormField with attachments, the `objectID` can be `null` if it is not an EditForm.
The language variable `wcf.attachment.upload.limits` requires the variable `attachmentHandler`