### PR TITLE
Deprecate dateutil format

### DIFF
--- a/wcfsetup/install/files/lib/system/box/TodaysBirthdaysBoxController.class.php
+++ b/wcfsetup/install/files/lib/system/box/TodaysBirthdaysBoxController.class.php
@@ -9,7 +9,6 @@ use wcf\system\cache\runtime\UserProfileRuntimeCache;
 use wcf\system\condition\IObjectCondition;
 use wcf\system\user\UserBirthdayCache;
 use wcf\system\WCF;
-use wcf\util\DateUtil;
 
 /**
  * Shows today's birthdays.
@@ -88,8 +87,9 @@ class TodaysBirthdaysBoxController extends AbstractDatabaseObjectListBoxControll
     protected function loadContent()
     {
         // get current date
-        $currentDay = DateUtil::format(null, 'm-d');
-        $date = \explode('-', DateUtil::format(null, 'Y-n-j'));
+        $now = new \DateTimeImmutable("now", WCF::getUser()->getTimeZone());
+        $currentDay = $now->format('m-d');
+        $date = \explode('-', $now->format('Y-n-j'));
 
         // get user ids
         $userIDs = UserBirthdayCache::getInstance()->getBirthdays($date[1], $date[2]);

--- a/wcfsetup/install/files/lib/system/form/builder/field/DateFormField.class.php
+++ b/wcfsetup/install/files/lib/system/form/builder/field/DateFormField.class.php
@@ -457,6 +457,12 @@ class DateFormField extends AbstractFormField implements
         );
     }
 
+    /**
+     * Returns an instance of `\IntlDateFormatter' for formatting `\DateTime` objects.
+     * The formatter displays the date and time (if supported) in the user's locale and timezone.
+     *
+     * @since 6.2
+     */
     protected function getDateTimeFormatter(): \IntlDateFormatter
     {
         $timeFormat = \IntlDateFormatter::NONE;

--- a/wcfsetup/install/files/lib/system/form/builder/field/DateFormField.class.php
+++ b/wcfsetup/install/files/lib/system/form/builder/field/DateFormField.class.php
@@ -385,22 +385,10 @@ class DateFormField extends AbstractFormField implements
                 );
 
                 if ($dateTime < $earliestDateTime) {
-                    $format = DateUtil::DATE_FORMAT;
-                    if ($this->supportsTime()) {
-                        $format = \str_replace(
-                            ['%date%', '%time%'],
-                            [
-                                WCF::getLanguage()->get(DateUtil::DATE_FORMAT),
-                                WCF::getLanguage()->get(DateUtil::TIME_FORMAT),
-                            ],
-                            WCF::getLanguage()->get('wcf.date.dateTimeFormat')
-                        );
-                    }
-
                     $this->addValidationError(new FormFieldValidationError(
                         'minimum',
                         'wcf.form.field.date.error.earliestDate',
-                        ['earliestDate' => DateUtil::format($earliestDateTime, $format)]
+                        ['earliestDate' => $this->getDateTimeFormatter()->format($earliestDateTime)]
                     ));
 
                     return;
@@ -415,22 +403,10 @@ class DateFormField extends AbstractFormField implements
                 );
 
                 if ($dateTime > $latestDateTime) {
-                    $format = DateUtil::DATE_FORMAT;
-                    if ($this->supportsTime()) {
-                        $format = \str_replace(
-                            ['%date%', '%time%'],
-                            [
-                                WCF::getLanguage()->get(DateUtil::DATE_FORMAT),
-                                WCF::getLanguage()->get(DateUtil::TIME_FORMAT),
-                            ],
-                            WCF::getLanguage()->get('wcf.date.dateTimeFormat')
-                        );
-                    }
-
                     $this->addValidationError(new FormFieldValidationError(
                         'minimum',
                         'wcf.form.field.date.error.latestDate',
-                        ['latestDate' => DateUtil::format($latestDateTime, $format)]
+                        ['latestDate' => $this->getDateTimeFormatter()->format($latestDateTime)]
                     ));
 
                     return;
@@ -478,6 +454,21 @@ class DateFormField extends AbstractFormField implements
                 'max',
                 'min',
             ]
