### PR TITLE
Refactor account templates

### DIFF
--- a/com.woltlab.wcf/templates/accountManagement.tpl
+++ b/com.woltlab.wcf/templates/accountManagement.tpl
@@ -9,7 +9,7 @@
 {if $success|isset && $success|count > 0}
 	<woltlab-core-notice type="success">
 		{foreach from=$success item=successMessage}
-			<p>{lang}{@$successMessage}{/lang}</p>
+			<p>{lang}{$successMessage}{/lang}</p>
 		{/foreach}
 	</woltlab-core-notice>
 {/if}
@@ -30,7 +30,7 @@
 							{if $errorType == 'empty'}
 								{lang}wcf.global.form.error.empty{/lang}
 							{else}
-								{lang}wcf.user.password.error.{@$errorType}{/lang}
+								{lang}wcf.user.password.error.{$errorType}{/lang}
 							{/if}
 						</small>
 					{/if}
@@ -59,7 +59,7 @@
 							{if $errorType == 'empty'}
 								{lang}wcf.global.form.error.empty{/lang}
 							{else}
-								{lang}wcf.user.username.error.{@$errorType}{/lang}
+								{lang}wcf.user.username.error.{$errorType}{/lang}
 							{/if}
 						</small>
 					{/if}
@@ -87,7 +87,7 @@
 							{if $errorType == 'empty'}
 								{lang}wcf.global.form.error.empty{/lang}
 							{else}
-								{lang}wcf.user.password.error.{@$errorType}{/lang}
+								{lang}wcf.user.password.error.{$errorType}{/lang}
 							{/if}
 						</small>
 					{/if}
@@ -129,7 +129,7 @@
 							{if $errorType == 'empty'}
 								{lang}wcf.global.form.error.empty{/lang}
 							{else}
-								{lang}wcf.user.email.error.{@$errorType}{/lang}
+								{lang}wcf.user.email.error.{$errorType}{/lang}
 							{/if}
 						</small>
 					{/if}
@@ -182,9 +182,9 @@
 			{content}
 				{if $__authProvider}
 					<dl>
-						<dt>{lang}wcf.user.3rdparty.{@$__authProvider}{/lang}</dt>
+						<dt>{lang}wcf.user.3rdparty.{$__authProvider}{/lang}</dt>
 						<dd>
-							<label><input type="checkbox" name="{@$__authProvider}Disconnect" value="1"> {lang}wcf.user.3rdparty.{@$__authProvider}.disconnect{/lang}</label>
+							<label><input type="checkbox" name="{$__authProvider}Disconnect" value="1"> {lang}wcf.user.3rdparty.{$__authProvider}.disconnect{/lang}</label>
 						</dd>
 					</dl>
 				{elseif !$__wcf->getUser()->hasAdministrativeAccess()}

--- a/com.woltlab.wcf/templates/accountSecurity.tpl
+++ b/com.woltlab.wcf/templates/accountSecurity.tpl
@@ -88,7 +88,7 @@
 						
 						<dl class="plain inlineDataList small">
 							<dt>{lang}wcf.user.security.lastActivity{/lang}</dt>
-							<dd>{if $session->isCurrentSession()}{lang}wcf.user.security.currentSession{/lang}{else}{@$session->getLastActivityTime()|time}{/if}</dd>
+							<dd>{if $session->isCurrentSession()}{lang}wcf.user.security.currentSession{/lang}{else}{time time=$session->getLastActivityTime()}{/if}</dd>
 							
 							<dt>{lang}wcf.user.security.ipAddress{/lang}</dt>
 							<dd title="{$session->getIpAddress()}">{$session->getIpAddress()->toBulletMasked(16, 48)}</dd>

--- a/com.woltlab.wcf/templates/accountSecurity.tpl
+++ b/com.woltlab.wcf/templates/accountSecurity.tpl
@@ -39,7 +39,7 @@
 							</h3>
 							
 							{if $enabledMultifactorMethods[$method->objectTypeID]|isset}
-								{@$method->getProcessor()->getStatusText($enabledMultifactorMethods[$method->objectTypeID])}
+								{unsafe:$method->getProcessor()->getStatusText($enabledMultifactorMethods[$method->objectTypeID])}
 							{else}
 								{lang}wcf.user.security.multifactor.{$method->objectType}.description{/lang}
 							{/if}

