### PR TITLE
Rename `ImageMetacodeUpcast` to `AbstractImageMetacodeUpcast`

### DIFF
--- a/com.woltlab.wcf/fileDelete.xml
+++ b/com.woltlab.wcf/fileDelete.xml
@@ -2790,6 +2790,7 @@
 		<file>lib/system/html/input/node/HtmlInputNodeWoltlabColor.class.php</file>
 		<file>lib/system/html/input/node/HtmlInputNodeWoltlabMention.class.php</file>
 		<file>lib/system/html/input/node/IHtmlInputNodeProcessor.class.php</file>
+		<file>lib/system/html/metacode/upcast/ImageMetacodeUpcast.class.php</file>
 		<file>lib/system/html/node/HtmlNodeProcessor.class.php</file>
 		<file>lib/system/html/output/AmpHtmlOutputProcessor.class.php</file>
 		<file>lib/system/html/output/HtmlOutputNodeProcessor.class.php</file>

--- a/wcfsetup/install/files/lib/system/html/metacode/upcast/AbstractImageMetacodeUpcast.class.php
+++ b/wcfsetup/install/files/lib/system/html/metacode/upcast/AbstractImageMetacodeUpcast.class.php
@@ -12,7 +12,7 @@ use wcf\util\DOMUtil;
  * @license     GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
  * @since       6.1
  */
-abstract class ImageMetacodeUpcast implements IMetacodeUpcast
+abstract class AbstractImageMetacodeUpcast implements IMetacodeUpcast
 {
     /**
      * Create the figure element for the image.

--- a/wcfsetup/install/files/lib/system/html/metacode/upcast/AttachMetacodeUpcast.class.php
+++ b/wcfsetup/install/files/lib/system/html/metacode/upcast/AttachMetacodeUpcast.class.php
@@ -15,7 +15,7 @@ use wcf\util\StringUtil;
  * @license     GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
  * @since       6.1
  */
-final class AttachMetacodeUpcast extends ImageMetacodeUpcast
+final class AttachMetacodeUpcast extends AbstractImageMetacodeUpcast
 {
     #[\Override]
     public function upcast(\DOMElement $element, array $attributes): void

--- a/wcfsetup/install/files/lib/system/html/metacode/upcast/WsmMetacodeUpcast.class.php
+++ b/wcfsetup/install/files/lib/system/html/metacode/upcast/WsmMetacodeUpcast.class.php
@@ -15,7 +15,7 @@ use wcf\util\StringUtil;
  * @license     GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
  * @since       6.1
  */
-final class WsmMetacodeUpcast extends ImageMetacodeUpcast
+final class WsmMetacodeUpcast extends AbstractImageMetacodeUpcast
 {
     #[\Override]
     public function upcast(\DOMElement $element, array $attributes): void


### PR DESCRIPTION
See https://www.woltlab.com/community/thread/309433-artikel-können-nach-update-auf-woltlab-suite-6-1-nicht-bearbeitet-werden/