### PR TITLE
Refactor comment templates

### DIFF
--- a/com.woltlab.wcf/templates/commentEditor.tpl
+++ b/com.woltlab.wcf/templates/commentEditor.tpl
@@ -1,4 +1,4 @@
-{capture assign='wysiwygSelector'}commentEditor{@$comment->commentID}{/capture}
+{capture assign='wysiwygSelector'}commentEditor{$comment->commentID}{/capture}
 <textarea id="{$wysiwygSelector}" class="wysiwygTextarea"
           data-disable-attachments="true"
           data-support-mention="true"
@@ -15,7 +15,7 @@
 
 <script data-relocate="true">
 	require(['WoltLabSuite/Core/Component/Comment/Add'], ({ setCommentEditorFeatures }) => {
-		setCommentEditorFeatures(document.getElementById('{$wysiwygSelector}'));
+		setCommentEditorFeatures(document.getElementById('{unsafe:$wysiwygSelector|encodeJS}'));
 	});
 </script>
 

--- a/com.woltlab.wcf/templates/commentList.tpl
+++ b/com.woltlab.wcf/templates/commentList.tpl
@@ -29,7 +29,7 @@
 						{/if}
 					</div>
 					<div class="comment__date">
-						<meta itemprop="datePublished" content="{$comment->time|date:'c'}">
+						<meta itemprop="datePublished" content="{time type='custom' time=$comment->time format='c'}">
 						<a href="{$comment->getLink()}" class="comment__permalink">{time time=$comment->time}</a>
 					</div>
 					<div class="comment__status">

--- a/com.woltlab.wcf/templates/commentList.tpl
+++ b/com.woltlab.wcf/templates/commentList.tpl
@@ -8,29 +8,29 @@
 		</div>
 	{else}
 		<div class="commentList__item jsComment{if $__wcf->getUserProfileHandler()->isIgnoredUser($comment->userID, 2)} ignoredUserContent{/if}"
-			data-comment-id="{@$comment->commentID}"
-			{@$__wcf->getReactionHandler()->getDataAttributes('com.woltlab.wcf.comment', $comment->commentID)}
+			data-comment-id="{$comment->commentID}"
+			{unsafe:$__wcf->getReactionHandler()->getDataAttributes('com.woltlab.wcf.comment', $comment->commentID)}
 			data-can-edit="{if $comment->isEditable()}true{else}false{/if}" data-can-delete="{if $comment->isDeletable()}true{else}false{/if}"
-			data-responses="{@$comment->responses}" data-last-response-time="{if $ignoreLastResponseTime|empty}{@$comment->getLastResponseTime()}{else}1{/if}" data-is-disabled="{@$comment->isDisabled}"
-			data-last-response-id="{if $ignoreLastResponseTime|empty}{@$comment->getLastResponseID()}{else}0{/if}"
+			data-responses="{$comment->responses}" data-last-response-time="{if $ignoreLastResponseTime|empty}{$comment->getLastResponseTime()}{else}1{/if}" data-is-disabled="{$comment->isDisabled}"
+			data-last-response-id="{if $ignoreLastResponseTime|empty}{$comment->getLastResponseID()}{else}0{/if}"
 		>
-			<woltlab-core-comment class="comment" comment-id="{@$comment->commentID}" itemprop="comment" itemscope itemtype="http://schema.org/Comment">
+			<woltlab-core-comment class="comment" comment-id="{$comment->commentID}" itemprop="comment" itemscope itemtype="http://schema.org/Comment">
 				<div class="comment__header">
 					<div class="comment__avatar">
 						{user object=$comment->getUserProfile() type='avatar32' ariaHidden='true' tabindex='-1'}
 					</div>
 					<div class="comment__author" itemprop="author" itemscope itemtype="http://schema.org/Person">
 						{if $comment->userID}
