### PR TITLE
Article Overview Improvement

### DIFF
--- a/com.woltlab.wcf/templates/articleListItems.tpl
+++ b/com.woltlab.wcf/templates/articleListItems.tpl
@@ -64,6 +64,12 @@
 							{include file='shared_topReaction' cachedReactions=$article->cachedReactions render='short'}
 						</div>
 					{/if}
+					{if $__wcf->getSession()->getPermission('admin.content.article.canManageArticle') || $__wcf->getSession()->getPermission('admin.content.article.canContributeArticle')}
+						<div class="contentItemMetaIcon">
+							{icon name="eye" type='solid'}
+							{$article->views}
+						</div>
+					{/if}
 					{if $article->getDiscussionProvider()->getDiscussionCountPhrase()}{* empty phrase indicates that comments are disabled *}
 						<div class="contentItemMetaIcon">
 							{icon name='comments'}

--- a/com.woltlab.wcf/templates/articleListItems.tpl
+++ b/com.woltlab.wcf/templates/articleListItems.tpl
@@ -3,7 +3,7 @@
 <div class="contentItemList">
 	{foreach from=$objects item='article' name='articles'}
 		{if $article->getArticleContent()}
-		<article class="contentItem contentItemMultiColumn">
+		<article class="contentItem contentItemMultiColumn {if !$article->isPublished()}contentItemUnpublished{/if}">
 			<div class="contentItemLink">
 				<div class="contentItemImage contentItemImageLarge">
 					<img

--- a/wcfsetup/install/files/style/ui/contentItem.scss
+++ b/wcfsetup/install/files/style/ui/contentItem.scss
@@ -29,6 +29,10 @@
 	flex-basis: calc(50% - 20px);
 }
 
+.contentItemUnpublished {
+	background-color: var(--wcfContentBackgroundDisabled);
+}
+
 .contentItemLink {
 	flex: 1 auto;
 }

--- a/wcfsetup/setup/db/install.sql
+++ b/wcfsetup/setup/db/install.sql
@@ -2419,6 +2419,7 @@ INSERT INTO wcf1_style_variable (variableName, defaultValue, defaultValueDarkMod
 INSERT INTO wcf1_style_variable (variableName, defaultValue, defaultValueDarkMode) VALUES('wcfButtonText', 'rgba(33, 33, 33, 1)', 'rgba(230, 231, 234, 1)');
 INSERT INTO wcf1_style_variable (variableName, defaultValue, defaultValueDarkMode) VALUES('wcfButtonTextActive', 'rgba(255, 255, 255, 1)', 'rgba(230, 231, 234, 1)');
 INSERT INTO wcf1_style_variable (variableName, defaultValue, defaultValueDarkMode) VALUES('wcfContentBackground', 'rgba(250, 250, 250, 1)', 'rgba(26, 29, 33, 1)');
+INSERT INTO wcf1_style_variable (variableName, defaultValue, defaultValueDarkMode) VALUES('wcfContentBackgroundDisabled', 'rgba(200, 205, 210, 1)', 'rgba(36, 46, 61, 1)');
 INSERT INTO wcf1_style_variable (variableName, defaultValue, defaultValueDarkMode) VALUES('wcfContentBorder', 'rgba(65, 121, 173, 1)', 'rgba(98, 113, 136, 1)');
 INSERT INTO wcf1_style_variable (variableName, defaultValue, defaultValueDarkMode) VALUES('wcfContentBorderInner', 'rgba(224, 224, 224, 1)', 'rgba(54, 55, 59, 1)');
 INSERT INTO wcf1_style_variable (variableName, defaultValue, defaultValueDarkMode) VALUES('wcfContentContainerBackground', 'rgba(255, 255, 255, 1)', 'rgba(34, 37, 41, 1)');


### PR DESCRIPTION
This PR introduces two minor improvements to the article overview for article managers. The first improvement changes the background color of unpublished articles, providing better visual separation between published and unpublished content than the "unpublished" tag alone. 

The second improvement adds view counts to the overview, making it easier for article managers to see how well received the articles are.

Disclaimer: I hope the locations of the changes are correct. I tested these modifications only in our forum using an updated template file and style changes.

![WCF_Disabled_Article_bright](https://github.com/user-attachments/assets/2b908ad5-aec2-4b80-8971-187e67cbb216)
![WCF_Disabled_Article_dark](https://github.com/user-attachments/assets/bcd52a74-5e45-4d88-9f78-1fe528803f9d)