--- a/com.woltlab.wcf/templates/lostPassword.tpl
+++ b/com.woltlab.wcf/templates/lostPassword.tpl
@@ -1,5 +1,5 @@
 {include file='authFlowHeader'}
 
-{@$form->getHtml()}
+{unsafe:$form->getHtml()}
 
 {include file='authFlowFooter'}

--- a/com.woltlab.wcf/templates/manageSubscription.tpl
+++ b/com.woltlab.wcf/templates/manageSubscription.tpl
@@ -1,14 +1,14 @@
 <div class="section">
 	<dl class="wide">
 		<dd>
-			<label><input type="radio" name="subscribe" value="1"{if $userObjectWatch} checked{/if}> {lang}wcf.user.objectWatch.subscribe.{@$objectType->objectType}{/lang}</label>
+			<label><input type="radio" name="subscribe" value="1"{if $userObjectWatch} checked{/if}> {lang}wcf.user.objectWatch.subscribe.{$objectType->objectType}{/lang}</label>
 			
-			<small><label><input type="checkbox" name="enableNotification" value="1"{if $userObjectWatch && $userObjectWatch->notification} checked{/if}> {lang}wcf.user.objectWatch.enableNotification.{@$objectType->objectType}{/lang}</label></small>
+			<small><label><input type="checkbox" name="enableNotification" value="1"{if $userObjectWatch && $userObjectWatch->notification} checked{/if}> {lang}wcf.user.objectWatch.enableNotification.{$objectType->objectType}{/lang}</label></small>
 		</dd>
 	</dl>
 	<dl class="wide">
 		<dd>
-			<label><input type="radio" name="subscribe" value="0"{if !$userObjectWatch} checked{/if}> {lang}wcf.user.objectWatch.unsubscribe.{@$objectType->objectType}{/lang}</label>
+			<label><input type="radio" name="subscribe" value="0"{if !$userObjectWatch} checked{/if}> {lang}wcf.user.objectWatch.unsubscribe.{$objectType->objectType}{/lang}</label>
 		</dd>
 	</dl>
 	

--- a/com.woltlab.wcf/templates/newPassword.tpl
+++ b/com.woltlab.wcf/templates/newPassword.tpl
@@ -2,7 +2,7 @@
 
 <woltlab-core-notice type="info">{lang}wcf.user.newPassword.info{/lang}</woltlab-core-notice>
 
-{@$form->getHtml()}
+{unsafe:$form->getHtml()}
 
 <script data-relocate="true">
 	require(['WoltLabSuite/Core/Ui/User/PasswordStrength', 'Language'], (PasswordStrength, Language) => {
@@ -10,8 +10,8 @@
 		
 		new PasswordStrength(document.getElementById('newPassword'), {
 			staticDictionary: [
-				'{$user->username|encodeJS}',
-				'{$user->email|encodeJS}',
+				'{unsafe:$user->username|encodeJS}',
+				'{unsafe:$user->email|encodeJS}',
 			]
 		});
 	})

--- a/com.woltlab.wcf/templates/notificationList.tpl
+++ b/com.woltlab.wcf/templates/notificationList.tpl
@@ -5,7 +5,9 @@
 {/capture}
 
 {capture assign='contentInteractionPagination'}
-	{pages print=true assign=pagesLinks controller='NotificationList' link="pageNo=%d"}
+	{if $pages > 1}
+		<woltlab-core-pagination page="{$pageNo}" count="{$pages}" url="{link controller='NotificationList'}{/link}"></woltlab-core-pagination>
+	{/if}
 {/capture}
 
 {capture assign='contentInteractionButtons'}
@@ -84,11 +86,11 @@
 	</section>
 	
 	<footer class="contentFooter">
-		{hascontent}
+		{if $pages > 1}
 			<div class="paginationBottom">
-				{content}{unsafe:$pagesLinks}{/content}
+				<woltlab-core-pagination page="{$pageNo}" count="{$pages}" url="{link controller='NotificationList'}{/link}"></woltlab-core-pagination>
 			</div>