-							<a href="{$comment->getUserProfile()->getLink()}" class="comment__author__link userLink" data-object-id="{@$comment->userID}" itemprop="url">
-								<span itemprop="name">{@$comment->getUserProfile()->getFormattedUsername()}</span>
+							<a href="{$comment->getUserProfile()->getLink()}" class="comment__author__link userLink" data-object-id="{$comment->userID}" itemprop="url">
+								<span itemprop="name">{unsafe:$comment->getUserProfile()->getFormattedUsername()}</span>
 							</a>
 						{else}
 							<span itemprop="name">{$comment->username}</span>
 						{/if}
 					</div>
 					<div class="comment__date">
-						<meta itemprop="datePublished" content="{@$comment->time|date:'c'}">
-						<a href="{$comment->getLink()}" class="comment__permalink">{@$comment->time|time}</a>
+						<meta itemprop="datePublished" content="{$comment->time|date:'c'}">
+						<a href="{$comment->getLink()}" class="comment__permalink">{time time=$comment->time}</a>
 					</div>
 					<div class="comment__status">
 						{if $comment->isDisabled}
@@ -44,7 +44,7 @@
 						{event name='commentStatus'}
 					</div>
 					{hascontent}
-						<div class="comment__menu dropdown" id="commentOptions{@$comment->commentID}">
+						<div class="comment__menu dropdown" id="commentOptions{$comment->commentID}">
 							<button type="button" class="dropdownToggle" aria-label="{lang}wcf.global.button.more{/lang}">{icon name='ellipsis-vertical'}</button>
 
 							<ul class="dropdownMenu">
@@ -95,7 +95,7 @@
 				{event name='commentBeforeMessage'}
 
 				<div class="comment__message">
-					<div class="htmlContent userMessage" itemprop="text">{@$comment->getFormattedMessage()}</div>
+					<div class="htmlContent userMessage" itemprop="text">{unsafe:$comment->getFormattedMessage()}</div>
 				</div>
 
 				{event name='commentAfterMessage'}
@@ -140,7 +140,7 @@
 
 			{if !$ignoreLastResponseTime|empty || $comment|count}
 				<div class="comment__responses">
-					<div class="commentResponseList" data-responses="{if $commentCanModerate}{@$comment->unfilteredResponses}{else}{@$comment->responses}{/if}">
+					<div class="commentResponseList" data-responses="{if $commentCanModerate}{$comment->unfilteredResponses}{else}{$comment->responses}{/if}">
 						{if $ignoreLastResponseTime|empty}{include file='commentResponseList' responseList=$comment}{/if}
 					</div>
 				</div>

--- a/com.woltlab.wcf/templates/commentResponseEditor.tpl
+++ b/com.woltlab.wcf/templates/commentResponseEditor.tpl
@@ -1,4 +1,4 @@
-{capture assign='wysiwygSelector'}commentResponseEditor{@$response->responseID}{/capture}
+{capture assign='wysiwygSelector'}commentResponseEditor{$response->responseID}{/capture}
 <textarea id="{$wysiwygSelector}" class="wysiwygTextarea"
           data-disable-attachments="true"
           data-support-mention="true"
@@ -15,7 +15,7 @@
 
 <script data-relocate="true">
 	require(['WoltLabSuite/Core/Component/Comment/Add'], ({ setCommentEditorFeatures }) => {
-		setCommentEditorFeatures(document.getElementById('{$wysiwygSelector}'));
+		setCommentEditorFeatures(document.getElementById('{unsafe:$wysiwygSelector|encodeJS}'));
 	});
 </script>
 

--- a/com.woltlab.wcf/templates/commentResponseList.tpl
+++ b/com.woltlab.wcf/templates/commentResponseList.tpl
@@ -26,7 +26,7 @@
 						{/if}
 					</div>
 					<div class="commentResponse__date">
-						<meta itemprop="datePublished" content="{$response->time|date:'c'}">
+						<meta itemprop="datePublished" content="{time type='custom' time=$response->time format='c'}">
 						<a href="{$response->getLink()}" class="commentResponse__permalink">{time time=$response->time}</a>
 					</div>
 					<div class="commentResponse__status">