+        );
+    }
+
+    protected function getDateTimeFormatter(): \IntlDateFormatter
+    {
+        $timeFormat = \IntlDateFormatter::NONE;
+        if ($this->supportsTime()) {
+            $timeFormat = \IntlDateFormatter::SHORT;
+        }
+
+        return new \IntlDateFormatter(
+            WCF::getLanguage()->getLocale(),
+            \IntlDateFormatter::LONG,
+            $timeFormat,
+            WCF::getUser()->getTimeZone()
         );
     }
 }

--- a/wcfsetup/install/files/lib/system/option/user/DateUserOptionOutput.class.php
+++ b/wcfsetup/install/files/lib/system/option/user/DateUserOptionOutput.class.php
@@ -4,7 +4,7 @@ namespace wcf\system\option\user;
 
 use wcf\data\user\option\UserOption;
 use wcf\data\user\User;
-use wcf\util\DateUtil;
+use wcf\system\WCF;
 
 /**
  * User option output implementation for for the output of a date input.
@@ -16,12 +16,6 @@ use wcf\util\DateUtil;
 class DateUserOptionOutput implements IUserOptionOutput
 {
     /**
-     * date format
-     * @var string
-     */
-    protected $dateFormat = DateUtil::DATE_FORMAT;
-
-    /**
      * @inheritDoc
      */
     public function getOutput(User $user, UserOption $option, $value)
@@ -32,11 +26,13 @@ class DateUserOptionOutput implements IUserOptionOutput
 
         $date = self::splitDate($value);
 
-        return DateUtil::format(
-            DateUtil::getDateTimeByTimestamp(
-                \gmmktime(12, 1, 1, $date['month'], $date['day'], $date['year'])
-            ),
-            $this->dateFormat
+        return \IntlDateFormatter::formatObject(
+            WCF::getUser()->getLocalDate(\gmmktime(12, 1, 1, $date['month'], $date['day'], $date['year'])),
+            [
+                \IntlDateFormatter::LONG,
+                \IntlDateFormatter::NONE,
+            ],
+            WCF::getLanguage()->getLocale()
         );
     }
 

--- a/wcfsetup/install/files/lib/system/template/plugin/DateModifierTemplatePlugin.class.php
+++ b/wcfsetup/install/files/lib/system/template/plugin/DateModifierTemplatePlugin.class.php
@@ -4,7 +4,6 @@ namespace wcf\system\template\plugin;
 
 use wcf\system\template\TemplateEngine;
 use wcf\system\WCF;
-use wcf\util\DateUtil;
 
 /**
  * Template modifier plugin which renders a \DateTimeInterface or
@@ -37,10 +36,7 @@ class DateModifierTemplatePlugin implements IModifierTemplatePlugin
         }
 
         if (!empty($tagArgs[1])) {
-            return DateUtil::format(
-                $dateTime,
-                $tagArgs[1]
-            );
+            return $dateTime->format($tagArgs[1]);
         } else {
             $locale = WCF::getLanguage()->getLocale();
             $timeZone = WCF::getUser()->getTimeZone();

--- a/wcfsetup/install/files/lib/system/user/notification/event/AbstractUserNotificationEvent.class.php
+++ b/wcfsetup/install/files/lib/system/user/notification/event/AbstractUserNotificationEvent.class.php
@@ -222,10 +222,15 @@ abstract class AbstractUserNotificationEvent extends DatabaseObjectDecorator imp
             $date->modify('-1 day');
             self::$periods[$date->getTimestamp()] = WCF::getLanguage()->get('wcf.date.period.yesterday');
 
+            $formatter = \IntlDateFormatter::create(
+                WCF::getLanguage()->getLocale(),
+                timezone: WCF::getUser()->getTimeZone(),
+                pattern: 'EEEE'
+            );
             // 2-6 days back
             for ($i = 0; $i < 6; $i++) {
                 $date->modify('-1 day');
-                self::$periods[$date->getTimestamp()] = DateUtil::format($date, 'l');
+                self::$periods[$date->getTimestamp()] = $formatter->format($date);
             }
         }
 

--- a/wcfsetup/install/files/lib/util/CLIUtil.class.php
+++ b/wcfsetup/install/files/lib/util/CLIUtil.class.php
@@ -83,36 +83,6 @@ final class CLIUtil
     }
 
     /**
-     * Formats time.
-     *
-     * @param int $timestamp
-     * @return  string
-     */
-    public static function formatTime($timestamp)
-    {
-        $dateTimeObject = DateUtil::getDateTimeByTimestamp($timestamp);
-        $date = DateUtil::format($dateTimeObject, DateUtil::DATE_FORMAT);
-        $time = DateUtil::format($dateTimeObject, DateUtil::TIME_FORMAT);
-
-        return \str_replace(
-            '%time%',
-            $time,
-            \str_replace('%date%', $date, CLIWCF::getLanguage()->get('wcf.date.dateTimeFormat'))
-        );
-    }
-
-    /**
-     * Formats dates.
-     *
-     * @param int $timestamp
-     * @return  string
-     */
-    public static function formatDate($timestamp)
-    {
-        return DateUtil::format(DateUtil::getDateTimeByTimestamp($timestamp), DateUtil::DATE_FORMAT);
-    }
-
-    /**
      * Forbid creation of CLIUtil objects.
      */
     private function __construct()

