### PR TITLE
Remove live-check of the `canHideOnlineStatus` permission

### DIFF
--- a/wcfsetup/install/files/lib/data/user/UserProfile.class.php
+++ b/wcfsetup/install/files/lib/data/user/UserProfile.class.php
@@ -470,7 +470,6 @@ class UserProfile extends DatabaseObjectDecorator implements ITitledLinkObject
     {
         return WCF::getUser()->userID == $this->userID
             || WCF::getSession()->getPermission('admin.user.canViewInvisible')
-            || !$this->getPermission('user.profile.canHideOnlineStatus')
             || $this->isAccessible('canViewOnlineStatus');
     }
 

--- a/wcfsetup/install/files/lib/system/worker/UserRebuildDataWorker.class.php
+++ b/wcfsetup/install/files/lib/system/worker/UserRebuildDataWorker.class.php
@@ -349,7 +349,7 @@ final class UserRebuildDataWorker extends AbstractLinearRebuildDataWorker
     private function updateUserOnlineStatus(array $users): void
     {
         foreach ($users as $user) {
-            if (!$user->canViewOnlineStatus) {
+            if ($user->canViewOnlineStatus == UserProfile::ACCESS_EVERYONE) {
                 continue;
             }
             $userProfile = new UserProfile($user->getDecoratedObject());
@@ -358,7 +358,7 @@ final class UserRebuildDataWorker extends AbstractLinearRebuildDataWorker
             }
 
             $user->updateUserOptions([
-                User::getUserOptionID('canViewOnlineStatus') => 0,
+                User::getUserOptionID('canViewOnlineStatus') => UserProfile::ACCESS_EVERYONE,
             ]);
         }
     }


### PR DESCRIPTION
The live check means that the user's group assignments and permissions had to be loaded. This is particularly unfavorable in places where many users are displayed (such as the member list).