--- a/com.woltlab.wcf/templates/commentResponseList.tpl
+++ b/com.woltlab.wcf/templates/commentResponseList.tpl
@@ -5,29 +5,29 @@
 		</div>
 	{else}
 		<div class="commentResponseList__item jsCommentResponse{if $__wcf->getUserProfileHandler()->isIgnoredUser($response->userID, 2)} ignoredUserContent{/if}"
-			data-response-id="{@$response->responseID}"
-			{@$__wcf->getReactionHandler()->getDataAttributes('com.woltlab.wcf.comment.response', $response->responseID)}
+			data-response-id="{$response->responseID}"
+			{unsafe:$__wcf->getReactionHandler()->getDataAttributes('com.woltlab.wcf.comment.response', $response->responseID)}
 			data-can-edit="{if $response->isEditable()}true{else}false{/if}"
 			data-can-delete="{if $response->isDeletable()}true{else}false{/if}"
-			data-user-id="{@$response->userID}"
+			data-user-id="{$response->userID}"
 		>
-			<woltlab-core-comment-response class="commentResponse" response-id="{@$response->responseID}" itemprop="comment" itemscope itemtype="http://schema.org/Comment">
+			<woltlab-core-comment-response class="commentResponse" response-id="{$response->responseID}" itemprop="comment" itemscope itemtype="http://schema.org/Comment">
 				<div class="commentResponse__header">
 					<div class="commentResponse__avatar">
 						{user object=$response->getUserProfile() type='avatar32' ariaHidden='true' tabindex='-1'}
 					</div>
 					<div class="commentResponse__author" itemprop="author" itemscope itemtype="http://schema.org/Person">
 						{if $response->userID}
-							<a href="{$response->getUserProfile()->getLink()}" class="commentResponse__author__link userLink" data-object-id="{@$response->userID}" itemprop="url">
-								<span itemprop="name">{@$response->getUserProfile()->getFormattedUsername()}</span>
+							<a href="{$response->getUserProfile()->getLink()}" class="commentResponse__author__link userLink" data-object-id="{$response->userID}" itemprop="url">
+								<span itemprop="name">{unsafe:$response->getUserProfile()->getFormattedUsername()}</span>
 							</a>
 						{else}
 							<span itemprop="name">{$response->username}</span>
 						{/if}
 					</div>
 					<div class="commentResponse__date">
-						<meta itemprop="datePublished" content="{@$response->time|date:'c'}">
-						<a href="{$response->getLink()}" class="commentResponse__permalink">{@$response->time|time}</a>
+						<meta itemprop="datePublished" content="{$response->time|date:'c'}">
+						<a href="{$response->getLink()}" class="commentResponse__permalink">{time time=$response->time}</a>
 					</div>
 					<div class="commentResponse__status">
 						{if $response->isDisabled}
@@ -42,7 +42,7 @@
 					</div>
 
 					{hascontent}
-						<div class="commentResponse__menu dropdown" id="commentResponseOptions{@$response->responseID}">
+						<div class="commentResponse__menu dropdown" id="commentResponseOptions{$response->responseID}">
 							<button type="button" class="dropdownToggle" aria-label="{lang}wcf.global.button.more{/lang}">{icon name='ellipsis-vertical'}</button>
 
 							<ul class="dropdownMenu">
@@ -93,7 +93,7 @@
 				{event name='commentBeforeMessage'}
 
 				<div class="commentResponse__message">
-					<div class="htmlContent userMessage" itemprop="text">{@$response->getFormattedMessage()}</div>
+					<div class="htmlContent userMessage" itemprop="text">{unsafe:$response->getFormattedMessage()}</div>
 				</div>
 
 				{event name='commentAfterMessage'}

--- a/com.woltlab.wcf/templates/comments.tpl
+++ b/com.woltlab.wcf/templates/comments.tpl
@@ -1,10 +1,8 @@
 <script data-relocate="true">