-		{/hascontent}
+		{/if}
 		
 		{hascontent}
 			<nav class="contentFooterNavigation">

--- a/com.woltlab.wcf/templates/notificationSettings.tpl
+++ b/com.woltlab.wcf/templates/notificationSettings.tpl
@@ -24,19 +24,19 @@
 				{foreach from=$eventList item=event}
 					<div class="notificationSettingsItem">
 						<div class="notificationSettingsEvent">
-							<label for="settings_{@$event->eventID}">{lang}wcf.user.notification.{$event->objectType}.{$event->eventName}{/lang}</label>
+							<label for="settings_{$event->eventID}">{lang}wcf.user.notification.{$event->objectType}.{$event->eventName}{/lang}</label>
 						</div>
 						<div class="notificationSettingsState">
 							<label>
-								<input type="checkbox" id="settings_{@$event->eventID}" name="settings[{@$event->eventID}][enabled]" class="jsCheckboxNotificationSettingsState" value="1" data-object-id="{@$event->eventID}"{if !$settings[$event->eventID][enabled]|empty} checked{/if}>
+								<input type="checkbox" id="settings_{$event->eventID}" name="settings[{$event->eventID}][enabled]" class="jsCheckboxNotificationSettingsState" value="1" data-object-id="{$event->eventID}"{if !$settings[$event->eventID][enabled]|empty} checked{/if}>
 								{icon size=24 name='bell' type='solid'}
 								{icon size=24 name='bell-slash'}
 							</label>
 						</div>
 						<div class="notificationSettingsEmail">
 							{if $event->supportsEmailNotification()}
-								<input type="hidden" id="settings_{$event->eventID}_mailNotificationType" name="settings[{@$event->eventID}][mailNotificationType]" value="{$settings[$event->eventID][mailNotificationType]}">
-								<button type="button" class="notificationSettingsEmailType jsTooltip{if $settings[$event->eventID][enabled]|empty} disabled{/if}" title="{lang}wcf.user.notification.mailNotificationType.{@$settings[$event->eventID][mailNotificationType]}{/lang}" data-object-id="{@$event->eventID}">
+								<input type="hidden" id="settings_{$event->eventID}_mailNotificationType" name="settings[{$event->eventID}][mailNotificationType]" value="{$settings[$event->eventID][mailNotificationType]}">
+								<button type="button" class="notificationSettingsEmailType jsTooltip{if $settings[$event->eventID][enabled]|empty} disabled{/if}" title="{lang}wcf.user.notification.mailNotificationType.{$settings[$event->eventID][mailNotificationType]}{/lang}" data-object-id="{$event->eventID}">
 									<span class="jsIconNotificationSettingsEmailType">
 										{if $settings[$event->eventID][mailNotificationType] === 'none'}
 											{icon size=24 name='xmark'}

--- a/com.woltlab.wcf/templates/paidSubscriptionList.tpl
+++ b/com.woltlab.wcf/templates/paidSubscriptionList.tpl
@@ -74,7 +74,7 @@
 						<div class="containerContent">
 							<dl class="plain inlineDataList">
 								<dt>{lang}wcf.paidSubscription.expires{/lang}</dt>
-								<dd>{@$userSubscription->endDate|time}</dd>
+								<dd>{time time=$userSubscription->endDate}</dd>
 							</dl>
 						</div>
 					{/if}

--- a/com.woltlab.wcf/templates/paidSubscriptionList.tpl
+++ b/com.woltlab.wcf/templates/paidSubscriptionList.tpl
@@ -42,13 +42,13 @@
 				<li>
 					<div class="containerHeadline">
 						<h3>{$subscription->getTitle()} <span class="badge label">{lang}wcf.paidSubscription.formattedCost{/lang}</span></h3>
-						<div class="htmlContent">{@$subscription->getFormattedDescription()}</div>
+						<div class="htmlContent">{unsafe:$subscription->getFormattedDescription()}</div>
 					</div>
 					
 					<div class="containerContent">
 						<ul class="buttonList">
 							{foreach from=$subscription->getPurchaseButtons() item=button}
-								<li>{@$button}</li>
+								<li>{unsafe:$button}</li>
 							{/foreach}
 						</ul>
 					</div>
