### PR TITLE
Replace `userListItem` with `userCard` on team page

### DIFF
--- a/com.woltlab.wcf/templates/team.tpl
+++ b/com.woltlab.wcf/templates/team.tpl
@@ -7,9 +7,9 @@
 			<p class="sectionDescription">{$team->getDescription()}</p>
 		</header>
 			
-		<ol class="containerList userList">
+		<ol class="containerList userCardList">
 			{foreach from=$team->getMembers() item=user}
-				{include file='userListItem'}
+				{include file='userCard'}
 			{/foreach}
 		</ol>
 	</section>
@@ -24,16 +24,5 @@
 		</nav>
 	{/hascontent}
 </footer>
-
-<script data-relocate="true">
-	$(function() {
-		WCF.Language.addObject({
-			'wcf.user.button.follow': '{jslang}wcf.user.button.follow{/jslang}',
-			'wcf.user.button.unfollow': '{jslang}wcf.user.button.unfollow{/jslang}',
-		});
-		
-		new WCF.User.Action.Follow($('.userList > li'));
-	});
-</script>
 
 {include file='footer'}


### PR DESCRIPTION
This pull request adjusts the style for the team page.

<img width="1437" alt="Bildschirmfoto 2024-07-06 um 14 15 40" src="https://github.com/WoltLab/WCF/assets/1224617/c223f8f2-4b7a-4670-b7b9-5d08e39b0c3a">