-	require(['Language', 'WoltLabSuite/Core/Component/Comment/List'], (Language, { setup }) => {
-		Language.addObject({
-			'wcf.comment.more': '{jslang}wcf.comment.more{/jslang}',
-			'wcf.comment.response.more': '{jslang}wcf.comment.response.more{/jslang}',
-		});
+	{jsphrase name='wcf.comment.more'}
+	{jsphrase name='wcf.comment.response.more'}
 
+	require(['WoltLabSuite/Core/Component/Comment/List'], ({ setup }) => {
 		setup('{unsafe:$commentContainerID|encodeJS}');
 	});
 </script>

--- a/com.woltlab.wcf/templates/comments.tpl
+++ b/com.woltlab.wcf/templates/comments.tpl
@@ -5,7 +5,7 @@
 			'wcf.comment.response.more': '{jslang}wcf.comment.response.more{/jslang}',
 		});
 
-		setup('{@$commentContainerID|encodeJS}');
+		setup('{unsafe:$commentContainerID|encodeJS}');
 	});
 </script>
 
@@ -26,7 +26,7 @@
 			<div class="commentList__item">
 				<div class="commentAdd commentAdd--collapsed">
 					<div class="commentAdd__avatar">
-						{@$__wcf->getUserProfileHandler()->getAvatar()->getImageTag(32)}
+						{unsafe:$__wcf->getUserProfileHandler()->getAvatar()->getImageTag(32)}
 					</div>
 					
 					<div class="commentAdd__content commentAdd__content--collapsed jsOuterEditorContainer">
@@ -69,7 +69,7 @@
 		{capture assign=_commentResponseWysiwygSelector}{$commentContainerID}AddCommentResponse{/capture}
 		<div class="commentResponseAdd" hidden>
 			<div class="commentResponseAdd__avatar">
-				{@$__wcf->getUserProfileHandler()->getAvatar()->getImageTag(32)}
+				{unsafe:$__wcf->getUserProfileHandler()->getAvatar()->getImageTag(32)}
 			</div>
 
 			<div class="commentResponseAdd__content jsOuterEditorContainer">

--- a/com.woltlab.wcf/templates/email_notification_comment.tpl
+++ b/com.woltlab.wcf/templates/email_notification_comment.tpl
@@ -25,7 +25,7 @@
 							{$comment->username}
 						{/if}
 						&#xb7;
-						<small>{$comment->time|plainTime}</small>
+						<small>{time time=$comment->time type='plainTime'}</small>
 					</h3>
 				</div>
 				<div>

--- a/com.woltlab.wcf/templates/email_notification_comment.tpl
+++ b/com.woltlab.wcf/templates/email_notification_comment.tpl
@@ -1,12 +1,12 @@
 {assign var='count' value=$event->getAuthors()|count}{assign var='guestTimesTriggered' value=$event->getNotification()->guestTimesTriggered}{assign var='authors' value=$event->getAuthors()|array_values}
 {if $mimeType === 'text/plain'}
 {capture assign='authorList'}{lang}wcf.user.notification.mail.authorList.plaintext{/lang}{/capture}
-{lang}{@$languageVariablePrefix}.mail.plaintext{/lang}{if $count == 1 && !$guestTimesTriggered} {* this line ends with a space *}
+{lang}{$languageVariablePrefix}.mail.plaintext{/lang}{if $count == 1 && !$guestTimesTriggered} {* this line ends with a space *}
 
-{@$event->getUserNotificationObject()->getMailText($mimeType)}{/if} {* this line ends with a space *}
+{unsafe:$event->getUserNotificationObject()->getMailText($mimeType)}{/if} {* this line ends with a space *}
 {else}
 	{capture assign='authorList'}{lang}wcf.user.notification.mail.authorList.html{/lang}{/capture}
-	{lang}{@$languageVariablePrefix}.mail.html{/lang}
+	{lang}{$languageVariablePrefix}.mail.html{/lang}
 	{assign var='user' value=$event->getAuthor()}
 	{assign var='comment' value=$event->getUserNotificationObject()}
 	
@@ -15,7 +15,7 @@
 	{capture assign='commentContent'}
 	<table cellpadding="0" cellspacing="0" border="0">
 		<tr>
