### PR TITLE
Database object collections

### DIFF
--- a/wcfsetup/install/files/lib/data/CollectionDatabaseObject.class.php
+++ b/wcfsetup/install/files/lib/data/CollectionDatabaseObject.class.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace wcf\data;
+
+/**
+ * Abstract class for a database object that uses collections.
+ *
+ * @author      Marcel Werk
+ * @copyright   2001-2025 WoltLab GmbH
+ * @license     GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @since       6.2
+ *
+ * @template TDatabaseObjectCollection of DatabaseObjectCollection
+ */
+abstract class CollectionDatabaseObject extends DatabaseObject
+{
+    /**
+     * @var TDatabaseObjectCollection
+     */
+    protected DatabaseObjectCollection $collection;
+
+    /**
+     * @param TDatabaseObjectCollection $collection
+     */
+    public function setCollection(DatabaseObjectCollection $collection): void
+    {
+        $this->collection = $collection;
+    }
+
+    /**
+     * @return TDatabaseObjectCollection
+     */
+    public function getCollection(): DatabaseObjectCollection
+    {
+        if (!isset($this->collection)) {
+            $this->collection = new ($this->getCollectionClassName())([
+                $this
+            ]);
+        }
+
+        return $this->collection;
+    }
+
+    public function getCollectionClassName(): string
+    {
+        return static::class . 'Collection';
+    }
+}

--- a/wcfsetup/install/files/lib/data/DatabaseObjectCollection.class.php
+++ b/wcfsetup/install/files/lib/data/DatabaseObjectCollection.class.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace wcf\data;
+
+/**
+ * Abstract class for a collection of database objects.
+ *
+ * @author      Marcel Werk
+ * @copyright   2001-2025 WoltLab GmbH
+ * @license     GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @since       6.2
+ *
+ * @template TDatabaseObject of DatabaseObject
+ */
+abstract class DatabaseObjectCollection
+{
+    /**
+     * @param TDatabaseObject[] $objects
+     */
+    public function __construct(protected readonly array $objects) {}
+
+    /**
+     * @return int[]
+     */
+    public function getObjectIDs(): array
+    {
+        return \array_map(static fn($object) => $object->getObjectID(), $this->objects);
+    }
+
+    /**
+     * @return TDatabaseObject[]
+     */
+    public function getObjects(): array
+    {
+        return $this->objects;
+    }
+}

--- a/wcfsetup/install/files/lib/data/DatabaseObjectList.class.php
+++ b/wcfsetup/install/files/lib/data/DatabaseObjectList.class.php
@@ -230,6 +230,28 @@ abstract class DatabaseObjectList implements \Countable, ITraversableObject
         }
         $this->objectIDs = $this->indexToObject;
         $this->objects = $objects;
+
+        $this->createCollection();
+    }
+
+    /**
+     * @since 6.2
+     */
+    protected function createCollection(): void
+    {
+        if ($this->getObjects() === []) {
+            return;
+        }
+
+        $firstObject = reset($this->objects);
+        if (!($firstObject instanceof CollectionDatabaseObject)) {
+            return;
+        }
+
+        $collection = new ($firstObject->getCollectionClassName())($this->getObjects());
+        foreach ($this->getObjects() as $object) {
+            $object->setCollection($collection);
+        }
     }
 
     /**

--- a/wcfsetup/install/files/lib/data/DatabaseObjectList.class.php
+++ b/wcfsetup/install/files/lib/data/DatabaseObjectList.class.php
@@ -212,6 +212,8 @@ abstract class DatabaseObjectList implements \Countable, ITraversableObject
             $this->objects = $statement->fetchObjects(($this->objectClassName ?: $this->className));
         }
 
+        $this->createCollection();
+
         // decorate objects
         if (!empty($this->decoratorClassName)) {
             foreach ($this->objects as &$object) {
@@ -230,8 +232,6 @@ abstract class DatabaseObjectList implements \Countable, ITraversableObject
         }
         $this->objectIDs = $this->indexToObject;
         $this->objects = $objects;
-
-        $this->createCollection();
     }
 
     /**
@@ -239,17 +239,13 @@ abstract class DatabaseObjectList implements \Countable, ITraversableObject
      */
     protected function createCollection(): void
     {
-        if ($this->getObjects() === []) {
-            return;
-        }
-
-        $firstObject = reset($this->objects);
+        $firstObject = \reset($this->objects);
         if (!($firstObject instanceof CollectionDatabaseObject)) {
             return;
         }
 
-        $collection = new ($firstObject->getCollectionClassName())($this->getObjects());
-        foreach ($this->getObjects() as $object) {
+        $collection = new ($firstObject->getCollectionClassName())($this->objects);
+        foreach ($this->objects as $object) {
             $object->setCollection($collection);
         }
     }


### PR DESCRIPTION
The idea behind database object collections is to lazy-load additional data when it is needed, abandoning the concept of the "viewable" decorators for database objects.

Example:
```php
class FoobarCollection extends DatabaseObjectCollection
{
    /**
     * @var Label[][]
     */
    private array $labels;

    /**
     * @return Label[]
     */
    public function getLabels(Foobar $object): array
    {
        $this->loadLabels();

        return $this->labels[$object->getObjectID()] ?? [];
    }

    private function loadLabels(): void
    {
        if (isset($this->labels)) {
            return;
        }

        $this->labels = LabelObjectHandler::getInstance()->getAssignedLabels(
            \array_map(
                static fn($object) => $object->getObjectID(),
                \array_filter($this->objects, static fn($object) => $object->hasLabels)
            )
        );
    }
}

class Foobar extends CollectionDatabaseObject {
    /**
     * @return Label[]
     */
    public function getLabels(): array
    {
        return $this->getCollection()->getLabels($this);
    }
}
```
