### PR TITLE
`AbstractCommentManager` no longer inherits from `SingletonFactory`

### DIFF
--- a/wcfsetup/install/files/lib/system/comment/manager/AbstractCommentManager.class.php
+++ b/wcfsetup/install/files/lib/system/comment/manager/AbstractCommentManager.class.php
@@ -6,7 +6,6 @@ use wcf\data\comment\Comment;
 use wcf\data\comment\response\CommentResponse;
 use wcf\data\DatabaseObjectDecorator;
 use wcf\system\bbcode\BBCodeHandler;
-use wcf\system\SingletonFactory;
 use wcf\system\WCF;
 
 /**
@@ -16,7 +15,7 @@ use wcf\system\WCF;
  * @copyright   2001-2019 WoltLab GmbH
  * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
  */
-abstract class AbstractCommentManager extends SingletonFactory implements ICommentManager
+abstract class AbstractCommentManager implements ICommentManager
 {
     /**
      * display comments per page


### PR DESCRIPTION
The dependency on `SingletonFactory` offers no added value, as the comment manager is not accessed directly and it is only instantiated once per object type in `ObjectType::getProcessor()`. At the same time, however, the dependency on `SingleFactory` prevents a `CommentManager` implementation from being used in different/multiple object types.

ref https://github.com/WoltLab/WCF/blob/master/wcfsetup/install/files/lib/data/object/type/ObjectType.class.php#L109