-			<td><a href="{link controller='User' object=$user isHtmlEmail=true}{/link}" title="{$comment->username}">{@$user->getAvatar()->getSafeImageTag($avatarSize)}</a></td>
+			<td><a href="{link controller='User' object=$user isHtmlEmail=true}{/link}" title="{$comment->username}">{unsafe:$user->getAvatar()->getSafeImageTag($avatarSize)}</a></td>
 			<td class="boxContent">
 				<div class="containerHeadline">
 					<h3>
@@ -29,7 +29,7 @@
 					</h3>
 				</div>
 				<div>
-					{@$comment->getMailText($mimeType)}
+					{unsafe:$comment->getMailText($mimeType)}
 				</div>
 			</td>
 		</tr>

--- a/com.woltlab.wcf/templates/email_notification_commentResponse.tpl
+++ b/com.woltlab.wcf/templates/email_notification_commentResponse.tpl
@@ -25,7 +25,7 @@
 							{$comment->username}
 						{/if}
 						&#xb7;
-						<small>{$comment->time|plainTime}</small>
+						<small>{time time=$comment->time type='plainTime'}</small>
 					</h3>
 				</div>
 				<div>

--- a/com.woltlab.wcf/templates/email_notification_commentResponse.tpl
+++ b/com.woltlab.wcf/templates/email_notification_commentResponse.tpl
@@ -1,12 +1,12 @@
 {assign var='count' value=$event->getAuthors()|count}{assign var='guestTimesTriggered' value=$event->getNotification()->guestTimesTriggered}{assign var='authors' value=$event->getAuthors()|array_values}
 {if $mimeType === 'text/plain'}
 {capture assign='authorList'}{lang}wcf.user.notification.mail.authorList.plaintext{/lang}{/capture}
-{lang}{@$languageVariablePrefix}.mail.plaintext{/lang}{if $count == 1 && !$guestTimesTriggered} {* this line ends with a space *}
+{lang}{$languageVariablePrefix}.mail.plaintext{/lang}{if $count == 1 && !$guestTimesTriggered} {* this line ends with a space *}
 
 {$event->getUserNotificationObject()->message}{/if} {* this line ends with a space *}
 {else}
 	{capture assign='authorList'}{lang}wcf.user.notification.mail.authorList.html{/lang}{/capture}
-	{lang}{@$languageVariablePrefix}.mail.html{/lang}
+	{lang}{$languageVariablePrefix}.mail.html{/lang}
 	{assign var='user' value=$event->getAuthor()}
 	{assign var='comment' value=$event->getUserNotificationObject()}
 	
@@ -15,7 +15,7 @@
 	{capture assign='commentContent'}
 	<table cellpadding="0" cellspacing="0" border="0">
 		<tr>
-			<td><a href="{link controller='User' object=$user isHtmlEmail=true}{/link}" title="{$comment->username}">{@$user->getAvatar()->getSafeImageTag($avatarSize)}</a></td>
+			<td><a href="{link controller='User' object=$user isHtmlEmail=true}{/link}" title="{$comment->username}">{unsafe:$user->getAvatar()->getSafeImageTag($avatarSize)}</a></td>
 			<td class="boxContent">
 				<div class="containerHeadline">
 					<h3>
@@ -29,7 +29,7 @@
 					</h3>
 				</div>
 				<div>
-					{@$comment->getMailText($mimeType)}
+					{unsafe:$comment->getMailText($mimeType)}
 				</div>
 			</td>
 		</tr>

--- a/com.woltlab.wcf/templates/email_notification_commentResponseOwner.tpl
+++ b/com.woltlab.wcf/templates/email_notification_commentResponseOwner.tpl
@@ -25,7 +25,7 @@
 							{$comment->username}
 						{/if}
 						&#xb7;
-						<small>{$comment->time|plainTime}</small>
+						<small>{time time=$comment->time type='plainTime'}</small>
 					</h3>
 				</div>
 				<div>

