### PR TITLE
Switch user after sending email

### DIFF
--- a/wcfsetup/install/files/lib/system/background/job/NotificationEmailDeliveryBackgroundJob.class.php
+++ b/wcfsetup/install/files/lib/system/background/job/NotificationEmailDeliveryBackgroundJob.class.php
@@ -160,12 +160,10 @@ class NotificationEmailDeliveryBackgroundJob extends AbstractBackgroundJob
 
                 return;
             }
+
+            $this->job->perform();
         } finally {
             SessionHandler::getInstance()->changeUser($user, true);
         }
-
-        // If none of the checks failed we can send the notification after we switched
-        // back to the regular user (guest within the context of the queue).
-        $this->job->perform();
     }
 }


### PR DESCRIPTION
The session should be reset to the original user after the email has been sent. Otherwise, the embedded content cannot be loaded and the user is informed in the email that they are not authorized to view this content.