### PR TITLE
Check whether the server response is empty and throw an exception

### DIFF
--- a/wcfsetup/install/files/lib/system/package/PackageUpdateDispatcher.class.php
+++ b/wcfsetup/install/files/lib/system/package/PackageUpdateDispatcher.class.php
@@ -223,6 +223,10 @@ final class PackageUpdateDispatcher extends SingletonFactory
         // parse given package update xml
         $allNewPackages = false;
         if ($apiVersion === '2.0' || $response->getStatusCode() != 304) {
+            if (!$response->getBody()->getSize()) {
+                throw new SystemException(WCF::getLanguage()->get('wcf.acp.package.update.error.listNotFound'));
+            }
+
             $allNewPackages = $this->parsePackageUpdateXML($updateServer, $response->getBody(), $apiVersion);
         }
 


### PR DESCRIPTION
See https://www.woltlab.com/community/thread/307950-fehlermeldung-domdocument-loadxml-argument-1-source-must-not-be-empty/