### PR TITLE
Refactor language templates

### DIFF
--- a/com.woltlab.wcf/templates/shared_languageChooser.tpl
+++ b/com.woltlab.wcf/templates/shared_languageChooser.tpl
@@ -4,9 +4,9 @@
 {if $languages|count}
 	<dl{if $errorField|isset && $errorField == $__languageChooserPrefix|concat:'languageID'} class="formError"{/if}>
 		<dt>{lang}{$label}{/lang}</dt>
-		<dd id="{@$__languageChooserPrefix}languageIDContainer">
+		<dd id="{$__languageChooserPrefix}languageIDContainer">
 			<noscript>
-				<select name="{@$__languageChooserPrefix}languageID" id="{@$__languageChooserPrefix}languageID">
+				<select name="{$__languageChooserPrefix}languageID" id="{$__languageChooserPrefix}languageID">
 					{foreach from=$languages item=_language}
 						<option value="{$_language->languageID}">{$_language}</option>
 					{/foreach}
@@ -19,14 +19,14 @@
 		require(['WoltLabSuite/Core/Language/Chooser'], function(LanguageChooser) {
 			var languages = {
 				{implode from=$languages item=_language}
-					'{@$_language->languageID}': {
-						iconPath: '{@$_language->getIconPath()|encodeJS}',
-						languageName: '{@$_language|encodeJS}'
+					'{$_language->languageID}': {
+						iconPath: '{unsafe:$_language->getIconPath()|encodeJS}',
+						languageName: '{unsafe:$_language|encodeJS}'
 					}
 				{/implode}
 			};
 			
-			LanguageChooser.init('{@$__languageChooserPrefix}languageIDContainer', '{@$__languageChooserPrefix}languageID', {$languageID}, languages)
+			LanguageChooser.init('{unsafe:$__languageChooserPrefix|encodeJS}languageIDContainer', '{unsafe:$__languageChooserPrefix|encodeJS}languageID', {$languageID}, languages)
 		});
 	</script>
 {/if}

--- a/wcfsetup/install/files/acp/templates/languageAdd.tpl
+++ b/wcfsetup/install/files/acp/templates/languageAdd.tpl
@@ -2,7 +2,7 @@
 
 <header class="contentHeader">
 	<div class="contentHeaderTitle">
-		<h1 class="contentTitle">{lang}wcf.acp.language.{@$action}{/lang}</h1>
+		<h1 class="contentTitle">{lang}wcf.acp.language.{$action}{/lang}</h1>
 	</div>
 	
 	<nav class="contentHeaderNavigation">
@@ -14,6 +14,6 @@
 	</nav>
 </header>
 
-{@$form->getHtml()}
+{unsafe:$form->getHtml()}
 
 {include file='footer'}

--- a/wcfsetup/install/files/acp/templates/languageExport.tpl
+++ b/wcfsetup/install/files/acp/templates/languageExport.tpl
@@ -27,7 +27,7 @@
 						{if $errorType == 'noValidSelection'}
 							{lang}wcf.global.form.error.noValidSelection{/lang}
 						{else}
-							{lang}wcf.acp.language.languageID.error.{@$errorType}{/lang}
+							{lang}wcf.acp.language.languageID.error.{$errorType}{/lang}
 						{/if}
 					</small>
 				{/if}
@@ -48,7 +48,7 @@
 						{if $errorType == 'empty'}
 							{lang}wcf.global.form.error.empty{/lang}
 						{else}
-							{lang}wcf.acp.language.export.package.error.{@$errorType}{/lang}
+							{lang}wcf.acp.language.export.package.error.{$errorType}{/lang}
 						{/if}
 					</small>
 				{/if}

--- a/wcfsetup/install/files/acp/templates/languageImport.tpl
+++ b/wcfsetup/install/files/acp/templates/languageImport.tpl
@@ -51,7 +51,7 @@
 						{if $errorType == 'empty'}
 							{lang}wcf.global.form.error.empty{/lang}
 						{else}
-							{lang}wcf.acp.language.add.source.error.{@$errorType}{/lang}
+							{lang}wcf.acp.language.add.source.error.{$errorType}{/lang}
 						{/if}
 					</small>
 				{/if}
@@ -73,7 +73,7 @@
 						{if $errorType == 'empty'}
 							{lang}wcf.global.form.error.empty{/lang}
 						{else}
-							{lang}wcf.acp.language.add.package.error.{@$errorType}{/lang}
+							{lang}wcf.acp.language.add.package.error.{$errorType}{/lang}
 						{/if}
 					</small>
 				{/if}

--- a/wcfsetup/install/files/acp/templates/languageItemAdd.tpl
+++ b/wcfsetup/install/files/acp/templates/languageItemAdd.tpl
@@ -14,6 +14,6 @@
 	</nav>
 </header>
 
-{@$form->getHtml()}
+{unsafe:$form->getHtml()}
 
 {include file='footer'}

--- a/wcfsetup/install/files/acp/templates/languageMultilingualism.tpl
+++ b/wcfsetup/install/files/acp/templates/languageMultilingualism.tpl
@@ -43,7 +43,7 @@
 				
 				{if $errorField == 'languageIDs'}
 					<small class="innerError">
-						{lang}wcf.acp.language.multilingualism.languages.error.{@$errorType}{/lang}
+						{lang}wcf.acp.language.multilingualism.languages.error.{$errorType}{/lang}
 					</small>
 				{/if}
 			</dd>


### PR DESCRIPTION
- Remove unnecessary `@`
- Use `unsafe:` instead of `@`
- Add missing `{unsafe:…|encodeJS}`