### PR TITLE
Allow the refresh of all rows after an interactions has been executed

### DIFF
--- a/ts/WoltLabSuite/Core/Component/GridView.ts
+++ b/ts/WoltLabSuite/Core/Component/GridView.ts
@@ -94,7 +94,7 @@ export class GridView {
   }
 
   #initEventListeners(): void {
-    this.#table.addEventListener("interaction:refresh-all", () => {
+    this.#table.addEventListener("interaction:invalidate-all", () => {
       void this.#loadRows(StateChangeCause.Change);
     });
 

--- a/ts/WoltLabSuite/Core/Component/GridView.ts
+++ b/ts/WoltLabSuite/Core/Component/GridView.ts
@@ -94,6 +94,10 @@ export class GridView {
   }
 
   #initEventListeners(): void {
+    this.#table.addEventListener("interaction:refresh-all", () => {
+      void this.#loadRows(StateChangeCause.Change);
+    });
+
     this.#table.addEventListener("refresh", (event) => {
       void this.#refreshRow(event.target as HTMLElement);
     });

--- a/ts/WoltLabSuite/Core/Component/Interaction/Rpc.ts
+++ b/ts/WoltLabSuite/Core/Component/Interaction/Rpc.ts
@@ -19,7 +19,7 @@ async function handleRpcInteraction(
   endpoint: string,
   confirmationType: ConfirmationType,
   customConfirmationMessage: string = "",
-  refreshAll = false,
+  invalidatesAllItems = false,
 ): Promise<void> {
   const confirmationResult = await handleConfirmation(objectName, confirmationType, customConfirmationMessage);
   if (!confirmationResult.result) {
@@ -51,8 +51,8 @@ async function handleRpcInteraction(
       );
     });
   } else {
-    if (refreshAll) {
-      container.dispatchEvent(new CustomEvent("interaction:refresh-all"));
+    if (invalidatesAllItems) {
+      container.dispatchEvent(new CustomEvent("interaction:invalidate-all"));
     } else {
       element.dispatchEvent(
         new CustomEvent("refresh", {
@@ -76,7 +76,7 @@ export function setup(identifier: string, container: HTMLElement): void {
         event.detail.endpoint,
         event.detail.confirmationType,
         event.detail.confirmationMessage,
-        event.detail.refreshAll,
+        event.detail.invalidatesAllItems === "true",
       );
     }
   });

--- a/ts/WoltLabSuite/Core/Component/Interaction/Rpc.ts
+++ b/ts/WoltLabSuite/Core/Component/Interaction/Rpc.ts
@@ -13,11 +13,13 @@ import { show as showNotification } from "WoltLabSuite/Core/Ui/Notification";
 import { ConfirmationType, handleConfirmation } from "./Confirmation";
 
 async function handleRpcInteraction(
+  container: HTMLElement,
   element: HTMLElement,
   objectName: string,
   endpoint: string,
   confirmationType: ConfirmationType,
   customConfirmationMessage: string = "",
+  refreshAll = false,
 ): Promise<void> {
   const confirmationResult = await handleConfirmation(objectName, confirmationType, customConfirmationMessage);
   if (!confirmationResult.result) {
@@ -49,11 +51,15 @@ async function handleRpcInteraction(
       );
     });
   } else {
-    element.dispatchEvent(
-      new CustomEvent("refresh", {
-        bubbles: true,
-      }),
-    );
+    if (refreshAll) {
+      container.dispatchEvent(new CustomEvent("interaction:refresh-all"));
+    } else {
+      element.dispatchEvent(
+        new CustomEvent("refresh", {
+          bubbles: true,
+        }),
+      );
+    }
 
     // TODO: This shows a generic success message and should be replaced with a more specific message.
     showNotification();
@@ -64,11 +70,13 @@ export function setup(identifier: string, container: HTMLElement): void {
   container.addEventListener("interaction", (event: CustomEvent) => {
     if (event.detail.interaction === identifier) {
       void handleRpcInteraction(
+        container,
         event.target as HTMLElement,
         event.detail.objectName,
         event.detail.endpoint,
         event.detail.confirmationType,
         event.detail.confirmationMessage,
+        event.detail.refreshAll,
       );
     }
   });

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Component/GridView.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Component/GridView.js
@@ -62,7 +62,7 @@ define(["require", "exports", "tslib", "../Api/Gridviews/GetRow", "../Api/Gridvi
             });
         }
         #initEventListeners() {
-            this.#table.addEventListener("interaction:refresh-all", () => {
+            this.#table.addEventListener("interaction:invalidate-all", () => {
                 void this.#loadRows(0 /* StateChangeCause.Change */);
             });
             this.#table.addEventListener("refresh", (event) => {

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Component/GridView.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Component/GridView.js
@@ -62,6 +62,9 @@ define(["require", "exports", "tslib", "../Api/Gridviews/GetRow", "../Api/Gridvi
             });
         }
         #initEventListeners() {
