### PR TITLE
Check whether there are further objects for the worker to execute

### DIFF
--- a/wcfsetup/install/files/lib/system/worker/BulkProcessingWorker.class.php
+++ b/wcfsetup/install/files/lib/system/worker/BulkProcessingWorker.class.php
@@ -73,10 +73,13 @@ final class BulkProcessingWorker extends AbstractWorker
     #[\Override]
     public function execute()
     {
+        $objectIDs = \array_slice($this->bulkProcessingData['objectIDs'], $this->limit * $this->loopCount, $this->limit);
+        if ($objectIDs === []) {
+            return;
+        }
+
         $objectList = $this->action->getObjectList();
-        $objectList->setObjectIDs(
-            \array_slice($this->bulkProcessingData['objectIDs'], $this->limit * $this->loopCount, $this->limit)
-        );
+        $objectList->setObjectIDs($objectIDs);
         $objectList->readObjects();
 
         $this->action->executeAction($objectList);


### PR DESCRIPTION
See https://www.woltlab.com/community/thread/312403-massenbearbeitung-benutzer-löschen-aufgrund-von-inaktivität-löst-fehlermeldung-a/