### PR TITLE
Refactor message templates

### DIFF
--- a/com.woltlab.wcf/templates/__messageFormPoll.tpl
+++ b/com.woltlab.wcf/templates/__messageFormPoll.tpl
@@ -8,7 +8,7 @@
 			
 			new UiPollEditor(
 				"pollOptionContainer",
-				[ {implode from=$pollOptions item=pollOption}{ optionID: {@$pollOption[optionID]}, optionValue: '{@$pollOption[optionValue]|encodeJS}' }{/implode} ],
+				[ {implode from=$pollOptions item=pollOption}{ optionID: {$pollOption[optionID]}, optionValue: '{unsafe:$pollOption[optionValue]|encodeJS}' }{/implode} ],
 				"",
 				{
 					maxOptions: {POLL_MAX_OPTIONS}
@@ -51,7 +51,7 @@
 				<input type="datetime" tabindex="-1" name="pollEndTime" id="pollEndTime" value="{if $pollEndTime}{@$pollEndTime|date:'c'}{/if}" class="medium">
 				{if $errorField == 'pollEndTime'}
 					<small class="innerError">
-						{lang}wcf.poll.endTime.error.{@$errorType}{/lang}
+						{lang}wcf.poll.endTime.error.{$errorType}{/lang}
 					</small>
 				{/if}
 			</dd>
@@ -64,7 +64,7 @@
 				<input type="number" name="pollMaxVotes" id="pollMaxVotes" value="{$pollMaxVotes}" min="1" class="tiny">
 				{if $errorField == 'pollMaxVotes'}
 					<small class="innerError">
-						{lang}wcf.poll.maxVotes.error.{@$errorType}{/lang}
+						{lang}wcf.poll.maxVotes.error.{$errorType}{/lang}
 					</small>
 				{/if}
 			</dd>

--- a/com.woltlab.wcf/templates/__messageFormPoll.tpl
+++ b/com.woltlab.wcf/templates/__messageFormPoll.tpl
@@ -48,7 +48,7 @@
 				<label for="pollEndTime">{lang}wcf.poll.endTime{/lang}</label>
 			</dt>
 			<dd>
-				<input type="datetime" tabindex="-1" name="pollEndTime" id="pollEndTime" value="{if $pollEndTime}{@$pollEndTime|date:'c'}{/if}" class="medium">
+				<input type="datetime" tabindex="-1" name="pollEndTime" id="pollEndTime" value="{if $pollEndTime}{time time=$pollEndTime type='custom' format='c'}{/if}" class="medium">
 				{if $errorField == 'pollEndTime'}
 					<small class="innerError">
 						{lang}wcf.poll.endTime.error.{$errorType}{/lang}

--- a/com.woltlab.wcf/templates/__messageFormPollInline.tpl
+++ b/com.woltlab.wcf/templates/__messageFormPollInline.tpl
@@ -8,7 +8,7 @@
 			
 			new UiPollEditor(
 				"pollOptionContainer_{$wysiwygSelector}",
-				[ {implode from=$pollOptions item=pollOption}{ optionID: {@$pollOption[optionID]}, optionValue: '{@$pollOption[optionValue]|encodeJS}' }{/implode} ],
+				[ {implode from=$pollOptions item=pollOption}{ optionID: {$pollOption[optionID]}, optionValue: '{unsafe:$pollOption[optionValue]|encodeJS}' }{/implode} ],
 				"{$wysiwygSelector}",
 				{
 					isAjax: true,

--- a/com.woltlab.wcf/templates/__messageFormPollInline.tpl
+++ b/com.woltlab.wcf/templates/__messageFormPollInline.tpl
@@ -39,7 +39,7 @@
 				<label for="{$wysiwygSelector}pollEndTime">{lang}wcf.poll.endTime{/lang}</label>
 			</dt>
 			<dd>
-				<input type="datetime" tabindex="-1" name="pollEndTime" id="{$wysiwygSelector}pollEndTime" value="{if $pollEndTime}{@$pollEndTime|date:'c'}{/if}" class="medium">
+				<input type="datetime" tabindex="-1" name="pollEndTime" id="{$wysiwygSelector}pollEndTime" value="{if $pollEndTime}{time time=$pollEndTime type='custom' format='c'}{/if}" class="medium">
 			</dd>
 		</dl>
 		<dl>

--- a/com.woltlab.wcf/templates/messageFormMultilingualism.tpl
+++ b/com.woltlab.wcf/templates/messageFormMultilingualism.tpl
@@ -21,9 +21,9 @@
 			require(['WoltLabSuite/Core/Language/Chooser'], function(LanguageChooser) {
 				var languages = {
 					{implode from=$availableContentLanguages item=_language}
-						'{@$_language->languageID}': {
-							iconPath: '{@$_language->getIconPath()|encodeJS}',
-							languageName: '{@$_language|encodeJS}'
+						'{$_language->languageID}': {
+							iconPath: '{unsafe:$_language->getIconPath()|encodeJS}',
+							languageName: '{unsafe:$_language|encodeJS}'
 						}
 					{/implode}
 				};

--- a/com.woltlab.wcf/templates/messageFormSettingsInline.tpl
+++ b/com.woltlab.wcf/templates/messageFormSettingsInline.tpl
@@ -8,7 +8,7 @@
 			
 			{if $__messageFormSettingsInlineSettings}
 				<dl>
-					{@$__messageFormSettingsInlineSettings}
+					{unsafe:$__messageFormSettingsInlineSettings}
 				</dl>
 			{/if}
 			

--- a/com.woltlab.wcf/templates/messageFormTabsInline.tpl
+++ b/com.woltlab.wcf/templates/messageFormTabsInline.tpl
@@ -59,7 +59,7 @@
 		{include file='shared_messageFormAttachments'}
 	{/if}
 
-	{if $__messageFormSettingsInlineContent}{@$__messageFormSettingsInlineContent}{/if}
+	{if $__messageFormSettingsInlineContent}{unsafe:$__messageFormSettingsInlineContent}{/if}
 
 	{include file='__messageFormPollInline'}
 

--- a/com.woltlab.wcf/templates/messageQuickReplyGuestDialog.tpl
+++ b/com.woltlab.wcf/templates/messageQuickReplyGuestDialog.tpl
@@ -19,5 +19,5 @@
 {include file='shared_captcha'}
 
 <div class="formSubmit">
-	<input type="submit" value="{lang}wcf.global.button.submit{/lang}" accesskey="s" data-captcha-id="{@$captchaID}">
+	<input type="submit" value="{lang}wcf.global.button.submit{/lang}" accesskey="s" data-captcha-id="{$captchaID}">
 </div>

--- a/com.woltlab.wcf/templates/messageSidebar.tpl
+++ b/com.woltlab.wcf/templates/messageSidebar.tpl
@@ -24,8 +24,8 @@
 			{/if}
 			
 			<div class="messageAuthorContainer">
-				<a href="{$userProfile->getLink()}" class="username userLink" data-object-id="{@$userProfile->userID}"{if $enableMicrodata} itemprop="url"{/if}>
-					<span{if $enableMicrodata} itemprop="name"{/if}>{@$userProfile->getFormattedUsername()}</span>
+				<a href="{$userProfile->getLink()}" class="username userLink" data-object-id="{$userProfile->userID}"{if $enableMicrodata} itemprop="url"{/if}>
+					<span{if $enableMicrodata} itemprop="name"{/if}>{unsafe:$userProfile->getFormattedUsername()}</span>
 				</a>
 				{if !$isReply}
 					{if $userProfile->banned}
@@ -45,7 +45,7 @@
 							{event name='beforeUserTitle'}
 						
 							{if MODULE_USER_RANK && $userProfile->getUserTitle()}
-								<span class="badge userTitleBadge{if $userProfile->getRank() && $userProfile->getRank()->cssClassName} {@$userProfile->getRank()->cssClassName}{/if}">{$userProfile->getUserTitle()}</span>
+								<span class="badge userTitleBadge{if $userProfile->getRank() && $userProfile->getRank()->cssClassName} {$userProfile->getRank()->cssClassName}{/if}">{$userProfile->getUserTitle()}</span>
 							{/if}
 						
 							{event name='afterUserTitle'}
@@ -54,7 +54,7 @@
 				{/hascontent}
 				
 				{if MODULE_USER_RANK && $userProfile->getRank() && $userProfile->getRank()->rankImage}
-					<div class="userRank">{@$userProfile->getRank()->getImage()}</div>
+					<div class="userRank">{unsafe:$userProfile->getRank()->getImage()}</div>
 				{/if}
 			{/if}
 
@@ -62,14 +62,14 @@
 				<div class="specialTrophyContainer">
 					<ul>
 						{foreach from=$userProfile->getSpecialTrophies() item=trophy}
-							<li><a href="{@$trophy->getLink()}">{@$trophy->renderTrophy(32, true)}</a></li>
+							<li><a href="{$trophy->getLink()}">{unsafe:$trophy->renderTrophy(32, true)}</a></li>
 						{/foreach}
 					</ul>
 				</div>
 			{/if}
 		{else}
 			<div class="userAvatar">
-				<span>{@$userProfile->getAvatar()->getImageTag(128)}</span>
+				<span>{unsafe:$userProfile->getAvatar()->getImageTag(128)}</span>
 			</div>
 			
 			<div class="messageAuthorContainer">
@@ -100,7 +100,7 @@
 							{/if}
 							
 							{if MESSAGE_SIDEBAR_ENABLE_ACTIVITY_POINTS && $userProfile->activityPoints}
-								<dt><a href="#" class="activityPointsDisplay jsTooltip" title="{lang user=$userProfile}wcf.user.activityPoint.showActivityPoints{/lang}" data-user-id="{@$userProfile->userID}">{lang}wcf.user.activityPoint{/lang}</a></dt>
+								<dt><a href="#" class="activityPointsDisplay jsTooltip" title="{lang user=$userProfile}wcf.user.activityPoint.showActivityPoints{/lang}" data-user-id="{$userProfile->userID}">{lang}wcf.user.activityPoint{/lang}</a></dt>
 								<dd>{#$userProfile->activityPoints}</dd>
 							{/if}
 							
@@ -118,7 +118,7 @@
 										{assign var='__formattedUserOption' value=$userProfile->getFormattedUserOption($__sidebarUserOption)}
 										{if $__formattedUserOption}
 											<dt>{lang}wcf.user.option.{$__sidebarUserOption}{/lang}</dt>
-											<dd>{@$__formattedUserOption}</dd>
+											<dd>{unsafe:$__formattedUserOption}</dd>
 										{/if}
 									{/if}
 								{/foreach}

--- a/com.woltlab.wcf/templates/poll.tpl
+++ b/com.woltlab.wcf/templates/poll.tpl
@@ -7,14 +7,14 @@
 	</script>
 {/if}
 
-<div id="poll{@$poll->pollID}" class="pollContainer{if POLL_FULL_WIDTH} pollContainerFullWidth{/if}"{*
-	*} data-poll-id="{@$poll->pollID}"{*
+<div id="poll{$poll->pollID}" class="pollContainer{if POLL_FULL_WIDTH} pollContainerFullWidth{/if}"{*
+	*} data-poll-id="{$poll->pollID}"{*
 	*} data-can-vote="{if $poll->canVote()}true{else}false{/if}"{*
 	*} data-can-view-result="{if $poll->canSeeResult()}true{else}false{/if}"{*
 	*} data-can-view-participants="{if $poll->canViewParticipants()}true{else}false{/if}"{*
 	*} data-in-vote="{if $poll->canVote() && !$poll->isParticipant()}true{else}false{/if}"{*
 	*} data-question="{$poll->question}"{*
-	*} data-max-votes="{@$poll->maxVotes}"{*
+	*} data-max-votes="{$poll->maxVotes}"{*
 	*} data-is-public="{if $poll->isPublic}true{else}false{/if}">
 	<section>
 		<h2>{$poll->question} <span class="badge jsTooltip pollTotalVotesBadge" title="{lang}wcf.poll.totalVotes{/lang}">{#$poll->votes}</span></h2>

--- a/com.woltlab.wcf/templates/pollResult.tpl
+++ b/com.woltlab.wcf/templates/pollResult.tpl
@@ -3,10 +3,10 @@
 		<li class="pollResultItem">
 			<div class="pollResultItemCaption">
 				<span class="pollOptionName">{$option->optionValue} ({#$option->votes})</span>
-				<span class="pollOptionRelativeValue">{@$option->getRelativeVotes($poll)}%</span>
+				<span class="pollOptionRelativeValue">{$option->getRelativeVotes($poll)}%</span>
 			</div>
 			<div class="pollMeter">
-				<div class="pollMeterValue" style="width: {if $option->getRelativeVotes($poll)}{@$option->getRelativeVotes($poll)}%{else}0{/if}"></div>
+				<div class="pollMeterValue" style="width: {if $option->getRelativeVotes($poll)}{$option->getRelativeVotes($poll)}%{else}0{/if}"></div>
 			</div>
 		</li>
 	{/foreach}

--- a/com.woltlab.wcf/templates/pollVote.tpl
+++ b/com.woltlab.wcf/templates/pollVote.tpl
@@ -1,9 +1,9 @@
-<dl class="wide pollVoteContainer" data-max-votes="{@$poll->maxVotes}">
+<dl class="wide pollVoteContainer" data-max-votes="{$poll->maxVotes}">
 	{foreach from=$poll->getOptions() item=option}
 		<dt></dt>
 		<dd>
 			<label>
-				{if $poll->canVote()}<input type="{if $poll->maxVotes > 1}checkbox{else}radio{/if}" name="pollOptions{@$poll->pollID}[]" value="{$option->optionID}"{if $option->voted} checked{/if}>{/if}
+				{if $poll->canVote()}<input type="{if $poll->maxVotes > 1}checkbox{else}radio{/if}" name="pollOptions{$poll->pollID}[]" value="{$option->optionID}"{if $option->voted} checked{/if}>{/if}
 				{$option->optionValue}
 			</label>
 		</dd>

--- a/com.woltlab.wcf/templates/shared_messageTableOfContents.tpl
+++ b/com.woltlab.wcf/templates/shared_messageTableOfContents.tpl
@@ -9,10 +9,10 @@
 				<li>
 					<span class="tocItemTitle"><a href="#{$item->getID()}">{$item->getTitle()}</a></span>
 					
-					{if $item->hasChildren()}<ol class="tableOfContents tocLevel{@$item->getDepth() + 1}">{else}</li>{/if}
+					{if $item->hasChildren()}<ol class="tableOfContents tocLevel{$item->getDepth() + 1}">{else}</li>{/if}
 					
 					{if !$item->hasChildren() && $item->isLastSibling()}
-						{@"</ol></li>"|str_repeat:$item->getOpenParentNodes()}
+						{unsafe:"</ol></li>"|str_repeat:$item->getOpenParentNodes()}
 					{/if}
 			{/foreach}
 		</ol>


### PR DESCRIPTION
- Remove unnecessary `@`
- Use `unsafe:` instead of `@`
- Replace deprecated `time` template modifier with `{time}`