+            this.#table.addEventListener("interaction:refresh-all", () => {
+                void this.#loadRows(0 /* StateChangeCause.Change */);
+            });
             this.#table.addEventListener("refresh", (event) => {
                 void this.#refreshRow(event.target);
             });

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Component/Interaction/Rpc.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Component/Interaction/Rpc.js
@@ -10,7 +10,7 @@ define(["require", "exports", "WoltLabSuite/Core/Api/DeleteObject", "WoltLabSuit
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.setup = setup;
-    async function handleRpcInteraction(container, element, objectName, endpoint, confirmationType, customConfirmationMessage = "", refreshAll = false) {
+    async function handleRpcInteraction(container, element, objectName, endpoint, confirmationType, customConfirmationMessage = "", invalidatesAllItems = false) {
         const confirmationResult = await (0, Confirmation_1.handleConfirmation)(objectName, confirmationType, customConfirmationMessage);
         if (!confirmationResult.result) {
             return;
@@ -36,8 +36,8 @@ define(["require", "exports", "WoltLabSuite/Core/Api/DeleteObject", "WoltLabSuit
             });
         }
         else {
-            if (refreshAll) {
-                container.dispatchEvent(new CustomEvent("interaction:refresh-all"));
+            if (invalidatesAllItems) {
+                container.dispatchEvent(new CustomEvent("interaction:invalidate-all"));
             }
             else {
                 element.dispatchEvent(new CustomEvent("refresh", {
@@ -51,7 +51,7 @@ define(["require", "exports", "WoltLabSuite/Core/Api/DeleteObject", "WoltLabSuit
     function setup(identifier, container) {
         container.addEventListener("interaction", (event) => {
             if (event.detail.interaction === identifier) {
-                void handleRpcInteraction(container, event.target, event.detail.objectName, event.detail.endpoint, event.detail.confirmationType, event.detail.confirmationMessage, event.detail.refreshAll);
+                void handleRpcInteraction(container, event.target, event.detail.objectName, event.detail.endpoint, event.detail.confirmationType, event.detail.confirmationMessage, event.detail.invalidatesAllItems === "true");
             }
         });
     }

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Component/Interaction/Rpc.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Component/Interaction/Rpc.js
@@ -10,7 +10,7 @@ define(["require", "exports", "WoltLabSuite/Core/Api/DeleteObject", "WoltLabSuit
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.setup = setup;
-    async function handleRpcInteraction(element, objectName, endpoint, confirmationType, customConfirmationMessage = "") {
+    async function handleRpcInteraction(container, element, objectName, endpoint, confirmationType, customConfirmationMessage = "", refreshAll = false) {
         const confirmationResult = await (0, Confirmation_1.handleConfirmation)(objectName, confirmationType, customConfirmationMessage);
         if (!confirmationResult.result) {
             return;
@@ -36,9 +36,14 @@ define(["require", "exports", "WoltLabSuite/Core/Api/DeleteObject", "WoltLabSuit
             });
         }
         else {
-            element.dispatchEvent(new CustomEvent("refresh", {
-                bubbles: true,
-            }));
+            if (refreshAll) {
+                container.dispatchEvent(new CustomEvent("interaction:refresh-all"));
+            }
+            else {
+                element.dispatchEvent(new CustomEvent("refresh", {
+                    bubbles: true,
+                }));
+            }
             // TODO: This shows a generic success message and should be replaced with a more specific message.
             (0, Notification_1.show)();
         }
@@ -46,7 +51,7 @@ define(["require", "exports", "WoltLabSuite/Core/Api/DeleteObject", "WoltLabSuit
     function setup(identifier, container) {
         container.addEventListener("interaction", (event) => {
             if (event.detail.interaction === identifier) {
-                void handleRpcInteraction(event.target, event.detail.objectName, event.detail.endpoint, event.detail.confirmationType, event.detail.confirmationMessage);
+                void handleRpcInteraction(container, event.target, event.detail.objectName, event.detail.endpoint, event.detail.confirmationType, event.detail.confirmationMessage, event.detail.refreshAll);
             }
         });
     }

--- a/wcfsetup/install/files/lib/system/interaction/RpcInteraction.class.php
+++ b/wcfsetup/install/files/lib/system/interaction/RpcInteraction.class.php
@@ -27,7 +27,7 @@ class RpcInteraction extends AbstractInteraction
         protected readonly InteractionConfirmationType $confirmationType = InteractionConfirmationType::None,
         protected readonly string|\Closure $confirmationMessage = '',
         ?\Closure $isAvailableCallback = null,
-        protected readonly bool $refreshAll = false,
+        protected readonly bool $invalidatesAllItems = false,
     ) {
         parent::__construct($identifier, $isAvailableCallback);
     }
@@ -68,6 +68,8 @@ class RpcInteraction extends AbstractInteraction
             }
         }
 
+        $invalidatesAllItems = $this->invalidatesAllItems ? 'true' : 'false';
+
         return <<<HTML
             <button
                 type="button"
@@ -76,7 +78,7 @@ class RpcInteraction extends AbstractInteraction
                 data-endpoint="{$endpoint}"
                 data-confirmation-type="{$this->confirmationType->toString()}"
                 data-confirmation-message="{$confirmationMessage}"
-                data-refresh-all={$this->refreshAll}
+                data-invalidates-all-items="{$invalidatesAllItems}"
             >
                 {$label}
             </button>

--- a/wcfsetup/install/files/lib/system/interaction/RpcInteraction.class.php
+++ b/wcfsetup/install/files/lib/system/interaction/RpcInteraction.class.php
@@ -26,7 +26,8 @@ class RpcInteraction extends AbstractInteraction
         protected readonly string|\Closure $languageItem,
         protected readonly InteractionConfirmationType $confirmationType = InteractionConfirmationType::None,
         protected readonly string|\Closure $confirmationMessage = '',
-        ?\Closure $isAvailableCallback = null
+        ?\Closure $isAvailableCallback = null,
+        protected readonly bool $refreshAll = false,
     ) {
         parent::__construct($identifier, $isAvailableCallback);
     }
@@ -75,6 +76,7 @@ class RpcInteraction extends AbstractInteraction
                 data-endpoint="{$endpoint}"
                 data-confirmation-type="{$this->confirmationType->toString()}"
                 data-confirmation-message="{$confirmationMessage}"
+                data-refresh-all={$this->refreshAll}
             >
                 {$label}
             </button>

--- a/wcfsetup/install/files/lib/system/interaction/admin/LanguageInteractions.class.php
+++ b/wcfsetup/install/files/lib/system/interaction/admin/LanguageInteractions.class.php
@@ -30,7 +30,7 @@ final class LanguageInteractions extends AbstractInteractionProvider
                 "core/languages/%s/default",
                 "wcf.acp.language.setAsDefault",
                 isAvailableCallback: static fn(Language $language) => !$language->isDefault,
-                refreshAll: true
+                invalidatesAllItems: true
             ),
             new DeleteInteraction(
                 "core/languages/%s",

--- a/wcfsetup/install/files/lib/system/interaction/admin/LanguageInteractions.class.php
+++ b/wcfsetup/install/files/lib/system/interaction/admin/LanguageInteractions.class.php
@@ -29,13 +29,13 @@ final class LanguageInteractions extends AbstractInteractionProvider
                 "setAsDefault",
                 "core/languages/%s/default",
                 "wcf.acp.language.setAsDefault",
-                isAvailableCallback: static function (Language $language) {
-                    return !$language->isDefault;
-                }
+                isAvailableCallback: static fn(Language $language) => !$language->isDefault,
+                refreshAll: true
             ),
-            new DeleteInteraction("core/languages/%s", static function (Language $language) {
-                return $language->isDeletable();
-            })
+            new DeleteInteraction(
+                "core/languages/%s",
+                static fn(Language $language) => $language->isDeletable()
+            )
         ]);
 
         EventHandler::getInstance()->fire(

--- a/wcfsetup/install/files/lib/system/interaction/admin/StyleInteractions.class.php
+++ b/wcfsetup/install/files/lib/system/interaction/admin/StyleInteractions.class.php
@@ -28,7 +28,7 @@ final class StyleInteractions extends AbstractInteractionProvider
                 'core/styles/%s/set-as-default',
                 'wcf.acp.style.button.setAsDefault',
                 isAvailableCallback: static fn(Style $object) => !$object->isDefault,
-                refreshAll: true
+                invalidatesAllItems: true
             ),
         ]);
 

--- a/wcfsetup/install/files/lib/system/interaction/admin/StyleInteractions.class.php
+++ b/wcfsetup/install/files/lib/system/interaction/admin/StyleInteractions.class.php
@@ -27,7 +27,8 @@ final class StyleInteractions extends AbstractInteractionProvider
                 'set-as-default',
                 'core/styles/%s/set-as-default',
                 'wcf.acp.style.button.setAsDefault',
-                isAvailableCallback: static fn(Style $object) => !$object->isDefault
+                isAvailableCallback: static fn(Style $object) => !$object->isDefault,
+                refreshAll: true
             ),
         ]);
 


### PR DESCRIPTION
This is necessary if an interaction on a row indirectly leads to a change on other rows.