### PR TITLE
Add events to delegate the WebP/thumbnail generation

### DIFF
--- a/wcfsetup/install/files/lib/data/file/File.class.php
+++ b/wcfsetup/install/files/lib/data/file/File.class.php
@@ -82,7 +82,7 @@ class File extends DatabaseObject implements ILinkableObject
         );
     }
 
-    private function getRelativePath(): string
+    public function getRelativePath(): string
     {
         $folderA = \substr($this->fileHash, 0, 2);
         $folderB = \substr($this->fileHash, 2, 2);

--- a/wcfsetup/install/files/lib/event/file/GenerateThumbnail.class.php
+++ b/wcfsetup/install/files/lib/event/file/GenerateThumbnail.class.php
@@ -16,13 +16,29 @@ use wcf\system\file\processor\ThumbnailFormat;
  */
 final class GenerateThumbnail implements IPsr14Event
 {
-    /**
-     * The absolute path to the generated WebP image.
-     */
-    public ?string $filename = null;
+    private string $pathname;
 
     public function __construct(
         public readonly File $file,
         public readonly ThumbnailFormat $thumbnailFormat,
     ) {}
+
+    /**
+     * Sets the pathname of the generated image unless it has already been set
+     * in which case the call will throw an exception. You must check the result
+     * of `hasFile()` first.
+     */
+    public function setGeneratedFile(string $pathname): void
+    {
+        if (isset($this->pathname)) {
+            throw new \BadMethodCallException("Cannot set the generated file, a value has already been set.");
+        }
+
+        $this->pathname = $pathname;
+    }
+
+    public function getPathname(): ?string
+    {
+        return $this->pathname ?? null;
+    }
 }

--- a/wcfsetup/install/files/lib/event/file/GenerateThumbnail.class.php
+++ b/wcfsetup/install/files/lib/event/file/GenerateThumbnail.class.php
@@ -24,6 +24,15 @@ final class GenerateThumbnail implements IPsr14Event
     ) {}
 
     /**
+     * Returns true if a file has already been set and no further files are
+     * being accepted.
+     */
+    public function hasFile(): bool
+    {
+        return isset($this->pathname);
+    }
+
+    /**
      * Sets the pathname of the generated image unless it has already been set
      * in which case the call will throw an exception. You must check the result
      * of `hasFile()` first.

--- a/wcfsetup/install/files/lib/event/file/GenerateThumbnail.class.php
+++ b/wcfsetup/install/files/lib/event/file/GenerateThumbnail.class.php
@@ -17,6 +17,7 @@ use wcf\system\file\processor\ThumbnailFormat;
 final class GenerateThumbnail implements IPsr14Event
 {
     private string $pathname;
+    private bool $sourceIsDamaged = false;
 
     public function __construct(
         public readonly File $file,
@@ -49,5 +50,19 @@ final class GenerateThumbnail implements IPsr14Event
     public function getPathname(): ?string
     {
         return $this->pathname ?? null;
+    }
+
+    /**
+     * Flags the source image as damaged which should stop further processing
+     * of this file.
+     */
+    public function markSourceAsDamaged(): void
+    {
+        $this->sourceIsDamaged = true;
+    }
+
+    public function sourceIsMarkedAsDamaged(): bool
+    {
+        return $this->sourceIsDamaged;
     }
 }

--- a/wcfsetup/install/files/lib/event/file/GenerateThumbnail.class.php
+++ b/wcfsetup/install/files/lib/event/file/GenerateThumbnail.class.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace wcf\event\file;
+
+use wcf\data\file\File;
+use wcf\event\IPsr14Event;
+use wcf\system\file\processor\ThumbnailFormat;
+
+/**
+ * Requests the generation of a thumbnail.
+ *
+ * @author      Alexander Ebert
+ * @copyright   2001-2024 WoltLab GmbH
+ * @license     GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @since       6.1
+ */
+final class GenerateThumbnail implements IPsr14Event
+{
+    /**
+     * The absolute path to the generated WebP image.
+     */
+    public ?string $filename = null;
+
+    public function __construct(
+        public readonly File $file,
+        public readonly ThumbnailFormat $thumbnailFormat,
+    ) {}
+}

--- a/wcfsetup/install/files/lib/event/file/GenerateWebpVariant.class.php
+++ b/wcfsetup/install/files/lib/event/file/GenerateWebpVariant.class.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace wcf\event\file;
+
+use wcf\data\file\File;
+use wcf\event\IPsr14Event;
+
+/**
+ * Requests the generation of a WebP variant of the provided file.
+ *
+ * @author      Alexander Ebert
+ * @copyright   2001-2024 WoltLab GmbH
+ * @license     GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @since       6.1
+ */
+final class GenerateWebpVariant implements IPsr14Event
+{
+    /**
+     * The absolute path to the generated WebP image.
+     */
+    public ?string $filename = null;
+
+    public function __construct(
+        public readonly File $file
+    ) {}
+}

