### PR TITLE
Fix issue with the accessibility of RSS feeds when "force login" is active

### DIFF
--- a/wcfsetup/install/files/lib/page/AbstractAuthedPage.class.php
+++ b/wcfsetup/install/files/lib/page/AbstractAuthedPage.class.php
@@ -4,6 +4,7 @@ namespace wcf\page;
 
 use wcf\data\user\User;
 use wcf\system\exception\IllegalLinkException;
+use wcf\system\exception\PermissionDeniedException;
 use wcf\system\session\SessionHandler;
 use wcf\system\WCF;
 
@@ -18,14 +19,28 @@ use wcf\system\WCF;
 abstract class AbstractAuthedPage extends AbstractPage
 {
     /**
+     * If “Force login” is active, this page is faked as available during offline mode
+     * in order to bypass the CheckForForceLogin middleware.
+     */
+    public const AVAILABLE_DURING_OFFLINE_MODE = \FORCE_LOGIN;
+
+    /**
      * @inheritDoc
      */
     public function readParameters()
     {
         parent::readParameters();
 
+        if (\OFFLINE) {
+            throw new IllegalLinkException();
+        }
+
         // check security token
         $this->checkAccessToken();
+
+        if (\FORCE_LOGIN && !WCF::getUser()->userID) {
+            throw new PermissionDeniedException();
+        }
     }
 
     /**


### PR DESCRIPTION
The pages were generally not accessible for users who were not logged in, as the access token was only evaluated after the CheckForForceLogin middleware had been executed.