### PR TITLE
Remove obsolete parameters from `getControllerLink()`

### DIFF
--- a/wcfsetup/install/files/lib/form/AbstractFormBuilderForm.class.php
+++ b/wcfsetup/install/files/lib/form/AbstractFormBuilderForm.class.php
@@ -71,6 +71,7 @@ abstract class AbstractFormBuilderForm extends AbstractForm
      * name of the application for the link to the edit form
      * @var string
      * @since 5.3
+     * @deprecated 6.2 No longer in use.
      */
     public $objectEditLinkApplication = 'wcf';
 
@@ -194,7 +195,6 @@ abstract class AbstractFormBuilderForm extends AbstractForm
             WCF::getTPL()->assign(
                 'objectEditLink',
                 LinkHandler::getInstance()->getControllerLink($this->objectEditLinkController, [
-                    'application' => $this->objectEditLinkApplication,
                     'id' => $this->objectAction->getReturnValues()['returnValues']->getObjectID(),
                 ])
             );

--- a/wcfsetup/install/files/lib/system/request/LinkHandler.class.php
+++ b/wcfsetup/install/files/lib/system/request/LinkHandler.class.php
@@ -83,10 +83,10 @@ final class LinkHandler extends SingletonFactory
 
         $matches = $this->controllerRegex->getMatches();
 
-        // important: matches cannot overwrite explicitly set parameters
-        $parameters['application'] = $parameters['application'] ?? $matches['application'];
-        $parameters['isACP'] = $parameters['isACP'] ?? $matches['isAcp'];
-        $parameters['forceFrontend'] = $parameters['forceFrontend'] ?? !$matches['isAcp'];
+        // Overwrite legacy parameters, as these always result from the given controller class.
+        $parameters['application'] = $matches['application'];
+        $parameters['isACP'] = $matches['isAcp'];
+        $parameters['forceFrontend'] = !$matches['isAcp'];
 
         return $this->getLink($matches['controller'], $parameters, $url);
     }


### PR DESCRIPTION
The parameters are obsolete as they always result from the given controller class.