### PR TITLE
Refactor email templates

### DIFF
--- a/com.woltlab.wcf/templates/emailActivation.tpl
+++ b/com.woltlab.wcf/templates/emailActivation.tpl
@@ -1,5 +1,5 @@
 {include file='authFlowHeader'}
 
-{@$form->getHtml()}
+{unsafe:$form->getHtml()}
 
 {include file='authFlowFooter'}

--- a/com.woltlab.wcf/templates/emailNewActivationCode.tpl
+++ b/com.woltlab.wcf/templates/emailNewActivationCode.tpl
@@ -1,5 +1,5 @@
 {include file='authFlowHeader'}
 
-{@$form->getHtml()}
+{unsafe:$form->getHtml()}
 
 {include file='authFlowFooter'}

--- a/com.woltlab.wcf/templates/email_changeEmailNeedReactivation.tpl
+++ b/com.woltlab.wcf/templates/email_changeEmailNeedReactivation.tpl
@@ -7,7 +7,7 @@
 	{lang}wcf.user.changeEmail.needReactivation.mail.html.intro{/lang}
 
 	{capture assign=button}
-	<a href="{link controller='EmailActivation' isHtmlEmail=true}u={@$mailbox->getUser()->userID}&a={@$mailbox->getUser()->reactivationCode}{/link}">
+	<a href="{link controller='EmailActivation' isHtmlEmail=true}u={$mailbox->getUser()->userID}&a={$mailbox->getUser()->reactivationCode}{/link}">
 		{lang}wcf.user.changeEmail.needReactivation.mail.html.activate{/lang}
 	</a>
 	{/capture}

--- a/com.woltlab.wcf/templates/email_dailyNotification.tpl
+++ b/com.woltlab.wcf/templates/email_dailyNotification.tpl
@@ -13,7 +13,7 @@
 {assign var='notificationContent' value=$notification[notificationContent]}
 {assign var='notificationType' value=$notification[notificationType]}
 {if $notificationContent|is_array}{if !$notificationContent[variables]|empty}{foreach from=$notificationContent[variables] key='__key' item='__item'}{assign var=$__key value=$__item}{/foreach}{/if}{include file=$notificationContent[template] application=$notificationContent[application] variables=$notificationContent[variables]}{*
-*}{else}{@$notificationContent}{/if}
+*}{else}{unsafe:$notificationContent}{/if}
 {/implode}
 
 ---------------
@@ -38,7 +38,7 @@
 			
 			{include file=$notificationContent[template] application=$notificationContent[application] variables=$notificationContent[variables]}
 		{else}
-			{@$notificationContent}
+			{unsafe:$notificationContent}
 		{/if}
 	</div>
 	{/foreach}

--- a/com.woltlab.wcf/templates/email_html.tpl
+++ b/com.woltlab.wcf/templates/email_html.tpl
@@ -14,7 +14,7 @@
 		}
 
 		body, body * {
-			font-family: {@$style->getEmailFontFamily()};
+			font-family: {unsafe:$style->getEmailFontFamily()};
 			font-size: {$style->getVariable('wcfFontSizeDefault')};
 		}
 
@@ -148,20 +148,20 @@
 	{/capture}
 	{include file='email_paddingHelper' block=true class='header' content=$header sandbox=true}
 
-	{if $beforeContent|isset}{@$beforeContent}{/if}
+	{if $beforeContent|isset}{unsafe:$beforeContent}{/if}
 
 	{include file='email_paddingHelper' block=true class='content' content=$content sandbox=true}
 
-	{if $afterContent|isset}{@$afterContent}{/if}
+	{if $afterContent|isset}{unsafe:$afterContent}{/if}
 
 	{capture assign='footer'}
 	{hascontent}
 	<span style="font-size: 0;">-- <br></span>
 	{content}
 	{if MAIL_SIGNATURE_HTML|phrase}
-	{@MAIL_SIGNATURE_HTML|phrase}
+	{unsafe:MAIL_SIGNATURE_HTML|phrase}
 	{else}