--- a/wcfsetup/install/files/lib/event/file/GenerateWebpVariant.class.php
+++ b/wcfsetup/install/files/lib/event/file/GenerateWebpVariant.class.php
@@ -17,6 +17,7 @@ use wcf\event\IPsr14Event;
 final class GenerateWebpVariant implements IPsr14Event
 {
     private string $pathname;
+    private bool $sourceIsDamaged = false;
 
     public function __construct(
         public readonly File $file
@@ -48,5 +49,19 @@ final class GenerateWebpVariant implements IPsr14Event
     public function getPathname(): ?string
     {
         return $this->pathname ?? null;
+    }
+
+    /**
+     * Flags the source image as damaged which should stop further processing
+     * of this file.
+     */
+    public function markSourceAsDamaged(): void
+    {
+        $this->sourceIsDamaged = true;
+    }
+
+    public function sourceIsMarkedAsDamaged(): bool
+    {
+        return $this->sourceIsDamaged;
     }
 }

--- a/wcfsetup/install/files/lib/event/file/GenerateWebpVariant.class.php
+++ b/wcfsetup/install/files/lib/event/file/GenerateWebpVariant.class.php
@@ -2,11 +2,12 @@
 
 namespace wcf\event\file;
 
+use BadMethodCallException;
 use wcf\data\file\File;
 use wcf\event\IPsr14Event;
 
 /**
- * Requests the generation of a WebP variant of the provided file.
+ * Requests the generation of a WebP variant for the provided image.
  *
  * @author      Alexander Ebert
  * @copyright   2001-2024 WoltLab GmbH
@@ -15,12 +16,37 @@ use wcf\event\IPsr14Event;
  */
 final class GenerateWebpVariant implements IPsr14Event
 {
-    /**
-     * The absolute path to the generated WebP image.
-     */
-    public ?string $filename = null;
+    private string $pathname;
 
     public function __construct(
         public readonly File $file
     ) {}
+
+    /**
+     * Returns true if a file has already been set and no further files are
+     * being accepted.
+     */
+    public function hasFile(): bool
+    {
+        return isset($this->pathname);
+    }
+
+    /**
+     * Sets the pathname of the generated image unless it has already been set
+     * in which case the call will throw an exception. You must check the result
+     * of `hasFile()` first.
+     */
+    public function setGeneratedFile(string $pathname): void
+    {
+        if (isset($this->pathname)) {
+            throw new \BadMethodCallException("Cannot set the generated file, a value has already been set.");
+        }
+
+        $this->pathname = $pathname;
+    }
+
+    public function getPathname(): ?string
+    {
+        return $this->pathname ?? null;
+    }
 }

--- a/wcfsetup/install/files/lib/system/file/processor/FileProcessor.class.php
+++ b/wcfsetup/install/files/lib/system/file/processor/FileProcessor.class.php
@@ -164,6 +164,9 @@ final class FileProcessor extends SingletonFactory
 
         $event = new GenerateWebpVariant($file);
         EventHandler::getInstance()->fire($event);
+        if ($event->sourceIsMarkedAsDamaged()) {
+            throw new DamagedImage($file->fileID);
+        }
 
         $filename = $event->getPathname();
         if ($filename === null) {
@@ -262,6 +265,9 @@ final class FileProcessor extends SingletonFactory
 
             $event = new GenerateThumbnail($file, $format);
             EventHandler::getInstance()->fire($event);
+            if ($event->sourceIsMarkedAsDamaged()) {
+                throw new DamagedImage($file->fileID);
+            }
 
             $filename = $event->getPathname();
             if ($filename === null) {

--- a/wcfsetup/install/files/lib/system/file/processor/FileProcessor.class.php
+++ b/wcfsetup/install/files/lib/system/file/processor/FileProcessor.class.php
@@ -165,7 +165,7 @@ final class FileProcessor extends SingletonFactory
         $event = new GenerateWebpVariant($file);
         EventHandler::getInstance()->fire($event);
 
-        $filename = $event->filename;
+        $filename = $event->getPathname();
         if ($filename === null) {
             $imageAdapter = ImageHandler::getInstance()->getAdapter();
             if (!$imageAdapter->checkMemoryLimit($file->width, $file->height, $file->mimeType)) {
@@ -263,7 +263,7 @@ final class FileProcessor extends SingletonFactory
             $event = new GenerateThumbnail($file, $format);
             EventHandler::getInstance()->fire($event);
 
-            $filename = $event->filename;
+            $filename = $event->getPathname();
             if ($filename === null) {
                 if ($imageAdapter === null) {
                     $imageAdapter = ImageHandler::getInstance()->getAdapter();

--- a/wcfsetup/install/files/lib/system/file/processor/FileProcessor.class.php
+++ b/wcfsetup/install/files/lib/system/file/processor/FileProcessor.class.php
@@ -9,7 +9,10 @@ use wcf\data\file\thumbnail\FileThumbnailEditor;
 use wcf\data\file\thumbnail\FileThumbnailList;
 use wcf\data\object\type\ObjectType;
 use wcf\data\object\type\ObjectTypeCache;
+use wcf\event\file\GenerateThumbnail;
+use wcf\event\file\GenerateWebpVariant;
 use wcf\system\database\util\PreparedStatementConditionBuilder;
+use wcf\system\event\EventHandler;
 use wcf\system\exception\SystemException;
 use wcf\system\file\processor\exception\DamagedImage;
 use wcf\system\image\adapter\exception\ImageNotProcessable;
@@ -159,32 +162,38 @@ final class FileProcessor extends SingletonFactory
             }
         }
 
-        $imageAdapter = ImageHandler::getInstance()->getAdapter();
-        if (!$imageAdapter->checkMemoryLimit($file->width, $file->height, $file->mimeType)) {
-            return;
-        }
+        $event = new GenerateWebpVariant($file);
+        EventHandler::getInstance()->fire($event);
 
-        try {
-            $imageAdapter->loadSingleFrameFromFile($file->getPathname());
-        } catch (SystemException | ImageNotReadable) {
-            throw new DamagedImage($file->fileID);
-        } catch (ImageNotProcessable $e) {
-            logThrowable($e);
-
-            return;
-        }
-
-        $filename = FileUtil::getTemporaryFilename(extension: 'webp');
-
-        try {
-            $imageAdapter->saveImageAs($imageAdapter->getImage(), $filename, 'webp', 80);
-        } catch (\Throwable $e) {
-            // Ignore any errors trying to save the file unless in debug mode.
-            if (\ENABLE_DEBUG_MODE) {
-                throw $e;
+        $filename = $event->filename;
+        if ($filename === null) {
+            $imageAdapter = ImageHandler::getInstance()->getAdapter();
+            if (!$imageAdapter->checkMemoryLimit($file->width, $file->height, $file->mimeType)) {
+                return;
             }
 
-            return;
+            try {
+                $imageAdapter->loadSingleFrameFromFile($file->getPathname());
+            } catch (SystemException | ImageNotReadable) {
+                throw new DamagedImage($file->fileID);
+            } catch (ImageNotProcessable $e) {
+                logThrowable($e);
+
+                return;
+            }
+
+            $filename = FileUtil::getTemporaryFilename(extension: 'webp');
+
+            try {
+                $imageAdapter->saveImageAs($imageAdapter->getImage(), $filename, 'webp', 80);
+            } catch (\Throwable $e) {
+                // Ignore any errors trying to save the file unless in debug mode.
+                if (\ENABLE_DEBUG_MODE) {
+                    throw $e;
+                }
+
+                return;
+            }
         }
 
         (new FileEditor($file))->update([
@@ -251,35 +260,41 @@ final class FileProcessor extends SingletonFactory
                 }
             }
 
-            if ($imageAdapter === null) {
-                $imageAdapter = ImageHandler::getInstance()->getAdapter();
-                if (!$imageAdapter->checkMemoryLimit($file->width, $file->height, $file->mimeType)) {
-                    return;
+            $event = new GenerateThumbnail($file, $format);
+            EventHandler::getInstance()->fire($event);
+
+            $filename = $event->filename;
+            if ($filename === null) {
+                if ($imageAdapter === null) {
+                    $imageAdapter = ImageHandler::getInstance()->getAdapter();
+                    if (!$imageAdapter->checkMemoryLimit($file->width, $file->height, $file->mimeType)) {
+                        return;
+                    }
+
+                    try {
+                        $imageAdapter->loadSingleFrameFromFile($file->getPathname());
+                    } catch (SystemException | ImageNotReadable $e) {
+                        throw new DamagedImage($file->fileID, $e);
+                    } catch (ImageNotProcessable $e) {
+                        logThrowable($e);
+
+                        return;
+                    }
                 }
+
+                \assert($imageAdapter instanceof ImageAdapter);
 
                 try {
-                    $imageAdapter->loadSingleFrameFromFile($file->getPathname());
-                } catch (SystemException | ImageNotReadable $e) {
-                    throw new DamagedImage($file->fileID, $e);
-                } catch (ImageNotProcessable $e) {
+                    $image = $imageAdapter->createThumbnail($format->width, $format->height, $format->retainDimensions);
+                } catch (\Throwable $e) {
                     logThrowable($e);
 
-                    return;
+                    continue;
                 }
+
+                $filename = FileUtil::getTemporaryFilename(extension: 'webp');
+                $imageAdapter->saveImageAs($image, $filename, 'webp', 80);
             }
-
-            \assert($imageAdapter instanceof ImageAdapter);
-
-            try {
-                $image = $imageAdapter->createThumbnail($format->width, $format->height, $format->retainDimensions);
-            } catch (\Throwable $e) {
-                logThrowable($e);
-
-                continue;
-            }
-
-            $filename = FileUtil::getTemporaryFilename(extension: 'webp');
-            $imageAdapter->saveImageAs($image, $filename, 'webp', 80);
 
             $fileThumbnail = FileThumbnailEditor::createFromTemporaryFile($file, $format, $filename);
             $processor->adoptThumbnail($fileThumbnail);


### PR DESCRIPTION
This allows to bypass the image adapter when generating the WebP variant and the thumbnails.

_Best reviewed with “Hide whitespace” changes._