### PR TITLE
Fixes the error that the description for an assigned trophy is `null`

### DIFF
--- a/wcfsetup/install/files/lib/acp/form/AbstractAcpForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/AbstractAcpForm.class.php
@@ -115,7 +115,7 @@ abstract class AbstractAcpForm extends AbstractForm
                 I18nHandler::getInstance()->setOptions(
                     $fieldName,
                     $value->getPackageID(),
-                    $databaseObject->{$fieldName},
+                    $databaseObject->{$fieldName} ?? '',
                     "{$value->getLanguageItem()}\\d+"
                 );
             }

--- a/wcfsetup/install/files/lib/system/trophy/condition/TrophyConditionHandler.class.php
+++ b/wcfsetup/install/files/lib/system/trophy/condition/TrophyConditionHandler.class.php
@@ -84,6 +84,7 @@ class TrophyConditionHandler extends SingletonFactory
                         'trophyID' => $trophy->trophyID,
                         'userID' => $userID,
                         'time' => TIME_NOW,
+                        'description' => '',
                     ],
                 ]))->executeAction();
 


### PR DESCRIPTION
See: https://www.woltlab.com/community/thread/307109-fehler-bei-entzug-von-trophäen/