-	{@MAIL_SIGNATURE|phrase|newlineToBreak}
+	{unsafe:MAIL_SIGNATURE|phrase|newlineToBreak}
 	{/if}
 	{/content}{/hascontent}{/capture}
 	{include file='email_paddingHelper' block=true class='footer' content=$footer sandbox=true}

--- a/com.woltlab.wcf/templates/email_lostPassword.tpl
+++ b/com.woltlab.wcf/templates/email_lostPassword.tpl
@@ -7,7 +7,7 @@
 	{lang}wcf.user.lostPassword.mail.html.intro{/lang}
 
 	{capture assign=button}
-	<a href="{link controller='NewPassword' object=$mailbox->getUser() isHtmlEmail=true}k={@$mailbox->getUser()->lostPasswordKey}{/link}">
+	<a href="{link controller='NewPassword' object=$mailbox->getUser() isHtmlEmail=true}k={$mailbox->getUser()->lostPasswordKey}{/link}">
 		{lang}wcf.user.lostPassword.mail.html.reset{/lang}
 	</a>
 	{/capture}

--- a/com.woltlab.wcf/templates/email_notification.tpl
+++ b/com.woltlab.wcf/templates/email_notification.tpl
@@ -3,7 +3,7 @@
 {lang}wcf.user.notification.mail.plaintext.intro{/lang}
 
 {if $notificationContent|is_array}{include file=$notificationContent[template] application=$notificationContent[application]}{*
-*}{else}{@$notificationContent}{/if}
+*}{else}{unsafe:$notificationContent}{/if}
 
 {lang}wcf.user.notification.mail.plaintext.outro{/lang}
 {/capture}
@@ -15,7 +15,7 @@
 	{if $notificationContent|is_array}
 		{include file=$notificationContent[template] application=$notificationContent[application]}
 	{else}
-		{@$notificationContent}
+		{unsafe:$notificationContent}
 	{/if}
 
 	{capture assign=button}

--- a/com.woltlab.wcf/templates/email_notification_article.tpl
+++ b/com.woltlab.wcf/templates/email_notification_article.tpl
@@ -1,9 +1,9 @@
 {if $mimeType === 'text/plain'}
-{lang}{@$languageVariablePrefix}.mail.plaintext{/lang}
+{lang}{$languageVariablePrefix}.mail.plaintext{/lang}
 
-{@$articleContent->getMailText($mimeType)} {* this line ends with a space *}
+{unsafe:$articleContent->getMailText($mimeType)} {* this line ends with a space *}
 {else}
-	{lang}{@$languageVariablePrefix}.mail.html{/lang}
+	{lang}{$languageVariablePrefix}.mail.html{/lang}
 	{assign var='user' value=$event->getAuthor()}
 	{assign var='article' value=$event->getUserNotificationObject()}
 	
@@ -12,7 +12,7 @@
 	{capture assign='articleContent'}
 	<table cellpadding="0" cellspacing="0" border="0">
 		<tr>
-			<td><a href="{link controller='User' object=$user isHtmlEmail=true}{/link}" title="{$article->username}">{@$user->getAvatar()->getSafeImageTag($avatarSize)}</a></td>
+			<td><a href="{link controller='User' object=$user isHtmlEmail=true}{/link}" title="{$article->username}">{unsafe:$user->getAvatar()->getSafeImageTag($avatarSize)}</a></td>
 			<td class="boxContent">
 				<div class="containerHeadline">
 					<h3>
@@ -26,7 +26,7 @@
 					</h3>
 				</div>
 				<div>
-					{@$articleContent->getMailText($mimeType)}
+					{unsafe:$articleContent->getMailText($mimeType)}
 				</div>
 			</td>
 		</tr>

--- a/com.woltlab.wcf/templates/email_notification_moderationQueueReport.tpl
+++ b/com.woltlab.wcf/templates/email_notification_moderationQueueReport.tpl
@@ -3,7 +3,7 @@
 {capture assign='authorList'}{lang}wcf.user.notification.mail.authorList.plaintext{/lang}{/capture}
 {lang}wcf.moderation.report.notification.mail.plaintext{/lang}
 
