### PR TITLE
Refactor multifactor templates

### DIFF
--- a/com.woltlab.wcf/templates/__multifactorTotpDeviceNode.tpl
+++ b/com.woltlab.wcf/templates/__multifactorTotpDeviceNode.tpl
@@ -6,7 +6,7 @@
 	<td class="columnText">
 		{foreach from=$container item='child'}
 			{if $child->isAvailable()}
-				{@$child->getHtml()}
+				{unsafe:$child->getHtml()}
 			{/if}
 		{/foreach}
 	</td>

--- a/com.woltlab.wcf/templates/__multifactorTotpDeviceNode.tpl
+++ b/com.woltlab.wcf/templates/__multifactorTotpDeviceNode.tpl
@@ -1,8 +1,8 @@
 
 <tr>
 	<td class="columnText">{$device[deviceName]}</td>
-	<td class="columnDate">{$device[createTime]|plainTime}</td>
-	<td class="columnDate">{if $device[useTime]}{$device[useTime]|plainTime}{else}&ndash;{/if}</td>
+	<td class="columnDate">{time time=$device[createTime] type='plainTime'}</td>
+	<td class="columnDate">{if $device[useTime]}{time time=$device[useTime] type='plainTime'}{else}&ndash;{/if}</td>
 	<td class="columnText">
 		{foreach from=$container item='child'}
 			{if $child->isAvailable()}

--- a/com.woltlab.wcf/templates/__multifactorTotpDevicesContainer.tpl
+++ b/com.woltlab.wcf/templates/__multifactorTotpDevicesContainer.tpl
@@ -6,11 +6,11 @@
 	{if $container->getLabel() !== null}
 		{if $container->getDescription() !== null}
 			<header class="sectionHeader">
-				<h2 class="sectionTitle">{@$container->getLabel()}{if $container->markAsRequired()} <span class="formFieldRequired">*</span>{/if}</h2>
-				<p class="sectionDescription">{@$container->getDescription()}</p>
+				<h2 class="sectionTitle">{unsafe:$container->getLabel()}{if $container->markAsRequired()} <span class="formFieldRequired">*</span>{/if}</h2>
+				<p class="sectionDescription">{unsafe:$container->getDescription()}</p>
 			</header>
 		{else}
-			<h2 class="sectionTitle">{@$container->getLabel()}{if $container->markAsRequired()} <span class="formFieldRequired">*</span>{/if}</h2>
+			<h2 class="sectionTitle">{unsafe:$container->getLabel()}{if $container->markAsRequired()} <span class="formFieldRequired">*</span>{/if}</h2>
 		{/if}
 	{/if}
 	
@@ -28,7 +28,7 @@
 			<tbody>
 				{foreach from=$container item='child'}
 					{if $child->isAvailable()}
-						{@$child->getHtml()}
+						{unsafe:$child->getHtml()}
 					{/if}
 				{/foreach}
 			</tbody>
@@ -40,6 +40,6 @@
 
 <script data-relocate="true">
 	require(['WoltLabSuite/Core/Form/Builder/Field/Dependency/Container/Default'], function(DefaultContainerDependency) {
-		new DefaultContainerDependency('{@$container->getPrefixedId()|encodeJS}Container');
+		new DefaultContainerDependency('{unsafe:$container->getPrefixedId()|encodeJS}Container');
 	});
 </script>

--- a/com.woltlab.wcf/templates/__multifactorTotpNewDeviceContainer.tpl
+++ b/com.woltlab.wcf/templates/__multifactorTotpNewDeviceContainer.tpl
@@ -6,11 +6,11 @@
 	{if $container->getLabel() !== null}
 		{if $container->getDescription() !== null}
 			<header class="sectionHeader">
-				<h2 class="sectionTitle">{@$container->getLabel()}{if $container->markAsRequired()} <span class="formFieldRequired">*</span>{/if}</h2>
-				<p class="sectionDescription">{@$container->getDescription()}</p>
+				<h2 class="sectionTitle">{unsafe:$container->getLabel()}{if $container->markAsRequired()} <span class="formFieldRequired">*</span>{/if}</h2>
+				<p class="sectionDescription">{unsafe:$container->getDescription()}</p>
 			</header>
 		{else}