--- a/wcfsetup/install/files/lib/util/DateUtil.class.php
+++ b/wcfsetup/install/files/lib/util/DateUtil.class.php
@@ -177,6 +177,8 @@ final class DateUtil
      * @param Language $language
      * @param User $user
      * @return  string
+     *
+     * @deprecated 6.2 use `\IntlDateFormatter` instead
      */
     public static function format(
         null|\DateTime|\DateTimeImmutable $time = null,

--- a/wcfsetup/install/files/lib/util/DateUtil.class.php
+++ b/wcfsetup/install/files/lib/util/DateUtil.class.php
@@ -630,7 +630,11 @@ final class DateUtil
             $currentDateTimeObject->setTime(0, 0, 0);
 
             $days = $dtoNoTime->diff($currentDateTimeObject)->days;
-            $day = self::format($dateTimeObject, 'l');
+            $day = \IntlDateFormatter::formatObject(
+                $dateTimeObject,
+                'EEEE',
+                WCF::getLanguage()->getLocale(),
+            );
 
             return WCF::getLanguage()->getDynamicVariable('wcf.date.relative.pastDays', [
                 'days' => $days,

--- a/wcfsetup/install/files/lib/util/DateUtil.class.php
+++ b/wcfsetup/install/files/lib/util/DateUtil.class.php
@@ -456,10 +456,12 @@ final class DateUtil
 
         // calc
         if ($year) {
-            $age = self::format(null, 'Y') - $year;
-            if (self::format(null, 'n') < $month) {
+            $now = new \DateTimeImmutable("now", WCF::getUser()->getTimeZone());
+
+            $age = $now->format('Y') - $year;
+            if ($now->format('n') < $month) {
                 $age--;
-            } elseif (self::format(null, 'n') == $month && self::format(null, 'j') < $day) {
+            } elseif ($now->format('n') == $month && $now->format('j') < $day) {
                 $age--;
             }
 

--- a/wcfsetup/install/files/lib/util/DateUtil.class.php
+++ b/wcfsetup/install/files/lib/util/DateUtil.class.php
@@ -178,7 +178,7 @@ final class DateUtil
      * @param User $user
      * @return  string
      *
-     * @deprecated 6.2 use `\IntlDateFormatter` instead
+     * @deprecated 6.2 use `\IntlDateFormatter` or `\DateTime::format()` instead
      */
     public static function format(
         null|\DateTime|\DateTimeImmutable $time = null,


### PR DESCRIPTION
Closes https://github.com/WoltLab/WCF/issues/5980

Add to docs
- `DateUserOptionOutput::$dateFormat` removed
- `CLIUtil::formatTime()` removed
- `CLIUtil::formatDate()` removed
- `DateUtil::format()` deprecated