--- a/com.woltlab.wcf/templates/email_notification_commentResponseOwner.tpl
+++ b/com.woltlab.wcf/templates/email_notification_commentResponseOwner.tpl
@@ -1,12 +1,12 @@
 {assign var='count' value=$event->getAuthors()|count}{assign var='guestTimesTriggered' value=$event->getNotification()->guestTimesTriggered}{assign var='authors' value=$event->getAuthors()|array_values}
 {if $mimeType === 'text/plain'}
 {capture assign='authorList'}{lang}wcf.user.notification.mail.authorList.plaintext{/lang}{/capture}
-{lang}{@$languageVariablePrefix}.mail.plaintext{/lang}{if $count == 1 && !$guestTimesTriggered} {* this line ends with a space *}
+{lang}{$languageVariablePrefix}.mail.plaintext{/lang}{if $count == 1 && !$guestTimesTriggered} {* this line ends with a space *}
 
 {$event->getUserNotificationObject()->message}{/if} {* this line ends with a space *}
 {else}
 	{capture assign='authorList'}{lang}wcf.user.notification.mail.authorList.html{/lang}{/capture}
-	{lang}{@$languageVariablePrefix}.mail.html{/lang}
+	{lang}{$languageVariablePrefix}.mail.html{/lang}
 	{assign var='user' value=$event->getAuthor()}
 	{assign var='comment' value=$event->getUserNotificationObject()}
 	
@@ -15,7 +15,7 @@
 	{capture assign='commentContent'}
 	<table cellpadding="0" cellspacing="0" border="0">
 		<tr>
-			<td><a href="{link controller='User' object=$user isHtmlEmail=true}{/link}" title="{$comment->username}">{@$user->getAvatar()->getSafeImageTag($avatarSize)}</a></td>
+			<td><a href="{link controller='User' object=$user isHtmlEmail=true}{/link}" title="{$comment->username}">{unsafe:$user->getAvatar()->getSafeImageTag($avatarSize)}</a></td>
 			<td class="boxContent">
 				<div class="containerHeadline">
 					<h3>
@@ -29,7 +29,7 @@
 					</h3>
 				</div>
 				<div>
-					{@$comment->getMailText($mimeType)}
+					{unsafe:$comment->getMailText($mimeType)}
 				</div>
 			</td>
 		</tr>

--- a/com.woltlab.wcf/templates/email_notification_moderationQueueComment.tpl
+++ b/com.woltlab.wcf/templates/email_notification_moderationQueueComment.tpl
@@ -25,7 +25,7 @@
 							{$comment->username}
 						{/if}
 						&#xb7;
-						<small>{$comment->time|plainTime}</small>
+						<small>{time time=$comment->time type='plainTime'}</small>
 					</h3>
 				</div>
 				<div>

--- a/com.woltlab.wcf/templates/email_notification_moderationQueueComment.tpl
+++ b/com.woltlab.wcf/templates/email_notification_moderationQueueComment.tpl
@@ -3,7 +3,7 @@
 {capture assign='authorList'}{lang}wcf.user.notification.mail.authorList.plaintext{/lang}{/capture}
 {lang}{$notificationContent[variables][languageItemPrefix]}.comment.mail.plaintext{/lang}{if $count == 1 && !$guestTimesTriggered} {* this line ends with a space *}
 
-{@$event->getUserNotificationObject()->getMailText($mimeType)}{/if} {* this line ends with a space *}
+{unsafe:$event->getUserNotificationObject()->getMailText($mimeType)}{/if} {* this line ends with a space *}
 {else}
 	{capture assign='authorList'}{lang}wcf.user.notification.mail.authorList.html{/lang}{/capture}
 	{lang}{$notificationContent[variables][languageItemPrefix]}.comment.mail.html{/lang}
@@ -15,7 +15,7 @@
 	{capture assign='commentContent'}
 	<table cellpadding="0" cellspacing="0" border="0">
 		<tr>
-			<td><a href="{link controller='User' object=$user isHtmlEmail=true}{/link}" title="{$comment->username}">{@$user->getAvatar()->getSafeImageTag($avatarSize)}</a></td>
+			<td><a href="{link controller='User' object=$user isHtmlEmail=true}{/link}" title="{$comment->username}">{unsafe:$user->getAvatar()->getSafeImageTag($avatarSize)}</a></td>
 			<td class="boxContent">
 				<div class="containerHeadline">
 					<h3>
