### PR TITLE
Implement `canAdopt()` in `IFileProcessor` and `FileProcessor`

### DIFF
--- a/wcfsetup/install/files/lib/system/endpoint/controller/core/files/upload/SaveChunk.class.php
+++ b/wcfsetup/install/files/lib/system/endpoint/controller/core/files/upload/SaveChunk.class.php
@@ -12,6 +12,7 @@ use wcf\http\Helper;
 use wcf\system\endpoint\IController;
 use wcf\system\endpoint\PostRequest;
 use wcf\system\exception\UserInputException;
+use wcf\system\file\processor\FileProcessor;
 use wcf\system\io\File;
 
 #[PostRequest('/core/files/upload/{identifier}/chunk/{sequenceNo:\d+}')]
@@ -118,9 +119,11 @@ final class SaveChunk implements IController
 
                     throw new UserInputException('validation', $exception->getType());
                 }
-            }
 
-            $processor?->adopt($file, $context);
+                if (FileProcessor::getInstance()->canAdopt($processor, $file, $context)) {
+                    $processor->adopt($file, $context);
+                }
+            }
 
             $generateThumbnails = false;
             if ($processor !== null && $file->isImage()) {

--- a/wcfsetup/install/files/lib/system/file/processor/AttachmentFileProcessor.class.php
+++ b/wcfsetup/install/files/lib/system/file/processor/AttachmentFileProcessor.class.php
@@ -41,6 +41,18 @@ final class AttachmentFileProcessor extends AbstractFileProcessor
     }
 
     #[\Override]
+    public function canAdopt(File $file, array $context): bool
+    {
+        $attachment = Attachment::findByFileID($file->fileID);
+
+        if ($attachment === null) {
+            return true;
+        }
+
+        return false;
+    }
+
+    #[\Override]
     public function adopt(File $file, array $context): void
     {
         $attachmentHandler = $this->getAttachmentHandlerFromContext($context);

--- a/wcfsetup/install/files/lib/system/file/processor/FileProcessor.class.php
+++ b/wcfsetup/install/files/lib/system/file/processor/FileProcessor.class.php
@@ -125,6 +125,16 @@ final class FileProcessor extends SingletonFactory
         );
     }
 
+    public function canAdopt(IFileProcessor $fileProcessor, File $file, array $context): bool
+    {
+        $objectType = $this->getObjectType($fileProcessor->getObjectTypeName());
+        if ($objectType->objectTypeID !== $file->objectTypeID) {
+            return false;
+        }
+
+        return $fileProcessor->canAdopt($file, $context);
+    }
+
     public function generateWebpVariant(File $file): void
     {
         $canGenerateThumbnail = match ($file->mimeType) {

--- a/wcfsetup/install/files/lib/system/file/processor/IFileProcessor.class.php
+++ b/wcfsetup/install/files/lib/system/file/processor/IFileProcessor.class.php
@@ -37,11 +37,21 @@ interface IFileProcessor
     public function validateUpload(File $file): void;
 
     /**
+     * Checks if the given `$file` can be assigned to the object referenced by the information
+     * contained in `$context`.
+     *
+     * The `$file` can be assigned if one of the following conditions is met:
+     * - The file has not yet been assigned to any object
+     * - The file is already assigned to the object referenced by `$context`
+     */
+    public function canAdopt(File $file, array $context): bool;
+
+    /**
      * Notifies the file processor that the upload of a file has been completed
      * that belongs to this type.
      *
      * `$context` are the exact same values that have previously been passed to
-     * `acceptUpload()` before.
+     * `canAdopt()` before.
      */
     public function adopt(File $file, array $context): void;
 

--- a/wcfsetup/install/files/lib/system/form/builder/field/FileProcessorFormField.class.php
+++ b/wcfsetup/install/files/lib/system/form/builder/field/FileProcessorFormField.class.php
@@ -194,13 +194,25 @@ final class FileProcessorFormField extends AbstractFormField
             $this->addValidationError(
                 new FormFieldValidationError(
                     'maximumFiles',
-                    'wcf.form.field.fileProcessor.error.maximumFiles',
+                    'wcf.upload.error.maximumCountReached',
                     [
                         'maximumCount' => $fileProcessor->getMaximumCount($this->context),
                         'count' => \count($this->files),
                     ]
                 )
             );
+        }
+
+        foreach ($this->files as $file) {
+            if (!FileProcessor::getInstance()->canAdopt($fileProcessor, $file, $this->context)) {
+                $this->addValidationError(
+                    new FormFieldValidationError(
+                        'adopt',
+                        'wcf.form.field.fileProcessor.error.adopt',
+                        ['file' => $file]
+                    )
+                );
+            }
         }
 
         parent::validate();

--- a/wcfsetup/install/lang/de.xml
+++ b/wcfsetup/install/lang/de.xml
@@ -4099,6 +4099,7 @@ Dateianhänge:
 		<item name="wcf.form.field.upload.error.maximumImageHeight"><![CDATA[Die Datei „{$file->getFilename()}“ darf maximal {#$maximumImageHeight} Pixel hoch sein.]]></item>
 		<item name="wcf.form.field.upload.error.minimum"><![CDATA[{if LANGUAGE_USE_INFORMAL_VARIANT}Du musst{else}Sie müssen{/if} mindestens {if $minimum > 1}{#$minimum} Dateien{else}eine Datei{/if} hochladen.]]></item>
 		<item name="wcf.form.field.upload.error.maximum"><![CDATA[{if LANGUAGE_USE_INFORMAL_VARIANT}Du darfst{else}Sie dürfen{/if} maximal {if $maximum > 1}{#$maximum} Dateien{else}eine Datei{/if} hochladen.]]></item>
+		<item name="wcf.form.field.fileProcessor.error.adopt"><![CDATA[Die Datei „{$file->filename}“ kann nicht zugewiesen werden.]]></item>
 	</category>
 	<category name="wcf.image">
 		<item name="wcf.image.coverPhoto"><![CDATA[Titelbild]]></item>

--- a/wcfsetup/install/lang/en.xml
+++ b/wcfsetup/install/lang/en.xml
@@ -4045,6 +4045,7 @@ Attachments:
 		<item name="wcf.form.field.upload.error.maximumImageHeight"><![CDATA[The file “{$file->getFilename()}” may have a maximum height of {#$maximumImageHeight} pixels.]]></item>
 		<item name="wcf.form.field.upload.error.minimum"><![CDATA[You must upload at least {if $minimum > 1}{#$minimum} files{else}one file{/if}.]]></item>
 		<item name="wcf.form.field.upload.error.maximum"><![CDATA[You can upload a maximum of {if $maximum > 1}{#$maximum} files{else}one file{/if}.]]></item>
+		<item name="wcf.form.field.fileProcessor.error.adopt"><![CDATA[The file „{$file->filename}“ cannot be assigned.]]></item>
 	</category>
 	<category name="wcf.image">
 		<item name="wcf.image.coverPhoto"><![CDATA[Cover Photo]]></item>


### PR DESCRIPTION
This function checks whether a file may be assigned to the `$context`. In addition, `FileProcessor::canAdopt()` checks whether the `objectType` is correct.