@@ -67,7 +67,7 @@
 				<li>
 					<div class="containerHeadline">
 						<h3>{$userSubscription->getSubscription()->getTitle()}</h3>
-						<div class="htmlContent">{@$userSubscription->getSubscription()->getFormattedDescription()}</div>
+						<div class="htmlContent">{unsafe:$userSubscription->getSubscription()->getFormattedDescription()}</div>
 					</div>
 					
 					{if $userSubscription->endDate}

--- a/com.woltlab.wcf/templates/paidSubscriptionList.tpl
+++ b/com.woltlab.wcf/templates/paidSubscriptionList.tpl
@@ -1,16 +1,19 @@
 {capture assign='headContent'}
 	{if PAID_SUBSCRIPTION_ENABLE_TOS_CONFIRMATION}
 		<script data-relocate="true">
-			const tosCheckbox = document.getElementById('tosConfirmed');
-			const buttons = document.querySelectorAll('.paidSubscriptionList button');
-			if (tosCheckbox) {
-				function toggleButtons() {
-					buttons.forEach(function(button) {
-						button.disabled = !tosCheckbox.checked;
-					});
+			{
+				const tosCheckbox = document.getElementById('tosConfirmed');
+				const buttons = document.querySelectorAll('.paidSubscriptionList button');
+				if (tosCheckbox) {
+					function toggleButtons () {
+						buttons.forEach(function(button) {
+							button.disabled = !tosCheckbox.checked;
+						});
+					}
+
+					tosCheckbox.addEventListener('change', toggleButtons);
+					toggleButtons();
 				}
-				tosCheckbox.addEventListener('change', toggleButtons);
-				toggleButtons();
 			}
 		</script>
 		

--- a/com.woltlab.wcf/templates/paidSubscriptionList.tpl
+++ b/com.woltlab.wcf/templates/paidSubscriptionList.tpl
@@ -1,17 +1,17 @@
 {capture assign='headContent'}
 	{if PAID_SUBSCRIPTION_ENABLE_TOS_CONFIRMATION}
 		<script data-relocate="true">
-			$(function() {
-				$('#tosConfirmed').change(function () {
-					if ($('#tosConfirmed').is(':checked')) {
-						$('.paidSubscriptionList button').enable();
-					}
-					else {
-						$('.paidSubscriptionList button').disable();
-					}
-				});
-				$('#tosConfirmed').change();
-			});
+			const tosCheckbox = document.getElementById('tosConfirmed');
+			const buttons = document.querySelectorAll('.paidSubscriptionList button');
+			if (tosCheckbox) {
+				function toggleButtons() {
+					buttons.forEach(function(button) {
+						button.disabled = !tosCheckbox.checked;
+					});
+				}
+				tosCheckbox.addEventListener('change', toggleButtons);
+				toggleButtons();
+			}
 		</script>
 		
 		<noscript>

--- a/com.woltlab.wcf/templates/reauthentication.tpl
+++ b/com.woltlab.wcf/templates/reauthentication.tpl
@@ -2,6 +2,6 @@
 
 <woltlab-core-notice type="info">{lang}wcf.user.reauthentication.explanation{/lang}</woltlab-core-notice>
 
-{@$form->getHtml()}
+{unsafe:$form->getHtml()}
 
 {include file='authFlowFooter'}

--- a/com.woltlab.wcf/templates/register.tpl
+++ b/com.woltlab.wcf/templates/register.tpl
@@ -39,13 +39,13 @@
 	<div class="section">
 		<dl{if $errorType[username]|isset} class="formError"{/if}>
 			<dt>
-				<label for="{@$randomFieldNames[username]}">{lang}wcf.user.username{/lang}</label> <span class="formFieldRequired">*</span>
+				<label for="{$randomFieldNames[username]}">{lang}wcf.user.username{/lang}</label> <span class="formFieldRequired">*</span>
 			</dt>
 			<dd>
 				<input
 					type="text"
-					id="{@$randomFieldNames[username]}"
-					name="{@$randomFieldNames[username]}"
+					id="{$randomFieldNames[username]}"
+					name="{$randomFieldNames[username]}"
 					value="{$username}"
 					required
 					class="long"
@@ -67,13 +67,13 @@
 		
 		<dl{if $errorType[email]|isset} class="formError"{/if}>
 			<dt>
-				<label for="{@$randomFieldNames[email]}">{lang}wcf.user.email{/lang}</label> <span class="formFieldRequired">*</span>
+				<label for="{$randomFieldNames[email]}">{lang}wcf.user.email{/lang}</label> <span class="formFieldRequired">*</span>
 			</dt>
 			<dd>
 				<input
 					type="email"
-					id="{@$randomFieldNames[email]}"
-					name="{@$randomFieldNames[email]}"
+					id="{$randomFieldNames[email]}"
+					name="{$randomFieldNames[email]}"
 					value="{$email}"
 					required
 					class="long"
@@ -95,13 +95,13 @@
 		{if !$isExternalAuthentication}
 			<dl{if $errorType[password]|isset} class="formError"{/if}>
 				<dt>
-					<label for="{@$randomFieldNames[password]}">{lang}wcf.user.password{/lang}</label> <span class="formFieldRequired">*</span>
+					<label for="{$randomFieldNames[password]}">{lang}wcf.user.password{/lang}</label> <span class="formFieldRequired">*</span>
 				</dt>
 				<dd>
 					<input
 						type="password"
-						id="{@$randomFieldNames[password]}"
-						name="{@$randomFieldNames[password]}"
+						id="{$randomFieldNames[password]}"
+						name="{$randomFieldNames[password]}"
 						value="{$password}"
 						required
 						class="long"
@@ -130,14 +130,14 @@
 						require(['WoltLabSuite/Core/Language/Chooser'], ({ init }) => {
 							const languages = {
 								{implode from=$availableLanguages item=language}
-								'{@$language->languageID}': {
-									iconPath: '{@$language->getIconPath()|encodeJS}',
-									languageName: '{@$language|encodeJS}'
+								'{$language->languageID}': {
+									iconPath: '{unsafe:$language->getIconPath()|encodeJS}',
+									languageName: '{unsafe:$language|encodeJS}'
 								}
 								{/implode}
 							};
 							
-							init('languageIDContainer', 'languageID', {@$languageID}, languages);
+							init('languageIDContainer', 'languageID', {$languageID}, languages);
 						});
 					</script>
 					<noscript>
@@ -214,22 +214,22 @@
 		{jsphrase name='wcf.user.email.error.notUnique'}
 		
 		setup(
-			document.getElementById('{@$randomFieldNames[username]}'),
-			document.getElementById('{@$randomFieldNames[email]}'),
-			document.getElementById('{@$randomFieldNames[password]}'),
+			document.getElementById('{unsafe:$randomFieldNames[username]|encodeJS}'),
+			document.getElementById('{unsafe:$randomFieldNames[email]|encodeJS}'),
+			document.getElementById('{unsafe:$randomFieldNames[password]|encodeJS}'),
 			{
-				minlength: {@REGISTER_USERNAME_MIN_LENGTH},
-				maxlength: {@REGISTER_USERNAME_MAX_LENGTH}
+				minlength: {REGISTER_USERNAME_MIN_LENGTH},
+				maxlength: {REGISTER_USERNAME_MAX_LENGTH}
 			}
 		);
 	});
 	require(['WoltLabSuite/Core/Ui/User/PasswordStrength', 'Language'], (PasswordStrength, Language) => {
 		{include file='shared_passwordStrengthLanguage'}
 		
-		new PasswordStrength(document.getElementById('{@$randomFieldNames[password]}'), {
+		new PasswordStrength(document.getElementById('{unsafe:$randomFieldNames[password]|encodeJS}'), {
 			relatedInputs: [
-				document.getElementById('{@$randomFieldNames[username]}'),
-				document.getElementById('{@$randomFieldNames[email]}')
+				document.getElementById('{unsafe:$randomFieldNames[username]|encodeJS}'),
+				document.getElementById('{unsafe:$randomFieldNames[email]|encodeJS}')
 			]
 		});
 	});

--- a/com.woltlab.wcf/templates/registerActivation.tpl
+++ b/com.woltlab.wcf/templates/registerActivation.tpl
@@ -4,6 +4,6 @@
 	<woltlab-core-notice type="info">{lang}wcf.user.registerActivation.info{/lang}</woltlab-core-notice>
 {/if}
 
-{@$form->getHtml()}
+{unsafe:$form->getHtml()}
 
 {include file='authFlowFooter'}

--- a/com.woltlab.wcf/templates/registerNewActivationCode.tpl
+++ b/com.woltlab.wcf/templates/registerNewActivationCode.tpl
@@ -1,5 +1,5 @@
 {include file='authFlowHeader'}
 
-{@$form->getHtml()}
+{unsafe:$form->getHtml()}
 
 {include file='authFlowFooter'}

--- a/com.woltlab.wcf/templates/settings.tpl
+++ b/com.woltlab.wcf/templates/settings.tpl
@@ -25,14 +25,14 @@
 							require(['WoltLabSuite/Core/Language/Chooser'], ({ init }) => {
 								const languages = {
 									{implode from=$availableLanguages item=language}
-									'{@$language->languageID}': {
-										iconPath: '{@$language->getIconPath()|encodeJS}',
-										languageName: '{@$language|encodeJS}'
+									'{$language->languageID}': {
+										iconPath: '{unsafe:$language->getIconPath()|encodeJS}',
+										languageName: '{unsafe:$language|encodeJS}'
 									}
 									{/implode}
 								};
 								
-								init('languageIDContainer', 'languageID', {@$languageID}, languages);
+								init('languageIDContainer', 'languageID', {$languageID}, languages);
 							});
 						</script>
 						<noscript>
@@ -104,11 +104,11 @@
 						<ul class="specialTrophyList">
 							{if $__wcf->getSession()->getPermission('user.profile.trophy.maxUserSpecialTrophies') == 1}
 								{foreach from=$availableTrophies item=trophy}
-									<li><label><input type="radio" name="specialTrophies[]" value="{$trophy->getObjectID()}"{if $trophy->getObjectID()|in_array:$specialTrophies} checked{/if}> {@$trophy->renderTrophy(32)} <span>{$trophy->getTitle()}</span></label></li>
+									<li><label><input type="radio" name="specialTrophies[]" value="{$trophy->getObjectID()}"{if $trophy->getObjectID()|in_array:$specialTrophies} checked{/if}> {unsafe:$trophy->renderTrophy(32)} <span>{$trophy->getTitle()}</span></label></li>
 								{/foreach}
 							{else}
 								{foreach from=$availableTrophies item=trophy}
-									<li><label><input type="checkbox" name="specialTrophies[]" value="{$trophy->getObjectID()}"{if $trophy->getObjectID()|in_array:$specialTrophies} checked{/if}> {@$trophy->renderTrophy(32)} <span>{$trophy->getTitle()}</span></label></li>
+									<li><label><input type="checkbox" name="specialTrophies[]" value="{$trophy->getObjectID()}"{if $trophy->getObjectID()|in_array:$specialTrophies} checked{/if}> {unsafe:$trophy->renderTrophy(32)} <span>{$trophy->getTitle()}</span></label></li>
 								{/foreach}
 							{/if}
 						</ul>
@@ -128,8 +128,8 @@
 	
 	{if !$optionTree|empty}
 		{foreach from=$optionTree[0][categories][0][categories] item=optionCategory}
-			<section class="section" id="optionCategory_{@$optionCategory[object]->categoryName}">
-				<h2 class="sectionTitle">{lang}wcf.user.option.category.{@$optionCategory[object]->categoryName}{/lang}</h2>
+			<section class="section" id="optionCategory_{$optionCategory[object]->categoryName}">
+				<h2 class="sectionTitle">{lang}wcf.user.option.category.{$optionCategory[object]->categoryName}{/lang}</h2>
 				
 				{include file='userProfileOptionFieldList' options=$optionCategory[options] langPrefix='wcf.user.option.'}
 			</section>


### PR DESCRIPTION
- Remove unnecessary `@`
- Use `unsafe:` instead of `@`
- Replace deprecated `time` template modifier with `{time}`
- Replace `{pages}` with`<woltlab-core-pagination>`
- Replace jQuery Code with normal JavaScript