### PR TITLE
Transfer the tmp hashes for the attachment handler when submitting

### DIFF
--- a/com.woltlab.wcf/templates/shared_wysiwygAttachmentFormField.tpl
+++ b/com.woltlab.wcf/templates/shared_wysiwygAttachmentFormField.tpl
@@ -15,6 +15,10 @@
 		</dd>
 	</dl>
 
+	{foreach from=$field->getAttachmentHandler()->getTmpHashes() item=tmpHash}
+		<input type="hidden" name="{$field->getPrefixedID()}_tmpHash[]" value="{$tmpHash}">
+	{/foreach}
+
 	<script data-relocate="true">
 		{jsphrase name='wcf.attachment.insert'}
 		{jsphrase name='wcf.attachment.insertFull'}


### PR DESCRIPTION
See https://www.woltlab.com/community/thread/307732-dateianhänge-lassen-sich-nicht-im-plugin-store-hochladen/