@@ -29,7 +29,7 @@
 					</h3>
 				</div>
 				<div>
-					{@$comment->getMailText($mimeType)}
+					{unsafe:$comment->getMailText($mimeType)}
 				</div>
 			</td>
 		</tr>

--- a/com.woltlab.wcf/templates/email_notification_moderationQueueCommentResponse.tpl
+++ b/com.woltlab.wcf/templates/email_notification_moderationQueueCommentResponse.tpl
@@ -3,7 +3,7 @@
 {capture assign='authorList'}{lang}wcf.user.notification.mail.authorList.plaintext{/lang}{/capture}
 {lang}{$notificationContent[variables][languageItemPrefix]}.commentResponse.mail.plaintext{/lang}{if $count == 1 && !$guestTimesTriggered} {* this line ends with a space *}
 
-{@$event->getUserNotificationObject()->getMailText($mimeType)}{/if} {* this line ends with a space *}
+{unsafe:$event->getUserNotificationObject()->getMailText($mimeType)}{/if} {* this line ends with a space *}
 {else}
 	{capture assign='authorList'}{lang}wcf.user.notification.mail.authorList.html{/lang}{/capture}
 	{lang}{$notificationContent[variables][languageItemPrefix]}.commentResponse.mail.html{/lang}
@@ -15,7 +15,7 @@
 	{capture assign='commentContent'}
 	<table cellpadding="0" cellspacing="0" border="0">
 		<tr>
-			<td><a href="{link controller='User' object=$user isHtmlEmail=true}{/link}" title="{$comment->username}">{@$user->getAvatar()->getSafeImageTag($avatarSize)}</a></td>
+			<td><a href="{link controller='User' object=$user isHtmlEmail=true}{/link}" title="{$comment->username}">{unsafe:$user->getAvatar()->getSafeImageTag($avatarSize)}</a></td>
 			<td class="boxContent">
 				<div class="containerHeadline">
 					<h3>
@@ -29,7 +29,7 @@
 					</h3>
 				</div>
 				<div>
-					{@$comment->getMailText($mimeType)}
+					{unsafe:$comment->getMailText($mimeType)}
 				</div>
 			</td>
 		</tr>

--- a/com.woltlab.wcf/templates/email_notification_moderationQueueCommentResponse.tpl
+++ b/com.woltlab.wcf/templates/email_notification_moderationQueueCommentResponse.tpl
@@ -25,7 +25,7 @@
 							{$comment->username}
 						{/if}
 						&#xb7;
-						<small>{$comment->time|plainTime}</small>
+						<small>{time time=$comment->time type='plainTime'}</small>
 					</h3>
 				</div>
 				<div>

--- a/com.woltlab.wcf/templates/moderationComment.tpl
+++ b/com.woltlab.wcf/templates/moderationComment.tpl
@@ -6,12 +6,12 @@
 				
 				<div class="messageHeaderBox">
 					<h2 class="messageTitle">
-						<a href="{@$message->getLink()}">{$message->getTitle()}</a>
+						<a href="{$message->getLink()}">{$message->getTitle()}</a>
 					</h2>
 					
 					<ul class="messageHeaderMetaData">
 						<li>{user object=$message->getUserProfile() class='username'}</li>
-						<li><span class="messagePublicationTime">{@$message->getTime()|time}</span></li>
+						<li><span class="messagePublicationTime">{time time=$message->getTime()}</span></li>
 						
 						{event name='messageHeaderMetaData'}
 					</ul>
@@ -25,7 +25,7 @@
 			{event name='beforeMessageText'}
 			
 			<div class="messageText">
-				{@$message->getFormattedMessage()}
+				{unsafe:$message->getFormattedMessage()}
 			</div>
 			
 			{event name='afterMessageText'}


### PR DESCRIPTION
- Remove unnecessary `@`
- Use `unsafe:` instead of `@`
- Replace deprecated template modifier