### PR TITLE
Refactor global templates

### DIFF
--- a/com.woltlab.wcf/templates/__menu.tpl
+++ b/com.woltlab.wcf/templates/__menu.tpl
@@ -3,7 +3,7 @@
 		{event name='menuBefore'}
 		
 		{foreach from=$menuItemNodeList item=menuItemNode}
-			<li class="{if $menuItemNode->isActiveNode()}active{/if}{if $menuItemNode->hasChildren()} boxMenuHasChildren{/if}" data-identifier="{@$menuItemNode->identifier}">
+			<li class="{if $menuItemNode->isActiveNode()}active{/if}{if $menuItemNode->hasChildren()} boxMenuHasChildren{/if}" data-identifier="{$menuItemNode->identifier}">
 				<a {anchorAttributes url=$menuItemNode->getURL() appendClassname=false} class="boxMenuLink"{if $menuItemNode->isActiveNode()} aria-current="page"{/if}>
 					<span class="boxMenuLinkTitle">{$menuItemNode->getTitle()}</span>
 					{if $menuItemNode->getOutstandingItems() > 0}
@@ -14,10 +14,10 @@
 					{/if}
 				</a>
 				
-				{if $menuItemNode->hasChildren()}<ol class="boxMenuDepth{@$menuItemNode->getDepth()}">{else}</li>{/if}
+				{if $menuItemNode->hasChildren()}<ol class="boxMenuDepth{$menuItemNode->getDepth()}">{else}</li>{/if}
 				
 				{if !$menuItemNode->hasChildren() && $menuItemNode->isLastSibling()}
-					{@"</ol></li>"|str_repeat:$menuItemNode->getOpenParentNodes()}
+					{unsafe:"</ol></li>"|str_repeat:$menuItemNode->getOpenParentNodes()}
 				{/if}
 		{/foreach}
 		

--- a/com.woltlab.wcf/templates/authFlowFooter.tpl
+++ b/com.woltlab.wcf/templates/authFlowFooter.tpl
@@ -21,7 +21,7 @@
 
 <!-- {$__wcf->getRequestNonce('JAVASCRIPT_RELOCATE_POSITION')} -->
 
-{@FOOTER_CODE}
+{unsafe:FOOTER_CODE}
 
 <span id="bottom"></span>
 

--- a/com.woltlab.wcf/templates/authFlowHeader.tpl
+++ b/com.woltlab.wcf/templates/authFlowHeader.tpl
@@ -9,7 +9,7 @@
 		{/if}
 	{/if}
 	
-	<title>{if $pageTitle}{@$pageTitle} - {/if}{PAGE_TITLE|phrase}</title>
+	<title>{if $pageTitle}{unsafe:$pageTitle} - {/if}{PAGE_TITLE|phrase}</title>
 	
 	{include file='headInclude'}
 	
@@ -18,14 +18,14 @@
 	{/if}
 	
 	{if !$headContent|empty}
-		{@$headContent}
+		{unsafe:$headContent}
 	{/if}
 </head>
 
 <body id="tpl_{$templateNameApplication}_{$templateName}"
 	itemscope itemtype="http://schema.org/WebPage"{if !$canonicalURL|empty} itemid="{$canonicalURL}"{/if}
-	data-template="{$templateName}" data-application="{$templateNameApplication}"{if $__wcf->getActivePage() != null} data-page-id="{@$__wcf->getActivePage()->pageID}" data-page-identifier="{$__wcf->getActivePage()->identifier}"{/if}
-	{if !$__pageDataAttributes|empty}{@$__pageDataAttributes}{/if}
+	data-template="{$templateName}" data-application="{$templateNameApplication}"{if $__wcf->getActivePage() != null} data-page-id="{$__wcf->getActivePage()->pageID}" data-page-identifier="{$__wcf->getActivePage()->identifier}"{/if}
+	{if !$__pageDataAttributes|empty}{unsafe:$__pageDataAttributes}{/if}
 	class="authFlow{if $__wcf->getActivePage() != null && $__wcf->getActivePage()->cssClassName} {$__wcf->getActivePage()->cssClassName}{/if}{if !$__pageCssClassName|empty} {$__pageCssClassName}{/if}">
 
 <span id="top"></span>
@@ -49,12 +49,12 @@
 		</header>
 	</div>
 	
-	<section id="main" class="main" role="main"{if !$__mainItemScope|empty} {@$__mainItemScope}{/if}>
+	<section id="main" class="main" role="main"{if !$__mainItemScope|empty} {unsafe:$__mainItemScope}{/if}>
 		<div class="layoutBoundary">
 			<div id="content" class="content">
 				{if $__disableContentHeader|empty}
 					{if !$contentHeader|empty}
-						{@$contentHeader}
+						{unsafe:$contentHeader}
 					{else}
 						{if $contentTitle|empty}
 							{if $__wcf->isLandingPage() && USE_PAGE_TITLE_ON_LANDING_PAGE}
@@ -68,8 +68,8 @@
 						{if !$contentTitle|empty}
 							<header class="contentHeader">
 								<div class="contentHeaderTitle">
-									<h1 class="contentTitle">{@$contentTitle}{if !$contentTitleBadge|empty} {@$contentTitleBadge}{/if}</h1>
-									{if !$contentDescription|empty}<p class="contentHeaderDescription">{@$contentDescription}</p>{/if}
+									<h1 class="contentTitle">{unsafe:$contentTitle}{if !$contentTitleBadge|empty} {unsafe:$contentTitleBadge}{/if}</h1>
+									{if !$contentDescription|empty}<p class="contentHeaderDescription">{unsafe:$contentDescription}</p>{/if}
 								</div>
 							</header>
 						{/if}

--- a/com.woltlab.wcf/templates/authFlowRedirect.tpl
+++ b/com.woltlab.wcf/templates/authFlowRedirect.tpl
@@ -1,13 +1,13 @@
 {capture assign='pageTitle'}{lang}wcf.page.redirect.title{/lang}{/capture}
 
 {capture assign='headContent'}
-	<meta http-equiv="refresh" content="{if $wait|isset}{@$wait}{else}10{/if};URL={$url}">
+	<meta http-equiv="refresh" content="{if $wait|isset}{$wait}{else}10{/if};URL={$url}">
 {/capture}
 
 {include file='authFlowHeader'}
 
-<div class="{if !$status|empty}{@$status}{else}success{/if}">
-	<p>{@$message}</p>
+<div class="{if !$status|empty}{$status}{else}success{/if}">
+	<p>{unsafe:$message}</p>
 	<br>
 	<p><a href="{$url}">{lang}wcf.page.redirect.url{/lang}</a></p>
 </div>

