### PR TITLE
Refactor FormBuilder templates

### DIFF
--- a/com.woltlab.wcf/templates/shared_bbcodeAttributesFormField.tpl
+++ b/com.woltlab.wcf/templates/shared_bbcodeAttributesFormField.tpl
@@ -9,48 +9,48 @@
 		
 		<dl>
 			<dt>
-				<label for="{$field->getPrefixedId()}[{ldelim}@$attributeNumber}][attributeHtml]">{lang}wcf.acp.bbcode.attribute.attributeHtml{/lang}</label>
+				<label for="{$field->getPrefixedId()}[{ldelim}$attributeNumber}][attributeHtml]">{lang}wcf.acp.bbcode.attribute.attributeHtml{/lang}</label>
 			</dt>
 			<dd>
-				<input type="text" id="{$field->getPrefixedId()}[{ldelim}@$attributeNumber}][attributeHtml]" name="{$field->getPrefixedId()}[{ldelim}@$attributeNumber}][attributeHtml]" value="" class="long" maxlength="255">
+				<input type="text" id="{$field->getPrefixedId()}[{ldelim}$attributeNumber}][attributeHtml]" name="{$field->getPrefixedId()}[{ldelim}$attributeNumber}][attributeHtml]" value="" class="long" maxlength="255">
 			</dd>
 		</dl>
 		
 		<dl>
 			<dt>
-				<label for="{$field->getPrefixedId()}[{ldelim}@$attributeNumber}][validationPattern]">{lang}wcf.acp.bbcode.attribute.validationPattern{/lang}</label>
+				<label for="{$field->getPrefixedId()}[{ldelim}$attributeNumber}][validationPattern]">{lang}wcf.acp.bbcode.attribute.validationPattern{/lang}</label>
 			</dt>
 			<dd>
-				<input type="text" id="{$field->getPrefixedId()}[{ldelim}@$attributeNumber}][validationPattern]" name="{$field->getPrefixedId()}[{ldelim}@$attributeNumber}][validationPattern]" value="" class="long" maxlength="255">
+				<input type="text" id="{$field->getPrefixedId()}[{ldelim}$attributeNumber}][validationPattern]" name="{$field->getPrefixedId()}[{ldelim}$attributeNumber}][validationPattern]" value="" class="long" maxlength="255">
 			</dd>
 		</dl>
 		
 		<dl>
 			<dt>
-				<label for="{$field->getPrefixedId()}_required_{ldelim}@$attributeNumber}">{lang}wcf.acp.bbcode.attribute.required{/lang}</label>
+				<label for="{$field->getPrefixedId()}_required_{ldelim}$attributeNumber}">{lang}wcf.acp.bbcode.attribute.required{/lang}</label>
 			</dt>
 			<dd>
 				<ol class="flexibleButtonGroup">
 					<li>
 						<input type="radio" {*
-							*}id="{$field->getPrefixedId()}_required_{ldelim}@$attributeNumber}" {*
-							*}name="{$field->getPrefixedId()}[{ldelim}@$attributeNumber}][required]" {*
+							*}id="{$field->getPrefixedId()}_required_{ldelim}$attributeNumber}" {*
+							*}name="{$field->getPrefixedId()}[{ldelim}$attributeNumber}][required]" {*
 							*}value="1" {*
-							*}data-no-input-id="{$field->getPrefixedId()}_required_{ldelim}@$attributeNumber}_no"{*
+							*}data-no-input-id="{$field->getPrefixedId()}_required_{ldelim}$attributeNumber}_no"{*
 						*}>
-						<label for="{$field->getPrefixedId()}_required_{ldelim}@$attributeNumber}" class="green">
+						<label for="{$field->getPrefixedId()}_required_{ldelim}$attributeNumber}" class="green">
 							{icon name='check'} {lang}wcf.global.form.boolean.yes{/lang}
 						</label>
 					</li>
 					<li>
 						<input type="radio" {*
-							*}id="{$field->getPrefixedId()}_required_{ldelim}@$attributeNumber}_no" {*
-							*}name="{$field->getPrefixedId()}[{ldelim}@$attributeNumber}][required]" {*
+							*}id="{$field->getPrefixedId()}_required_{ldelim}$attributeNumber}_no" {*
+							*}name="{$field->getPrefixedId()}[{ldelim}$attributeNumber}][required]" {*
 							*}value="0" {*
-							*}name="{$field->getPrefixedId()}[{ldelim}@$attributeNumber}][required]" {*
+							*}name="{$field->getPrefixedId()}[{ldelim}$attributeNumber}][required]" {*
 							*}checked{*
 						*}>
-						<label for="{$field->getPrefixedId()}_required_{ldelim}@$attributeNumber}_no" class="red">
+						<label for="{$field->getPrefixedId()}_required_{ldelim}$attributeNumber}_no" class="red">
 							{icon name='xmark'} {lang}wcf.global.form.boolean.no{/lang}
 						</label>
 					</li>
@@ -60,30 +60,30 @@
 		
 		<dl>
 			<dt>
-				<label for="{$field->getPrefixedId()}_useText_{ldelim}@$attributeNumber}">{lang}wcf.acp.bbcode.attribute.useText{/lang}</label>
+				<label for="{$field->getPrefixedId()}_useText_{ldelim}$attributeNumber}">{lang}wcf.acp.bbcode.attribute.useText{/lang}</label>
 			</dt>
 			<dd>
 				<ol class="flexibleButtonGroup">
 					<li>
 						<input type="radio" {*
-							*}id="{$field->getPrefixedId()}_useText_{ldelim}@$attributeNumber}" {*
-							*}name="{$field->getPrefixedId()}[{ldelim}@$attributeNumber}][useText]" {*
+							*}id="{$field->getPrefixedId()}_useText_{ldelim}$attributeNumber}" {*
+							*}name="{$field->getPrefixedId()}[{ldelim}$attributeNumber}][useText]" {*
 							*}value="1" {*
-							*}data-no-input-id="{$field->getPrefixedId()}_useText_{ldelim}@$attributeNumber}_no"{*
+							*}data-no-input-id="{$field->getPrefixedId()}_useText_{ldelim}$attributeNumber}_no"{*
 						*}>
-						<label for="{$field->getPrefixedId()}_useText_{ldelim}@$attributeNumber}" class="green">
+						<label for="{$field->getPrefixedId()}_useText_{ldelim}$attributeNumber}" class="green">
 							{icon name='check'} {lang}wcf.global.form.boolean.yes{/lang}
 						</label>
 					</li>
 					<li>
 						<input type="radio" {*
-							*}id="{$field->getPrefixedId()}_useText_{ldelim}@$attributeNumber}_no" {*
-							*}name="{$field->getPrefixedId()}[{ldelim}@$attributeNumber}][useText]" {*
+							*}id="{$field->getPrefixedId()}_useText_{ldelim}$attributeNumber}_no" {*
+							*}name="{$field->getPrefixedId()}[{ldelim}$attributeNumber}][useText]" {*
 							*}value="0" {*
-							*}name="{$field->getPrefixedId()}[{ldelim}@$attributeNumber}][useText]" {*
+							*}name="{$field->getPrefixedId()}[{ldelim}$attributeNumber}][useText]" {*
 							*}checked{*
 						*}>
-						<label for="{$field->getPrefixedId()}_useText_{ldelim}@$attributeNumber}_no" class="red">
+						<label for="{$field->getPrefixedId()}_useText_{ldelim}$attributeNumber}_no" class="red">
 							{icon name='xmark'} {lang}wcf.global.form.boolean.no{/lang}
 						</label>
 					</li>
