### PR TITLE
Make it easier to find a form field from a FormBuilder form

### DIFF
--- a/wcfsetup/install/files/lib/system/form/builder/FormDocument.class.php
+++ b/wcfsetup/install/files/lib/system/form/builder/FormDocument.class.php
@@ -783,4 +783,20 @@ class FormDocument implements IFormDocument
             $this->traitValidate();
         }
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function getFormField(string $nodeId): ?IFormField
+    {
+        $node = $this->getNodeById($nodeId);
+        if ($node === null) {
+            return null;
+        }
+        if (!($node instanceof IFormField)) {
+            return null;
+        }
+
+        return $node;
+    }
 }

--- a/wcfsetup/install/files/lib/system/form/builder/IFormDocument.class.php
+++ b/wcfsetup/install/files/lib/system/form/builder/IFormDocument.class.php
@@ -5,6 +5,7 @@ namespace wcf\system\form\builder;
 use wcf\data\IStorableObject;
 use wcf\system\form\builder\button\IFormButton;
 use wcf\system\form\builder\data\IFormDataHandler;
+use wcf\system\form\builder\field\IFormField;
 
 /**
  * Represents a "whole" form (document).
@@ -410,4 +411,11 @@ interface IFormDocument extends IFormParentNode
      * @throws  \InvalidArgumentException   if the given form mode is invalid
      */
     public function successMessage($languageItem = null, array $variables = []);
+
+    /**
+     * Returns the form field with the given id or `null` if no such field exists.
+     *
+     * @since 6.1
+     */
+    public function getFormField(string $nodeId): ?IFormField;
 }


### PR DESCRIPTION
Basically, it is just a wrapper around `getNodeById()`, which also checks whether it is a `IFormField`.