### PR TITLE
Extra check that the user also has the right to upload attachment when editing a user

### DIFF
--- a/wcfsetup/install/files/lib/system/attachment/SignatureAttachmentObjectType.class.php
+++ b/wcfsetup/install/files/lib/system/attachment/SignatureAttachmentObjectType.class.php
@@ -173,6 +173,7 @@ class SignatureAttachmentObjectType extends AbstractAttachmentObjectType
     private function canEditUser(UserProfile $userProfile): bool
     {
         return WCF::getSession()->getPermission('admin.user.canEditUser')
-            && UserGroup::isAccessibleGroup($userProfile->getGroupIDs());
+            && UserGroup::isAccessibleGroup($userProfile->getGroupIDs())
+            && WCF::getSession()->getPermission('user.signature.attachment.canUpload');
     }
 }


### PR DESCRIPTION
See https://www.woltlab.com/community/thread/306725-fehler-bei-dateianhang-hochladen-in-signatur-und-konversation/

If an administrator is currently editing the signature of himself or another user, the tab for attachments is displayed. This is also the case if the right to upload attachments in the signature has been withdrawn from all user groups.