### PR TITLE
Simplify the API to manage a snackbar progress

### DIFF
--- a/ts/WoltLabSuite/Core/Component/Interaction/Bulk/Rpc.ts
+++ b/ts/WoltLabSuite/Core/Component/Interaction/Bulk/Rpc.ts
@@ -11,7 +11,6 @@ import { deleteObject } from "WoltLabSuite/Core/Api/DeleteObject";
 import { postObject } from "WoltLabSuite/Core/Api/PostObject";
 import { ConfirmationType, handleConfirmation } from "../Confirmation";
 import { showProgressSnackbar } from "WoltLabSuite/Core/Component/Snackbar";
-import { getPhrase } from "WoltLabSuite/Core/Language";
 
 async function handleRpcInteraction(
   container: HTMLElement,
@@ -26,13 +25,7 @@ async function handleRpcInteraction(
     return;
   }
 
-  const snackbar = showProgressSnackbar(
-    getPhrase("wcf.global.snackbar.progress", {
-      label,
-      iteration: 0,
-      length: objectIds.length,
-    }),
-  );
+  const snackbar = showProgressSnackbar(label, objectIds.length);
 
   for (let i = 0; i < objectIds.length; i++) {
     if (confirmationType == ConfirmationType.Delete) {
@@ -44,11 +37,7 @@ async function handleRpcInteraction(
       );
     }
 
-    snackbar.message = getPhrase("wcf.global.snackbar.progress", {
-      label,
-      iteration: i + 1,
-      length: objectIds.length,
-    });
+    snackbar.setIteration(i + 1);
 
     const element = container.querySelector(`[data-object-id="${objectIds[i]}"]`);
     if (!element) {

--- a/ts/WoltLabSuite/Core/Component/Snackbar.ts
+++ b/ts/WoltLabSuite/Core/Component/Snackbar.ts
@@ -208,12 +208,46 @@ class SnackbarContainer {
   }
 }
 
+class SnackbarProgress {
+  readonly #snackbar: Snackbar;
+  readonly #label: string;
+  readonly #length: number;
+  #iteration = 0;
+
+  constructor(label: string, length: number) {
+    this.#label = label;
+    this.#length = length;
+
+    this.#snackbar = new Snackbar(this.#getMessage(), SnackbarType.Progress);
+  }
+
+  setIteration(iteration: number): void {
+    this.#iteration = iteration;
+  }
+
+  markAsDone(): void {
+    this.#snackbar.markAsDone();
+  }
+
+  get element(): Snackbar {
+    return this.#snackbar;
+  }
+
+  #getMessage(): string {
+    return getPhrase("wcf.global.snackbar.progress", {
+      label: this.#label,
+      iteration: this.#iteration,
+      length: this.#length,
+    });
+  }
+}
+
 export function showSuccessSnackbar(message: string): Snackbar {
   return new Snackbar(message, SnackbarType.Success);
 }
 
-export function showProgressSnackbar(message: string): Snackbar {
-  return new Snackbar(message, SnackbarType.Progress);
+export function showProgressSnackbar(label: string, length: number): SnackbarProgress {
+  return new SnackbarProgress(label, length);
 }
 
 export function showDefaultSuccessSnackbar(): Snackbar {

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Component/Interaction/Bulk/Rpc.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Component/Interaction/Bulk/Rpc.js
@@ -6,7 +6,7 @@
  * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
  * @since 6.2
  */
-define(["require", "exports", "WoltLabSuite/Core/Api/DeleteObject", "WoltLabSuite/Core/Api/PostObject", "../Confirmation", "WoltLabSuite/Core/Component/Snackbar", "WoltLabSuite/Core/Language"], function (require, exports, DeleteObject_1, PostObject_1, Confirmation_1, Snackbar_1, Language_1) {
+define(["require", "exports", "WoltLabSuite/Core/Api/DeleteObject", "WoltLabSuite/Core/Api/PostObject", "../Confirmation", "WoltLabSuite/Core/Component/Snackbar"], function (require, exports, DeleteObject_1, PostObject_1, Confirmation_1, Snackbar_1) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.setup = setup;
@@ -15,11 +15,7 @@ define(["require", "exports", "WoltLabSuite/Core/Api/DeleteObject", "WoltLabSuit
         if (!confirmationResult.result) {
             return;
         }
-        const snackbar = (0, Snackbar_1.showProgressSnackbar)((0, Language_1.getPhrase)("wcf.global.snackbar.progress", {
-            label,
-            iteration: 0,
-            length: objectIds.length,
-        }));
+        const snackbar = (0, Snackbar_1.showProgressSnackbar)(label, objectIds.length);
         for (let i = 0; i < objectIds.length; i++) {
             if (confirmationType == Confirmation_1.ConfirmationType.Delete) {
                 await (0, DeleteObject_1.deleteObject)(endpoint.replace(/%s/, objectIds[i].toString()));
@@ -27,11 +23,7 @@ define(["require", "exports", "WoltLabSuite/Core/Api/DeleteObject", "WoltLabSuit
             else {
                 await (0, PostObject_1.postObject)(endpoint.replace(/%s/, objectIds[i].toString()), confirmationResult.reason ? { reason: confirmationResult.reason } : undefined);
             }
-            snackbar.message = (0, Language_1.getPhrase)("wcf.global.snackbar.progress", {
-                label,
-                iteration: i + 1,
-                length: objectIds.length,
-            });
+            snackbar.setIteration(i + 1);
             const element = container.querySelector(`[data-object-id="${objectIds[i]}"]`);
             if (!element) {
                 continue;

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Component/Snackbar.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Component/Snackbar.js
@@ -155,11 +155,38 @@ define(["require", "exports", "WoltLabSuite/Core/Language", "WoltLabSuite/Core/H
             return parseInt(match[1]);
         }
     }
+    class SnackbarProgress {
+        #snackbar;
+        #label;
+        #length;
+        #iteration = 0;
+        constructor(label, length) {
+            this.#label = label;
+            this.#length = length;
+            this.#snackbar = new Snackbar(this.#getMessage(), SnackbarType.Progress);
+        }
+        setIteration(iteration) {
+            this.#iteration = iteration;
+        }
+        markAsDone() {
+            this.#snackbar.markAsDone();
+        }
+        get element() {
+            return this.#snackbar;
+        }
+        #getMessage() {
+            return (0, Language_1.getPhrase)("wcf.global.snackbar.progress", {
+                label: this.#label,
+                iteration: this.#iteration,
+                length: this.#length,
+            });
+        }
+    }
     function showSuccessSnackbar(message) {
         return new Snackbar(message, SnackbarType.Success);
     }
-    function showProgressSnackbar(message) {
-        return new Snackbar(message, SnackbarType.Progress);
+    function showProgressSnackbar(label, length) {
+        return new SnackbarProgress(label, length);
     }
     function showDefaultSuccessSnackbar() {
         return showSuccessSnackbar((0, Language_1.getPhrase)("wcf.global.success"));


### PR DESCRIPTION
The internal `SnackbarProgress` class keeps track of the current state and offers convenient methods to update the iteration and to mark it as done. The original `Snackbar` element is accessible through the `.element` property although it is unlikely that one needs access to the events, which is why they are omitted from this implementation.

Closes #6219