-			<h2 class="sectionTitle">{@$container->getLabel()}{if $container->markAsRequired()} <span class="formFieldRequired">*</span>{/if}</h2>
+			<h2 class="sectionTitle">{unsafe:$container->getLabel()}{if $container->markAsRequired()} <span class="formFieldRequired">*</span>{/if}</h2>
 		{/if}
 	{/if}
 	
@@ -18,19 +18,19 @@
 	
 	<div class="multifactorTotpNewDevice">
 		{if $container->getNodeById('secret')->isAvailable()}
-			{@$container->getNodeById('secret')->getFieldHtml()}
+			{unsafe:$container->getNodeById('secret')->getFieldHtml()}
 		{/if}
 		
 		<div class="multifactorTotpNewDeviceFields">
 			{foreach from=$container item='child'}
 				{if $child->getId() !== 'secret' && $child->getId() !== 'submitButton' && $child->isAvailable()}
-					{@$child->getHtml()}
+					{unsafe:$child->getHtml()}
 				{/if}
 			{/foreach}
 			
 			{if $container->getNodeById('submitButton')->isAvailable()}
 				<div class="formSubmit">
-					{@$container->getNodeById('submitButton')->getHtml()}
+					{unsafe:$container->getNodeById('submitButton')->getHtml()}
 				</div>
 			{/if}
 		</div>
@@ -41,6 +41,6 @@
 
 <script data-relocate="true">
 	require(['WoltLabSuite/Core/Form/Builder/Field/Dependency/Container/Default'], function(DefaultContainerDependency) {
-		new DefaultContainerDependency('{@$container->getPrefixedId()|encodeJS}Container');
+		new DefaultContainerDependency('{unsafe:$container->getPrefixedId()|encodeJS}Container');
 	});
 </script>

--- a/com.woltlab.wcf/templates/multifactorAuthentication.tpl
+++ b/com.woltlab.wcf/templates/multifactorAuthentication.tpl
@@ -4,7 +4,7 @@
 
 {include file='authFlowHeader'}
 
-{@$form->getHtml()}
+{unsafe:$form->getHtml()}
 
 <div class="authOtherOptionButtons" hidden>
 	<div class="authOtherOptionButtons__separator">

--- a/com.woltlab.wcf/templates/multifactorDisable.tpl
+++ b/com.woltlab.wcf/templates/multifactorDisable.tpl
@@ -2,6 +2,6 @@
 
 {include file='header' __disableAds=true __sidebarLeftHasMenu=true}
 
-{@$form->getHtml()}
+{unsafe:$form->getHtml()}
 
 {include file='footer' __disableAds=true}

--- a/com.woltlab.wcf/templates/multifactorManage.tpl
+++ b/com.woltlab.wcf/templates/multifactorManage.tpl
@@ -7,12 +7,12 @@
 
 {if $backupForm}
 	{if $form->showsSuccessMessage()}
-		<woltlab-core-notice type="success">{@$form->getSuccessMessage()}</woltlab-core-notice>
+		<woltlab-core-notice type="success">{unsafe:$form->getSuccessMessage()}</woltlab-core-notice>
 	{/if}
 	
-	{@$backupForm->getNodeById('existingCodesContainer')->getHtml()}
+	{unsafe:$backupForm->getNodeById('existingCodesContainer')->getHtml()}
 {else}
-	{@$form->getHtml()}
+	{unsafe:$form->getHtml()}
 {/if}
 
 {include file='footer' __disableAds=true}

--- a/wcfsetup/install/files/acp/templates/multifactorAuthentication.tpl
+++ b/wcfsetup/install/files/acp/templates/multifactorAuthentication.tpl
@@ -9,7 +9,7 @@
 	</div>
 </header>
 
-{@$form->getHtml()}
+{unsafe:$form->getHtml()}
 
 <div class="authOtherOptionButtons" hidden>
 	<div class="authOtherOptionButtons__separator">


### PR DESCRIPTION
- Use `unsafe:` instead of `@`
- Replace deprecated `plainTime` template modifier with `{time}`