@@ -97,7 +97,7 @@
 
 <script data-relocate="true">
 	require(['Dom/ChangeListener', 'Dom/Traverse', 'Dom/Util', 'WoltLabSuite/Core/Template'], function(DomChangeListener, DomTraverse, DomUtil, Template) {
-		var parentContainer = elById('{@$field->getParent()->getPrefixedId()|encodeJS}Container');
+		var parentContainer = elById('{unsafe:$field->getParent()->getPrefixedId()|encodeJS}Container');
 		
 		var parentTitle = DomTraverse.childBySel(parentContainer, 'h2.sectionTitle');
 		parentTitle.innerHTML = `
@@ -122,9 +122,9 @@
 		addDeleteButtonListeners();
 		
 		var attributeNumber = {if $field->getValue()|empty}0{else}{$field->getValue()|count}{/if};
-		var attributeTemplate = new Template('{@$attributeTemplate|encodeJS}');
+		var attributeTemplate = new Template('{unsafe:$attributeTemplate|encodeJS}');
 		
-		elById('{@$field->getPrefixedId()|encodeJS}AddAttribute').addEventListener('click', function(event) {
+		elById('{unsafe:$field->getPrefixedId()|encodeJS}AddAttribute').addEventListener('click', function(event) {
 			var html = attributeTemplate.fetch({ attributeNumber: attributeNumber++ });
 			
 			DomUtil.insertHtml(html, parentContainer, 'append');
@@ -147,10 +147,10 @@
 		
 		<dl>
 			<dt>
-				<label for="{$field->getPrefixedId()}[{@$attributeNumber}][attributeHtml]">{lang}wcf.acp.bbcode.attribute.attributeHtml{/lang}</label>
+				<label for="{$field->getPrefixedId()}[{$attributeNumber}][attributeHtml]">{lang}wcf.acp.bbcode.attribute.attributeHtml{/lang}</label>
 			</dt>
 			<dd>
-				<input type="text" name="{$field->getPrefixedId()}[{@$attributeNumber}][attributeHtml]" value="{if $attributeData[attributeHtml]|isset}{$attributeData[attributeHtml]}{/if}" class="long" maxlength="255">
+				<input type="text" name="{$field->getPrefixedId()}[{$attributeNumber}][attributeHtml]" value="{if $attributeData[attributeHtml]|isset}{$attributeData[attributeHtml]}{/if}" class="long" maxlength="255">
 			</dd>
 		</dl>
 		
@@ -162,43 +162,43 @@
 		{/foreach}
 		<dl{if $__attributeValidationError !== null} class="formError"{/if}>
 			<dt>
-				<label for="{$field->getPrefixedId()}[{@$attributeNumber}][validationPattern]">{lang}wcf.acp.bbcode.attribute.validationPattern{/lang}</label>
+				<label for="{$field->getPrefixedId()}[{$attributeNumber}][validationPattern]">{lang}wcf.acp.bbcode.attribute.validationPattern{/lang}</label>
 			</dt>
 			<dd>
-				<input type="text" name="{$field->getPrefixedId()}[{@$attributeNumber}][validationPattern]" value="{if $attributeData[validationPattern]|isset}{$attributeData[validationPattern]}{/if}" class="long" maxlength="255">
+				<input type="text" name="{$field->getPrefixedId()}[{$attributeNumber}][validationPattern]" value="{if $attributeData[validationPattern]|isset}{$attributeData[validationPattern]}{/if}" class="long" maxlength="255">
 				{if $__attributeValidationError !== null}
-					<small class="innerError">{@$__attributeValidationError->getMessage()}</small>
+					<small class="innerError">{unsafe:$__attributeValidationError->getMessage()}</small>
 				{/if}
 			</dd>
 		</dl>
 		
 		<dl>
 			<dt>
-				<label for="{$field->getPrefixedId()}_required_{@$attributeNumber}">{lang}wcf.acp.bbcode.attribute.required{/lang}</label>
+				<label for="{$field->getPrefixedId()}_required_{$attributeNumber}">{lang}wcf.acp.bbcode.attribute.required{/lang}</label>
 			</dt>
 			<dd>
 				<ol class="flexibleButtonGroup">
 					<li>
 						<input type="radio" {*
-							*}id="{$field->getPrefixedId()}_required_{@$attributeNumber}" {*
-							*}name="{$field->getPrefixedId()}[{@$attributeNumber}][required]" {*
+							*}id="{$field->getPrefixedId()}_required_{$attributeNumber}" {*
+							*}name="{$field->getPrefixedId()}[{$attributeNumber}][required]" {*
 							*}value="1" {*
-							*}data-no-input-id="{$field->getPrefixedId()}_required_{@$attributeNumber}_no"{*
+							*}data-no-input-id="{$field->getPrefixedId()}_required_{$attributeNumber}_no"{*
 							*}{if !$attributeData[required]|empty} checked{/if}{*
 						*}>
-						<label for="{$field->getPrefixedId()}_required_{@$attributeNumber}" class="green">
+						<label for="{$field->getPrefixedId()}_required_{$attributeNumber}" class="green">
 							{icon name='check'} {lang}wcf.global.form.boolean.yes{/lang}
 						</label>
 					</li>
 					<li>
 						<input type="radio" {*
-							*}id="{$field->getPrefixedId()}_required_{@$attributeNumber}_no" {*
-							*}name="{$field->getPrefixedId()}[{@$attributeNumber}][required]" {*
+							*}id="{$field->getPrefixedId()}_required_{$attributeNumber}_no" {*
+							*}name="{$field->getPrefixedId()}[{$attributeNumber}][required]" {*
 							*}value="0" {*
-							*}name="{$field->getPrefixedId()}[{@$attributeNumber}][required]"{*
+							*}name="{$field->getPrefixedId()}[{$attributeNumber}][required]"{*
 							*}{if $attributeData[required]|empty} checked{/if}{*
 						*}>
-						<label for="{$field->getPrefixedId()}_required_{@$attributeNumber}_no" class="red">
+						<label for="{$field->getPrefixedId()}_required_{$attributeNumber}_no" class="red">
 							{icon name='xmark'} {lang}wcf.global.form.boolean.no{/lang}
 						</label>
 					</li>
@@ -208,31 +208,31 @@
 		
 		<dl>
 			<dt>
-				<label for="{$field->getPrefixedId()}_useText_{@$attributeNumber}">{lang}wcf.acp.bbcode.attribute.useText{/lang}</label>
+				<label for="{$field->getPrefixedId()}_useText_{$attributeNumber}">{lang}wcf.acp.bbcode.attribute.useText{/lang}</label>
 			</dt>
 			<dd>
 				<ol class="flexibleButtonGroup">
 					<li>
 						<input type="radio" {*
-							*}id="{$field->getPrefixedId()}_useText_{@$attributeNumber}" {*
-							*}name="{$field->getPrefixedId()}[{@$attributeNumber}][useText]" {*
+							*}id="{$field->getPrefixedId()}_useText_{$attributeNumber}" {*
+							*}name="{$field->getPrefixedId()}[{$attributeNumber}][useText]" {*
 							*}value="1" {*
-							*}data-no-input-id="{$field->getPrefixedId()}_useText_{@$attributeNumber}_no"{*
+							*}data-no-input-id="{$field->getPrefixedId()}_useText_{$attributeNumber}_no"{*
 							*}{if !$attributeData[useText]|empty} checked{/if}{*
 						*}>
-						<label for="{$field->getPrefixedId()}_useText_{@$attributeNumber}" class="green">
+						<label for="{$field->getPrefixedId()}_useText_{$attributeNumber}" class="green">
 							{icon name='check'} {lang}wcf.global.form.boolean.yes{/lang}
 						</label>
 					</li>
 					<li>
 						<input type="radio" {*
-							*}id="{$field->getPrefixedId()}_useText_{@$attributeNumber}_no" {*
-							*}name="{$field->getPrefixedId()}[{@$attributeNumber}][useText]" {*
+							*}id="{$field->getPrefixedId()}_useText_{$attributeNumber}_no" {*
+							*}name="{$field->getPrefixedId()}[{$attributeNumber}][useText]" {*
 							*}value="0" {*
-							*}name="{$field->getPrefixedId()}[{@$attributeNumber}][useText]"{*
+							*}name="{$field->getPrefixedId()}[{$attributeNumber}][useText]"{*
 							*}{if $attributeData[useText]|empty} checked{/if}{*
 						*}>
-						<label for="{$field->getPrefixedId()}_useText_{@$attributeNumber}_no" class="red">
+						<label for="{$field->getPrefixedId()}_useText_{$attributeNumber}_no" class="red">
 							{icon name='xmark'} {lang}wcf.global.form.boolean.no{/lang}
 						</label>
 					</li>

--- a/com.woltlab.wcf/templates/shared_captchaFormField.tpl
+++ b/com.woltlab.wcf/templates/shared_captchaFormField.tpl
@@ -1,1 +1,1 @@
-{@$field->getObjectType()->getProcessor()->getFormElement()}
+{unsafe:$field->getObjectType()->getProcessor()->getFormElement()}

--- a/com.woltlab.wcf/templates/shared_checkboxFormField.tpl
+++ b/com.woltlab.wcf/templates/shared_checkboxFormField.tpl
@@ -12,7 +12,7 @@
 				*}{if $field->getValue()} checked{/if}{*
 				*}{foreach from=$field->getFieldAttributes() key='attributeName' item='attributeValue'} {$attributeName}="{$attributeValue}"{/foreach}{*
 			*}>
-			{@$field->getLabel()}{if $field->isRequired()} <span class="formFieldRequired">*</span>{/if}
+			{unsafe:$field->getLabel()}{if $field->isRequired()} <span class="formFieldRequired">*</span>{/if}
 		</label>
 
 		{include file='shared_formFieldDescription'}

--- a/com.woltlab.wcf/templates/shared_colorFormField.tpl
+++ b/com.woltlab.wcf/templates/shared_colorFormField.tpl
@@ -15,7 +15,7 @@
 
 	<script data-relocate="true">
 		require(['WoltLabSuite/Core/Ui/Color/Picker'], (UiColorPicker) => {
-			UiColorPicker.fromSelector("#{@$field->getPrefixedId()|encodeJS}_colorPickerButton");
+			UiColorPicker.fromSelector("#{unsafe:$field->getPrefixedId()|encodeJS}_colorPickerButton");
 		});
 	</script>
 {/if}

--- a/com.woltlab.wcf/templates/shared_contentLanguageFormField.tpl
+++ b/com.woltlab.wcf/templates/shared_contentLanguageFormField.tpl
@@ -13,17 +13,17 @@
 	require(['WoltLabSuite/Core/Language/Chooser', 'Dom/Traverse', 'Dom/Util'], function(LanguageChooser, DomTraverse, DomUtil) {
 		var languages = {
 			{implode from=$field->getContentLanguages() item=contentLanguage}
-				'{@$contentLanguage->languageID}': {
-					iconPath: '{@$contentLanguage->getIconPath()|encodeJS}',
-					languageName: '{@$contentLanguage|encodeJS}'
+				'{$contentLanguage->languageID}': {
+					iconPath: '{unsafe:$contentLanguage->getIconPath()|encodeJS}',
+					languageName: '{unsafe:$contentLanguage|encodeJS}'
 				}
 			{/implode}
 		};
 		
 		LanguageChooser.init(
-			DomUtil.identify(DomTraverse.childByTag(elById('{@$field->getPrefixedId()|encodeJS}Container'), 'DD')),
-			'{@$field->getPrefixedId()|encodeJS}',
-			{if $field->getValue()}{@$field->getValue()}{else}0{/if},
+			DomUtil.identify(DomTraverse.childByTag(elById('{unsafe:$field->getPrefixedId()|encodeJS}Container'), 'DD')),
+			'{unsafe:$field->getPrefixedId()|encodeJS}',
+			{if $field->getValue()}{$field->getValue()}{else}0{/if},
 			languages,
 			undefined,
 			{if !$field->isRequired()}true{else}false{/if}

--- a/com.woltlab.wcf/templates/shared_emptyFormFieldDependency.tpl
+++ b/com.woltlab.wcf/templates/shared_emptyFormFieldDependency.tpl
@@ -1,7 +1,7 @@
 require(['WoltLabSuite/Core/Form/Builder/Field/Dependency/Empty'], function(EmptyFieldDependency) {
-	// dependency '{@$dependency->getId()}'
+	// dependency '{unsafe:$dependency->getId()}'
 	new EmptyFieldDependency(
-		'{@$dependency->getDependentNode()->getPrefixedId()|encodeJS}Container',
-		'{@$dependency->getField()->getPrefixedId()|encodeJS}'
+		'{unsafe:$dependency->getDependentNode()->getPrefixedId()|encodeJS}Container',
+		'{unsafe:$dependency->getField()->getPrefixedId()|encodeJS}'
 	);
 });

--- a/com.woltlab.wcf/templates/shared_emptyFormFieldDependency.tpl
+++ b/com.woltlab.wcf/templates/shared_emptyFormFieldDependency.tpl
@@ -1,5 +1,5 @@
 require(['WoltLabSuite/Core/Form/Builder/Field/Dependency/Empty'], function(EmptyFieldDependency) {
-	// dependency '{unsafe:$dependency->getId()}'
+	// dependency '{unsafe:$dependency->getId()|encodeJS}'
 	new EmptyFieldDependency(
 		'{unsafe:$dependency->getDependentNode()->getPrefixedId()|encodeJS}Container',
 		'{unsafe:$dependency->getField()->getPrefixedId()|encodeJS}'

--- a/com.woltlab.wcf/templates/shared_fileProcessorFormField.tpl
+++ b/com.woltlab.wcf/templates/shared_fileProcessorFormField.tpl
@@ -26,7 +26,7 @@
 			{if $field->isBigPreview()}true{else}false{/if},
 			{if $field->isSimpleReplace()}true{else}false{/if},
 			{if $field->isHideDeleteButton()}true{else}false{/if},
-			{if $field->getThumbnailSize() === null}undefined{else}'{$field->getThumbnailSize()|encodeJS}'{/if},
+			{if $field->getThumbnailSize() === null}undefined{else}'{unsafe:$field->getThumbnailSize()|encodeJS}'{/if},
 			[{implode from=$actionButtons item=actionButton}{
 				title: '{unsafe:$actionButton['title']|encodeJS}',
 				icon: {if $actionButton['icon'] === null}undefined{else}'{unsafe:$actionButton['icon']->toHtml()|encodeJS}'{/if},

--- a/com.woltlab.wcf/templates/shared_form.tpl
+++ b/com.woltlab.wcf/templates/shared_form.tpl
@@ -11,21 +11,21 @@
 			, FormBuilderManager
 		{/if}
 	) {
-		FormBuilderFieldDependencyManager.register('{@$form->getId()|encodeJS}');
+		FormBuilderFieldDependencyManager.register('{unsafe:$form->getId()|encodeJS}');
 		
 		{if $form->isAjax()}
-			FormBuilderManager.registerForm('{@$form->getId()|encodeJS}');
+			FormBuilderManager.registerForm('{unsafe:$form->getId()|encodeJS}');
 		{/if}
 	});
 </script>
 
 {if $form->hasValidationErrors() && $form->showsErrorMessage()}
-	<woltlab-core-notice type="error">{@$form->getErrorMessage()}</woltlab-core-notice>
+	<woltlab-core-notice type="error">{unsafe:$form->getErrorMessage()}</woltlab-core-notice>
 {/if}
 
 {if $form->showsSuccessMessage()}
 	<woltlab-core-notice type="success">
-		<span>{@$form->getSuccessMessage()}</span>
+		<span>{unsafe:$form->getSuccessMessage()}</span>
 		{if !$objectEditLink|empty}
 			<span>{lang}wcf.global.success.add.editCreatedObject{/lang}</span>
 		{/if}
@@ -38,7 +38,7 @@
 		*}{foreach from=$form->getAttributes() key='attributeName' item='attributeValue'} {$attributeName}="{$attributeValue}"{/foreach}{*
 	*}>
 {else}
-	<form method="{@$form->getMethod()}" {*
+	<form method="{$form->getMethod()}" {*
 		*}action="{$form->getAction()}" {*
 		*}id="{$form->getId()}"{*
 		*}{if !$form->getClasses()|empty} class="{implode from=$form->getClasses() item='class' glue=' '}{$class}{/implode}"{/if}{*
@@ -47,7 +47,7 @@
 {/if}
 	{foreach from=$form item='child'}
 		{if $child->isAvailable()}
-			{@$child->getHtml()}
+			{unsafe:$child->getHtml()}
 		{/if}
 	{/foreach}
 	
@@ -55,7 +55,7 @@
 		<div class="formSubmit">
 			{foreach from=$form->getButtons() item=button}
 				{if $button->isAvailable()}
-					{@$button->getHtml()}
+					{unsafe:$button->getHtml()}
 				{/if}
 			{/foreach}
 		</div>

--- a/com.woltlab.wcf/templates/shared_formContainer.tpl
+++ b/com.woltlab.wcf/templates/shared_formContainer.tpl
@@ -6,11 +6,11 @@
 	{if $container->getLabel() !== null}
 		{if $container->getDescription() !== null}
 			<header class="sectionHeader">
-				<h2 class="sectionTitle">{@$container->getLabel()}{if $container->markAsRequired()} <span class="formFieldRequired">*</span>{/if}</h2>
-				<p class="sectionDescription">{@$container->getDescription()}</p>
+				<h2 class="sectionTitle">{unsafe:$container->getLabel()}{if $container->markAsRequired()} <span class="formFieldRequired">*</span>{/if}</h2>
+				<p class="sectionDescription">{unsafe:$container->getDescription()}</p>
 			</header>
 		{else}
-			<h2 class="sectionTitle">{@$container->getLabel()}{if $container->markAsRequired()} <span class="formFieldRequired">*</span>{/if}</h2>
+			<h2 class="sectionTitle">{unsafe:$container->getLabel()}{if $container->markAsRequired()} <span class="formFieldRequired">*</span>{/if}</h2>
 		{/if}
 	{/if}
 
@@ -21,6 +21,6 @@
 
 <script data-relocate="true">
 	require(['WoltLabSuite/Core/Form/Builder/Field/Dependency/Container/Default'], function(DefaultContainerDependency) {
-		new DefaultContainerDependency('{@$container->getPrefixedId()|encodeJS}Container');
+		new DefaultContainerDependency('{unsafe:$container->getPrefixedId()|encodeJS}Container');
 	});
 </script>

--- a/com.woltlab.wcf/templates/shared_formContainerChildren.tpl
+++ b/com.woltlab.wcf/templates/shared_formContainerChildren.tpl
@@ -1,5 +1,5 @@
 {foreach from=$container item='child'}
 	{if $child->isAvailable()}
-		{@$child->getHtml()}
+		{unsafe:$child->getHtml()}
 	{/if}
 {/foreach}

--- a/com.woltlab.wcf/templates/shared_formContainerDependencies.tpl
+++ b/com.woltlab.wcf/templates/shared_formContainerDependencies.tpl
@@ -1,7 +1,7 @@
 {if !$container->getDependencies()|empty}
 	<script data-relocate="true">
 		{foreach from=$container->getDependencies() item=dependency}
-			{@$dependency->getHtml()}
+			{unsafe:$dependency->getHtml()}
 		{/foreach}
 	</script>
 {/if}

--- a/com.woltlab.wcf/templates/shared_formField.tpl
+++ b/com.woltlab.wcf/templates/shared_formField.tpl
@@ -3,9 +3,9 @@
 	*}{foreach from=$field->getAttributes() key='attributeName' item='attributeValue'} {$attributeName}="{$attributeValue}"{/foreach}{*
 	*}{if !$field->checkDependencies()} style="display: none;"{/if}{*
 *}>
-	<dt>{if $field->getLabel() !== null}<label for="{$field->getPrefixedId()}">{@$field->getLabel()}</label>{if $field->isRequired() && $form->marksRequiredFields()} <span class="formFieldRequired">*</span>{/if}{/if}</dt>
+	<dt>{if $field->getLabel() !== null}<label for="{$field->getPrefixedId()}">{unsafe:$field->getLabel()}</label>{if $field->isRequired() && $form->marksRequiredFields()} <span class="formFieldRequired">*</span>{/if}{/if}</dt>
 	<dd>
-		{@$field->getFieldHtml()}
+		{unsafe:$field->getFieldHtml()}
 
 		{include file='shared_formFieldErrors'}
 		{include file='shared_formFieldDescription'}

--- a/com.woltlab.wcf/templates/shared_formFieldDataHandler.tpl
+++ b/com.woltlab.wcf/templates/shared_formFieldDataHandler.tpl
@@ -2,7 +2,7 @@
 	<script data-relocate="true">
 		require([
 			'tslib',
-			'{$field->getJavaScriptDataHandlerModule()}',
+			'{unsafe:$field->getJavaScriptDataHandlerModule()|encodeJS}',
 			'WoltLabSuite/Core/Form/Builder/Manager'
 		], function(
 			tslib,

--- a/com.woltlab.wcf/templates/shared_formFieldDataHandler.tpl
+++ b/com.woltlab.wcf/templates/shared_formFieldDataHandler.tpl
@@ -12,8 +12,8 @@
 			FormBuilderField = tslib.__importDefault(FormBuilderField);
 
 			FormBuilderManager.registerField(
-				'{@$field->getDocument()->getId()|encodeJS}',
-				new (FormBuilderField.default)('{@$field->getPrefixedId()|encodeJS}')
+				'{unsafe:$field->getDocument()->getId()|encodeJS}',
+				new (FormBuilderField.default)('{unsafe:$field->getPrefixedId()|encodeJS}')
 			);
 		});
 	</script>

--- a/com.woltlab.wcf/templates/shared_formFieldDependencies.tpl
+++ b/com.woltlab.wcf/templates/shared_formFieldDependencies.tpl
@@ -1,7 +1,7 @@
 {if !$field->getDependencies()|empty}
 	<script data-relocate="true">
 		{foreach from=$field->getDependencies() item=dependency}
-			{@$dependency->getHtml()}
+			{unsafe:$dependency->getHtml()}
 		{/foreach}
 	</script>
 {/if}

--- a/com.woltlab.wcf/templates/shared_formFieldDescription.tpl
+++ b/com.woltlab.wcf/templates/shared_formFieldDescription.tpl
@@ -1,3 +1,3 @@
 {if $field->getDescription() !== null}
-	<small>{@$field->getDescription()}</small>
+	<small>{unsafe:$field->getDescription()}</small>
 {/if}

--- a/com.woltlab.wcf/templates/shared_formFieldError.tpl
+++ b/com.woltlab.wcf/templates/shared_formFieldError.tpl
@@ -1,1 +1,1 @@
-<small class="innerError">{@$error->getMessage()}</small>
+<small class="innerError">{unsafe:$error->getMessage()}</small>

--- a/com.woltlab.wcf/templates/shared_formFieldErrors.tpl
+++ b/com.woltlab.wcf/templates/shared_formFieldErrors.tpl
@@ -1,3 +1,3 @@
 {foreach from=$field->getValidationErrors() item='validationError'}
-	{@$validationError->getHtml()}
+	{unsafe:$validationError->getHtml()}
 {/foreach}

--- a/com.woltlab.wcf/templates/shared_iconFormField.tpl
+++ b/com.woltlab.wcf/templates/shared_iconFormField.tpl
@@ -1,6 +1,6 @@
 <span id="{$field->getPrefixedId()}_icon">
 	{if $field->getIcon()}
-		{@$field->getIcon()->toHtml(64)}
+		{unsafe:$field->getIcon()->toHtml(64)}
 	{/if}
 </span>
 {if !$field->isImmutable()}
@@ -16,9 +16,9 @@
 	
 	<script data-relocate="true">
 		require(['WoltLabSuite/Core/Ui/Style/FontAwesome'], (UiStyleFontAwesome) => {
-			const iconContainer = document.getElementById('{@$field->getPrefixedId()|encodeJS}_icon');
-			const input = document.getElementById('{@$field->getPrefixedId()|encodeJS}');
-			const buttonRemoveIcon = document.getElementById('{@$field->getPrefixedId()|encodeJS}_removeIcon');
+			const iconContainer = document.getElementById('{unsafe:$field->getPrefixedId()|encodeJS}_icon');
+			const input = document.getElementById('{unsafe:$field->getPrefixedId()|encodeJS}');
+			const buttonRemoveIcon = document.getElementById('{unsafe:$field->getPrefixedId()|encodeJS}_removeIcon');
 			
 			const callback = (iconName, forceSolid) => {
 				input.value = `${ iconName };${ forceSolid }`;
@@ -36,7 +36,7 @@
 				buttonRemoveIcon.hidden = false;
 			};
 			
-			const button = document.getElementById('{@$field->getPrefixedId()|encodeJS}_openIconDialog');
+			const button = document.getElementById('{unsafe:$field->getPrefixedId()|encodeJS}_openIconDialog');
 			button.addEventListener('click', () => UiStyleFontAwesome.open(callback));
 			buttonRemoveIcon.addEventListener("click", () => {
 				input.value = "";

--- a/com.woltlab.wcf/templates/shared_isNotClickedFormFieldDependency.tpl
+++ b/com.woltlab.wcf/templates/shared_isNotClickedFormFieldDependency.tpl
@@ -1,7 +1,7 @@
 require(['WoltLabSuite/Core/Form/Builder/Field/Dependency/IsNotClicked'], ({ IsNotClicked }) => {
-	// dependency '{@$dependency->getId()}'
+	// dependency '{unsafe:$dependency->getId()}'
 	new IsNotClicked(
-		'{@$dependency->getDependentNode()->getPrefixedId()|encodeJS}Container',
-		'{@$dependency->getField()->getPrefixedId()|encodeJS}'
+		'{unsafe:$dependency->getDependentNode()->getPrefixedId()|encodeJS}Container',
+		'{unsafe:$dependency->getField()->getPrefixedId()|encodeJS}'
 	);
 });

--- a/com.woltlab.wcf/templates/shared_isNotClickedFormFieldDependency.tpl
+++ b/com.woltlab.wcf/templates/shared_isNotClickedFormFieldDependency.tpl
@@ -1,5 +1,5 @@
 require(['WoltLabSuite/Core/Form/Builder/Field/Dependency/IsNotClicked'], ({ IsNotClicked }) => {
-	// dependency '{unsafe:$dependency->getId()}'
+	// dependency '{unsafe:$dependency->getId()|encodeJS}'
 	new IsNotClicked(
 		'{unsafe:$dependency->getDependentNode()->getPrefixedId()|encodeJS}Container',
 		'{unsafe:$dependency->getField()->getPrefixedId()|encodeJS}'

--- a/com.woltlab.wcf/templates/shared_itemListFormField.tpl
+++ b/com.woltlab.wcf/templates/shared_itemListFormField.tpl
@@ -10,11 +10,11 @@
 <script data-relocate="true">
 	require(['WoltLabSuite/Core/Ui/ItemList/Static'], function(UiItemListStatic) {
 		UiItemListStatic.init(
-			'{@$field->getPrefixedId()|encodeJS}',
-			[{if $field->getValue() !== null && !$field->getValue()|empty}{implode from=$field->getValue() item=item}'{@$item|encodeJS}'{/implode}{/if}],
+			'{unsafe:$field->getPrefixedId()|encodeJS}',
+			[{if $field->getValue() !== null && !$field->getValue()|empty}{implode from=$field->getValue() item=item}'{unsafe:$item|encodeJS}'{/implode}{/if}],
 			{
-				maxItems: {if $field->allowsMultiple()}{@$field->getMaximumMultiples()}{else}1{/if},
-				submitFieldName: '{@$field->getPrefixedId()|encodeJS}[]'
+				maxItems: {if $field->allowsMultiple()}{$field->getMaximumMultiples()}{else}1{/if},
+				submitFieldName: '{unsafe:$field->getPrefixedId()|encodeJS}[]'
 			}
 		);
 	});

--- a/com.woltlab.wcf/templates/shared_labelFormField.tpl
+++ b/com.woltlab.wcf/templates/shared_labelFormField.tpl
@@ -1,13 +1,13 @@
-<ul class="labelList jsOnly" data-object-id="{@$field->getLabelGroup()->groupID}">
-	<li class="dropdown labelChooser" data-group-id="{@$field->getLabelGroup()->groupID}">
-		<div class="dropdownToggle" data-toggle="labelGroup{@$field->getLabelGroup()->groupID}">
+<ul class="labelList jsOnly" data-object-id="{$field->getLabelGroup()->groupID}">
+	<li class="dropdown labelChooser" data-group-id="{$field->getLabelGroup()->groupID}">
+		<div class="dropdownToggle" data-toggle="labelGroup{$field->getLabelGroup()->groupID}">
 			<span class="badge label">{lang}wcf.label.none{/lang}</span>
 		</div>
 		<div class="dropdownMenu">
 			<ul class="scrollableDropdownMenu">
 				{foreach from=$field->getLabelGroup() item=label}
-					<li data-label-id="{@$label->labelID}">
-						<span>{@$label->render()}</span>
+					<li data-label-id="{$label->labelID}">
+						<span>{unsafe:$label->render()}</span>
 					</li>
 				{/foreach}
 			</ul>
@@ -16,7 +16,7 @@
 </ul>
 
 <noscript>
-	<select name="{$field->getPrefixedId()}[{@$field->getLabelGroup()->groupID}]">
+	<select name="{$field->getPrefixedId()}[{$field->getLabelGroup()->groupID}]">
 		{foreach from=$field->getLabelGroup() item=label}
 			<option value="{$label->labelID}">{$label->getTitle()}</option>
 		{/foreach}
@@ -31,7 +31,7 @@
 		});
 		
 		new FormBuilderFieldLabel(
-			'{@$field->getPrefixedId()|encodeJS}',
+			'{unsafe:$field->getPrefixedId()|encodeJS}',
 			{if $field->getValue()}'{$field->getValue()|encodeJS}'{else}null{/if},
 			{
 				forceSelection: {if $field->getLabelGroup()->forceSelection}true{else}false{/if}

--- a/com.woltlab.wcf/templates/shared_labelFormField.tpl
+++ b/com.woltlab.wcf/templates/shared_labelFormField.tpl
@@ -32,7 +32,7 @@
 		
 		new FormBuilderFieldLabel(
 			'{unsafe:$field->getPrefixedId()|encodeJS}',
-			{if $field->getValue()}'{$field->getValue()|encodeJS}'{else}null{/if},
+			{if $field->getValue()}'{unsafe:$field->getValue()|encodeJS}'{else}null{/if},
 			{
 				forceSelection: {if $field->getLabelGroup()->forceSelection}true{else}false{/if}
 			}

--- a/com.woltlab.wcf/templates/shared_messageFormAttachments.tpl
+++ b/com.woltlab.wcf/templates/shared_messageFormAttachments.tpl
@@ -23,7 +23,7 @@
 		{jsphrase name='wcf.attachment.moreOptions'}
 
 		require(["WoltLabSuite/Core/Component/Attachment/List"], ({ setup }) => {
-			setup("{if $wysiwygSelector|isset}{$wysiwygSelector}{else}text{/if}");
+			setup("{if $wysiwygSelector|isset}{unsafe:$wysiwygSelector|encodeJS}{else}text{/if}");
 		});
 	</script>
 	

--- a/com.woltlab.wcf/templates/shared_messageFormSmileyTab.tpl
+++ b/com.woltlab.wcf/templates/shared_messageFormSmileyTab.tpl
@@ -25,7 +25,7 @@
 		</nav>
 		
 		{foreach from=$smileyCategories item=smileyCategory}
-			<div class="messageTabMenuContent" id="smilies-{if $wysiwygSelector|isset}{$wysiwygSelector|encodeJS}{else}text{/if}-{$smileyCategory->categoryID}">
+			<div class="messageTabMenuContent" id="smilies-{if $wysiwygSelector|isset}{$wysiwygSelector}{else}text{/if}-{$smileyCategory->categoryID}">
 				{if $__firstSmileyCategory->categoryID == $smileyCategory->categoryID}
 					{unsafe:$__defaultSmilies}
 				{else}

--- a/com.woltlab.wcf/templates/shared_messageFormSmileyTab.tpl
+++ b/com.woltlab.wcf/templates/shared_messageFormSmileyTab.tpl
@@ -41,7 +41,7 @@
 	
 	<script data-relocate="true">
 		require(['WoltLabSuite/Core/Ui/Smiley/Insert'], function (UiSmileyInsert) {
-			new UiSmileyInsert('{if $wysiwygSelector|isset}{$wysiwygSelector|encodeJS}{else}text{/if}');
+			new UiSmileyInsert('{if $wysiwygSelector|isset}{unsafe:$wysiwygSelector|encodeJS}{else}text{/if}');
 		});
 	</script>
 </div>

--- a/com.woltlab.wcf/templates/shared_messageFormSmileyTab.tpl
+++ b/com.woltlab.wcf/templates/shared_messageFormSmileyTab.tpl
@@ -3,7 +3,7 @@
 	{foreach from=$smileyCategories item=smileyCategory}
 		{assign var=__tabCount value=$__tabCount + 1}
 		{assign var='__smileyAnchor' value='smilies-'|concat:$smileyCategory->categoryID}
-		<li data-name="smilies-{@$smileyCategory->categoryID}" data-smiley-category-id="{@$smileyCategory->categoryID}"><button type="button">{$smileyCategory->getTitle()}</button></li>
+		<li data-name="smilies-{$smileyCategory->categoryID}" data-smiley-category-id="{$smileyCategory->categoryID}"><button type="button">{$smileyCategory->getTitle()}</button></li>
 	{/foreach}
 {/capture}
 
@@ -20,21 +20,21 @@
 	{if $__tabCount > 1}
 		<nav class="jsOnly">
 			<ul>
-				{@$__categoryTabs}
+				{unsafe:$__categoryTabs}
 			</ul>
 		</nav>
 		
 		{foreach from=$smileyCategories item=smileyCategory}
-			<div class="messageTabMenuContent" id="smilies-{if $wysiwygSelector|isset}{$wysiwygSelector|encodeJS}{else}text{/if}-{@$smileyCategory->categoryID}">
+			<div class="messageTabMenuContent" id="smilies-{if $wysiwygSelector|isset}{$wysiwygSelector|encodeJS}{else}text{/if}-{$smileyCategory->categoryID}">
 				{if $__firstSmileyCategory->categoryID == $smileyCategory->categoryID}
-					{@$__defaultSmilies}
+					{unsafe:$__defaultSmilies}
 				{else}
 					{include file='shared_messageFormSmilies' smilies=$__wcf->getSmileyCache()->getCategorySmilies($smileyCategory->categoryID)}
 				{/if}
 			</div>
 		{/foreach}
 	{else}
-		{@$__defaultSmilies}
+		{unsafe:$__defaultSmilies}
 	{/if}
 	
 	{event name='fields'}

--- a/com.woltlab.wcf/templates/shared_messageFormSmilies.tpl
+++ b/com.woltlab.wcf/templates/shared_messageFormSmilies.tpl
@@ -1,5 +1,5 @@
 <ul class="inlineList smileyList">
 	{foreach from=$smilies item=smiley name=smilies}
-		<li><a class="jsSmiley" role="button" tabindex="{if $tpl.foreach.smilies.iteration === 1}0{else}-1{/if}">{@$smiley->getHtml('jsTooltip')}</a></li>
+		<li><a class="jsSmiley" role="button" tabindex="{if $tpl.foreach.smilies.iteration === 1}0{else}-1{/if}">{unsafe:$smiley->getHtml('jsTooltip')}</a></li>
 	{/foreach}
 </ul>

--- a/com.woltlab.wcf/templates/shared_multilineItemListFormField.tpl
+++ b/com.woltlab.wcf/templates/shared_multilineItemListFormField.tpl
@@ -24,8 +24,8 @@
 		{jsphrase name='wcf.global.button.edit'}
 		WoltLabLanguage.registerPhrase("wcf.acp.option.type.lineBreakSeparatedText.error.duplicate", '{jslang __literal=true}wcf.acp.option.type.lineBreakSeparatedText.error.duplicate{/jslang}');
 
-		new MultilineItemListFormField(document.getElementById('lineBreakSeparatedTextOption_{@$field->getPrefixedId()|encodeJS}'), {
-			submitFieldName: '{@$field->getPrefixedId()|encodeJS}[]',
+		new MultilineItemListFormField(document.getElementById('lineBreakSeparatedTextOption_{unsafe:$field->getPrefixedId()|encodeJS}'), {
+			submitFieldName: '{unsafe:$field->getPrefixedId()|encodeJS}[]',
 		});
 	});
 	{if $field->isFilterable()}
@@ -38,7 +38,7 @@
 		{jsphrase name='wcf.global.filter.visibility.highlightActive'}
 		{jsphrase name='wcf.global.filter.visibility.showAll'}
 
-		new UiItemListFilter('lineBreakSeparatedTextOption_{@$field->getPrefixedId()|encodeJS}');
+		new UiItemListFilter('lineBreakSeparatedTextOption_{unsafe:$field->getPrefixedId()|encodeJS}');
 	});
 	{/if}
 </script>

--- a/com.woltlab.wcf/templates/shared_multipleLanguageInputJavascript.tpl
+++ b/com.woltlab.wcf/templates/shared_multipleLanguageInputJavascript.tpl
@@ -5,16 +5,16 @@
 				'wcf.global.button.disabledI18n': '{jslang}wcf.global.button.disabledI18n{/jslang}'
 			});
 
-			var availableLanguages = { {implode from=$availableLanguages key=languageID item=languageName}{@$languageID}: '{$languageName}'{/implode} };
-			var values = { {implode from=$i18nValues[$elementIdentifier] key=languageID item=value}'{@$languageID}': '{$value}'{/implode} };
+			var availableLanguages = { {implode from=$availableLanguages key=languageID item=languageName}{$languageID}: '{$languageName}'{/implode} };
+			var values = { {implode from=$i18nValues[$elementIdentifier] key=languageID item=value}'{$languageID}': '{$value}'{/implode} };
 			
-			var element = elById('{@$elementIdentifier}');
+			var element = elById('{unsafe:$elementIdentifier|encodeJS}');
 			var type = LanguageInput;
 			if (element && element.nodeName === 'TEXTAREA' && element.classList.contains('wysiwygTextarea')) {
 				type = LanguageText;
 			}
 			
-			type['init']('{@$elementIdentifier}', values, availableLanguages, {if $forceSelection}true{else}false{/if});
+			type['init']('{unsafe:$elementIdentifier|encodeJS}', values, availableLanguages, {if $forceSelection}true{else}false{/if});
 		});
 	</script>
 {/if}

--- a/com.woltlab.wcf/templates/shared_multiplePagesSelectionFormField.tpl
+++ b/com.woltlab.wcf/templates/shared_multiplePagesSelectionFormField.tpl
@@ -3,9 +3,9 @@
 {if $field->getVisibleEverywhereFieldId() !== null}
 	<script data-relocate="true">
 		{
-			const label = document.querySelector('label[for="{$field->getPrefixedId()}"]');
+			const label = document.querySelector('label[for="{unsafe:$field->getPrefixedId()|encodeJS}"]');
 
-			document.querySelectorAll('input[name="{$field->getVisibleEverywhereFieldId()}"]').forEach((input) => {
+			document.querySelectorAll('input[name="{unsafe:$field->getVisibleEverywhereFieldId()|encodeJS}"]').forEach((input) => {
 				input.addEventListener("change", () => {
 					setLabelText(input.value);
 				});
@@ -15,7 +15,7 @@
 				label.innerHTML = parseInt(value) === 0 ? '{unsafe:$field->getLabel()|encodeJS}' : '{unsafe:$field->getInvertedLabel()|encodeJS}';
 			}
 
-			setLabelText(document.querySelector('input[name="{$field->getVisibleEverywhereFieldId()}"]:checked').value);
+			setLabelText(document.querySelector('input[name="{unsafe:$field->getVisibleEverywhereFieldId()|encodeJS}"]:checked').value);
 		}
 	</script>
 {/if}

--- a/com.woltlab.wcf/templates/shared_multipleSelectFormField.tpl
+++ b/com.woltlab.wcf/templates/shared_multipleSelectFormField.tpl
@@ -10,6 +10,6 @@
 			value="{$__fieldNestedOption[value]}"
 			{if $field->getValue() !== null && $__fieldNestedOption[value]|in_array:$field->getValue() && $__fieldNestedOption[isSelectable]} selected{/if}
 			{if $field->isImmutable() || !$__fieldNestedOption[isSelectable]} disabled{/if}
-		>{@'&nbsp;'|str_repeat:$__fieldNestedOption[depth] * 4}{@$__fieldNestedOption[label]}</option>
+		>{unsafe:'&nbsp;'|str_repeat:$__fieldNestedOption[depth] * 4}{unsafe:$__fieldNestedOption[label]}</option>
 	{/foreach}
 </select>

--- a/com.woltlab.wcf/templates/shared_multipleSelectionFormField.tpl
+++ b/com.woltlab.wcf/templates/shared_multipleSelectionFormField.tpl
@@ -11,7 +11,7 @@
 				'wcf.global.filter.visibility.showAll': '{jslang}wcf.global.filter.visibility.showAll{/jslang}'
 			});
 			
-			new UiItemListFilter('{@$field->getPrefixedId()|encodeJS}_list');
+			new UiItemListFilter('{unsafe:$field->getPrefixedId()|encodeJS}_list');
 		});
 	</script>
 {/if}
@@ -29,7 +29,7 @@
 					*}{if $field->isImmutable() || !$__fieldNestedOption[isSelectable]} disabled{/if}{*
 					*}{foreach from=$field->getFieldAttributes() key='attributeName' item='attributeValue'} {$attributeName}="{$attributeValue}"{/foreach}{*
 				*}>
-				{@$__fieldNestedOption[label]}
+				{unsafe:$__fieldNestedOption[label]}
 			</label>
 		</li>
 	{/foreach}

--- a/com.woltlab.wcf/templates/shared_nonEmptyFormFieldDependency.tpl
+++ b/com.woltlab.wcf/templates/shared_nonEmptyFormFieldDependency.tpl
@@ -1,7 +1,7 @@
 require(['WoltLabSuite/Core/Form/Builder/Field/Dependency/NonEmpty'], function(NonEmptyFieldDependency) {
-	// dependency '{@$dependency->getId()}'
+	// dependency '{unsafe:$dependency->getId()}'
 	new NonEmptyFieldDependency(
-		'{@$dependency->getDependentNode()->getPrefixedId()|encodeJS}Container',
-		'{@$dependency->getField()->getPrefixedId()|encodeJS}'
+		'{unsafe:$dependency->getDependentNode()->getPrefixedId()|encodeJS}Container',
+		'{unsafe:$dependency->getField()->getPrefixedId()|encodeJS}'
 	);
 });

--- a/com.woltlab.wcf/templates/shared_nonEmptyFormFieldDependency.tpl
+++ b/com.woltlab.wcf/templates/shared_nonEmptyFormFieldDependency.tpl
@@ -1,5 +1,5 @@
 require(['WoltLabSuite/Core/Form/Builder/Field/Dependency/NonEmpty'], function(NonEmptyFieldDependency) {
-	// dependency '{unsafe:$dependency->getId()}'
+	// dependency '{unsafe:$dependency->getId()|encodeJS}'
 	new NonEmptyFieldDependency(
 		'{unsafe:$dependency->getDependentNode()->getPrefixedId()|encodeJS}Container',
 		'{unsafe:$dependency->getField()->getPrefixedId()|encodeJS}'

--- a/com.woltlab.wcf/templates/shared_numericFormField.tpl
+++ b/com.woltlab.wcf/templates/shared_numericFormField.tpl
@@ -3,7 +3,7 @@
 {/if}
 
 <input type="number" {*
-	*}step="{@$field->getStep()}" {*
+	*}step="{$field->getStep()}" {*
 	*}id="{$field->getPrefixedId()}" {*
 	*}name="{$field->getPrefixedId()}" {*
 	*}value="{$field->getValue()}"{*
@@ -21,6 +21,6 @@
 *}>
 
 {if $field->getSuffix() !== null}
-		<span class="inputSuffix">{@$field->getSuffix()}</span>
+		<span class="inputSuffix">{unsafe:$field->getSuffix()}</span>
 	</div>
 {/if}

--- a/com.woltlab.wcf/templates/shared_numericRangeFormField.tpl
+++ b/com.woltlab.wcf/templates/shared_numericRangeFormField.tpl
@@ -3,7 +3,7 @@
 	id="{$field->getPrefixedId()}_from"
 	name="{$field->getPrefixedId()}[from]"
 	value="{$field->getFromValue()}"
-	step="{@$field->getDefaultStep()}"
+	step="{$field->getDefaultStep()}"
 	placeholder="{lang}wcf.date.period.start{/lang}"
 	{if !$field->getFieldClasses()|empty} class="{implode from=$field->getFieldClasses() item='class' glue=' '}{$class}{/implode}"{/if}
 	{if $field->isAutofocused()} autofocus{/if}

--- a/com.woltlab.wcf/templates/shared_pollOptionsFormField.tpl
+++ b/com.woltlab.wcf/templates/shared_pollOptionsFormField.tpl
@@ -14,8 +14,8 @@
 		{jsphrase name='wcf.poll.maxVotes.error.invalid'}
 		
 		var pollEditor = new UiPollEditor(
-			DomUtil.identify(DomTraverse.childByTag(elById('{@$field->getPrefixedId()|encodeJS}Container'), 'DD')),
-			[ {implode from=$field->getValue() item=pollOption}{ optionID: {@$pollOption[optionID]}, optionValue: '{$pollOption[optionValue]|encodeJS}' }{/implode} ],
+			DomUtil.identify(DomTraverse.childByTag(elById('{unsafe:$field->getPrefixedId()|encodeJS}Container'), 'DD')),
+			[ {implode from=$field->getValue() item=pollOption}{ optionID: {$pollOption[optionID]}, optionValue: '{$pollOption[optionValue]|encodeJS}' }{/implode} ],
 			'{@$field->getPrefixedWysiwygId()}',
 			{
 				isAjax: {if $field->getDocument()->isAjax()}true{else}false{/if},
@@ -24,7 +24,7 @@
 		);
 		
 		EventHandler.add('WoltLabSuite/Core/Form/Builder/Manager', 'registerField', function(data) {
-			if (data.formId === '{@$field->getDocument()->getId()|encodeJS}' && data.field.getId() === '{@$field->getPrefixedId()|encodeJS}') {
+			if (data.formId === '{unsafe:$field->getDocument()->getId()|encodeJS}' && data.field.getId() === '{unsafe:$field->getPrefixedId()|encodeJS}') {
 				data.field.setPollEditor(pollEditor);
 			}
 		});

--- a/com.woltlab.wcf/templates/shared_pollOptionsFormField.tpl
+++ b/com.woltlab.wcf/templates/shared_pollOptionsFormField.tpl
@@ -16,7 +16,7 @@
 		var pollEditor = new UiPollEditor(
 			DomUtil.identify(DomTraverse.childByTag(elById('{unsafe:$field->getPrefixedId()|encodeJS}Container'), 'DD')),
 			[ {implode from=$field->getValue() item=pollOption}{ optionID: {$pollOption[optionID]}, optionValue: '{$pollOption[optionValue]|encodeJS}' }{/implode} ],
-			'{@$field->getPrefixedWysiwygId()}',
+			'{unsafe:$field->getPrefixedWysiwygId()|encodeJS}',
 			{
 				isAjax: {if $field->getDocument()->isAjax()}true{else}false{/if},
 				maxOptions: {POLL_MAX_OPTIONS}

--- a/com.woltlab.wcf/templates/shared_pollOptionsFormField.tpl
+++ b/com.woltlab.wcf/templates/shared_pollOptionsFormField.tpl
@@ -15,7 +15,7 @@
 		
 		var pollEditor = new UiPollEditor(
 			DomUtil.identify(DomTraverse.childByTag(elById('{unsafe:$field->getPrefixedId()|encodeJS}Container'), 'DD')),
-			[ {implode from=$field->getValue() item=pollOption}{ optionID: {$pollOption[optionID]}, optionValue: '{$pollOption[optionValue]|encodeJS}' }{/implode} ],
+			[ {implode from=$field->getValue() item=pollOption}{ optionID: {$pollOption[optionID]}, optionValue: '{unsafe:$pollOption[optionValue]|encodeJS}' }{/implode} ],
 			'{unsafe:$field->getPrefixedWysiwygId()|encodeJS}',
 			{
 				isAjax: {if $field->getDocument()->isAjax()}true{else}false{/if},

--- a/com.woltlab.wcf/templates/shared_radioButtonFormField.tpl
+++ b/com.woltlab.wcf/templates/shared_radioButtonFormField.tpl
@@ -21,6 +21,6 @@
 			*}{if $field->getValue() !== null && $field->getValue() == $__fieldValue} checked{/if}{*
 			*}{if $field->isImmutable()} disabled{/if}{*
 			*}{foreach from=$field->getFieldAttributes() key='attributeName' item='attributeValue'} {$attributeName}="{$attributeValue}"{/foreach}{*
-		*}> {@$__fieldLabel}
+		*}> {unsafe:$__fieldLabel}
 	</label>
 {/foreach}

--- a/com.woltlab.wcf/templates/shared_ratingFormField.tpl
+++ b/com.woltlab.wcf/templates/shared_ratingFormField.tpl
@@ -1,6 +1,6 @@
 <ul class="ratingList jsOnly">
 	{foreach from=$field->getRatings() item=rating}
-		<li data-rating="{@$rating}">
+		<li data-rating="{$rating}">
 			<button type="button" class="jsTooltip" title="{lang maximumRating=$field->getMaximum()}wcf.form.field.rating.ratingTitle{/lang}">
 				{if $rating <= $field->getValue()}
 					{icon size=24 name='star' type='solid'}
@@ -21,7 +21,7 @@
 <noscript>
 	<select name="{$field->getPrefixedId()}" {if $field->isImmutable()} disabled{/if}>
 		{foreach from=$field->getRatings() item=rating}
-			<option value="{$rating}">{@$rating}</option>
+			<option value="{$rating}">{$rating}</option>
 		{/foreach}
 	</select>
 </noscript>
@@ -30,7 +30,7 @@
 	require(['WoltLabSuite/Core/Form/Builder/Field/Controller/Rating'], function(FormBuilderFieldRating) {
 		new FormBuilderFieldRating(
 			'{$field->getPrefixedId()}',
-			{if $field->getValue() !== null}{@$field->getValue()}{else}''{/if}
+			{if $field->getValue() !== null}{$field->getValue()}{else}''{/if}
 		);
 	});
 </script>

--- a/com.woltlab.wcf/templates/shared_ratingFormField.tpl
+++ b/com.woltlab.wcf/templates/shared_ratingFormField.tpl
@@ -29,7 +29,7 @@
 <script data-relocate="true">
 	require(['WoltLabSuite/Core/Form/Builder/Field/Controller/Rating'], function(FormBuilderFieldRating) {
 		new FormBuilderFieldRating(
-			'{$field->getPrefixedId()}',
+			'{unsafe:$field->getPrefixedId()|encodeJS}',
 			{if $field->getValue() !== null}{$field->getValue()}{else}''{/if}
 		);
 	});

--- a/com.woltlab.wcf/templates/shared_rowFormContainer.tpl
+++ b/com.woltlab.wcf/templates/shared_rowFormContainer.tpl
@@ -10,6 +10,6 @@
 
 <script data-relocate="true">
 	require(['WoltLabSuite/Core/Form/Builder/Field/Dependency/Container/Default'], function(DefaultContainerDependency) {
-		new DefaultContainerDependency('{@$container->getPrefixedId()|encodeJS}Container');
+		new DefaultContainerDependency('{unsafe:$container->getPrefixedId()|encodeJS}Container');
 	});
 </script>

--- a/com.woltlab.wcf/templates/shared_rowFormFieldContainer.tpl
+++ b/com.woltlab.wcf/templates/shared_rowFormFieldContainer.tpl
@@ -3,13 +3,13 @@
 	*}{foreach from=$container->getAttributes() key='attributeName' item='attributeValue'} {$attributeName}="{$attributeValue}"{/foreach}{*
 	*}{if !$container->checkDependencies()} style="display: none;"{/if}{*
 *}>
-	<dt>{if $container->getLabel() !== null}<label for="{$container->getPrefixedId()}">{@$container->getLabel()}</label>{/if}</dt>
+	<dt>{if $container->getLabel() !== null}<label for="{$container->getPrefixedId()}">{unsafe:$container->getLabel()}</label>{/if}</dt>
 	<dd>
 		<div class="row rowColGap formGrid">
 			{foreach from=$container item='field'}
 				{if $field->isAvailable()}
 					<div id="{$field->getPrefixedId()}Container" {if !$field->getClasses()|empty} class="{implode from=$field->getClasses() item='class' glue=' '}{$class}{/implode}"{/if}{foreach from=$field->getAttributes() key='attributeName' item='attributeValue'} {$attributeName}="{$attributeValue}"{/foreach}{if !$field->checkDependencies()} style="display: none;"{/if}>
-						{@$field->getFieldHtml()}
+						{unsafe:$field->getFieldHtml()}
 						
 						{include file='shared_formFieldErrors'}
 						{include file='shared_formFieldDependencies'}
@@ -19,7 +19,7 @@
 			{/foreach}
 		</div>
 		{if $container->getDescription() !== null}
-			<small>{@$container->getDescription()}</small>
+			<small>{unsafe:$container->getDescription()}</small>
 		{/if}
 	</dd>
 </dl>
@@ -28,6 +28,6 @@
 
 <script data-relocate="true">
 	require(['WoltLabSuite/Core/Form/Builder/Field/Dependency/Container/Default'], function(DefaultContainerDependency) {
-		new DefaultContainerDependency('{@$container->getPrefixedId()|encodeJS}Container');
+		new DefaultContainerDependency('{unsafe:$container->getPrefixedId()|encodeJS}Container');
 	});
 </script>

--- a/com.woltlab.wcf/templates/shared_selectFormField.tpl
+++ b/com.woltlab.wcf/templates/shared_selectFormField.tpl
@@ -10,6 +10,6 @@
 			value="{$__fieldNestedOption[value]}"
 			{if $field->getValue() !== null && $field->getValue() == $__fieldNestedOption[value] && $__fieldNestedOption[isSelectable]} selected{/if}
 			{if $field->isImmutable() || !$__fieldNestedOption[isSelectable]} disabled{/if}
-		>{@'&nbsp;'|str_repeat:$__fieldNestedOption[depth] * 4}{@$__fieldNestedOption[label]}</option>
+		>{unsafe:'&nbsp;'|str_repeat:$__fieldNestedOption[depth] * 4}{unsafe:$__fieldNestedOption[label]}</option>
 	{/foreach}
 </select>

--- a/com.woltlab.wcf/templates/shared_singleMediaSelectionFormField.tpl
+++ b/com.woltlab.wcf/templates/shared_singleMediaSelectionFormField.tpl
@@ -1,11 +1,11 @@
 {if $field->isImmutable() && $field->getValue()}
 	{if $field->getMedia()->isImage && $field->getMedia()->hasThumbnail('small')}
 		<div id="{$field->getPrefixedId()}_preview" class="selectedImagePreview">
-			{@$field->getMedia()->getThumbnailTag('small')}
+			{unsafe:$field->getMedia()->getThumbnailTag('small')}
 		</div>
 	{else}
 		<div class="box16 selectedImagePreview">
-			{@$field->getMedia()->getElementTag(16)}
+			{unsafe:$field->getMedia()->getElementTag(16)}
 			
 			<p>{$field->getMedia()->getTitle()}</p>
 		</div>
@@ -14,7 +14,7 @@
 	{if $field->isImageOnly()}
 		<div id="{$field->getPrefixedId()}_preview" class="selectedImagePreview">
 			{if $field->getValue() && $field->getMedia()->hasThumbnail('small')}
-				{@$field->getMedia()->getThumbnailTag('small')}
+				{unsafe:$field->getMedia()->getThumbnailTag('small')}
 			{/if}
 		</div>
 	{/if}
@@ -30,7 +30,7 @@
 		
 		require(['WoltLabSuite/Core/Media/Manager/Select'], function(MediaManagerSelect) {
 			new MediaManagerSelect({
-				buttonClass: 'jsMediaSelectButton_{@$field->getPrefixedId()|encodeJS}',
+				buttonClass: 'jsMediaSelectButton_{unsafe:$field->getPrefixedId()|encodeJS}',
 				{if $field->isImageOnly()}
 					dialogTitle: '{jslang}wcf.media.chooseImage{/jslang}',
 					imagesOnly: 1

--- a/com.woltlab.wcf/templates/shared_singleSelectionFormField.tpl
+++ b/com.woltlab.wcf/templates/shared_singleSelectionFormField.tpl
@@ -11,7 +11,7 @@
 				'wcf.global.filter.visibility.showAll': '{jslang}wcf.global.filter.visibility.showAll{/jslang}'
 			});
 			
-			new UiItemListFilter('{@$field->getPrefixedId()|encodeJS}_list');
+			new UiItemListFilter('{unsafe:$field->getPrefixedId()|encodeJS}_list');
 		});
 	</script>
 	
@@ -25,7 +25,7 @@
 						*}{if !$field->getFieldClasses()|empty} class="{implode from=$field->getFieldClasses() item='class' glue=' '}{$class}{/implode}"{/if}{*
 						*}{if $field->getValue() == $__fieldNestedOption[value] && $__fieldNestedOption[isSelectable]} checked{/if}{*
 						*}{if $field->isImmutable() || !$__fieldNestedOption[isSelectable]} disabled{/if}{*
-					*}> {@$__fieldNestedOption[label]}</label>
+					*}> {unsafe:$__fieldNestedOption[label]}</label>
 			</li>
 		{/foreach}
 	</ul>
@@ -39,7 +39,7 @@
 				*}value="{$__fieldNestedOption[value]}"{*
 				*}{if $field->getValue() == $__fieldNestedOption[value] && $__fieldNestedOption[isSelectable]} selected{/if}{*
 				*}{if $field->isImmutable() || !$__fieldNestedOption[isSelectable]} disabled{/if}{*
-			*}>{@'&nbsp;'|str_repeat:$__fieldNestedOption[depth] * 4}{@$__fieldNestedOption[label]}</option>
+			*}>{unsafe:'&nbsp;'|str_repeat:$__fieldNestedOption[depth] * 4}{unsafe:$__fieldNestedOption[label]}</option>
 		{/foreach}
 	</select>
 {/if}

--- a/com.woltlab.wcf/templates/shared_sourceCodeFormField.tpl
+++ b/com.woltlab.wcf/templates/shared_sourceCodeFormField.tpl
@@ -10,6 +10,6 @@
 
 <script data-relocate="true">
 	(() => {
-		document.getElementById('{@$field->getPrefixedId()|encodeJS}').parentNode.dir = 'ltr';
+		document.getElementById('{unsafe:$field->getPrefixedId()|encodeJS}').parentNode.dir = 'ltr';
 	})();
 </script>

--- a/com.woltlab.wcf/templates/shared_suffixFormFieldContainer.tpl
+++ b/com.woltlab.wcf/templates/shared_suffixFormFieldContainer.tpl
@@ -3,23 +3,23 @@
 	*}{foreach from=$element->getField()->getAttributes() key='attributeName' item='attributeValue'} {$attributeName}="{$attributeValue}"{/foreach}{*
 	*}{if !$element->getField()->checkDependencies()} style="display: none;"{/if}{*
 *}>
-	<dt>{if $element->getLabel() !== null}<label for="{$element->getField()->getPrefixedId()}">{@$element->getLabel()}</label>{/if}</dt>
+	<dt>{if $element->getLabel() !== null}<label for="{$element->getField()->getPrefixedId()}">{unsafe:$element->getLabel()}</label>{/if}</dt>
 	<dd>
 		<div class="inputAddon">
-			{@$element->getField()->getFieldHtml()}
+			{unsafe:$element->getField()->getFieldHtml()}
 			
 			{if $element->getSuffixField() !== null && $element->getSuffixField()->isAvailable()}
 				{if !$element->suffixHasSelectableOptions()}
 					{if $element->getSuffixLabel() !== ''}
-						<span class="inputSuffix">{@$element->getSuffixLabel()}</span>
+						<span class="inputSuffix">{unsafe:$element->getSuffixLabel()}</span>
 					{/if}
 				{else}
 					<span class="inputSuffix dropdown" id="{$element->getSuffixField()->getPrefixedId()}_dropdown">
-						<span class="dropdownToggle">{@$element->getSelectedSuffixOption()[label]} {icon name='caret-down' type='solid'}</span>
+						<span class="dropdownToggle">{unsafe:$element->getSelectedSuffixOption()[label]} {icon name='caret-down' type='solid'}</span>
 						
 						<ul class="dropdownMenu">
 							{foreach from=$element->getSuffixField()->getNestedOptions() item=__fieldNestedOption}
-								<li{if ($element->getSuffixField()->getValue() == $__fieldNestedOption[value] && $__fieldNestedOption[isSelectable]) || !$__fieldNestedOption[isSelectable]} class="{if $element->getSuffixField()->getValue() == $__fieldNestedOption[value] && $__fieldNestedOption[isSelectable]}active{if !$__fieldNestedOption[isSelectable]} disabled{/if}{else}disabled{/if}"{/if} data-value="{$__fieldNestedOption[value]}" data-label="{$__fieldNestedOption[label]}"><span>{@'&nbsp;'|str_repeat:$__fieldNestedOption[depth] * 4}{@$__fieldNestedOption[label]}</span></li>
+								<li{if ($element->getSuffixField()->getValue() == $__fieldNestedOption[value] && $__fieldNestedOption[isSelectable]) || !$__fieldNestedOption[isSelectable]} class="{if $element->getSuffixField()->getValue() == $__fieldNestedOption[value] && $__fieldNestedOption[isSelectable]}active{if !$__fieldNestedOption[isSelectable]} disabled{/if}{else}disabled{/if}"{/if} data-value="{$__fieldNestedOption[value]}" data-label="{$__fieldNestedOption[label]}"><span>{unsafe:'&nbsp;'|str_repeat:$__fieldNestedOption[depth] * 4}{unsafe:$__fieldNestedOption[label]}</span></li>
 							{/foreach}
 						</ul>
 						<input type="hidden" id="{$element->getSuffixField()->getPrefixedId()}" name="{$element->getSuffixField()->getPrefixedId()}" value="{if $element->getSuffixField()->getValue() === null}{$element->getSelectedSuffixOption()[value]}{else}{$element->getSuffixField()->getValue()}{/if}" />
@@ -32,14 +32,14 @@
 		</div>
 		
 		{if $element->getDescription() !== null}
-			<small>{@$element->getDescription()}</small>
+			<small>{unsafe:$element->getDescription()}</small>
 		{/if}
 		
 		{include file='shared_formFieldErrors' field=$element->getField()}
 		
 		{if $element->getSuffixField() !== null && $element->getSuffixField()->isAvailable()}
 			{foreach from=$element->getSuffixField()->getValidationErrors() item='validationError'}
-				{@$validationError->getHtml()}
+				{unsafe:$validationError->getHtml()}
 			{/foreach}
 		{/if}
 		
@@ -52,8 +52,8 @@
 <script data-relocate="true">
 	require(['WoltLabSuite/Core/Form/Builder/Container/SuffixFormField'], function(FormBuilderSuffixFormFieldContainer) {
 		new FormBuilderSuffixFormFieldContainer(
-			'{@$element->getDocument()->getId()|encodeJS}',
-			'{@$element->getSuffixField()->getPrefixedId()|encodeJS}'
+			'{unsafe:$element->getDocument()->getId()|encodeJS}',
+			'{unsafe:$element->getSuffixField()->getPrefixedId()|encodeJS}'
 		);
 	});
 </script>

--- a/com.woltlab.wcf/templates/shared_tabFormContainer.tpl
+++ b/com.woltlab.wcf/templates/shared_tabFormContainer.tpl
@@ -10,6 +10,6 @@
 
 <script data-relocate="true">
 	require(['WoltLabSuite/Core/Form/Builder/Field/Dependency/Container/Tab'], function(TabContainerDependency) {
-		new TabContainerDependency('{$container->getPrefixedId()|encodeJS}Container');
+		new TabContainerDependency('{unsafe:$container->getPrefixedId()|encodeJS}Container');
 	});
 </script>

--- a/com.woltlab.wcf/templates/shared_tabMenuFormContainer.tpl
+++ b/com.woltlab.wcf/templates/shared_tabMenuFormContainer.tpl
@@ -3,11 +3,11 @@
 	*}{foreach from=$container->getAttributes() key='attributeName' item='attributeValue'} {$attributeName}="{$attributeValue}"{/foreach}{*
 	*}{if !$container->checkDependencies()} style="display: none;"{/if}{*
 *}>
-	<nav class="{if !$__tabMenuCSSClassName|empty}{@$__tabMenuCSSClassName}{else}tabMenu{/if}">
+	<nav class="{if !$__tabMenuCSSClassName|empty}{$__tabMenuCSSClassName}{else}tabMenu{/if}">
 		<ul>
 			{foreach from=$container item='child'}
 				{if $child->isAvailable()}
-					<li{if !$child->checkDependencies()} style="display: none;"{/if}><a{if $container->usesAnchors()} href="#{$child->getPrefixedId()|rawurlencode}Container"{/if}>{@$child->getLabel()}</a></li>
+					<li{if !$child->checkDependencies()} style="display: none;"{/if}><a{if $container->usesAnchors()} href="#{$child->getPrefixedId()|rawurlencode}Container"{/if}>{unsafe:$child->getLabel()}</a></li>
 				{/if}
 			{/foreach}
 		</ul>
@@ -20,6 +20,6 @@
 
 <script data-relocate="true">
 	require(['WoltLabSuite/Core/Form/Builder/Field/Dependency/Container/TabMenu'], function(TabMenuContainerDependency) {
-		new TabMenuContainerDependency('{@$container->getPrefixedId()|encodeJS}Container');
+		new TabMenuContainerDependency('{unsafe:$container->getPrefixedId()|encodeJS}Container');
 	});
 </script>

--- a/com.woltlab.wcf/templates/shared_tabTabMenuFormContainer.tpl
+++ b/com.woltlab.wcf/templates/shared_tabTabMenuFormContainer.tpl
@@ -6,7 +6,7 @@
 		<ul>
 			{foreach from=$container item='child'}
 				{if $child->isAvailable()}
-					<li{if !$child->checkDependencies()} style="display: none;"{/if}><a{if $container->usesAnchors()} href="#{$child->getPrefixedId()|rawurlencode}Container"{/if}>{@$child->getLabel()}</a></li>
+					<li{if !$child->checkDependencies()} style="display: none;"{/if}><a{if $container->usesAnchors()} href="#{$child->getPrefixedId()|rawurlencode}Container"{/if}>{unsafe:$child->getLabel()}</a></li>
 				{/if}
 			{/foreach}
 		</ul>

--- a/com.woltlab.wcf/templates/shared_tagFormField.tpl
+++ b/com.woltlab.wcf/templates/shared_tagFormField.tpl
@@ -8,14 +8,14 @@
 <script data-relocate="true">
 	require(['WoltLabSuite/Core/Ui/ItemList'], function(UiItemList) {
 		UiItemList.init(
-			'{@$field->getPrefixedId()|encodeJS}',
-			[{if $field->getValue() !== null && !$field->getValue()|empty}{implode from=$field->getValue() item=tag}'{@$tag|encodeJS}'{/implode}{/if}],
+			'{unsafe:$field->getPrefixedId()|encodeJS}',
+			[{if $field->getValue() !== null && !$field->getValue()|empty}{implode from=$field->getValue() item=tag}'{unsafe:$tag|encodeJS}'{/implode}{/if}],
 			{
 				ajax: {
 					className: 'wcf\\data\\tag\\TagAction'
 				},
-				maxLength: {@TAGGING_MAX_TAG_LENGTH},
-				submitFieldName: '{@$field->getPrefixedId()|encodeJS}[]'
+				maxLength: {TAGGING_MAX_TAG_LENGTH},
+				submitFieldName: '{unsafe:$field->getPrefixedId()|encodeJS}[]'
 			}
 		);
 	});

--- a/com.woltlab.wcf/templates/shared_uploadFormField.tpl
+++ b/com.woltlab.wcf/templates/shared_uploadFormField.tpl
@@ -1,1 +1,1 @@
-{@$__wcf->getUploadHandler()->renderField($field->getPrefixedId())}
+{unsafe:$__wcf->getUploadHandler()->renderField($field->getPrefixedId())}

--- a/com.woltlab.wcf/templates/shared_userFormField.tpl
+++ b/com.woltlab.wcf/templates/shared_userFormField.tpl
@@ -9,9 +9,9 @@
 
 <script data-relocate="true">
 	require(['WoltLabSuite/Core/Ui/ItemList/User'], function(UiItemListUser) {
-		UiItemListUser.init('{@$field->getPrefixedId()|encodeJS}', {
+		UiItemListUser.init('{unsafe:$field->getPrefixedId()|encodeJS}', {
 			{if $field->getMaximumMultiples() !== -1}
-				maxItems: {@$field->getMaximumMultiples()},
+				maxItems: {$field->getMaximumMultiples()},
 			{/if}
 		});
 	});

--- a/com.woltlab.wcf/templates/shared_valueFormFieldDependency.tpl
+++ b/com.woltlab.wcf/templates/shared_valueFormFieldDependency.tpl
@@ -1,8 +1,8 @@
 require(['WoltLabSuite/Core/Form/Builder/Field/Dependency/Value'], function(ValueFieldDependency) {
-	// dependency '{@$dependency->getId()}'
+	// dependency '{unsafe:$dependency->getId()}'
 	new ValueFieldDependency(
-		'{@$dependency->getDependentNode()->getPrefixedId()|encodeJS}Container',
-		'{@$dependency->getField()->getPrefixedId()|encodeJS}'
+		'{unsafe:$dependency->getDependentNode()->getPrefixedId()|encodeJS}Container',
+		'{unsafe:$dependency->getField()->getPrefixedId()|encodeJS}'
 	).values([ {implode from=$dependency->getValues() item=dependencyValue}'{$dependencyValue|encodeJS}'{/implode} ])
 	.negate({if $dependency->isNegated()}true{else}false{/if});
 });

--- a/com.woltlab.wcf/templates/shared_valueFormFieldDependency.tpl
+++ b/com.woltlab.wcf/templates/shared_valueFormFieldDependency.tpl
@@ -3,6 +3,6 @@ require(['WoltLabSuite/Core/Form/Builder/Field/Dependency/Value'], function(Valu
 	new ValueFieldDependency(
 		'{unsafe:$dependency->getDependentNode()->getPrefixedId()|encodeJS}Container',
 		'{unsafe:$dependency->getField()->getPrefixedId()|encodeJS}'
-	).values([ {implode from=$dependency->getValues() item=dependencyValue}'{$dependencyValue|encodeJS}'{/implode} ])
+	).values([ {implode from=$dependency->getValues() item=dependencyValue}'{unsafe:$dependencyValue|encodeJS}'{/implode} ])
 	.negate({if $dependency->isNegated()}true{else}false{/if});
 });

--- a/com.woltlab.wcf/templates/shared_valueFormFieldDependency.tpl
+++ b/com.woltlab.wcf/templates/shared_valueFormFieldDependency.tpl
@@ -1,5 +1,5 @@
 require(['WoltLabSuite/Core/Form/Builder/Field/Dependency/Value'], function(ValueFieldDependency) {
-	// dependency '{unsafe:$dependency->getId()}'
+	// dependency '{unsafe:$dependency->getId()|encodeJS}'
 	new ValueFieldDependency(
 		'{unsafe:$dependency->getDependentNode()->getPrefixedId()|encodeJS}Container',
 		'{unsafe:$dependency->getField()->getPrefixedId()|encodeJS}'

--- a/com.woltlab.wcf/templates/shared_valueIntervalFormFieldDependency.tpl
+++ b/com.woltlab.wcf/templates/shared_valueIntervalFormFieldDependency.tpl
@@ -1,5 +1,5 @@
 require(['WoltLabSuite/Core/Form/Builder/Field/Dependency/ValueInterval'], ({ ValueInterval }) => {
-	// dependency '{unsafe:$dependency->getId()}'
+	// dependency '{unsafe:$dependency->getId()|encodeJS}'
 	new ValueInterval(
 		'{unsafe:$dependency->getDependentNode()->getPrefixedId()|encodeJS}Container',
 		'{unsafe:$dependency->getField()->getPrefixedId()|encodeJS}'

--- a/com.woltlab.wcf/templates/shared_valueIntervalFormFieldDependency.tpl
+++ b/com.woltlab.wcf/templates/shared_valueIntervalFormFieldDependency.tpl
@@ -1,9 +1,9 @@
 require(['WoltLabSuite/Core/Form/Builder/Field/Dependency/ValueInterval'], ({ ValueInterval }) => {
-	// dependency '{@$dependency->getId()}'
+	// dependency '{unsafe:$dependency->getId()}'
 	new ValueInterval(
-		'{@$dependency->getDependentNode()->getPrefixedId()|encodeJS}Container',
-		'{@$dependency->getField()->getPrefixedId()|encodeJS}'
+		'{unsafe:$dependency->getDependentNode()->getPrefixedId()|encodeJS}Container',
+		'{unsafe:$dependency->getField()->getPrefixedId()|encodeJS}'
 	)
-	.minimum({if $dependency->getMinimum() !== null}{@$dependency->getMinimum()}{else}null{/if})
-	.maximum({if $dependency->getMaximum() !== null}{@$dependency->getMaximum()}{else}null{/if});
+	.minimum({if $dependency->getMinimum() !== null}{$dependency->getMinimum()}{else}null{/if})
+	.maximum({if $dependency->getMaximum() !== null}{$dependency->getMaximum()}{else}null{/if});
 });

--- a/com.woltlab.wcf/templates/shared_wysiwygAttachmentFormField.tpl
+++ b/com.woltlab.wcf/templates/shared_wysiwygAttachmentFormField.tpl
@@ -25,7 +25,7 @@
 		{jsphrase name='wcf.attachment.moreOptions'}
 
 		require(["WoltLabSuite/Core/Component/Attachment/List"], ({ setup }) => {
-			setup("{$field->getPrefixedWysiwygId()}");
+			setup("{unsafe:$field->getPrefixedWysiwygId()|encodeJS}");
 		});
 	</script>
 </div>

--- a/com.woltlab.wcf/templates/shared_wysiwygFormField.tpl
+++ b/com.woltlab.wcf/templates/shared_wysiwygFormField.tpl
@@ -5,9 +5,9 @@
 	*}data-disable-attachments="{if $field->supportsAttachments()}false{else}true{/if}" {*
 	*}data-support-mention="{if $field->supportsMentions()}true{else}false{/if}"{*
 	*}{if $field->getAutosaveId() !== null}{*
-		*} data-autosave="{@$field->getAutosaveId()}"{*
+		*} data-autosave="{$field->getAutosaveId()}"{*
 		*}{if $field->getLastEditTime() !== 0}{*
-			*} data-autosave-last-edit-time="{@$field->getLastEditTime()}"{*
+			*} data-autosave-last-edit-time="{$field->getLastEditTime()}"{*
 		*}{/if}{*
 	*}{/if}{*
 	*}{foreach from=$field->getFieldAttributes() key='attributeName' item='attributeValue'} {$attributeName}="{$attributeValue}"{/foreach}{*

--- a/com.woltlab.wcf/templates/shared_wysiwygQuoteFormContainer.tpl
+++ b/com.woltlab.wcf/templates/shared_wysiwygQuoteFormContainer.tpl
@@ -3,7 +3,7 @@
 
 <script data-relocate="true">
 	require(["WoltLabSuite/Core/Component/Quote/List"], ({ setup }) => {
-		setup("{$container->getWysiwygId()|encodeJS}", "{$container->getPrefixedId()|encodeJS}Container");
+		setup("{unsafe:$container->getWysiwygId()|encodeJS}", "{unsafe:$container->getPrefixedId()|encodeJS}Container");
 	});
 </script>
 
@@ -11,6 +11,6 @@
 
 <script data-relocate="true">
 	require(['WoltLabSuite/Core/Form/Builder/Field/Dependency/Container/WysiwygTab'], ({ WysiwygTab }) => {
-		new WysiwygTab('{$container->getPrefixedId()|encodeJS}Container', '{$container->getName()|encodeJS}', '{$container->getWysiwygId()|encodeJS}');
+		new WysiwygTab('{unsafe:$container->getPrefixedId()|encodeJS}Container', '{unsafe:$container->getName()|encodeJS}', '{unsafe:$container->getWysiwygId()|encodeJS}');
 	});
 </script>

--- a/com.woltlab.wcf/templates/shared_wysiwygQuoteFormContainer.tpl
+++ b/com.woltlab.wcf/templates/shared_wysiwygQuoteFormContainer.tpl
@@ -1,4 +1,4 @@
-<div id="{$container->getPrefixedId()|encodeJS}Container"{*
+<div id="{$container->getPrefixedId()}Container"{*
 	*} class="messageTabMenuContent messageTabMenuContent--quotes"></div>
 
 <script data-relocate="true">

--- a/com.woltlab.wcf/templates/shared_wysiwygSmileyFormContainer.tpl
+++ b/com.woltlab.wcf/templates/shared_wysiwygSmileyFormContainer.tpl
@@ -2,6 +2,6 @@
 
 <script data-relocate="true">
 	require(['WoltLabSuite/Core/Ui/Smiley/Insert'], function(UiSmileyInsert) {
-		new UiSmileyInsert('{@$container->getPrefixedWysiwygId()|encodeJS}');
+		new UiSmileyInsert('{unsafe:$container->getPrefixedWysiwygId()|encodeJS}');
 	});
 </script>

--- a/com.woltlab.wcf/templates/shared_wysiwygSmileyFormNode.tpl
+++ b/com.woltlab.wcf/templates/shared_wysiwygSmileyFormNode.tpl
@@ -1,5 +1,5 @@
 <ul class="inlineList smileyList">
 	{foreach from=$node->getSmilies() item=smiley name=smilies}
-		<li><a class="jsSmiley" role="button" tabindex="{if $tpl.foreach.smilies.iteration === 1}0{else}-1{/if}">{@$smiley->getHtml('jsTooltip')}</a></li>
+		<li><a class="jsSmiley" role="button" tabindex="{if $tpl.foreach.smilies.iteration === 1}0{else}-1{/if}">{unsafe:$smiley->getHtml('jsTooltip')}</a></li>
 	{/foreach}
 </ul>

--- a/com.woltlab.wcf/templates/shared_wysiwygTabFormContainer.tpl
+++ b/com.woltlab.wcf/templates/shared_wysiwygTabFormContainer.tpl
@@ -10,6 +10,6 @@
 
 <script data-relocate="true">
 	require(['WoltLabSuite/Core/Form/Builder/Field/Dependency/Container/WysiwygTab'], ({ WysiwygTab }) => {
-		new WysiwygTab('{$container->getPrefixedId()|encodeJS}Container', '{$container->getName()|encodeJS}', '{$container->getWysiwygId()|encodeJS}');
+		new WysiwygTab('{unsafe:$container->getPrefixedId()|encodeJS}Container', '{unsafe:$container->getName()|encodeJS}', '{unsafe:$container->getWysiwygId()|encodeJS}');
 	});
 </script>

--- a/com.woltlab.wcf/templates/shared_wysiwygTabMenuFormContainer.tpl
+++ b/com.woltlab.wcf/templates/shared_wysiwygTabMenuFormContainer.tpl
@@ -9,7 +9,7 @@
 					<li data-name="{$child->getName()}"{if !$child->checkDependencies()} hidden{/if}>
 						<button type="button">
 							{if $child->getIcon()}{unsafe:$child->getIcon()->toHtml()}{/if}
-							<span>{@$child->getLabel()}</span>
+							<span>{unsafe:$child->getLabel()}</span>
 						</button>
 					</li>
 				{/if}
@@ -24,6 +24,6 @@
 
 <script data-relocate="true">
 	require(['WoltLabSuite/Core/Form/Builder/Field/Dependency/Container/WysiwygTabMenu'], ({ WysiwygTabMenu }) => {
-		new WysiwygTabMenu('{@$container->getPrefixedId()|encodeJS}Container');
+		new WysiwygTabMenu('{unsafe:$container->getPrefixedId()|encodeJS}Container');
 	});
 </script>


### PR DESCRIPTION
- Remove unnecessary `@`
- Remove unnecessary `encodeJS`
- Use `unsafe:` instead of `@`
- Use `encodeJS` to output variables to JavaScript code