### PR TITLE
Add snackbar like notifications

### DIFF
--- a/ts/WoltLabSuite/Core/Component/Snackbar.ts
+++ b/ts/WoltLabSuite/Core/Component/Snackbar.ts
@@ -1,0 +1,160 @@
+import { getPhrase } from "WoltLabSuite/Core/Language";
+import { getPageOverlayContainer } from "WoltLabSuite/Core/Helper/PageOverlay";
+
+enum SnackbarType {
+  Success,
+  Progress,
+}
+
+class Snackbar {
+  #message: string = "";
+  readonly #type: SnackbarType;
+  #snackbarElement: HTMLElement;
+  readonly #hidden: Promise<void>;
+  #hiddenResolve: () => void;
+
+  constructor(message: string, type: SnackbarType) {
+    this.#message = message;
+    this.#type = type;
+
+    this.#hidden = new Promise<void>((resolve) => {
+      this.#hiddenResolve = resolve;
+    });
+    this.#render();
+  }
+
+  get message(): string {
+    return this.#message;
+  }
+
+  set message(message: string) {
+    this.#message = message;
+
+    this.#snackbarElement.querySelector(".snackbar__message")!.textContent = message;
+  }
+
+  markAsDone(message: string): void {
+    this.message = message;
+
+    const iconWrapper = this.#snackbarElement.querySelector(".snackbar__icon")!;
+    iconWrapper.classList.remove("snackbar__icon--progress");
+    iconWrapper.classList.add("snackbar__icon--success");
+
+    const icon = iconWrapper.querySelector("fa-icon")!;
+    icon.setIcon("check");
+
+    this.#setHideTimeout();
+  }
+
+  #render(): void {
+    const iconWrapper = document.createElement("div");
+    iconWrapper.classList.add("snackbar__icon");
+    iconWrapper.classList.add(this.isProgress() ? "snackbar__icon--progress" : "snackbar__icon--success");
+
+    const icon = document.createElement("fa-icon");
+    icon.size = 24;
+    icon.setIcon(this.isProgress() ? "spinner" : "check");
+    iconWrapper.append(icon);
+
+    const message = document.createElement("div");
+    message.classList.add("snackbar__message");
+    message.append(this.message);
+
+    const dismissButton = document.createElement("button");
+    dismissButton.type = "button";
+    dismissButton.classList.add("snackbar__dismissButton");
+    dismissButton.setAttribute("aria-label", getPhrase("wcf.global.button.close"));
+    dismissButton.addEventListener("click", () => {
+      this.hide();
+    });
+
+    const dismissIcon = document.createElement("fa-icon");
+    dismissIcon.size = 24;
+    dismissIcon.setIcon("xmark");
+    dismissButton.append(dismissIcon);
+
+    this.#snackbarElement = document.createElement("div");
+    this.#snackbarElement.classList.add("snackbar");
+    this.#snackbarElement.setAttribute("role", "status");
+    this.#snackbarElement.append(iconWrapper, message, dismissButton);
+
+    getSnackbarContainer().addSnackbar(this);
+
+    if (!this.isProgress()) {
+      this.#setHideTimeout();
+    }
+  }
+
+  #setHideTimeout(): void {
+    window.setTimeout(() => {
+      //this.hide();
+    }, 5000);
+  }
+
+  isProgress(): boolean {
+    return this.#type == SnackbarType.Progress;
+  }
+
+  hide(): void {
+    this.#snackbarElement.remove();
+    this.#hiddenResolve();
+  }
+
+  get hidden(): Promise<void> {
+    return this.#hidden;
+  }
+
+  get element(): HTMLElement {
+    return this.#snackbarElement;
+  }
+}
+
+let snackbarContainer: SnackbarContainer;
+
+function getSnackbarContainer(): SnackbarContainer {
+  if (!snackbarContainer) {
+    snackbarContainer = new SnackbarContainer();
+  }
+
+  return snackbarContainer;
+}
+
+class SnackbarContainer {
+  readonly #element: HTMLElement;
+  #snackbars: Snackbar[] = [];
+
+  constructor() {
+    this.#element = document.createElement("div");
+    this.#element.classList.add("snackbarContainer");
+    getPageOverlayContainer().append(this.#element);
+  }
+
+  addSnackbar(snackbar: Snackbar): void {
+    if (this.#snackbars.length > 2) {
+      const oldSnackbar = this.#snackbars.shift();
+      oldSnackbar?.hide();
+    }
+
+    this.#snackbars.push(snackbar);
+    this.#element.prepend(snackbar.element);
+
+    void snackbar.hidden.then(() => {
+      const i = this.#snackbars.indexOf(snackbar);
+      if (i !== -1) {
+        this.#snackbars = this.#snackbars.splice(i, 1);
+      }
+    });
+  }
+}
+
+export function showSuccessSnackbar(message: string): Snackbar {
+  return new Snackbar(message, SnackbarType.Success);
+}
+
+export function showProgressSnackbar(message: string): Snackbar {
+  return new Snackbar(message, SnackbarType.Progress);
+}
+
+export function showDefaultSuccessSnackbar(): Snackbar {
+  return showSuccessSnackbar(getPhrase("wcf.global.success"));
+}

--- a/ts/WoltLabSuite/Core/Component/Snackbar.ts
+++ b/ts/WoltLabSuite/Core/Component/Snackbar.ts
@@ -117,7 +117,7 @@ class Snackbar extends EventTarget {
       return;
     }
 
-    this.dispatchEvent(new CustomEvent("close"));
+    this.dispatchEvent(new CustomEvent("snackbar:close"));
 
     // The animation to move the element vertically relative to its height
     // requires the value to be computed first.
@@ -138,7 +138,7 @@ class Snackbar extends EventTarget {
 }
 
 interface SnackbarEventMap {
-  close: CustomEvent<void>;
+  "snackbar:close": CustomEvent<void>;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
@@ -182,7 +182,7 @@ class SnackbarContainer {
     this.#snackbars.push(snackbar);
     this.#element.prepend(snackbar.element);
 
-    void snackbar.addEventListener("close", () => {
+    void snackbar.addEventListener("snackbar:close", () => {
       const i = this.#snackbars.indexOf(snackbar);
       if (i !== -1) {
         this.#snackbars = this.#snackbars.splice(i, 1);

--- a/ts/WoltLabSuite/Core/Component/Snackbar.ts
+++ b/ts/WoltLabSuite/Core/Component/Snackbar.ts
@@ -173,9 +173,10 @@ class SnackbarContainer {
   }
 
   addSnackbar(snackbar: Snackbar): void {
-    if (this.#snackbars.length > 2) {
-      const oldSnackbar = this.#snackbars.shift();
-      oldSnackbar?.close();
+    const existingStaticSnackbars = this.#snackbars.filter((snackbar) => !snackbar.isProgress());
+    if (existingStaticSnackbars.length > 2) {
+      const oldSnackbar = existingStaticSnackbars.shift();
+      oldSnackbar!.close();
     }
 
     this.#snackbars.push(snackbar);

--- a/ts/WoltLabSuite/Core/Component/Snackbar.ts
+++ b/ts/WoltLabSuite/Core/Component/Snackbar.ts
@@ -9,7 +9,7 @@ enum SnackbarType {
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 class Snackbar extends EventTarget {
   #message: string = "";
-  readonly #type: SnackbarType;
+  #type: SnackbarType;
   #snackbarElement: HTMLElement;
 
   constructor(message: string, type: SnackbarType) {
@@ -34,11 +34,10 @@ class Snackbar extends EventTarget {
   markAsDone(message: string): void {
     this.message = message;
 
-    const iconWrapper = this.#snackbarElement.querySelector(".snackbar__icon")!;
-    iconWrapper.classList.remove("snackbar__icon--progress");
-    iconWrapper.classList.add("snackbar__icon--success");
+    this.#type = SnackbarType.Success;
+    this.#updateVisualType();
 
-    const icon = iconWrapper.querySelector("fa-icon")!;
+    const icon = this.#snackbarElement.querySelector(".snackbar__icon fa-icon") as FaIcon;
     icon.setIcon("check");
 
     this.#setHideTimeout();
@@ -47,7 +46,6 @@ class Snackbar extends EventTarget {
   #render(): void {
     const iconWrapper = document.createElement("div");
     iconWrapper.classList.add("snackbar__icon");
-    iconWrapper.classList.add(this.isProgress() ? "snackbar__icon--progress" : "snackbar__icon--success");
 
     const icon = document.createElement("fa-icon");
     icon.size = 24;
@@ -61,28 +59,34 @@ class Snackbar extends EventTarget {
     }
     message.append(this.message);
 
-    const dismissButton = document.createElement("button");
-    dismissButton.type = "button";
-    dismissButton.classList.add("snackbar__dismissButton");
-    dismissButton.setAttribute("aria-label", getPhrase("wcf.global.button.close"));
-    dismissButton.addEventListener("click", () => {
-      this.close();
-    });
-
-    const dismissIcon = document.createElement("fa-icon");
-    dismissIcon.size = 24;
-    dismissIcon.setIcon("xmark");
-    dismissButton.append(dismissIcon);
-
     this.#snackbarElement = document.createElement("div");
     this.#snackbarElement.classList.add("snackbar");
     this.#snackbarElement.setAttribute("role", "status");
-    this.#snackbarElement.append(iconWrapper, message, dismissButton);
+    this.#updateVisualType();
+    this.#snackbarElement.addEventListener("click", () => {
+      if (this.isProgress()) {
+        return;
+      }
+
+      this.close();
+    });
+
+    this.#snackbarElement.append(iconWrapper, message);
 
     getSnackbarContainer().addSnackbar(this);
 
     if (!this.isProgress()) {
       this.#setHideTimeout();
+    }
+  }
+
+  #updateVisualType(): void {
+    if (this.isProgress()) {
+      this.#snackbarElement.classList.add("snackbar--progress");
+      this.#snackbarElement.classList.remove("snackbar--success");
+    } else {
+      this.#snackbarElement.classList.remove("snackbar--progress");
+      this.#snackbarElement.classList.add("snackbar--success");
     }
   }
 

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Component/Snackbar.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Component/Snackbar.js
@@ -125,9 +125,10 @@ define(["require", "exports", "WoltLabSuite/Core/Language", "WoltLabSuite/Core/H
             (0, PageOverlay_1.getPageOverlayContainer)().append(this.#element);
         }
         addSnackbar(snackbar) {
-            if (this.#snackbars.length > 2) {
-                const oldSnackbar = this.#snackbars.shift();
-                oldSnackbar?.close();
+            const existingStaticSnackbars = this.#snackbars.filter((snackbar) => !snackbar.isProgress());
+            if (existingStaticSnackbars.length > 2) {
+                const oldSnackbar = existingStaticSnackbars.shift();
+                oldSnackbar.close();
             }
             this.#snackbars.push(snackbar);
             this.#element.prepend(snackbar.element);

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Component/Snackbar.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Component/Snackbar.js
@@ -1,0 +1,131 @@
+define(["require", "exports", "WoltLabSuite/Core/Language", "WoltLabSuite/Core/Helper/PageOverlay"], function (require, exports, Language_1, PageOverlay_1) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.showSuccessSnackbar = showSuccessSnackbar;
+    exports.showProgressSnackbar = showProgressSnackbar;
+    exports.showDefaultSuccessSnackbar = showDefaultSuccessSnackbar;
+    var SnackbarType;
+    (function (SnackbarType) {
+        SnackbarType[SnackbarType["Success"] = 0] = "Success";
+        SnackbarType[SnackbarType["Progress"] = 1] = "Progress";
+    })(SnackbarType || (SnackbarType = {}));
+    class Snackbar {
+        #message = "";
+        #type;
+        #snackbarElement;
+        #hidden;
+        #hiddenResolve;
+        constructor(message, type) {
+            this.#message = message;
+            this.#type = type;
+            this.#hidden = new Promise((resolve) => {
+                this.#hiddenResolve = resolve;
+            });
+            this.#render();
+        }
+        get message() {
+            return this.#message;
+        }
+        set message(message) {
+            this.#message = message;
+            this.#snackbarElement.querySelector(".snackbar__message").textContent = message;
+        }
+        markAsDone(message) {
+            this.message = message;
+            const iconWrapper = this.#snackbarElement.querySelector(".snackbar__icon");
+            iconWrapper.classList.remove("snackbar__icon--progress");
+            iconWrapper.classList.add("snackbar__icon--success");
+            const icon = iconWrapper.querySelector("fa-icon");
+            icon.setIcon("check");
+            this.#setHideTimeout();
+        }
+        #render() {
+            const iconWrapper = document.createElement("div");
+            iconWrapper.classList.add("snackbar__icon");
+            iconWrapper.classList.add(this.isProgress() ? "snackbar__icon--progress" : "snackbar__icon--success");
+            const icon = document.createElement("fa-icon");
+            icon.size = 24;
+            icon.setIcon(this.isProgress() ? "spinner" : "check");
+            iconWrapper.append(icon);
+            const message = document.createElement("div");
+            message.classList.add("snackbar__message");
+            message.append(this.message);
+            const dismissButton = document.createElement("button");
+            dismissButton.type = "button";
+            dismissButton.classList.add("snackbar__dismissButton");
+            dismissButton.setAttribute("aria-label", (0, Language_1.getPhrase)("wcf.global.button.close"));
+            dismissButton.addEventListener("click", () => {
+                this.hide();
+            });
+            const dismissIcon = document.createElement("fa-icon");
+            dismissIcon.size = 24;
+            dismissIcon.setIcon("xmark");
+            dismissButton.append(dismissIcon);
+            this.#snackbarElement = document.createElement("div");
+            this.#snackbarElement.classList.add("snackbar");
+            this.#snackbarElement.setAttribute("role", "status");
+            this.#snackbarElement.append(iconWrapper, message, dismissButton);
+            getSnackbarContainer().addSnackbar(this);
+            if (!this.isProgress()) {
+                this.#setHideTimeout();
+            }
+        }
+        #setHideTimeout() {
+            window.setTimeout(() => {
+                //this.hide();
+            }, 5000);
+        }
+        isProgress() {
+            return this.#type == SnackbarType.Progress;
+        }
+        hide() {
+            this.#snackbarElement.remove();
+            this.#hiddenResolve();
+        }
+        get hidden() {
+            return this.#hidden;
+        }
+        get element() {
+            return this.#snackbarElement;
+        }
+    }
+    let snackbarContainer;
+    function getSnackbarContainer() {
+        if (!snackbarContainer) {
+            snackbarContainer = new SnackbarContainer();
+        }
+        return snackbarContainer;
+    }
+    class SnackbarContainer {
+        #element;
+        #snackbars = [];
+        constructor() {
+            this.#element = document.createElement("div");
+            this.#element.classList.add("snackbarContainer");
+            (0, PageOverlay_1.getPageOverlayContainer)().append(this.#element);
+        }
+        addSnackbar(snackbar) {
+            if (this.#snackbars.length > 2) {
+                const oldSnackbar = this.#snackbars.shift();
+                oldSnackbar?.hide();
+            }
+            this.#snackbars.push(snackbar);
+            this.#element.prepend(snackbar.element);
+            void snackbar.hidden.then(() => {
+                const i = this.#snackbars.indexOf(snackbar);
+                if (i !== -1) {
+                    this.#snackbars = this.#snackbars.splice(i, 1);
+                }
+            });
+        }
+    }
+    function showSuccessSnackbar(message) {
+        return new Snackbar(message, SnackbarType.Success);
+    }
+    function showProgressSnackbar(message) {
+        return new Snackbar(message, SnackbarType.Progress);
+    }
+    function showDefaultSuccessSnackbar() {
+        return showSuccessSnackbar((0, Language_1.getPhrase)("wcf.global.success"));
+    }
+});

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Component/Snackbar.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Component/Snackbar.js
@@ -29,17 +29,15 @@ define(["require", "exports", "WoltLabSuite/Core/Language", "WoltLabSuite/Core/H
         }
         markAsDone(message) {
             this.message = message;
-            const iconWrapper = this.#snackbarElement.querySelector(".snackbar__icon");
-            iconWrapper.classList.remove("snackbar__icon--progress");
-            iconWrapper.classList.add("snackbar__icon--success");
-            const icon = iconWrapper.querySelector("fa-icon");
+            this.#type = SnackbarType.Success;
+            this.#updateVisualType();
+            const icon = this.#snackbarElement.querySelector(".snackbar__icon fa-icon");
             icon.setIcon("check");
             this.#setHideTimeout();
         }
         #render() {
             const iconWrapper = document.createElement("div");
             iconWrapper.classList.add("snackbar__icon");
-            iconWrapper.classList.add(this.isProgress() ? "snackbar__icon--progress" : "snackbar__icon--success");
             const icon = document.createElement("fa-icon");
             icon.size = 24;
             icon.setIcon(this.isProgress() ? "spinner" : "check");
@@ -50,24 +48,30 @@ define(["require", "exports", "WoltLabSuite/Core/Language", "WoltLabSuite/Core/H
                 message.setAttribute("aria-live", "polite");
             }
             message.append(this.message);
-            const dismissButton = document.createElement("button");
-            dismissButton.type = "button";
-            dismissButton.classList.add("snackbar__dismissButton");
-            dismissButton.setAttribute("aria-label", (0, Language_1.getPhrase)("wcf.global.button.close"));
-            dismissButton.addEventListener("click", () => {
-                this.close();
-            });
-            const dismissIcon = document.createElement("fa-icon");
-            dismissIcon.size = 24;
-            dismissIcon.setIcon("xmark");
-            dismissButton.append(dismissIcon);
             this.#snackbarElement = document.createElement("div");
             this.#snackbarElement.classList.add("snackbar");
             this.#snackbarElement.setAttribute("role", "status");
-            this.#snackbarElement.append(iconWrapper, message, dismissButton);
+            this.#updateVisualType();
+            this.#snackbarElement.addEventListener("click", () => {
+                if (this.isProgress()) {
+                    return;
+                }
+                this.close();
+            });
+            this.#snackbarElement.append(iconWrapper, message);
             getSnackbarContainer().addSnackbar(this);
             if (!this.isProgress()) {
                 this.#setHideTimeout();
+            }
+        }
+        #updateVisualType() {
+            if (this.isProgress()) {
+                this.#snackbarElement.classList.add("snackbar--progress");
+                this.#snackbarElement.classList.remove("snackbar--success");
+            }
+            else {
+                this.#snackbarElement.classList.remove("snackbar--progress");
+                this.#snackbarElement.classList.add("snackbar--success");
             }
         }
         #setHideTimeout() {

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Component/Snackbar.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Component/Snackbar.js
@@ -95,7 +95,7 @@ define(["require", "exports", "WoltLabSuite/Core/Language", "WoltLabSuite/Core/H
             if (!this.isVisible()) {
                 return;
             }
-            this.dispatchEvent(new CustomEvent("close"));
+            this.dispatchEvent(new CustomEvent("snackbar:close"));
             // The animation to move the element vertically relative to its height
             // requires the value to be computed first.
             const height = Math.trunc(getSnackbarContainer().getGapValue() + this.#snackbarElement.getBoundingClientRect().height);
@@ -132,7 +132,7 @@ define(["require", "exports", "WoltLabSuite/Core/Language", "WoltLabSuite/Core/H
             }
             this.#snackbars.push(snackbar);
             this.#element.prepend(snackbar.element);
-            void snackbar.addEventListener("close", () => {
+            void snackbar.addEventListener("snackbar:close", () => {
                 const i = this.#snackbars.indexOf(snackbar);
                 if (i !== -1) {
                     this.#snackbars = this.#snackbars.splice(i, 1);

--- a/wcfsetup/install/files/style/ui/snackbar.scss
+++ b/wcfsetup/install/files/style/ui/snackbar.scss
@@ -1,0 +1,53 @@
+.snackbarContainer {
+	position: fixed;
+	left: 20px;
+	bottom: 20px;
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
+}
+
+.snackbar {
+	color: #fff;
+	background-color: rgb(50, 50, 50);
+	display: flex;
+	user-select: none;
+	box-shadow:
+		rgba(0, 0, 0, 0.2) 0px 3px 5px -1px,
+		rgba(0, 0, 0, 0.14) 0px 6px 10px 0px,
+		rgba(0, 0, 0, 0.12) 0px 1px 18px 0px;
+	border-radius: 4px;
+	gap: 10px;
+	overflow: hidden;
+	min-width: 200px;
+}
+
+.snackbar__icon {
+	border-right: 2px solid transparent;
+	display: flex;
+	align-items: center;
+	width: 36px;
+	text-align: center;
+	justify-content: center;
+}
+
+.snackbar__icon--success {
+	background-color: var(--wcfStatusSuccessBackground);
+	border-color: var(--wcfStatusSuccessBorder);
+	color: var(--wcfStatusSuccessText);
+}
+
+.snackbar__icon--progress {
+	background-color: var(--wcfStatusInfoBackground);
+	border-color: var(--wcfStatusInfoBorder);
+	color: var(--wcfStatusInfoText);
+}
+
+.snackbar__message {
+	padding: 5px 0;
+	flex: 1 0 auto;
+}
+
+.snackbar__dismissButton {
+	padding-right: 5px;
+}

--- a/wcfsetup/install/files/style/ui/snackbar.scss
+++ b/wcfsetup/install/files/style/ui/snackbar.scss
@@ -1,10 +1,11 @@
 .snackbarContainer {
-	position: fixed;
-	left: 20px;
+	align-items: start;
 	bottom: 20px;
 	display: flex;
 	flex-direction: column;
 	gap: 10px;
+	left: 20px;
+	position: fixed;
 }
 
 @keyframes snackbarIn {
@@ -46,51 +47,47 @@
 
 .snackbar {
 	animation: snackbarIn 0.12s ease-in-out;
-	color: #fff;
-	background-color: rgb(50, 50, 50);
-	display: flex;
-	user-select: none;
-	box-shadow:
-		rgba(0, 0, 0, 0.2) 0px 3px 5px -1px,
-		rgba(0, 0, 0, 0.14) 0px 6px 10px 0px,
-		rgba(0, 0, 0, 0.12) 0px 1px 18px 0px;
+	background-color: var(--wcfContentBackground);
+	border: 1px solid var(--wcfContentBorderInner);
 	border-radius: 4px;
-	gap: 10px;
-	overflow: hidden;
-	min-width: 200px;
-}
-
-.snackbar.snackbar--closing {
-	animation-name: snackbarOut;
-	animation-duration: .24s;
-}
-
-.snackbar__icon {
-	border-right: 2px solid transparent;
+	box-shadow: var(--wcfBoxShadow);
+	color: var(--wcfContentText);
 	display: flex;
-	align-items: center;
-	width: 36px;
-	text-align: center;
-	justify-content: center;
+	isolation: isolate;
+	min-width: 200px;
+	overflow: hidden;
+	padding: 0 5px;
+	user-select: none;
 }
 
-.snackbar__icon--success {
+.snackbar--closing {
+	animation-name: snackbarOut;
+	animation-duration: 0.24s;
+}
+
+.snackbar--success {
 	background-color: var(--wcfStatusSuccessBackground);
 	border-color: var(--wcfStatusSuccessBorder);
 	color: var(--wcfStatusSuccessText);
 }
 
-.snackbar__icon--progress {
+.snackbar--progress {
 	background-color: var(--wcfStatusInfoBackground);
 	border-color: var(--wcfStatusInfoBorder);
 	color: var(--wcfStatusInfoText);
 }
 
-.snackbar__message {
-	padding: 5px 0;
-	flex: 1 0 auto;
+.snackbar__icon {
+	align-items: center;
+	border: 1px solid transparent;
+	display: flex;
+	justify-content: center;
+	text-align: center;
+	width: 36px;
 }
 
-.snackbar__dismissButton {
-	padding-right: 5px;
+.snackbar__message {
+	flex: 1 0 auto;
+	padding: 10px 5px 10px 0;
 }
+

--- a/wcfsetup/install/files/style/ui/snackbar.scss
+++ b/wcfsetup/install/files/style/ui/snackbar.scss
@@ -7,7 +7,45 @@
 	gap: 10px;
 }
 
+@keyframes snackbarIn {
+	0% {
+		opacity: 0;
+		transform: translateX(-100%);
+	}
+	50% {
+		opacity: 1;
+		transform: translateX(-50%);
+	}
+	100% {
+		opacity: 1;
+		transform: translateX(0);
+	}
+}
+
+@keyframes snackbarOut {
+	0% {
+		opacity: 1;
+		transform: translateX(0);
+		margin-bottom: 0;
+	}
+	25% {
+		opacity: 1;
+		transform: translateX(-50%);
+	}
+	50% {
+		margin-bottom: 0;
+		opacity: 0;
+		transform: translateX(-100%);
+	}
+	100% {
+		margin-bottom: calc(var(--height) * -1);
+		opacity: 0;
+		transform: translateX(-100%);
+	}
+}
+
 .snackbar {
+	animation: snackbarIn 0.12s ease-in-out;
 	color: #fff;
 	background-color: rgb(50, 50, 50);
 	display: flex;
@@ -20,6 +58,11 @@
 	gap: 10px;
 	overflow: hidden;
 	min-width: 200px;
+}
+
+.snackbar.snackbar--closing {
+	animation-name: snackbarOut;
+	animation-duration: .24s;
 }
 
 .snackbar__icon {


### PR DESCRIPTION
Use this template code for testing:

```
<button type="button" class="button" id="showSnackbar">Show Snackbar</button>
<button type="button" class="button" id="showProgressSnackbar">Show Progress Snackbar</button>

<script data-relocate="true">
	require(['WoltLabSuite/Core/Component/Snackbar'], ({ showDefaultSuccessSnackbar, showProgressSnackbar }) => {
		document.getElementById('showSnackbar').addEventListener('click', () => {
			const snackbar = showDefaultSuccessSnackbar();
			snackbar.addEventListener("close", () => {
				console.log('Closed');
			});
		});
		document.getElementById('showProgressSnackbar').addEventListener('click', () => {
			const snackbar = showProgressSnackbar('1 of 10');
			snackbar.addEventListener("close", () => {
				console.log('Closed');
			});

			window.setTimeout(() => {
				snackbar.message = '5 of 10';
			}, 2000);

			window.setTimeout(() => {
				snackbar.markAsDone('done!');
			}, 4000);
		});
	});
</script>
```

ref https://github.com/WoltLab/WCF/issues/6134