--- a/com.woltlab.wcf/templates/breadcrumbs.tpl
+++ b/com.woltlab.wcf/templates/breadcrumbs.tpl
@@ -17,7 +17,7 @@
 								<span class="breadcrumbs__title"{if $__microdata} itemprop="name"{/if}>{$breadcrumb->getLabel()}</span>
 							</a>
 							{if $__microdata}
-								<meta itemprop="position" content="{@$__breadcrumbPos}">
+								<meta itemprop="position" content="{$__breadcrumbPos}">
 								{assign var='__breadcrumbPos' value=$__breadcrumbPos+1}
 							{/if}
 						</li>

--- a/com.woltlab.wcf/templates/error.tpl
+++ b/com.woltlab.wcf/templates/error.tpl
@@ -12,7 +12,7 @@
 {if $exception !== null}
 <!--
 {* A comment may not contain double dashes. *}
-{@'--'|str_replace:'- -':$exception}
+{unsafe:'--'|str_replace:'- -':$exception}
 -->
 {/if}
 {/if}
@@ -21,7 +21,7 @@
 	<div class="box64 userException">
 		{icon size=64 name='circle-exclamation'}
 		<p class="userExceptionMessage">
-			{@$message}
+			{unsafe:$message}
 		</p>
 	</div>
 </div>

--- a/com.woltlab.wcf/templates/footer.tpl
+++ b/com.woltlab.wcf/templates/footer.tpl
@@ -5,11 +5,11 @@
 						<div class="boxContainer">
 							{content}
 								{if !$boxesContentBottom|empty}
-									{@$boxesContentBottom}
+									{unsafe:$boxesContentBottom}
 								{/if}
 								
 								{foreach from=$__wcf->getBoxHandler()->getBoxes('contentBottom') item=box}
-									{@$box->render()}
+									{unsafe:$box->render()}
 								{/foreach}
 							{/content}
 						</div>

--- a/com.woltlab.wcf/templates/footer.tpl
+++ b/com.woltlab.wcf/templates/footer.tpl
@@ -17,14 +17,14 @@
 				{/hascontent}
 				
 				{if MODULE_WCF_AD && $__disableAds|empty}
-					{@$__wcf->getAdHandler()->getAds('com.woltlab.wcf.footer.content')}
+					{unsafe:$__wcf->getAdHandler()->getAds('com.woltlab.wcf.footer.content')}
 				{/if}
 			</div>
 			
 			{hascontent}
 				<aside class="sidebar boxesSidebarRight" aria-label="{lang}wcf.page.sidebar.right{/lang}">
 					<div class="boxContainer">
-						{content}{@$__sidebarRightContent}{/content}
+						{content}{unsafe:$__sidebarRightContent}{/content}
 					</div>
 				</aside>
 			{/hascontent}
@@ -36,11 +36,11 @@
 			<div class="boxContainer">
 				{content}
 					{if !$boxesBottom|empty}
-						{@$boxesBottom}
+						{unsafe:$boxesBottom}
 					{/if}
 				
 					{foreach from=$__wcf->getBoxHandler()->getBoxes('bottom') item=box}
-						{@$box->render()}
+						{unsafe:$box->render()}
 					{/foreach}
 				{/content}
 			</div>
@@ -53,11 +53,11 @@
 				<div class="boxContainer">
 					{content}
 						{if !$footerBoxes|empty}
-							{@$footerBoxes}
+							{unsafe:$footerBoxes}
 						{/if}
 					
 						{foreach from=$__wcf->getBoxHandler()->getBoxes('footerBoxes') item=box}
-							{@$box->render()}
+							{unsafe:$box->render()}
 						{/foreach}
 					{/content}
 				</div>
@@ -84,7 +84,7 @@
 
 <!-- {$__wcf->getRequestNonce('JAVASCRIPT_RELOCATE_POSITION')} -->
 
-{@FOOTER_CODE}
+{unsafe:FOOTER_CODE}
 
 <span id="bottom"></span>
 

--- a/com.woltlab.wcf/templates/headInclude.tpl
+++ b/com.woltlab.wcf/templates/headInclude.tpl
@@ -1,11 +1,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="format-detection" content="telephone=no">
 {include file='headIncludeRobotsMetaTag'}
-{implode from=$__wcf->getMetaTagHandler() item=__metaTag glue="\n"}{@$__metaTag}{/implode}
+{implode from=$__wcf->getMetaTagHandler() item=__metaTag glue="\n"}{unsafe:$__metaTag}{/implode}
 {event name='metaTags'}
 
 <!-- Stylesheets -->
-{@$__wcf->getStyleHandler()->getStylesheet()}
+{unsafe:$__wcf->getStyleHandler()->getStylesheet()}
 {event name='stylesheets'}
 
 <meta name="timezone" content="{$__wcf->user->getTimeZone()->getName()}">
@@ -13,4 +13,4 @@
 {include file='headIncludeJavaScript'}
 {include file='headIncludeIcons'}
 
-{@HEAD_CODE}
+{unsafe:HEAD_CODE}

--- a/com.woltlab.wcf/templates/headIncludeJavaScript.tpl
+++ b/com.woltlab.wcf/templates/headIncludeJavaScript.tpl
@@ -3,20 +3,20 @@
 *}
 
 <script data-cfasync="false">
-	var WCF_PATH = '{@$__wcf->getPath()}';
-	var WSC_API_URL = '{@$__wcf->getPath()}';
+	var WCF_PATH = '{unsafe:$__wcf->getPath()|encodeJS}';
+	var WSC_API_URL = '{unsafe:$__wcf->getPath()|encodeJS}';
 	var WSC_RPC_API_URL = '{link controller="Api" id="rpc"}{/link}';
 	{* The SECURITY_TOKEN is defined in wcf.globalHelper.js *}
-	var LANGUAGE_ID = {@$__wcf->getLanguage()->languageID};
+	var LANGUAGE_ID = {$__wcf->getLanguage()->languageID};
 	var LANGUAGE_USE_INFORMAL_VARIANT = {if LANGUAGE_USE_INFORMAL_VARIANT}true{else}false{/if};
-	var TIME_NOW = {@TIME_NOW};
-	var LAST_UPDATE_TIME = {@LAST_UPDATE_TIME};
+	var TIME_NOW = {TIME_NOW};
+	var LAST_UPDATE_TIME = {LAST_UPDATE_TIME};
 	var ENABLE_DEBUG_MODE = {if ENABLE_DEBUG_MODE}true{else}false{/if};
 	var ENABLE_PRODUCTION_DEBUG_MODE = {if ENABLE_PRODUCTION_DEBUG_MODE}true{else}false{/if};
 	var ENABLE_DEVELOPER_TOOLS = {if ENABLE_DEVELOPER_TOOLS}true{else}false{/if};
-	var PAGE_TITLE = '{PAGE_TITLE|phrase|encodeJS}';
+	var PAGE_TITLE = '{unsafe:PAGE_TITLE|phrase|encodeJS}';
 	