-{@$moderationQueue->getMailText($mimeType)} {* this line ends with a space *}
+{unsafe:$moderationQueue->getMailText($mimeType)} {* this line ends with a space *}
 {else}
 	{capture assign='authorList'}{lang}wcf.user.notification.mail.authorList.html{/lang}{/capture}
 	{lang}wcf.moderation.report.notification.mail.html{/lang}
@@ -15,7 +15,7 @@
 		<table cellpadding="0" cellspacing="0" border="0">
 			<tr>
 				<td><a href="{link controller='User' object=$user isHtmlEmail=true}{/link}"
-					   title="{$user->username}">{@$user->getAvatar()->getSafeImageTag($avatarSize)}</a></td>
+					   title="{$user->username}">{unsafe:$user->getAvatar()->getSafeImageTag($avatarSize)}</a></td>
 				<td class="boxContent">
 					<div class="containerHeadline">
 						<h3>
@@ -29,7 +29,7 @@
 						</h3>
 					</div>
 					<div>
-						{@$moderationQueue->getMailText($mimeType)}
+						{unsafe:$moderationQueue->getMailText($mimeType)}
 					</div>
 				</td>
 			</tr>

--- a/com.woltlab.wcf/templates/email_paddingHelper.tpl
+++ b/com.woltlab.wcf/templates/email_paddingHelper.tpl
@@ -2,7 +2,7 @@
 <table cellpadding="0" cellspacing="0" border="0" class="paddingHelper{if $block|isset && $block} block{/if}{if $outerClass|isset && $outerClass} {$outerClass}{/if}">
 	<tr>
 		<td class="{$class}">
-			{@$content}
+			{unsafe:$content}
 		</td>
 	</tr>
 </table>

--- a/com.woltlab.wcf/templates/email_plaintext.tpl
+++ b/com.woltlab.wcf/templates/email_plaintext.tpl
@@ -1,12 +1,12 @@
-{if $beforeContent|isset}{@$beforeContent}
+{if $beforeContent|isset}{unsafe:$beforeContent}
 
-{/if}{@$content}{if $afterContent|isset}
+{/if}{unsafe:$content}{if $afterContent|isset}
 
-{@$afterContent}{/if}
+{unsafe:$afterContent}{/if}
 {hascontent} {* this line ends with a space *}
 
 -- {* this line ends with a space *}
 {content}
-{@MAIL_SIGNATURE|phrase}
+{unsafe:MAIL_SIGNATURE|phrase}
 {/content}
 {/hascontent}

--- a/com.woltlab.wcf/templates/email_registerNeedActivation.tpl
+++ b/com.woltlab.wcf/templates/email_registerNeedActivation.tpl
@@ -7,7 +7,7 @@
 	{lang}wcf.user.register.needActivation.mail.html.intro{/lang}
 
 	{capture assign=button}
-	<a href="{link controller='RegisterActivation' isHtmlEmail=true}u={@$mailbox->getUser()->userID}&a={@$mailbox->getUser()->emailConfirmed}{/link}">
+	<a href="{link controller='RegisterActivation' isHtmlEmail=true}u={$mailbox->getUser()->userID}&a={$mailbox->getUser()->emailConfirmed}{/link}">
 		{lang}wcf.user.register.needActivation.mail.html.activate{/lang}
 	</a>
 	{/capture}

--- a/com.woltlab.wcf/templates/email_sendNewPassword.tpl
+++ b/com.woltlab.wcf/templates/email_sendNewPassword.tpl
@@ -7,7 +7,7 @@
 	{lang}wcf.acp.user.sendNewPassword.mail.html.intro{/lang}
 
 	{capture assign=button}
-	<a href="{link controller='NewPassword' object=$mailbox->getUser() isHtmlEmail=true}k={@$mailbox->getUser()->lostPasswordKey}{/link}">
+	<a href="{link controller='NewPassword' object=$mailbox->getUser() isHtmlEmail=true}k={$mailbox->getUser()->lostPasswordKey}{/link}">
 		{lang}wcf.acp.user.sendNewPassword.mail.html.reset{/lang}
 	</a>
 	{/capture}


### PR DESCRIPTION
- Remove unnecessary `@`
- Use `unsafe:` instead of `@`