### PR TITLE
Fix the permission check for email notifications for new moderation queues

### DIFF
--- a/wcfsetup/install/files/lib/data/moderation/queue/ViewableModerationQueue.class.php
+++ b/wcfsetup/install/files/lib/data/moderation/queue/ViewableModerationQueue.class.php
@@ -163,13 +163,10 @@ class ViewableModerationQueue extends DatabaseObjectDecorator implements ILinkab
 
     /**
      * Returns a viewable moderation queue entry.
-     *
-     * @param int $queueID
-     * @return  ViewableModerationQueue
      */
-    public static function getViewableModerationQueue($queueID)
+    public static function getViewableModerationQueue(int $queueID, ?User $target = null): ?ViewableModerationQueue
     {
-        $queueList = new ViewableModerationQueueList();
+        $queueList = new ViewableModerationQueueList($target);
         $queueList->getConditionBuilder()->add("moderation_queue.queueID = ?", [$queueID]);
         $queueList->sqlLimit = 1;
         $queueList->readObjects();

--- a/wcfsetup/install/files/lib/data/moderation/queue/ViewableModerationQueueList.class.php
+++ b/wcfsetup/install/files/lib/data/moderation/queue/ViewableModerationQueueList.class.php
@@ -2,6 +2,7 @@
 
 namespace wcf\data\moderation\queue;
 
+use wcf\data\user\User;
 use wcf\system\cache\runtime\UserProfileRuntimeCache;
 use wcf\system\moderation\queue\ModerationQueueManager;
 use wcf\system\WCF;
@@ -38,9 +39,13 @@ class ViewableModerationQueueList extends ModerationQueueList
     /**
      * @inheritDoc
      */
-    public function __construct()
+    public function __construct(?User $target = null)
     {
         parent::__construct();
+
+        if ($target === null) {
+            $target = WCF::getUser();
+        }
 
         $this->sqlSelects = "moderation_queue.*, assigned_user.username AS assignedUsername, user_table.username";
         $this->sqlConditionJoins = ", wcf" . WCF_N . "_moderation_queue moderation_queue";
@@ -51,7 +56,7 @@ class ViewableModerationQueueList extends ModerationQueueList
             LEFT JOIN   wcf" . WCF_N . "_user user_table
             ON          user_table.userID = moderation_queue.userID";
         $this->getConditionBuilder()->add("moderation_queue_to_user.queueID = moderation_queue.queueID");
-        $this->getConditionBuilder()->add("moderation_queue_to_user.userID = ?", [WCF::getUser()->userID]);
+        $this->getConditionBuilder()->add("moderation_queue_to_user.userID = ?", [$target->userID]);
         $this->getConditionBuilder()->add("moderation_queue_to_user.isAffected = ?", [1]);
     }
 

--- a/wcfsetup/install/files/lib/system/user/notification/UserNotificationHandler.class.php
+++ b/wcfsetup/install/files/lib/system/user/notification/UserNotificationHandler.class.php
@@ -27,6 +27,7 @@ use wcf\system\event\EventHandler;
 use wcf\system\exception\SystemException;
 use wcf\system\request\LinkHandler;
 use wcf\system\SingletonFactory;
+use wcf\system\user\notification\event\IRecipientAwareUserNotificationEvent;
 use wcf\system\user\notification\event\IUserNotificationEvent;
 use wcf\system\user\notification\object\IUserNotificationObject;
 use wcf\system\user\notification\object\type\IUserNotificationObjectType;
@@ -761,6 +762,10 @@ class UserNotificationHandler extends SingletonFactory
 
         // recipient's language
         $event->setLanguage($user->getLanguage());
+
+        if ($event instanceof IRecipientAwareUserNotificationEvent) {
+            $event->setRecipient($user);
+        }
 
         // generate token if not present
         if (!$user->notificationMailToken) {

--- a/wcfsetup/install/files/lib/system/user/notification/event/IRecipientAwareUserNotificationEvent.class.php
+++ b/wcfsetup/install/files/lib/system/user/notification/event/IRecipientAwareUserNotificationEvent.class.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace wcf\system\user\notification\event;
+
+use wcf\data\user\User;
+
+/**
+ * @author      Alexander Ebert
+ * @copyright   2001-2025 WoltLab GmbH, Oliver Kliebisch
+ * @license     GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @since       6.1
+ */
+interface IRecipientAwareUserNotificationEvent extends IUserNotificationEvent
+{
+    /**
+     * Sets the recipient of the notification event to allow filtering of any
+     * additional data.
+     */
+    public function setRecipient(User $user): void;
+}


### PR DESCRIPTION
The existing implementation implicitly validated the permissions using the current user. This causes issues when the reporting user does not have access to the moderation queue which would yield an empty object.

See https://www.woltlab.com/community/thread/310285-fehlermeldung-bei-reportmoderationqueueusernotificationevent-class-php/