-	var REACTION_TYPES = {@$__wcf->getReactionHandler()->getReactionsJSVariable()};
+	var REACTION_TYPES = {unsafe:$__wcf->getReactionHandler()->getReactionsJSVariable()};
 	
 	{if ENABLE_DEBUG_MODE}
 		{* This constant is a compiler option, it does not exist in production. *}
@@ -31,7 +31,7 @@
 	{/if}
 </script>
 
-<script data-cfasync="false" src="{$__wcf->getPath()}js/WoltLabSuite/WebComponent.min.js?v={@LAST_UPDATE_TIME}"></script>
+<script data-cfasync="false" src="{$__wcf->getPath()}js/WoltLabSuite/WebComponent.min.js?v={LAST_UPDATE_TIME}"></script>
 <script data-cfasync="false" src="{$phrasePreloader->getUrl($__wcf->language)}"></script>
 
 {js application='wcf' file='require' bundle='WoltLabSuite.Core' core='true' hasTiny=true}
@@ -41,8 +41,8 @@
 {js application='wcf' file='3rdParty/tslib' bundle='WoltLabSuite.Core' core='true' hasTiny=true}
 <script data-cfasync="false">
 requirejs.config({
-	baseUrl: '{@$__wcf->getPath()}js',
-	urlArgs: 't={@LAST_UPDATE_TIME}'
+	baseUrl: '{unsafe:$__wcf->getPath()|encodeJS}js',
+	urlArgs: 't={LAST_UPDATE_TIME}'
 	{hascontent}
 	, paths: {
 		{content}{event name='requirePaths'}{/content}
@@ -66,9 +66,9 @@ window.addEventListener('pageshow', function(event) {
 		{/hascontent}
 		
 		User.init(
-			{@$__wcf->user->userID},
-			{if $__wcf->user->userID}'{@$__wcf->user->username|encodeJS}'{else}''{/if},
-			{if $__wcf->user->userID}'{@$__wcf->user->getLink()|encodeJS}'{else}''{/if},
+			{$__wcf->user->userID},
+			{if $__wcf->user->userID}'{unsafe:$__wcf->user->username|encodeJS}'{else}''{/if},
+			{if $__wcf->user->userID}'{unsafe:$__wcf->user->getLink()|encodeJS}'{else}''{/if},
 			'{link controller='GuestTokenDialog'}{/link}'
 		);
 		
@@ -79,7 +79,7 @@ window.addEventListener('pageshow', function(event) {
 			},
 			{if $__wcf->user->userID && SERVICE_WORKER_PUBLIC_KEY !== ''}
 			serviceWorker: {
-				publicKey: '{@SERVICE_WORKER_PUBLIC_KEY|encodeJS}',
+				publicKey: '{unsafe:SERVICE_WORKER_PUBLIC_KEY|encodeJS}',
 				serviceWorkerJsUrl: '{$__wcf->getPath('wcf')}service-worker/',
 				registerUrl: '{link controller="RegisterServiceWorker"}{/link}',
 				notificationLastReadTime: {$__wcf->getUserNotificationHandler()->getTimeOfLastReadNotification()}
@@ -137,8 +137,8 @@ window.addEventListener('pageshow', function(event) {
 
 <script data-relocate="true">
 	WCF.User.init(
-		{@$__wcf->user->userID},
-		{if $__wcf->user->userID}'{@$__wcf->user->username|encodeJS}'{else}''{/if}
+		{$__wcf->user->userID},
+		{if $__wcf->user->userID}'{unsafe:$__wcf->user->username|encodeJS}'{else}''{/if}
 	);
 </script>
 

--- a/com.woltlab.wcf/templates/headIncludeJsonLd.tpl
+++ b/com.woltlab.wcf/templates/headIncludeJsonLd.tpl
@@ -4,10 +4,10 @@
 {
 "@context": "http://schema.org",
 "@type": "WebSite",
-"url": {@$__websiteUrl|json},
+"url": {unsafe:$__websiteUrl|json},
 "potentialAction": {
 "@type": "SearchAction",
-"target": {@$__searchTargetUrl|json},
+"target": {unsafe:$__searchTargetUrl|json},
 "query-input": "required name=search_term_string"
 }
 }

--- a/com.woltlab.wcf/templates/header.tpl
+++ b/com.woltlab.wcf/templates/header.tpl
@@ -9,7 +9,7 @@
 		{/if}
 	{/if}
 	
-	<title>{if $pageTitle}{@$pageTitle} - {/if}{PAGE_TITLE|phrase}</title>
+	<title>{if $pageTitle}{unsafe:$pageTitle} - {/if}{PAGE_TITLE|phrase}</title>
 	
 	{include file='headInclude'}
 	
@@ -18,14 +18,14 @@
 	{/if}
 	
 	{if !$headContent|empty}
-		{@$headContent}
+		{unsafe:$headContent}
 	{/if}
 </head>
 
 <body id="tpl_{$templateNameApplication}_{$templateName}"
 	itemscope itemtype="http://schema.org/WebPage"{if !$canonicalURL|empty} itemid="{$canonicalURL}"{/if}
-	data-template="{$templateName}" data-application="{$templateNameApplication}"{if $__wcf->getActivePage() != null} data-page-id="{@$__wcf->getActivePage()->pageID}" data-page-identifier="{$__wcf->getActivePage()->identifier}"{/if}
-	{if !$__pageDataAttributes|empty}{@$__pageDataAttributes}{/if}
+	data-template="{$templateName}" data-application="{$templateNameApplication}"{if $__wcf->getActivePage() != null} data-page-id="{$__wcf->getActivePage()->pageID}" data-page-identifier="{$__wcf->getActivePage()->identifier}"{/if}
+	{if !$__pageDataAttributes|empty}{unsafe:$__pageDataAttributes}{/if}
 	class="{if $__wcf->getActivePage() != null && $__wcf->getActivePage()->cssClassName}{$__wcf->getActivePage()->cssClassName}{/if}{if !$__pageCssClassName|empty} {$__pageCssClassName}{/if}">
 
 <span id="top"></span>
@@ -43,11 +43,11 @@
 				<div class="boxContainer">
 					{content}
 						{if !$headerBoxes|empty}
-							{@$headerBoxes}
+							{unsafe:$headerBoxes}
 						{/if}
 						
 						{foreach from=$__wcf->getBoxHandler()->getBoxes('headerBoxes') item=box}
-							{@$box->render()}
+							{unsafe:$box->render()}
 						{/foreach}
 					{/content}
 				</div>
@@ -62,18 +62,18 @@
 			<div class="boxContainer">
 				{content}
 					{if !$boxesTop|empty}
-						{@$boxesTop}
+						{unsafe:$boxesTop}
 					{/if}
 				
 					{foreach from=$__wcf->getBoxHandler()->getBoxes('top') item=box}
-						{@$box->render()}
+						{unsafe:$box->render()}
 					{/foreach}
 				{/content}
 			</div>
 		</div>
 	{/hascontent}
 	
-	<section id="main" class="main" role="main"{if !$__mainItemScope|empty} {@$__mainItemScope}{/if}>
+	<section id="main" class="main" role="main"{if !$__mainItemScope|empty} {unsafe:$__mainItemScope}{/if}>
 		{if !$beforeMaincontent|empty}
 			{unsafe:$beforeMaincontent}
 		{/if}
@@ -91,16 +91,16 @@
 							{* WCF2.1 Fallback *}
 							{if !$sidebar|empty}
 								{if !$sidebarOrientation|isset || $sidebarOrientation == 'left'}
-									{@$sidebar}
+									{unsafe:$sidebar}
 								{/if}
 							{/if}
 							
 							{if !$sidebarLeft|empty}
-								{@$sidebarLeft}
+								{unsafe:$sidebarLeft}
 							{/if}
 							
 							{foreach from=$__wcf->getBoxHandler()->getBoxes('sidebarLeft') item=box}
-								{@$box->render()}
+								{unsafe:$box->render()}
 							{/foreach}
 							
 							{event name='boxesSidebarLeftBottom'}
@@ -113,7 +113,7 @@
 				{if MODULE_WCF_AD && $__disableAds|empty && $__wcf->getAdHandler()->getAds('com.woltlab.wcf.sidebar.top')}
 					<div class="box boxBorderless">
 						<div class="boxContent">
-							{@$__wcf->getAdHandler()->getAds('com.woltlab.wcf.sidebar.top')}
+							{unsafe:$__wcf->getAdHandler()->getAds('com.woltlab.wcf.sidebar.top')}
 						</div>
 					</div>
 				{/if}
@@ -123,16 +123,16 @@
 				{* WCF2.1 Fallback *}
 				{if !$sidebar|empty}
 					{if !$sidebarOrientation|isset || $sidebarOrientation == 'right'}
-						{@$sidebar}
+						{unsafe:$sidebar}
 					{/if}
 				{/if}
 				
 				{if !$sidebarRight|empty}
-					{@$sidebarRight}
+					{unsafe:$sidebarRight}
 				{/if}
 				
 				{foreach from=$__wcf->getBoxHandler()->getBoxes('sidebarRight') item=box}
-					{@$box->render()}
+					{unsafe:$box->render()}
 				{/foreach}
 				
 				{event name='boxesSidebarRightBottom'}
@@ -140,18 +140,18 @@
 				{if MODULE_WCF_AD && $__disableAds|empty && $__wcf->getAdHandler()->getAds('com.woltlab.wcf.sidebar.bottom')}
 					<div class="box boxBorderless">
 						<div class="boxContent">
-							{@$__wcf->getAdHandler()->getAds('com.woltlab.wcf.sidebar.bottom')}
+							{unsafe:$__wcf->getAdHandler()->getAds('com.woltlab.wcf.sidebar.bottom')}
 						</div>
 					</div>
 				{/if}
 			{/capture}
 			
 			<div id="content" class="content{if $__sidebarRightContent|trim} content--sidebar-right{/if}">
-				{if MODULE_WCF_AD && $__disableAds|empty}{@$__wcf->getAdHandler()->getAds('com.woltlab.wcf.header.content')}{/if}
+				{if MODULE_WCF_AD && $__disableAds|empty}{unsafe:$__wcf->getAdHandler()->getAds('com.woltlab.wcf.header.content')}{/if}
 				
 				{if $__disableContentHeader|empty}
 					{if !$contentHeader|empty}
-						{@$contentHeader}
+						{unsafe:$contentHeader}
 					{else}
 						{if $contentTitle|empty}
 							{if $__wcf->isLandingPage() && USE_PAGE_TITLE_ON_LANDING_PAGE}
@@ -165,15 +165,15 @@
 						{if !$contentTitle|empty}
 							<header class="contentHeader">
 								<div class="contentHeaderTitle">
-									<h1 class="contentTitle">{@$contentTitle}{if !$contentTitleBadge|empty} {@$contentTitleBadge}{/if}</h1>
-									{if !$contentDescription|empty}<p class="contentHeaderDescription">{@$contentDescription}</p>{/if}
+									<h1 class="contentTitle">{unsafe:$contentTitle}{if !$contentTitleBadge|empty} {unsafe:$contentTitleBadge}{/if}</h1>
+									{if !$contentDescription|empty}<p class="contentHeaderDescription">{unsafe:$contentDescription}</p>{/if}
 								</div>
 								
 								{hascontent}
 									<nav class="contentHeaderNavigation">
 										<ul>
 											{content}
-												{if !$contentHeaderNavigation|empty}{@$contentHeaderNavigation}{/if}
+												{if !$contentHeaderNavigation|empty}{unsafe:$contentHeaderNavigation}{/if}
 												
 												{event name='contentHeaderNavigation'}
 											{/content}
@@ -192,11 +192,11 @@
 						<div class="boxContainer">
 							{content}
 								{if !$boxesContentTop|empty}
-									{@$boxesContentTop}
+									{unsafe:$boxesContentTop}
 								{/if}
 								
 								{foreach from=$__wcf->getBoxHandler()->getBoxes('contentTop') item=box}
-									{@$box->render()}
+									{unsafe:$box->render()}
 								{/foreach}
 							{/content}
 						</div>

--- a/com.woltlab.wcf/templates/offline.tpl
+++ b/com.woltlab.wcf/templates/offline.tpl
@@ -2,7 +2,7 @@
 
 <woltlab-core-notice type="warning">
 	<p><strong>{lang}wcf.page.offline{/lang}</strong></p>
-	<p>{if OFFLINE_MESSAGE_ALLOW_HTML}{@OFFLINE_MESSAGE|phrase}{else}{@OFFLINE_MESSAGE|phrase|newlineToBreak}{/if}</p>
+	<p>{if OFFLINE_MESSAGE_ALLOW_HTML}{unsafe:OFFLINE_MESSAGE|phrase}{else}{unsafe:OFFLINE_MESSAGE|phrase|newlineToBreak}{/if}</p>
 </woltlab-core-notice>
 
 {include file='footer'}

--- a/com.woltlab.wcf/templates/pageFooter.tpl
+++ b/com.woltlab.wcf/templates/pageFooter.tpl
@@ -36,11 +36,11 @@
 					<div class="boxContainer">
 						{content}
 							{if !$boxesFooter|empty}
-								{@$boxesFooter}
+								{unsafe:$boxesFooter}
 							{/if}
 
 							{foreach from=$__boxesFooter item=box}
-								{@$box->render()}
+								{unsafe:$box->render()}
 							{/foreach}
 						{/content}
 					</div>
@@ -60,7 +60,7 @@
 					{include file='pageFooterCopyright'}
 				
 					{if MODULE_WCF_AD && $__disableAds|empty}
-						{@$__wcf->getAdHandler()->getAds('com.woltlab.wcf.footer.bottom')}
+						{unsafe:$__wcf->getAdHandler()->getAds('com.woltlab.wcf.footer.bottom')}
 					{/if}
 				{/content}
 			</div>

--- a/com.woltlab.wcf/templates/pageHeader.tpl
+++ b/com.woltlab.wcf/templates/pageHeader.tpl
@@ -23,11 +23,11 @@
 				<div class="boxContainer">
 					{content}
 						{if !$boxesHero|empty}
-							{@$boxesHero}
+							{unsafe:$boxesHero}
 						{/if}
 
 						{foreach from=$__wcf->getBoxHandler()->getBoxes('hero') item=box}
-							{@$box->render()}
+							{unsafe:$box->render()}
 						{/foreach}
 					{/content}
 				</div>

--- a/com.woltlab.wcf/templates/pageHeaderLogo.tpl
+++ b/com.woltlab.wcf/templates/pageHeaderLogo.tpl
@@ -1,14 +1,14 @@
 <div id="pageHeaderLogo" class="pageHeaderLogo">
-	{if MODULE_WCF_AD && $__disableAds|empty}{@$__wcf->getAdHandler()->getAds('com.woltlab.wcf.logo')}{/if}
+	{if MODULE_WCF_AD && $__disableAds|empty}{unsafe:$__wcf->getAdHandler()->getAds('com.woltlab.wcf.logo')}{/if}
 	
 	<a href="{if PAGE_LOGO_LINK_TO_APP_DEFAULT}{link application=$__wcf->getActiveApplication()->getAbbreviation()}{/link}{else}{link}{/link}{/if}" aria-label="{PAGE_TITLE|phrase}">
 		<img src="{$__wcf->getStyleHandler()->getStyle()->getPageLogo()}" alt="" class="pageHeaderLogoLarge"{*
-			*}{if $__wcf->getStyleHandler()->getStyle()->getVariable('pageLogoHeight')} height="{@$__wcf->getStyleHandler()->getStyle()->getVariable('pageLogoHeight')}"{/if}{*
-			*}{if $__wcf->getStyleHandler()->getStyle()->getVariable('pageLogoWidth')} width="{@$__wcf->getStyleHandler()->getStyle()->getVariable('pageLogoWidth')}"{/if}{*
+			*}{if $__wcf->getStyleHandler()->getStyle()->getVariable('pageLogoHeight')} height="{$__wcf->getStyleHandler()->getStyle()->getVariable('pageLogoHeight')}"{/if}{*
+			*}{if $__wcf->getStyleHandler()->getStyle()->getVariable('pageLogoWidth')} width="{$__wcf->getStyleHandler()->getStyle()->getVariable('pageLogoWidth')}"{/if}{*
 			*} loading="eager">
 		<img src="{$__wcf->getStyleHandler()->getStyle()->getPageLogoMobile()}" alt="" class="pageHeaderLogoSmall"{*
-			*}{if $__wcf->getStyleHandler()->getStyle()->getPageLogoSmallHeight()} height="{@$__wcf->getStyleHandler()->getStyle()->getPageLogoSmallHeight()}"{/if}{*
-			*}{if $__wcf->getStyleHandler()->getStyle()->getPageLogoSmallWidth()} width="{@$__wcf->getStyleHandler()->getStyle()->getPageLogoSmallWidth()}"{/if}{*
+			*}{if $__wcf->getStyleHandler()->getStyle()->getPageLogoSmallHeight()} height="{$__wcf->getStyleHandler()->getStyle()->getPageLogoSmallHeight()}"{/if}{*
+			*}{if $__wcf->getStyleHandler()->getStyle()->getPageLogoSmallWidth()} width="{$__wcf->getStyleHandler()->getStyle()->getPageLogoSmallWidth()}"{/if}{*
 			*} loading="eager">
 		
 		{event name='headerLogo'}

--- a/com.woltlab.wcf/templates/pageHeaderMenu.tpl
+++ b/com.woltlab.wcf/templates/pageHeaderMenu.tpl
@@ -1,4 +1,4 @@
-{@$__wcf->getBoxHandler()->getBoxByIdentifier('com.woltlab.wcf.MainMenu')->render()}
+{unsafe:$__wcf->getBoxHandler()->getBoxByIdentifier('com.woltlab.wcf.MainMenu')->render()}
 <button type="button" class="pageHeaderMenuMobile" aria-expanded="false" aria-label="{lang}wcf.menu.page{/lang}">
 	<span class="pageHeaderMenuMobileInactive">
 		{icon size=32 name='bars'}

--- a/com.woltlab.wcf/templates/pageHeaderSearch.tpl
+++ b/com.woltlab.wcf/templates/pageHeaderSearch.tpl
@@ -45,7 +45,7 @@
 					
 					{foreach from=$__wcf->getSearchEngine()->getAvailableObjectTypes() key=_searchObjectTypeName item=_searchObjectType}
 						{if $_searchObjectType->isAccessible()}
-							<li><a href="#" data-extended-link="{link controller='Search'}type={$_searchObjectTypeName}&extended=1{/link}" data-object-type="{$_searchObjectTypeName}">{lang}wcf.search.type.{$_searchObjectTypeName}{/lang}</a></li>
+							<li><a href="#" data-extended-link="{link controller='Search' type=$_searchObjectTypeName extended=1}{/link}" data-object-type="{$_searchObjectTypeName}">{lang}wcf.search.type.{$_searchObjectTypeName}{/lang}</a></li>
 						{/if}
 					{/foreach}
 					

--- a/com.woltlab.wcf/templates/pageHeaderSearch.tpl
+++ b/com.woltlab.wcf/templates/pageHeaderSearch.tpl
@@ -1,5 +1,5 @@
 {if $__searchTypeLabel|empty}
-	{capture assign='__searchTypeLabel'}{lang}wcf.search.type.{if !$__searchObjectTypeName|empty}{@$__searchObjectTypeName}{else}everywhere{/if}{/lang}{/capture}
+	{capture assign='__searchTypeLabel'}{lang}wcf.search.type.{if !$__searchObjectTypeName|empty}{$__searchObjectTypeName}{else}everywhere{/if}{/lang}{/capture}
 {/if}
 
 {if MODULE_ARTICLE && SEARCH_ENABLE_ARTICLES && $__wcf->getActivePage() != null && ($__wcf->getActivePage()->identifier == 'com.woltlab.wcf.ArticleList' || $__wcf->getActivePage()->identifier == 'com.woltlab.wcf.CategoryArticleList' || $__wcf->getActivePage()->identifier == 'com.woltlab.wcf.Article')}
@@ -12,7 +12,7 @@
 	{assign var='__searchObjectTypeName' value='com.woltlab.wcf.article'}
 	
 	{capture assign='__searchTypesScoped'}
-		{if $category|isset}<li><a href="#" data-extended-link="{link controller='Search'}type=com.woltlab.wcf.article&extended=1{/link}" data-object-type="com.woltlab.wcf.article" data-parameters='{ "articleCategoryID": {@$category->categoryID} }'>{$category->getTitle()}</a></li>{/if}
+		{if $category|isset}<li><a href="#" data-extended-link="{link controller='Search'}type=com.woltlab.wcf.article&extended=1{/link}" data-object-type="com.woltlab.wcf.article" data-parameters='{ "articleCategoryID": {$category->categoryID} }'>{$category->getTitle()}</a></li>{/if}
 	{/capture}
 	{assign var='__searchAreaInitialized' value=true}
 {/if}
@@ -28,7 +28,7 @@
 		<div id="pageHeaderSearchInputContainer" class="pageHeaderSearchInputContainer">
 			<div class="pageHeaderSearchType dropdown">
 				<a href="#" class="button dropdownToggle" id="pageHeaderSearchTypeSelect">
-					<span class="pageHeaderSearchTypeLabel">{@$__searchTypeLabel}</span>
+					<span class="pageHeaderSearchTypeLabel">{unsafe:$__searchTypeLabel}</span>
 					{icon name='angle-down' type='solid'}
 				</a>
 				<ul class="dropdownMenu">
@@ -37,7 +37,7 @@
 					
 					{hascontent}
 						{content}
-							{if !$__searchTypesScoped|empty}{@$__searchTypesScoped}{/if}
+							{if !$__searchTypesScoped|empty}{unsafe:$__searchTypesScoped}{/if}
 						{/content}
 						
 						<li class="dropdownDivider"></li>
@@ -45,7 +45,7 @@
 					
 					{foreach from=$__wcf->getSearchEngine()->getAvailableObjectTypes() key=_searchObjectTypeName item=_searchObjectType}
 						{if $_searchObjectType->isAccessible()}
-							<li><a href="#" data-extended-link="{link controller='Search'}type={@$_searchObjectTypeName}&extended=1{/link}" data-object-type="{@$_searchObjectTypeName}">{lang}wcf.search.type.{@$_searchObjectTypeName}{/lang}</a></li>
+							<li><a href="#" data-extended-link="{link controller='Search'}type={$_searchObjectTypeName}&extended=1{/link}" data-object-type="{$_searchObjectTypeName}">{lang}wcf.search.type.{$_searchObjectTypeName}{/lang}</a></li>
 						{/if}
 					{/foreach}
 					
@@ -62,7 +62,7 @@
 			
 			<div id="pageHeaderSearchParameters"></div>
 			
-			{if !$__searchStaticOptions|empty}{@$__searchStaticOptions}{/if}
+			{if !$__searchStaticOptions|empty}{unsafe:$__searchStaticOptions}{/if}
 		</div>
 	</form>
 </div>
@@ -70,7 +70,7 @@
 {if (!OFFLINE || $__wcf->session->getPermission('admin.general.canViewPageDuringOfflineMode')) && (!FORCE_LOGIN || $__wcf->user->userID)}
 	<script data-relocate="true">
 		require(['WoltLabSuite/Core/Ui/Search/Page'], function(UiSearchPage) {
-			UiSearchPage.init('{if !$__searchObjectTypeName|empty}{@$__searchObjectTypeName}{elseif !$searchPreselectObjectType|empty}{$searchPreselectObjectType}{else}everywhere{/if}');
+			UiSearchPage.init('{if !$__searchObjectTypeName|empty}{unsafe:$__searchObjectTypeName|encodeJS}{elseif !$searchPreselectObjectType|empty}{$searchPreselectObjectType}{else}everywhere{/if}');
 		});
 	</script>
 {/if}

--- a/com.woltlab.wcf/templates/pageHeaderUser.tpl
+++ b/com.woltlab.wcf/templates/pageHeaderUser.tpl
@@ -96,7 +96,7 @@
 			
 			<!-- user notifications -->
 			{if !$__hideUserMenu|isset}
-				<li id="userNotifications" data-count="{#$__wcf->getUserNotificationHandler()->getNotificationCount()}">
+				<li id="userNotifications" data-count="{$__wcf->getUserNotificationHandler()->getNotificationCount()}">
 					<a
 						class="jsTooltip"
 						href="{link controller='NotificationList'}{/link}"
@@ -184,7 +184,7 @@
 		
 		{if !$__hideUserMenu|isset}
 			{if $__wcf->user->userID && $__wcf->session->getPermission('mod.general.canUseModeration')}
-				<li id="outstandingModeration" data-count="{#$__wcf->getModerationQueueManager()->getUnreadModerationCount()}">
+				<li id="outstandingModeration" data-count="{$__wcf->getModerationQueueManager()->getUnreadModerationCount()}">
 					<a
 						class="jsTooltip"
 						href="{link controller='ModerationList'}{/link}"

--- a/com.woltlab.wcf/templates/permissionDenied.tpl
+++ b/com.woltlab.wcf/templates/permissionDenied.tpl
@@ -23,7 +23,7 @@
 	
 	<p id="errorMessage" class="fullPageErrorMessage" data-exception-class-name="{$exceptionClassName}">
 		{if $message|isset}
-			{@$message}
+			{unsafe:$message}
 		{else}
 			{lang}wcf.page.error.permissionDenied{/lang}
 		{/if}
@@ -49,7 +49,7 @@
 
 {if ENABLE_DEBUG_MODE}
 	<!-- 
-	{$name} thrown in {$file} ({@$line})
+	{$name} thrown in {$file} ({$line})
 	Stacktrace:
 	{$stacktrace}
 	-->

--- a/com.woltlab.wcf/templates/redirect.tpl
+++ b/com.woltlab.wcf/templates/redirect.tpl
@@ -1,13 +1,13 @@
 {capture assign='pageTitle'}{lang}wcf.page.redirect.title{/lang}{/capture}
 
 {capture assign='headContent'}
-	<meta http-equiv="refresh" content="{if $wait|isset}{@$wait}{else}10{/if};URL={$url}">
+	<meta http-equiv="refresh" content="{if $wait|isset}{$wait}{else}10{/if};URL={$url}">
 {/capture}
 
 {include file='header' __disableAds=true}
 
-<div class="{if !$status|empty}{@$status}{else}success{/if}">
-	<p>{@$message}</p>
+<div class="{if !$status|empty}{$status}{else}success{/if}">
+	<p>{unsafe:$message}</p>
 	<a href="{$url}">{lang}wcf.page.redirect.url{/lang}</a>
 </div>
 

--- a/wcfsetup/install/files/acp/templates/error.tpl
+++ b/wcfsetup/install/files/acp/templates/error.tpl
@@ -4,7 +4,7 @@
 {if $exception !== null}
 <!--
 {* A comment may not contain double dashes. *}
-{@'--'|str_replace:'- -':$exception}
+{unsafe:'--'|str_replace:'- -':$exception}
 -->
 {/if}
 {/if}
@@ -19,7 +19,7 @@
 	<div class="box64 userException">
 		{icon size=64 name='circle-exclamation'}
 		<p class="userExceptionMessage">
-			{@$message}
+			{unsafe:$message}
 		</p>
 	</div>
 </div>

--- a/wcfsetup/install/files/acp/templates/header.tpl
+++ b/wcfsetup/install/files/acp/templates/header.tpl
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html
-	dir="{@$__wcf->getLanguage()->getPageDirection()}"
+	dir="{$__wcf->getLanguage()->getPageDirection()}"
 	lang="{$__wcf->getLanguage()->getBcp47()}"
 	data-color-scheme="{$__wcf->getStyleHandler()->getColorScheme()}"
 >
@@ -8,13 +8,13 @@
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<meta name="robots" content="noindex">
-	<title>{if $pageTitle|isset}{@$pageTitle|language} - {/if}{jslang}wcf.global.acp{/jslang}{if PACKAGE_ID} - {PAGE_TITLE|phrase}{/if}</title>
+	<title>{if $pageTitle|isset}{unsafe:$pageTitle|language} - {/if}{jslang}wcf.global.acp{/jslang}{if PACKAGE_ID} - {PAGE_TITLE|phrase}{/if}</title>
 	
 	{* work-around for Microsoft Edge that sometimes does not apply this style, if it was set via an external stylesheet *}
 	<style>ol, ul { list-style: none; }</style>
 	
 	<!-- Stylesheets -->
-	{@$__wcf->getStyleHandler()->getStylesheet(true)}
+	{unsafe:$__wcf->getStyleHandler()->getStylesheet(true)}
 	{event name='stylesheets'}
 	
 	<!-- Icons -->
@@ -48,14 +48,14 @@
 	<meta name="timezone" content="{$__wcf->user->getTimeZone()->getName()}">
 	
 	<script data-eager="true">
-		var WCF_PATH = '{@$__wcf->getPath()}';
-		var WSC_API_URL = '{@$__wcf->getPath()}acp/';
+		var WCF_PATH = '{unsafe:$__wcf->getPath()|encodeJS}';
+		var WSC_API_URL = '{unsafe:$__wcf->getPath()|encodeJS}acp/';
 		var WSC_RPC_API_URL = '{link controller="Api" forceFrontend=true id="rpc"}{/link}';
 		{* The SECURITY_TOKEN is defined in wcf.globalHelper.js *}
-		var LANGUAGE_ID = {@$__wcf->getLanguage()->languageID};
+		var LANGUAGE_ID = {$__wcf->getLanguage()->languageID};
 		var LANGUAGE_USE_INFORMAL_VARIANT = {if LANGUAGE_USE_INFORMAL_VARIANT}true{else}false{/if};
-		var TIME_NOW = {@TIME_NOW};
-		var LAST_UPDATE_TIME = {@LAST_UPDATE_TIME};
+		var TIME_NOW = {TIME_NOW};
+		var LAST_UPDATE_TIME = {LAST_UPDATE_TIME};
 		var ENABLE_DEBUG_MODE = {if ENABLE_DEBUG_MODE}true{else}false{/if};
 		var ENABLE_PRODUCTION_DEBUG_MODE = {if ENABLE_PRODUCTION_DEBUG_MODE}true{else}false{/if};
 		var ENABLE_DEVELOPER_TOOLS = {if ENABLE_DEVELOPER_TOOLS}true{else}false{/if};
@@ -65,7 +65,7 @@
 		var COMPILER_TARGET_DEFAULT = true;
 	</script>
 
-	<script data-eager="true" src="{$__wcf->getPath()}js/WoltLabSuite/WebComponent.min.js?v={@LAST_UPDATE_TIME}"></script>
+	<script data-eager="true" src="{$__wcf->getPath()}js/WoltLabSuite/WebComponent.min.js?v={LAST_UPDATE_TIME}"></script>
 	<script data-eager="true" src="{$phrasePreloader->getUrl($__wcf->language)}"></script>
 	
 	{js application='wcf' file='require' bundle='WoltLabSuite.Core' core='true'}
@@ -75,8 +75,8 @@
 	{js application='wcf' file='3rdParty/tslib' bundle='WoltLabSuite.Core' core='true'}
 	<script>
 		requirejs.config({
-			baseUrl: '{@$__wcf->getPath()}js',
-			urlArgs: 't={@LAST_UPDATE_TIME}'
+			baseUrl: '{unsafe:$__wcf->getPath()|encodeJS}js',
+			urlArgs: 't={LAST_UPDATE_TIME}'
 			{hascontent}
 			, paths: {
 				{content}{event name='requirePaths'}{/content}
@@ -94,9 +94,9 @@
 			});
 			
 			User.init(
-				{@$__wcf->user->userID},
-				{if $__wcf->user->userID}'{@$__wcf->user->username|encodeJS}'{else}''{/if},
-				{if $__wcf->user->userID}'{@$__wcf->user->getLink()|encodeJS}'{else}''{/if}
+				{$__wcf->user->userID},
+				{if $__wcf->user->userID}'{unsafe:$__wcf->user->username|encodeJS}'{else}''{/if},
+				{if $__wcf->user->userID}'{unsafe:$__wcf->user->getLink()|encodeJS}'{else}''{/if}
 			);
 			
 			AcpBootstrap.setup({
@@ -126,8 +126,8 @@
 		define.amd = __require_define_amd;
 		$.holdReady(true);
 		WCF.User.init(
-			{@$__wcf->user->userID},
-			{if $__wcf->user->userID}'{@$__wcf->user->username|encodeJS}'{else}''{/if}
+			{$__wcf->user->userID},
+			{if $__wcf->user->userID}'{unsafe:$__wcf->user->username|encodeJS}'{else}''{/if}
 		);
 	</script>
 	{js application='wcf' file='WCF.Message' bundle='WCF.Combined'}
@@ -165,7 +165,7 @@
 	{event name='javascriptInclude'}
 	
 	{if !$headContent|empty}
-		{@$headContent}
+		{unsafe:$headContent}
 	{/if}
 </head>
 

--- a/wcfsetup/install/files/acp/templates/index.tpl
+++ b/wcfsetup/install/files/acp/templates/index.tpl
@@ -31,7 +31,7 @@
 		<div class="acpDashboardBox" data-name="{$box->getName()}">
 			<h2 class="acpDashboardBox__title">{$box->getTitle()}</h2>
 			<div class="acpDashboardBox__content">
-				{@$box->getContent()}
+				{unsafe:$box->getContent()}
 			</div>
 		</div>
 	{/foreach}

--- a/wcfsetup/install/files/acp/templates/pageHeaderLogo.tpl
+++ b/wcfsetup/install/files/acp/templates/pageHeaderLogo.tpl
@@ -7,7 +7,7 @@
 	"
 >
 	<a href="{link}{/link}">
-		<img src="{@$__wcf->getPath()}acp/images/woltlabSuite.png" alt="" width="562" height="80" loading="eager" class="pageHeaderLogoLarge">
-		<img src="{@$__wcf->getPath()}acp/images/woltlabSuite-small.png" alt="" width="55" height="30" loading="eager" class="pageHeaderLogoSmall">
+		<img src="{$__wcf->getPath()}acp/images/woltlabSuite.png" alt="" width="562" height="80" loading="eager" class="pageHeaderLogoLarge">
+		<img src="{$__wcf->getPath()}acp/images/woltlabSuite-small.png" alt="" width="55" height="30" loading="eager" class="pageHeaderLogoSmall">
 	</a>
 </div>

--- a/wcfsetup/install/files/acp/templates/pageHeaderSearch.tpl
+++ b/wcfsetup/install/files/acp/templates/pageHeaderSearch.tpl
@@ -14,7 +14,7 @@
 				<li class="dropdownDivider"></li>
 				
 				{foreach from=$availableAcpSearchProviders key='availableAcpSearchProviderName' item='availableAcpSearchProviderLabel'}
-					<li><a href="#" data-provider-name="{@$availableAcpSearchProviderName}">{@$availableAcpSearchProviderLabel}</a></li>
+					<li><a href="#" data-provider-name="{$availableAcpSearchProviderName}">{unsafe:$availableAcpSearchProviderLabel}</a></li>
 				{/foreach}
 			</ul>
 		</div>

--- a/wcfsetup/install/files/acp/templates/pageHeaderUser.tpl
+++ b/wcfsetup/install/files/acp/templates/pageHeaderUser.tpl
@@ -3,7 +3,7 @@
 		{if $__wcf->user->userID}
 			{if PACKAGE_ID}
 				<li id="userMenu" class="dropdown">
-					<a href="#" class="dropdownToggle jsTooltip" title="{$__wcf->user->username}">{@$__wcf->getUserProfileHandler()->getAvatar()->getImageTag(24)}</a>
+					<a href="#" class="dropdownToggle jsTooltip" title="{$__wcf->user->username}">{unsafe:$__wcf->getUserProfileHandler()->getAvatar()->getImageTag(24)}</a>
 					<ul class="dropdownMenu dropdownMenuUserPanel" data-dropdown-alignment-horizontal="right">
 						<li><a href="{link controller='Logout'}t={csrfToken type=url}{/link}">{lang}wcf.user.logout{/lang}</a></li>
 					</ul>

--- a/wcfsetup/install/files/acp/templates/phpInfo.tpl
+++ b/wcfsetup/install/files/acp/templates/phpInfo.tpl
@@ -4,6 +4,6 @@
 	<h1 class="contentTitle">PHP Version {PHP_VERSION}</h1>
 </header>
 
-{@$phpInfo}
+{unsafe:$phpInfo}
 
 {include file='footer'}

--- a/wcfsetup/install/files/acp/templates/rescueMode.tpl
+++ b/wcfsetup/install/files/acp/templates/rescueMode.tpl
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html dir="{@$__wcf->getLanguage()->getPageDirection()}" lang="{@$__wcf->getLanguage()->getFixedLanguageCode()}">
+<html dir="{$__wcf->getLanguage()->getPageDirection()}" lang="{$__wcf->getLanguage()->getFixedLanguageCode()}">
 <head>
 	<meta charset="utf-8">
 	<meta name="robots" content="noindex">
@@ -63,7 +63,7 @@
 						{elseif $errorType == 'notAuthorized'}
 							{lang}wcf.acp.rescueMode.username.notAuthorized{/lang}
 						{else}
-							{lang}wcf.user.username.error.{@$errorType}{/lang}
+							{lang}wcf.user.username.error.{$errorType}{/lang}
 						{/if}
 					</small>
 				{/if}
@@ -79,7 +79,7 @@
 						{if $errorType == 'empty'}
 							{lang}wcf.global.form.error.empty{/lang}
 						{else}
-							{lang}wcf.user.password.error.{@$errorType}{/lang}
+							{lang}wcf.user.password.error.{$errorType}{/lang}
 						{/if}
 					</small>
 				{/if}
@@ -105,7 +105,7 @@
 						{if $errorType == 'empty'}
 							{lang}wcf.global.form.error.empty{/lang}
 						{else}
-							{lang}wcf.acp.application.domainName.error.{@$errorType}{/lang}
+							{lang}wcf.acp.application.domainName.error.{$errorType}{/lang}
 						{/if}
 					</small>
 				{/if}
@@ -120,21 +120,21 @@
 		</header>
 
 		{foreach from=$applications item=application}
-			{capture assign=applicationSectionPath}application_{@$application->packageID}{/capture}
+			{capture assign=applicationSectionPath}application_{$application->packageID}{/capture}
 			
 			<dl{if $errorField == $applicationSectionPath} class="formError"{/if}>
-				<dt><label for="application{@$application->packageID}">{$application->getPackage()}</label></dt>
+				<dt><label for="application{$application->packageID}">{$application->getPackage()}</label></dt>
 				<dd>
 					<div class="inputAddon">
 						<span class="inputPrefix">{lang}wcf.acp.application.domainPath{/lang}</span>
-						<input type="text" name="applicationValues[{@$application->packageID}]" value="{$applicationValues[$application->packageID]}" class="long" required>
+						<input type="text" name="applicationValues[{$application->packageID}]" value="{$applicationValues[$application->packageID]}" class="long" required>
 					</div>
 					{if $errorField == $applicationSectionPath}
 						<small class="innerError">
 							{if $errorType == 'empty'}
 								{lang}wcf.global.form.error.empty{/lang}
 							{else}
-								{lang}wcf.acp.application.domainPath.error.{@$errorType}{/lang}
+								{lang}wcf.acp.application.domainPath.error.{$errorType}{/lang}
 							{/if}
 						</small>
 					{/if}

--- a/wcfsetup/install/files/acp/templates/success.tpl
+++ b/wcfsetup/install/files/acp/templates/success.tpl
@@ -1,5 +1,5 @@
 {include file='header' templateName='success' templateNameApplication='wcf'}
 
-<woltlab-core-notice type="success">{lang}{@$message}{/lang}</woltlab-core-notice>
+<woltlab-core-notice type="success">{lang}{unsafe:$message}{/lang}</woltlab-core-notice>
 
 {include file='footer'}


### PR DESCRIPTION
- Remove unnecessary `@`
- Use `unsafe:` instead of `@`
- Use `encodeJS` to output variables in JavaScript