### PR TITLE
Add missing space in shared_buttonFormField.tpl

### DIFF
--- a/com.woltlab.wcf/templates/shared_buttonFormField.tpl
+++ b/com.woltlab.wcf/templates/shared_buttonFormField.tpl
@@ -2,7 +2,7 @@
 	*}type="submit" {*
 	*}id="{$field->getPrefixedId()}" {*
 	*}name="{$field->getPrefixedId()}" {*
-	*}value="{$field->getValue()}"{*
+	*}value="{$field->getValue()}" {*
 	*}class="button {implode from=$field->getFieldClasses() item='class' glue=' '}{$class}{/implode}"{*
 	*}{foreach from=$field->getFieldAttributes() key='attributeName' item='attributeValue'} {$attributeName}="{$attributeValue}"{/foreach}{*
 *}>{$field->getButtonLabel()}</button>


### PR DESCRIPTION
The `value` and `class` attributes were missing a separating space.

This small issue was introduced in ea82ca5.