### PR TITLE
Use time() instead of TIME_NOW

### DIFF
--- a/wcfsetup/install/files/lib/system/email/Email.class.php
+++ b/wcfsetup/install/files/lib/system/email/Email.class.php
@@ -170,7 +170,7 @@ class Email
     public function getDate()
     {
         if ($this->date === null) {
-            $this->date = DateUtil::getDateTimeByTimestamp(TIME_NOW);
+            $this->date = DateUtil::getDateTimeByTimestamp(\time());
         }
 
         return $this->date;


### PR DESCRIPTION
Sending hundreds of emails in a long running task might take some time (depending on the provider and other work in the task) which could result in some emails having an "old" timestamp. An email might arrive at 12:53 (actual time) but have a timestamp of 12:50, because of the long running task.