### PR TITLE
Refactor acp form templates

### DIFF
--- a/wcfsetup/install/files/acp/templates/__objectTypePipGui.tpl
+++ b/wcfsetup/install/files/acp/templates/__objectTypePipGui.tpl
@@ -3,13 +3,13 @@
 		Language.addObject({
 			'wcf.form.field.className.description.interface': '{jslang __literal=true}wcf.form.field.className.description.interface{/jslang}',
 			{implode from=$definitionNames item=definitionName}
-				'wcf.acp.pip.objectType.definitionName.{@$definitionName}.description': '{jslang __literal=true __optional=true}wcf.acp.pip.objectType.definitionName.{@$definitionName}.description{/jslang}'
+				'wcf.acp.pip.objectType.definitionName.{$definitionName}.description': '{jslang __literal=true __optional=true}wcf.acp.pip.objectType.definitionName.{$definitionName}.description{/jslang}'
 			{/implode}
 		});
 		
 		var definitionInterfaces = {
 			{implode from=$definitionInterfaces key=definitionID item=interfaceName}
-				{@$definitionID}: '{@$interfaceName|encodeJS}'
+				{$definitionID}: '{unsafe:$interfaceName|encodeJS}'
 			{/implode}
 		};
 		

--- a/wcfsetup/install/files/acp/templates/__pageAddContent.tpl
+++ b/wcfsetup/install/files/acp/templates/__pageAddContent.tpl
@@ -2,8 +2,8 @@
 
 {if $pageType == 'html' || $pageType == 'tpl'}
 	<ul class="codemirrorToolbar">
-		<li><button type="button" id="codemirror-{@$__pageContentID}-media" class="jsTooltip" title="{lang}wcf.editor.button.media{/lang}">{icon name='file'}</button></li>
-		<li><button type="button" id="codemirror-{@$__pageContentID}-page" class="jsTooltip" title="{lang}wcf.editor.button.page{/lang}">{icon name='file-lines'}</button></li>
+		<li><button type="button" id="codemirror-{$__pageContentID}-media" class="jsTooltip" title="{lang}wcf.editor.button.media{/lang}">{icon name='file'}</button></li>
+		<li><button type="button" id="codemirror-{$__pageContentID}-page" class="jsTooltip" title="{lang}wcf.editor.button.page{/lang}">{icon name='file-lines'}</button></li>
 	</ul>
 	<script data-relocate="true">
 		{include file='mediaJavaScript'}
@@ -25,27 +25,27 @@
 				'wcf.page.search.results': '{jslang}wcf.page.search.results{/jslang}',
 			});
 			
-			new AcpUiCodeMirrorMedia('{@$__pageContentID}');
-			new AcpUiCodeMirrorPage('{@$__pageContentID}');
+			new AcpUiCodeMirrorMedia('{unsafe:$__pageContentID|encodeJS}');
+			new AcpUiCodeMirrorPage('{unsafe:$__pageContentID|encodeJS}');
 		});
 	</script>
 {/if}
 
 {if $pageType == 'text'}
-	<textarea name="content[{@$languageID}]" id="{@$__pageContentID}"
+	<textarea name="content[{$languageID}]" id="{$__pageContentID}"
 		{if $pageType == 'text'}
-			class="wysiwygTextarea" data-disable-attachments="true" data-autosave="com.woltlab.wcf.page{$action|ucfirst}-{if $action == 'edit'}{@$pageID}{else}0{/if}-{@$languageID}"
-			{if $action === 'edit'}data-autosave-last-edit-time="{@$page->lastUpdateTime}"{/if}
+			class="wysiwygTextarea" data-disable-attachments="true" data-autosave="com.woltlab.wcf.page{$action|ucfirst}-{if $action == 'edit'}{$pageID}{else}0{/if}-{$languageID}"
+			{if $action === 'edit'}data-autosave-last-edit-time="{$page->lastUpdateTime}"{/if}
 		{/if}
 	>{if !$content[$languageID]|empty}{$content[$languageID]}{/if}</textarea>
 	{include file='shared_wysiwygCmsToolbar' wysiwygSelector=$__pageContentID}
 	{include file='shared_wysiwyg' wysiwygSelector=$__pageContentID}
 {else}
 	<div dir="ltr">
-		<textarea name="content[{@$languageID}]" id="{@$__pageContentID}"
+		<textarea name="content[{$languageID}]" id="{$__pageContentID}"
 			{if $pageType == 'text'}
-				class="wysiwygTextarea" data-disable-attachments="true" data-autosave="com.woltlab.wcf.page{$action|ucfirst}-{if $action == 'edit'}{@$pageID}{else}0{/if}-{@$languageID}"
-				{if $action === 'edit'}data-autosave-last-edit-time="{@$page->lastUpdateTime}"{/if}
+				class="wysiwygTextarea" data-disable-attachments="true" data-autosave="com.woltlab.wcf.page{$action|ucfirst}-{if $action == 'edit'}{$pageID}{else}0{/if}-{$languageID}"
+				{if $action === 'edit'}data-autosave-last-edit-time="{$page->lastUpdateTime}"{/if}
 			{/if}
 		>{if !$content[$languageID]|empty}{$content[$languageID]}{/if}</textarea>
 	</div>

--- a/wcfsetup/install/files/acp/templates/__pageObjectIDFormField.tpl
+++ b/wcfsetup/install/files/acp/templates/__pageObjectIDFormField.tpl
@@ -32,11 +32,11 @@
 			{foreach from=$pageNodeList item=pageNode}
 			{capture assign='pageObjectIDLanguageItem'}{lang __optional=true}wcf.page.pageObjectID.{$pageNode->identifier}{/lang}{/capture}
 			{if $pageObjectIDLanguageItem}
-				'wcf.page.pageObjectID.{$pageNode->identifier}': '{@$pageObjectIDLanguageItem|encodeJS}',
+				'wcf.page.pageObjectID.{$pageNode->identifier}': '{unsafe:$pageObjectIDLanguageItem|encodeJS}',
 			{/if}
 			{capture assign='pageObjectIDLanguageItem'}{lang __optional=true}wcf.page.pageObjectID.search.{$pageNode->identifier}{/lang}{/capture}
 			{if $pageObjectIDLanguageItem}
-				'wcf.page.pageObjectID.search.{$pageNode->identifier}': '{@$pageObjectIDLanguageItem|encodeJS}',
+				'wcf.page.pageObjectID.search.{$pageNode->identifier}': '{unsafe:$pageObjectIDLanguageItem|encodeJS}',
 			{/if}
 			{/foreach}
 		});

--- a/wcfsetup/install/files/acp/templates/adAdd.tpl
+++ b/wcfsetup/install/files/acp/templates/adAdd.tpl
@@ -3,7 +3,7 @@
 <script data-relocate="true">
 	$(function() {
 		new WCF.ACP.Ad.LocationHandler({
-			{implode from=$variablesDescriptions key=objectType item=description}'{$objectType}': '{@$description|encodeJS}'{/implode}
+			{implode from=$variablesDescriptions key=objectType item=description}'{$objectType}': '{unsafe:$description|encodeJS}'{/implode}
 		});
 	});
 </script>
@@ -73,7 +73,7 @@
 					<option value="0"{if !$objectTypeID} selected{/if}>{lang}wcf.global.noSelection{/lang}</option>
 					{foreach from=$locations key='locationGroupLabel' item='locationGroup'}
 						{assign var='__firstLocationID' value=$locationGroup|key}
-						<optgroup label="{$locationGroupLabel}" data-category-name="{@$locationObjectTypes[$__firstLocationID]->categoryname}">
+						<optgroup label="{$locationGroupLabel}" data-category-name="{$locationObjectTypes[$__firstLocationID]->categoryname}">
 							{foreach from=$locationGroup key='locationID' item='location'}
 								<option value="{$locationID}"{if $locationObjectTypes[$locationID]->page} data-page="{$locationObjectTypes[$locationID]->page}"{/if}{if $objectTypeID == $locationID} selected{/if}>{$location}</option>
 							{/foreach}
@@ -120,7 +120,7 @@
 			</header>
 			
 			{foreach from=$groupedConditionObjectTypes['com.woltlab.wcf.page'] item='pageConditionObjectType'}
-				{@$pageConditionObjectType->getProcessor()->getHtml()}
+				{unsafe:$pageConditionObjectType->getProcessor()->getHtml()}
 			{/foreach}
 		</section>
 		
@@ -131,7 +131,7 @@
 			</header>
 				
 			{foreach from=$groupedConditionObjectTypes['com.woltlab.wcf.pointInTime'] item='pointInTimeConditionObjectType'}
-				{@$pointInTimeConditionObjectType->getProcessor()->getHtml()}
+				{unsafe:$pointInTimeConditionObjectType->getProcessor()->getHtml()}
 			{/foreach}
 		</section>
 		

--- a/wcfsetup/install/files/acp/templates/applicationManagement.tpl
+++ b/wcfsetup/install/files/acp/templates/applicationManagement.tpl
@@ -104,7 +104,7 @@
 									
 									{foreach from=$pageNodeList item=pageNode}
 										{if !$pageNode->isDisabled && !$pageNode->requireObjectID && !$pageNode->excludeFromLandingPage}
-											<option value="{$pageNode->pageID}"{if $pageNode->pageID == $application->landingPageID} selected{/if} data-identifier="{@$pageNode->identifier}">{if $pageNode->getDepth() > 1}{@"&nbsp;&nbsp;&nbsp;&nbsp;"|str_repeat:($pageNode->getDepth() - 1)}{/if}{$pageNode->name}</option>
+											<option value="{$pageNode->pageID}"{if $pageNode->pageID == $application->landingPageID} selected{/if} data-identifier="{$pageNode->identifier}">{if $pageNode->getDepth() > 1}{unsafe:"&nbsp;&nbsp;&nbsp;&nbsp;"|str_repeat:($pageNode->getDepth() - 1)}{/if}{$pageNode->name}</option>
 										{/if}
 									{/foreach}
 								</select>

--- a/wcfsetup/install/files/acp/templates/bbcodeAdd.tpl
+++ b/wcfsetup/install/files/acp/templates/bbcodeAdd.tpl
@@ -10,30 +10,30 @@
 		</h2>
 		
 		<dl>
-			<dt><label for="attributes[{ldelim}@$attributeNo}][attributeHtml]">{lang}wcf.acp.bbcode.attribute.attributeHtml{/lang}</label></dt>
+			<dt><label for="attributes[{ldelim}$attributeNo}][attributeHtml]">{lang}wcf.acp.bbcode.attribute.attributeHtml{/lang}</label></dt>
 			<dd>
-				<input type="text" id="attributes[{ldelim}@$attributeNo}][attributeHtml]" name="attributes[{ldelim}@$attributeNo}][attributeHtml]" value="" class="long">
+				<input type="text" id="attributes[{ldelim}$attributeNo}][attributeHtml]" name="attributes[{ldelim}$attributeNo}][attributeHtml]" value="" class="long">
 			</dd>
 		</dl>
 		
 		<dl>
-			<dt><label for="attributes[{ldelim}@$attributeNo}][validationPattern]">{lang}wcf.acp.bbcode.attribute.validationPattern{/lang}</label></dt>
+			<dt><label for="attributes[{ldelim}$attributeNo}][validationPattern]">{lang}wcf.acp.bbcode.attribute.validationPattern{/lang}</label></dt>
 			<dd>
-				<input type="text" id="attributes[{ldelim}@$attributeNo}][validationPattern]" name="attributes[{ldelim}@$attributeNo}][validationPattern]" value="" class="long">
-			</dd>
-		</dl>
-		
-		<dl>
-			<dt></dt>
-			<dd>
-				<label for="attributes[{ldelim}@$attributeNo}][required]"><input type="checkbox" id="attributes[{ldelim}@$attributeNo}][required]" name="attributes[{ldelim}@$attributeNo}][required]" value="1"> {lang}wcf.acp.bbcode.attribute.required{/lang}</label>
+				<input type="text" id="attributes[{ldelim}$attributeNo}][validationPattern]" name="attributes[{ldelim}$attributeNo}][validationPattern]" value="" class="long">
 			</dd>
 		</dl>
 		
 		<dl>
 			<dt></dt>
 			<dd>
-				<label for="attributes[{ldelim}@$attributeNo}][useText]"><input type="checkbox" id="attributes[{ldelim}@$attributeNo}][useText]" name="attributes[{ldelim}@$attributeNo}][useText]" value="1"> {lang}wcf.acp.bbcode.attribute.useText{/lang}</label>
+				<label for="attributes[{ldelim}$attributeNo}][required]"><input type="checkbox" id="attributes[{ldelim}$attributeNo}][required]" name="attributes[{ldelim}$attributeNo}][required]" value="1"> {lang}wcf.acp.bbcode.attribute.required{/lang}</label>
+			</dd>
+		</dl>
+		
+		<dl>
+			<dt></dt>
+			<dd>
+				<label for="attributes[{ldelim}$attributeNo}][useText]"><input type="checkbox" id="attributes[{ldelim}$attributeNo}][useText]" name="attributes[{ldelim}$attributeNo}][useText]" value="1"> {lang}wcf.acp.bbcode.attribute.useText{/lang}</label>
 				<small>{lang}wcf.acp.bbcode.attribute.useText.description{/lang}</small>
 			</dd>
 		</dl>
@@ -50,7 +50,7 @@
 			});
 			
 			var attributeNo = {if !$attributes|count}0{else}{assign var='lastAttribute' value=$attributes|end}{$lastAttribute->attributeNo+1}{/if};
-			var attributeTemplate = new Template('{@$attributeTemplate|encodeJS}');
+			var attributeTemplate = new Template('{unsafe:$attributeTemplate|encodeJS}');
 			
 			$('.jsAddButton').click(function (event) {
 				var $html = $($.parseHTML(attributeTemplate.fetch({ attributeNo: attributeNo++ })));
@@ -180,7 +180,7 @@
 							{elseif $errorType == 'multilingual'}
 								{lang}wcf.global.form.error.multilingual{/lang}
 							{else}
-								{lang}wcf.acp.bbcode.buttonLabel.error.{@$errorType}{/lang}
+								{lang}wcf.acp.bbcode.buttonLabel.error.{$errorType}{/lang}
 							{/if}
 						</small>
 					{/if}
@@ -201,7 +201,7 @@
 							{if $errorType == 'empty'}
 								{lang}wcf.global.form.error.empty{/lang}
 							{else}
-								{lang}wcf.acp.bbcode.wysiwygIcon.error.{@$errorType}{/lang}
+								{lang}wcf.acp.bbcode.wysiwygIcon.error.{$errorType}{/lang}
 							{/if}
 						</small>
 					{/if}
@@ -231,16 +231,16 @@
 				</h2>
 				
 				<dl{if $errorField == 'attributeHtml'|concat:$attribute->attributeNo} class="formError"{/if}>
-					<dt><label for="attributes[{@$attribute->attributeNo}][attributeHtml]">{lang}wcf.acp.bbcode.attribute.attributeHtml{/lang}</label></dt>
+					<dt><label for="attributes[{$attribute->attributeNo}][attributeHtml]">{lang}wcf.acp.bbcode.attribute.attributeHtml{/lang}</label></dt>
 					<dd>
-						<input type="text" id="attributes[{@$attribute->attributeNo}][attributeHtml]" name="attributes[{@$attribute->attributeNo}][attributeHtml]" value="{$attribute->attributeHtml}" class="long">
+						<input type="text" id="attributes[{$attribute->attributeNo}][attributeHtml]" name="attributes[{$attribute->attributeNo}][attributeHtml]" value="{$attribute->attributeHtml}" class="long">
 					</dd>
 				</dl>
 				
 				<dl{if $errorField == 'attributeValidationPattern'|concat:$attribute->attributeNo} class="formError"{/if}>
-					<dt><label for="attributes[{@$attribute->attributeNo}][validationPattern]">{lang}wcf.acp.bbcode.attribute.validationPattern{/lang}</label></dt>
+					<dt><label for="attributes[{$attribute->attributeNo}][validationPattern]">{lang}wcf.acp.bbcode.attribute.validationPattern{/lang}</label></dt>
 					<dd>
-						<input type="text" id="attributes[{@$attribute->attributeNo}][validationPattern]" name="attributes[{@$attribute->attributeNo}][validationPattern]" value="{$attribute->validationPattern}" class="long">
+						<input type="text" id="attributes[{$attribute->attributeNo}][validationPattern]" name="attributes[{$attribute->attributeNo}][validationPattern]" value="{$attribute->validationPattern}" class="long">
 						{if $errorField == 'attributeValidationPattern'|concat:$attribute->attributeNo}
 							<small class="innerError">
 								{if $errorType == 'invalid'}
@@ -253,13 +253,13 @@
 				
 				<dl{if $errorField == 'attributeRequired'|concat:$attribute->attributeNo} class="formError"{/if}>
 					<dd>
-						<label for="attributes[{@$attribute->attributeNo}][required]"><input type="checkbox" id="attributes[{@$attribute->attributeNo}][required]" name="attributes[{@$attribute->attributeNo}][required]" value="1"{if $attribute->required} checked{/if}> {lang}wcf.acp.bbcode.attribute.required{/lang}</label>
+						<label for="attributes[{$attribute->attributeNo}][required]"><input type="checkbox" id="attributes[{$attribute->attributeNo}][required]" name="attributes[{$attribute->attributeNo}][required]" value="1"{if $attribute->required} checked{/if}> {lang}wcf.acp.bbcode.attribute.required{/lang}</label>
 					</dd>
 				</dl>
 				
 				<dl{if $errorField == 'attributeUseText'|concat:$attribute->attributeNo} class="formError"{/if}>
 					<dd>
-						<label for="attributes[{@$attribute->attributeNo}][useText]"><input type="checkbox" id="attributes[{@$attribute->attributeNo}][useText]" name="attributes[{@$attribute->attributeNo}][useText]" value="1"{if $attribute->useText} checked{/if}> {lang}wcf.acp.bbcode.attribute.useText{/lang}</label>
+						<label for="attributes[{$attribute->attributeNo}][useText]"><input type="checkbox" id="attributes[{$attribute->attributeNo}][useText]" name="attributes[{$attribute->attributeNo}][useText]" value="1"{if $attribute->useText} checked{/if}> {lang}wcf.acp.bbcode.attribute.useText{/lang}</label>
 						<small>{lang}wcf.acp.bbcode.attribute.useText.description{/lang}</small>
 					</dd>
 				</dl>

--- a/wcfsetup/install/files/acp/templates/bbcodeAdd.tpl
+++ b/wcfsetup/install/files/acp/templates/bbcodeAdd.tpl
@@ -43,37 +43,45 @@
 {/capture}
 
 <script data-relocate="true">
-	require(['WoltLabSuite/Core/Template'], (Template) => {
-		$(function() {
-			$('.jsDeleteButton').click(function (event) {
-				$(event.target).parent().parent().remove();
+	require(['WoltLabSuite/Core/Template', 'WoltLabSuite/Core/Dom/Util'], (Template, { hide, show }) => {
+		document.querySelectorAll('.jsDeleteButton').forEach((btn) => {
+			btn.addEventListener('click', () => {
+				btn.closest('.section').remove();
 			});
-			
-			var attributeNo = {if !$attributes|count}0{else}{assign var='lastAttribute' value=$attributes|end}{$lastAttribute->attributeNo+1}{/if};
-			var attributeTemplate = new Template('{unsafe:$attributeTemplate|encodeJS}');
-			
-			$('.jsAddButton').click(function (event) {
-				var $html = $($.parseHTML(attributeTemplate.fetch({ attributeNo: attributeNo++ })));
-				$html.find('.jsDeleteButton').click(function (event) {
-					$(event.target).parent().parent().remove();
-				});
-				$('#attributeFieldset').append($html);
-			});
-			
-			var $buttonSettings = $('.jsButtonSetting');
-			var $showButton = $('#showButton');
-			function toggleButtonSettings() {
-				if ($showButton.is(':checked')) {
-					$buttonSettings.show();
-				}
-				else {
-					$buttonSettings.hide();
-				}
-			}
-			
-			$showButton.change(toggleButtonSettings);
-			toggleButtonSettings();
 		});
+
+		let attributeNo = {if !$attributes|count}0{else}{assign var='lastAttribute' value=$attributes|end}{$lastAttribute->attributeNo+1}{/if};
+		const attributeTemplate = new Template('{unsafe:$attributeTemplate|encodeJS}');
+
+		document.querySelectorAll('.jsAddButton').forEach((btn) => {
+			btn.addEventListener('click', () => {
+				const html = attributeTemplate.fetch({ attributeNo: attributeNo++ });
+				const tempDiv = document.createElement('div');
+				tempDiv.innerHTML = html;
+				const section = tempDiv.firstElementChild;
+				section.querySelectorAll('.jsDeleteButton').forEach((delBtn) => {
+					delBtn.addEventListener('click', () => {
+						delBtn.closest('.section').remove();
+					});
+				});
+				document.getElementById('attributeFieldset').appendChild(section);
+			});
+		});
+
+		const buttonSettings = document.querySelectorAll('.jsButtonSetting');
+		const showButton = document.getElementById('showButton');
+		function toggleButtonSettings() {
+			if (showButton.checked) {
+				buttonSettings.forEach(el => show(el));
+			} else {
+				buttonSettings.forEach(el => hide(el));
+			}
+		}
+
+		if (showButton) {
+			showButton.addEventListener('change', toggleButtonSettings);
+			toggleButtonSettings();
+		}
 	});
 </script>
 

--- a/wcfsetup/install/files/acp/templates/bulkProcessing.tpl
+++ b/wcfsetup/install/files/acp/templates/bulkProcessing.tpl
@@ -34,7 +34,7 @@
 				dialogTitle: '{jslang}{$pageTitle}{/jslang}',
 				className: "wcf\\system\\worker\\BulkProcessingWorker",
 				parameters: {
-					bulkProcessingID: {@$bulkProcessingID},
+					bulkProcessingID: {$bulkProcessingID},
 				},
 			});
 		});
@@ -63,12 +63,12 @@
 			<dt></dt>
 			<dd>
 				{foreach from=$actions item=actionObjectType}
-					<label><input type="radio" name="action" value="{$actionObjectType->action}"{if $actionObjectType->action == $action} checked{/if}> {lang}{$objectType->getProcessor()->getLanguageItemPrefix()}.{@$actionObjectType->action}{/lang}</label>
+					<label><input type="radio" name="action" value="{$actionObjectType->action}"{if $actionObjectType->action == $action} checked{/if}> {lang}{$objectType->getProcessor()->getLanguageItemPrefix()}.{$actionObjectType->action}{/lang}</label>
 				{/foreach}
 				
 				{if $errorField == 'action'}
 					<small class="innerError">
-						{lang}wcf.global.form.error.{@$errorType}{/lang}
+						{lang}wcf.global.form.error.{$errorType}{/lang}
 					</small>
 				{/if}
 			</dd>
@@ -77,10 +77,10 @@
 	
 	{foreach from=$actions item=actionObjectType}
 		{if $actionObjectType->getProcessor()->getHTML()}
-			<section class="section jsBulkProcessingActionSettings" data-action="{@$actionObjectType->action}" {if $actionObjectType->action != $action}style="display: none;"{/if}>
-				<h2 class="sectionTitle">{lang}{$objectType->getProcessor()->getLanguageItemPrefix()}.{@$actionObjectType->action}{/lang}</h2>
+			<section class="section jsBulkProcessingActionSettings" data-action="{$actionObjectType->action}" {if $actionObjectType->action != $action}style="display: none;"{/if}>
+				<h2 class="sectionTitle">{lang}{$objectType->getProcessor()->getLanguageItemPrefix()}.{$actionObjectType->action}{/lang}</h2>
 				
-				{@$actionObjectType->getProcessor()->getHTML()}
+				{unsafe:$actionObjectType->getProcessor()->getHTML()}
 			</section>
 		{/if}
 	{/foreach}
@@ -91,7 +91,7 @@
 			{hascontent}<p class="sectionDescription">{content}{lang __optional=true}{$objectType->getProcessor()->getLanguageItemPrefix()}.conditions.descriptions{/lang}{/content}</p>{/hascontent}
 		</header>
 		
-		{@$objectType->getProcessor()->getConditionHTML()}
+		{unsafe:$objectType->getProcessor()->getConditionHTML()}
 	</section>
 	
 	<div class="formSubmit">

--- a/wcfsetup/install/files/acp/templates/categoryAddFormBuilder.tpl
+++ b/wcfsetup/install/files/acp/templates/categoryAddFormBuilder.tpl
@@ -2,7 +2,7 @@
 
 <header class="contentHeader">
 	<div class="contentHeaderTitle">
-		<h1 class="contentTitle">{@$objectType->getProcessor()->getLanguageVariable($action)}</h1>
+		<h1 class="contentTitle">{unsafe:$objectType->getProcessor()->getLanguageVariable($action)}</h1>
 	</div>
 
 	{hascontent}
@@ -12,7 +12,7 @@
 					{if $action == 'edit' && $categoryNodeList !== null && $categoryNodeList->hasChildren()}
 						<li class="dropdown">
 							<a class="button dropdownToggle">
-								{icon name='sort'} <span>{@$objectType->getProcessor()->getLanguageVariable('button.choose')}</span>
+								{icon name='sort'} <span>{unsafe:$objectType->getProcessor()->getLanguageVariable('button.choose')}</span>
 							</a>
 							<div class="dropdownMenu">
 								<ul class="scrollableDropdownMenu">
@@ -28,7 +28,7 @@
 
 					{if $objectType->getProcessor()->canDeleteCategory() || $objectType->getProcessor()->canEditCategory()}
 						<li>
-							<a href="{link controller=$listController application=$objectType->getProcessor()->getApplication()}{/link}" class="button">{icon name='list'} <span>{@$objectType->getProcessor()->getLanguageVariable('button.list')}</span></a>
+							<a href="{link controller=$listController application=$objectType->getProcessor()->getApplication()}{/link}" class="button">{icon name='list'} <span>{unsafe:$objectType->getProcessor()->getLanguageVariable('button.list')}</span></a>
 						</li>
 					{/if}
 
@@ -39,6 +39,6 @@
 	{/hascontent}
 </header>
 
-{@$form->getHtml()}
+{unsafe:$form->getHtml()}
 
 {include file='footer'}

--- a/wcfsetup/install/files/acp/templates/contactRecipientAdd.tpl
+++ b/wcfsetup/install/files/acp/templates/contactRecipientAdd.tpl
@@ -2,7 +2,7 @@
 
 <header class="contentHeader">
 	<div class="contentHeaderTitle">
-		<h1 class="contentTitle">{lang}wcf.acp.contact.recipient.{@$action}{/lang}</h1>
+		<h1 class="contentTitle">{lang}wcf.acp.contact.recipient.{$action}{/lang}</h1>
 	</div>
 	
 	<nav class="contentHeaderNavigation">

--- a/wcfsetup/install/files/acp/templates/dataImport.tpl
+++ b/wcfsetup/install/files/acp/templates/dataImport.tpl
@@ -6,11 +6,11 @@
 			Language.addObject({
 				'wcf.acp.dataImport': '{jslang}wcf.acp.dataImport{/jslang}',
 				'wcf.acp.dataImport.completed': '{jslang}wcf.acp.dataImport.completed{/jslang}',
-				{implode from=$importers item=importer}'wcf.acp.dataImport.data.{@$importer}': '{jslang}wcf.acp.dataImport.data.{@$importer}{/jslang}'{/implode}
+				{implode from=$importers item=importer}'wcf.acp.dataImport.data.{$importer}': '{jslang}wcf.acp.dataImport.data.{$importer}{/jslang}'{/implode}
 			});
 			
-			const queue = [ {implode from=$queue item=item}'{@$item}'{/implode} ];
-			new AcpUiDataImportManager(queue, '{link controller='RebuildData' encode=false}{/link}', '{$cacheClearEndpoint|encodeJS}');
+			const queue = [ {implode from=$queue item=item}'{unsafe:$item|encodeJS}'{/implode} ];
+			new AcpUiDataImportManager(queue, '{link controller='RebuildData' encode=false}{/link}', '{unsafe:$cacheClearEndpoint|encodeJS}');
 		});
 	</script>
 {/if}
@@ -38,7 +38,7 @@
 	<div class="contentHeaderTitle">
 		<h1 class="contentTitle">{lang}wcf.acp.dataImport{/lang}</h1>
 		{if $exporterName}
-			<p class="contentHeaderDescription">{lang}wcf.acp.dataImport.exporter.{@$exporterName}{/lang}</p>
+			<p class="contentHeaderDescription">{lang}wcf.acp.dataImport.exporter.{$exporterName}{/lang}</p>
 		{/if}
 	</div>
 	
@@ -75,7 +75,7 @@
 					<dd>
 						<select name="exporterName" id="exporterName">
 							{foreach from=$availableExporters key=availableExporterName item=availableExporter}
-								<option value="{$availableExporterName}">{lang}wcf.acp.dataImport.exporter.{@$availableExporterName}{/lang}</option>
+								<option value="{$availableExporterName}">{lang}wcf.acp.dataImport.exporter.{$availableExporterName}{/lang}</option>
 							{/foreach}
 						</select>
 						{if $errorField == 'exporterName'}
@@ -83,7 +83,7 @@
 								{if $errorType == 'empty'}
 									{lang}wcf.global.form.error.empty{/lang}
 								{else}
-									{lang}wcf.acp.dataImport.exporterName.error.{@$errorType}{/lang}
+									{lang}wcf.acp.dataImport.exporterName.error.{$errorType}{/lang}
 								{/if}
 							</small>
 						{/if}
@@ -112,10 +112,10 @@
 				<dl class="wide">
 					<dt></dt>
 					<dd class="jsImportCollection">
-						<label><input type="checkbox" name="selectedData[]" value="{$objectTypeName}" class="jsImportSection"{if $objectTypeName|in_array:$selectedData} checked{/if}> {lang}wcf.acp.dataImport.data.{@$objectTypeName}{/lang}</label>
+						<label><input type="checkbox" name="selectedData[]" value="{$objectTypeName}" class="jsImportSection"{if $objectTypeName|in_array:$selectedData} checked{/if}> {lang}wcf.acp.dataImport.data.{$objectTypeName}{/lang}</label>
 						<p>
 							{foreach from=$objectTypes item=objectTypeName}
-								<label><input type="checkbox" name="selectedData[]" value="{$objectTypeName}" class="jsImportItem"{if $objectTypeName|in_array:$selectedData} checked{/if}> {lang}wcf.acp.dataImport.data.{@$objectTypeName}{/lang}</label>
+								<label><input type="checkbox" name="selectedData[]" value="{$objectTypeName}" class="jsImportItem"{if $objectTypeName|in_array:$selectedData} checked{/if}> {lang}wcf.acp.dataImport.data.{$objectTypeName}{/lang}</label>
 							{/foreach}
 						</p>
 					</dd>
@@ -189,7 +189,7 @@
 							{if $errorType == 'empty'}
 								{lang}wcf.global.form.error.empty{/lang}
 							{else}
-								{lang}wcf.acp.dataImport.configure.database.error.{@$errorType}{/lang}
+								{lang}wcf.acp.dataImport.configure.database.error.{$errorType}{/lang}
 							{/if}
 						</small>
 					{/if}
@@ -211,7 +211,7 @@
 							{if $errorType == 'empty'}
 								{lang}wcf.global.form.error.empty{/lang}
 							{else}
-								{lang}wcf.acp.dataImport.configure.fileSystem.path.error.{@$errorType}{/lang}
+								{lang}wcf.acp.dataImport.configure.fileSystem.path.error.{$errorType}{/lang}
 							{/if}
 						</small>
 					{/if}

--- a/wcfsetup/install/files/acp/templates/firstTimeSetupLicense.tpl
+++ b/wcfsetup/install/files/acp/templates/firstTimeSetupLicense.tpl
@@ -6,6 +6,6 @@
 	</div>
 </header>
 
-{@$form->getHtml()}
+{unsafe:$form->getHtml()}
 
 {include file='footer'}

--- a/wcfsetup/install/files/acp/templates/labelGroupAdd.tpl
+++ b/wcfsetup/install/files/acp/templates/labelGroupAdd.tpl
@@ -53,9 +53,9 @@
 						{if $errorField == 'groupName'}
 							<small class="innerError">
 								{if $errorType == 'empty' || $errorType == 'multilingual'}
-									{lang}wcf.global.form.error.{@$errorType}{/lang}
+									{lang}wcf.global.form.error.{$errorType}{/lang}
 								{else}
-									{lang}wcf.acp.label.group.groupName.error.{@$errorType}{/lang}
+									{lang}wcf.acp.label.group.groupName.error.{$errorType}{/lang}
 								{/if}
 							</small>
 						{/if}
@@ -75,7 +75,7 @@
 				<dl>
 					<dt><label for="showOrder">{lang}wcf.global.showOrder{/lang}</label></dt>
 					<dd>
-						<input type="number" min="0" id="showOrder" name="showOrder" class="tiny" value="{if $showOrder}{@$showOrder}{/if}">
+						<input type="number" min="0" id="showOrder" name="showOrder" class="tiny" value="{if $showOrder}{$showOrder}{/if}">
 					</dd>
 				</dl>
 				
@@ -103,9 +103,9 @@
 						<dd>
 							<ul class="structuredList">
 								{foreach from=$container item=objectType}
-									<li class="{if $objectType->isCategory()} category{/if}"{if $objectType->getDepth()} style="padding-left: {$objectType->getDepth() * 20}px"{/if} data-depth="{@$objectType->getDepth()}">
+									<li class="{if $objectType->isCategory()} category{/if}"{if $objectType->getDepth()} style="padding-left: {$objectType->getDepth() * 20}px"{/if} data-depth="{$objectType->getDepth()}">
 										<span>{$objectType->getLabel()}</span>
-										<label><input id="checkbox_{@$container->getObjectTypeID()}_{@$objectType->getObjectID()}" type="checkbox" name="objectTypes[{@$container->getObjectTypeID()}][]" value="{$objectType->getObjectID()}"{if $objectType->getOptionValue()} checked{/if}></label>
+										<label><input id="checkbox_{$container->getObjectTypeID()}_{$objectType->getObjectID()}" type="checkbox" name="objectTypes[{$container->getObjectTypeID()}][]" value="{$objectType->getObjectID()}"{if $objectType->getOptionValue()} checked{/if}></label>
 									</li>
 								{/foreach}
 							</ul>

--- a/wcfsetup/install/files/acp/templates/licenseEdit.tpl
+++ b/wcfsetup/install/files/acp/templates/licenseEdit.tpl
@@ -25,6 +25,6 @@
 	{/hascontent}
 </header>
 
-{@$form->getHtml()}
+{unsafe:$form->getHtml()}
 
 {include file='footer'}

--- a/wcfsetup/install/files/acp/templates/mediaEditor.tpl
+++ b/wcfsetup/install/files/acp/templates/mediaEditor.tpl
@@ -35,7 +35,7 @@
 		
 		{if $media->downloads}
 			<dt>{lang}wcf.media.lastDownloadTime{/lang}</dt>
-			<dd id="mediaDownloads">{@$media->lastDownloadTime|time}</dd>
+			<dd id="mediaDownloads">{time time=$media->lastDownloadTime}</dd>
 		{/if}
 	</dl>
 </div>

--- a/wcfsetup/install/files/acp/templates/mediaEditor.tpl
+++ b/wcfsetup/install/files/acp/templates/mediaEditor.tpl
@@ -4,7 +4,7 @@
 
 {if $media->isImage && $media->hasThumbnail('small')}
 	<div class="mediaThumbnail">
-		{@$media->getThumbnailTag('small')}
+		{unsafe:$media->getThumbnailTag('small')}
 	</div>
 {/if}
 
@@ -12,7 +12,7 @@
 	{if $media->isImage}
 		{icon size=48 name='file-image'}
 	{else}
-		{@$media->getElementTag(48)}
+		{unsafe:$media->getElementTag(48)}
 	{/if}
 	
 	<dl class="plain dataList">
@@ -20,7 +20,7 @@
 		<dd id="mediaFilename">{$media->filename}</dd>
 		
 		<dt>{lang}wcf.media.filesize{/lang}</dt>
-		<dd id="mediaFilesize">{@$media->filesize|filesize}</dd>
+		<dd id="mediaFilesize">{$media->filesize|filesize}</dd>
 		
 		{if $media->isImage}
 			<dt>{lang}wcf.media.imageDimensions{/lang}</dt>
@@ -45,9 +45,9 @@
 	
 	{hascontent}
 		<dl>
-			<dt><label for="categoryID_{@$media->mediaID}">{lang}wcf.global.category{/lang}</label></dt>
+			<dt><label for="categoryID_{$media->mediaID}">{lang}wcf.global.category{/lang}</label></dt>
 			<dd>
-				<select id="categoryID_{@$media->mediaID}" name="categoryID">
+				<select id="categoryID_{$media->mediaID}" name="categoryID">
 					<option value="0">{lang}wcf.global.noSelection{/lang}</option>
 					
 					{content}
@@ -86,9 +86,9 @@
 	{/if}
 	
 	<dl>
-		<dt><label for="title_{@$media->mediaID}">{lang}wcf.global.title{/lang}</label></dt>
+		<dt><label for="title_{$media->mediaID}">{lang}wcf.global.title{/lang}</label></dt>
 		<dd>
-			<input type="text" id="title_{@$media->mediaID}" name="title" class="long">
+			<input type="text" id="title_{$media->mediaID}" name="title" class="long">
 		</dd>
 	</dl>
 	{if $availableLanguages|count > 1}
@@ -97,9 +97,9 @@
 	
 	{if $media->isImage}
 		<dl>
-			<dt><label for="caption_{@$media->mediaID}">{lang}wcf.media.caption{/lang}</label></dt>
+			<dt><label for="caption_{$media->mediaID}">{lang}wcf.media.caption{/lang}</label></dt>
 			<dd>
-				<textarea id="caption_{@$media->mediaID}" name="caption" cols="40" rows="3"></textarea>
+				<textarea id="caption_{$media->mediaID}" name="caption" cols="40" rows="3"></textarea>
 			</dd>
 		</dl>
 		{if $availableLanguages|count > 1}
@@ -117,9 +117,9 @@
 		</dl>
 		
 		<dl>
-			<dt><label for="altText_{@$media->mediaID}">{lang}wcf.media.altText{/lang}</label></dt>
+			<dt><label for="altText_{$media->mediaID}">{lang}wcf.media.altText{/lang}</label></dt>
 			<dd>
-				<input type="text" id="altText_{@$media->mediaID}" name="altText" class="long">
+				<input type="text" id="altText_{$media->mediaID}" name="altText" class="long">
 			</dd>
 		</dl>
 		{if $availableLanguages|count > 1}

--- a/wcfsetup/install/files/acp/templates/menuItemAdd.tpl
+++ b/wcfsetup/install/files/acp/templates/menuItemAdd.tpl
@@ -19,7 +19,7 @@
 					<div class="dropdownMenu">
 						<ul class="scrollableDropdownMenu">
 							{foreach from=$menuItemNodeList item='menuItemNode'}
-								<li{if $menuItemNode->itemID == $formObject->itemID} class="active"{/if}><a href="{link controller='MenuItemEdit' object=$menuItemNode}{/link}">{if $menuItemNode->getDepth() > 1}{@"&nbsp;&nbsp;&nbsp;&nbsp;"|str_repeat:($menuItemNode->getDepth() - 1)}{/if}{$menuItemNode->getTitle()}</a></li>
+								<li{if $menuItemNode->itemID == $formObject->itemID} class="active"{/if}><a href="{link controller='MenuItemEdit' object=$menuItemNode}{/link}">{if $menuItemNode->getDepth() > 1}{unsafe:"&nbsp;&nbsp;&nbsp;&nbsp;"|str_repeat:($menuItemNode->getDepth() - 1)}{/if}{$menuItemNode->getTitle()}</a></li>
 							{/foreach}
 						</ul>
 					</div>

--- a/wcfsetup/install/files/acp/templates/noticeAdd.tpl
+++ b/wcfsetup/install/files/acp/templates/noticeAdd.tpl
@@ -88,7 +88,7 @@
 						{if $errorType == 'empty'}
 							{lang}wcf.global.form.error.empty{/lang}
 						{else}
-							{lang}wcf.acp.notice.cssClassName.error.{@$errorType}{/lang}
+							{lang}wcf.acp.notice.cssClassName.error.{$errorType}{/lang}
 						{/if}
 					</small>
 				{/if}
@@ -141,7 +141,7 @@
 			</header>
 			
 			{foreach from=$groupedConditionObjectTypes['com.woltlab.wcf.page'] item='pageConditionObjectType'}
-				{@$pageConditionObjectType->getProcessor()->getHtml()}
+				{unsafe:$pageConditionObjectType->getProcessor()->getHtml()}
 			{/foreach}
 		</section>
 		
@@ -152,7 +152,7 @@
 			</header>
 			
 			{foreach from=$groupedConditionObjectTypes['com.woltlab.wcf.pointInTime'] item='pointInTimeConditionObjectType'}
-				{@$pointInTimeConditionObjectType->getProcessor()->getHtml()}
+				{unsafe:$pointInTimeConditionObjectType->getProcessor()->getHtml()}
 			{/foreach}
 		</section>
 		

--- a/wcfsetup/install/files/acp/templates/notificationPresetSettings.tpl
+++ b/wcfsetup/install/files/acp/templates/notificationPresetSettings.tpl
@@ -55,19 +55,19 @@
 				{foreach from=$eventList item=event}
 					<div class="notificationSettingsItem">
 						<div class="notificationSettingsEvent">
-							<label for="settings_{@$event->eventID}">{lang}wcf.user.notification.{$event->objectType}.{$event->eventName}{/lang}</label>
+							<label for="settings_{$event->eventID}">{lang}wcf.user.notification.{$event->objectType}.{$event->eventName}{/lang}</label>
 						</div>
 						<div class="notificationSettingsState">
 							<label>
-								<input type="checkbox" id="settings_{@$event->eventID}" name="settings[{@$event->eventID}][enabled]" class="jsCheckboxNotificationSettingsState" value="1" data-object-id="{@$event->eventID}"{if !$settings[$event->eventID][enabled]|empty} checked{/if}>
+								<input type="checkbox" id="settings_{$event->eventID}" name="settings[{$event->eventID}][enabled]" class="jsCheckboxNotificationSettingsState" value="1" data-object-id="{$event->eventID}"{if !$settings[$event->eventID][enabled]|empty} checked{/if}>
 								{icon size=24 name='bell' type='solid'}
 								{icon size=24 name='bell-slash'}
 							</label>
 						</div>
 						<div class="notificationSettingsEmail">
 							{if $event->supportsEmailNotification()}
-								<input type="hidden" id="settings_{$event->eventID}_mailNotificationType" name="settings[{@$event->eventID}][mailNotificationType]" value="{$settings[$event->eventID][mailNotificationType]}">
-								<button type="button" class="notificationSettingsEmailType jsTooltip{if $settings[$event->eventID][enabled]|empty} disabled{/if}" title="{lang}wcf.user.notification.mailNotificationType.{@$settings[$event->eventID][mailNotificationType]}{/lang}" data-object-id="{@$event->eventID}">
+								<input type="hidden" id="settings_{$event->eventID}_mailNotificationType" name="settings[{$event->eventID}][mailNotificationType]" value="{$settings[$event->eventID][mailNotificationType]}">
+								<button type="button" class="notificationSettingsEmailType jsTooltip{if $settings[$event->eventID][enabled]|empty} disabled{/if}" title="{lang}wcf.user.notification.mailNotificationType.{$settings[$event->eventID][mailNotificationType]}{/lang}" data-object-id="{$event->eventID}">
 									<span class="jsIconNotificationSettingsEmailType">
 										{if $settings[$event->eventID][mailNotificationType] === 'none'}
 											{icon size=24 name='xmark'}

--- a/wcfsetup/install/files/acp/templates/pageAdd.tpl
+++ b/wcfsetup/install/files/acp/templates/pageAdd.tpl
@@ -14,8 +14,8 @@
 				}
 			{else}
 				{foreach from=$availableLanguages item=availableLanguage}
-					if (elById('customURL{@$availableLanguage->languageID}').value === '') {
-						elById('customURL{@$availableLanguage->languageID}').value = name + '-{@$availableLanguage->languageCode}';
+					if (elById('customURL{$availableLanguage->languageID}').value === '') {
+						elById('customURL{$availableLanguage->languageID}').value = name + '-{unsafe:$availableLanguage->languageCode|encodeJS}';
 					}
 				{/foreach}
 			{/if}
@@ -100,7 +100,7 @@
 								{if $errorType == 'empty'}
 									{lang}wcf.global.form.error.empty{/lang}
 								{else}
-									{lang}wcf.acp.page.name.error.{@$errorType}{/lang}
+									{lang}wcf.acp.page.name.error.{$errorType}{/lang}
 								{/if}
 							</small>
 						{/if}
@@ -114,7 +114,7 @@
 							<option value="0">{lang}wcf.acp.page.parentPage.none{/lang}</option>
 
 							{foreach from=$pageNodeList item=pageNode}
-								<option value="{$pageNode->pageID}"{if $pageNode->pageID == $parentPageID} selected{/if}{if $pageNode->requireObjectID || ($action === 'edit' && $pageNode->pageID == $page->pageID)} disabled{/if}>{if $pageNode->getDepth() > 1}{@"&nbsp;&nbsp;&nbsp;&nbsp;"|str_repeat:($pageNode->getDepth() - 1)}{/if}{$pageNode->name}</option>
+								<option value="{$pageNode->pageID}"{if $pageNode->pageID == $parentPageID} selected{/if}{if $pageNode->requireObjectID || ($action === 'edit' && $pageNode->pageID == $page->pageID)} disabled{/if}>{if $pageNode->getDepth() > 1}{unsafe:"&nbsp;&nbsp;&nbsp;&nbsp;"|str_repeat:($pageNode->getDepth() - 1)}{/if}{$pageNode->name}</option>
 							{/foreach}
 						</select>
 						{if $errorField == 'parentPageID'}
@@ -122,7 +122,7 @@
 								{if $errorType == 'empty'}
 									{lang}wcf.global.form.error.empty{/lang}
 								{else}
-									{lang}wcf.acp.page.parentPage.error.{@$errorType}{/lang}
+									{lang}wcf.acp.page.parentPage.error.{$errorType}{/lang}
 								{/if}
 							</small>
 						{/if}
@@ -142,7 +142,7 @@
 								{if $errorType == 'empty'}
 									{lang}wcf.global.form.error.empty{/lang}
 								{else}
-									{lang}wcf.acp.page.application.error.{@$errorType}{/lang}
+									{lang}wcf.acp.page.application.error.{$errorType}{/lang}
 								{/if}
 							</small>
 						{/if}
@@ -165,7 +165,7 @@
 									{if $errorType == 'empty'}
 										{lang}wcf.global.form.error.empty{/lang}
 									{else}
-										{lang}wcf.acp.page.application.error.{@$errorType}{/lang}
+										{lang}wcf.acp.page.application.error.{$errorType}{/lang}
 									{/if}
 								</small>
 							{/if}
@@ -183,7 +183,7 @@
 									{if $errorType == 'empty'}
 										{lang}wcf.global.form.error.empty{/lang}
 									{else}
-										{lang}wcf.acp.page.customURL.error.{@$errorType}{/lang}
+										{lang}wcf.acp.page.customURL.error.{$errorType}{/lang}
 									{/if}
 								</small>
 							{/if}
@@ -193,15 +193,15 @@
 					{foreach from=$availableLanguages item=availableLanguage}
 						{assign var='__errorFieldName' value='customURL_'|concat:$availableLanguage->languageID}
 						<dl{if $errorField == $__errorFieldName} class="formError"{/if}>
-							<dt><label for="customURL{@$availableLanguage->languageID}">{lang}wcf.acp.page.customURL{/lang} ({$availableLanguage->languageName})</label></dt>
+							<dt><label for="customURL{$availableLanguage->languageID}">{lang}wcf.acp.page.customURL{/lang} ({$availableLanguage->languageName})</label></dt>
 							<dd>
-								<input type="text" id="customURL{@$availableLanguage->languageID}" name="customURL[{@$availableLanguage->languageID}]" value="{if !$customURL[$availableLanguage->languageID]|empty}{$customURL[$availableLanguage->languageID]}{/if}" class="long" maxlength="255">
+								<input type="text" id="customURL{$availableLanguage->languageID}" name="customURL[{$availableLanguage->languageID}]" value="{if !$customURL[$availableLanguage->languageID]|empty}{$customURL[$availableLanguage->languageID]}{/if}" class="long" maxlength="255">
 								{if $errorField == $__errorFieldName}
 									<small class="innerError">
 										{if $errorType == 'empty'}
 											{lang}wcf.global.form.error.empty{/lang}
 										{else}
-											{lang}wcf.acp.page.customURL.error.{@$errorType}{/lang}
+											{lang}wcf.acp.page.customURL.error.{$errorType}{/lang}
 										{/if}
 									</small>
 								{/if}
@@ -219,7 +219,7 @@
 								{if $errorType == 'empty'}
 									{lang}wcf.global.form.error.empty{/lang}
 								{else}
-									{lang}wcf.acp.page.cssClassName.error.{@$errorType}{/lang}
+									{lang}wcf.acp.page.cssClassName.error.{$errorType}{/lang}
 								{/if}
 							</small>
 						{/if}
@@ -275,7 +275,7 @@
 								<option value="0">{lang}wcf.global.noSelection{/lang}</option>
 
 								{foreach from=$menuItemNodeList item=menuItemNode}
-									<option value="{$menuItemNode->itemID}"{if $menuItemNode->itemID == $parentMenuItemID} selected{/if}>{if $menuItemNode->getDepth() > 1}{@"&nbsp;&nbsp;&nbsp;&nbsp;"|str_repeat:($menuItemNode->getDepth() - 1)}{/if}{$menuItemNode->getTitle()}</option>
+									<option value="{$menuItemNode->itemID}"{if $menuItemNode->itemID == $parentMenuItemID} selected{/if}>{if $menuItemNode->getDepth() > 1}{unsafe:"&nbsp;&nbsp;&nbsp;&nbsp;"|str_repeat:($menuItemNode->getDepth() - 1)}{/if}{$menuItemNode->getTitle()}</option>
 								{/foreach}
 							</select>
 							{if $errorField == 'parentMenuItemID'}
@@ -283,7 +283,7 @@
 									{if $errorType == 'empty'}
 										{lang}wcf.global.form.error.empty{/lang}
 									{else}
-										{lang}wcf.acp.page.parentMenuItem.error.{@$errorType}{/lang}
+										{lang}wcf.acp.page.parentMenuItem.error.{$errorType}{/lang}
 									{/if}
 								</small>
 							{/if}
@@ -316,7 +316,7 @@
 									{if $errorType == 'empty'}
 										{lang}wcf.global.form.error.empty{/lang}
 									{else}
-										{lang}wcf.acp.page.title.error.{@$errorType}{/lang}
+										{lang}wcf.acp.page.title.error.{$errorType}{/lang}
 									{/if}
 								</small>
 							{/if}
@@ -335,7 +335,7 @@
 									{if $errorType == 'empty'}
 										{lang}wcf.global.form.error.empty{/lang}
 									{else}
-										{lang}wcf.acp.page.content.error.{@$errorType}{/lang}
+										{lang}wcf.acp.page.content.error.{$errorType}{/lang}
 									{/if}
 								</small>
 							{/if}
@@ -357,7 +357,7 @@
 									{if $errorType == 'empty'}
 										{lang}wcf.global.form.error.empty{/lang}
 									{else}
-										{lang}wcf.acp.page.metaDescription.error.{@$errorType}{/lang}
+										{lang}wcf.acp.page.metaDescription.error.{$errorType}{/lang}
 									{/if}
 								</small>
 							{/if}
@@ -377,19 +377,19 @@
 					</nav>
 
 					{foreach from=$availableLanguages item=availableLanguage}
-						<div id="language{@$availableLanguage->languageID}" class="tabMenuContent">
+						<div id="language{$availableLanguage->languageID}" class="tabMenuContent">
 							<div class="section">
 								{assign var='__errorFieldName' value='title_'|concat:$availableLanguage->languageID}
 								<dl{if $errorField == $__errorFieldName} class="formError"{/if}>
-									<dt><label for="title{@$availableLanguage->languageID}">{lang}wcf.global.title{/lang}</label></dt>
+									<dt><label for="title{$availableLanguage->languageID}">{lang}wcf.global.title{/lang}</label></dt>
 									<dd>
-										<input type="text" id="title{@$availableLanguage->languageID}" name="title[{@$availableLanguage->languageID}]" value="{if !$title[$availableLanguage->languageID]|empty}{$title[$availableLanguage->languageID]}{/if}" class="long" maxlength="255">
+										<input type="text" id="title{$availableLanguage->languageID}" name="title[{$availableLanguage->languageID}]" value="{if !$title[$availableLanguage->languageID]|empty}{$title[$availableLanguage->languageID]}{/if}" class="long" maxlength="255">
 										{if $errorField == $__errorFieldName}
 											<small class="innerError">
 												{if $errorType == 'empty'}
 													{lang}wcf.global.form.error.empty{/lang}
 												{else}
-													{lang}wcf.acp.page.title.error.{@$errorType}{/lang}
+													{lang}wcf.acp.page.title.error.{$errorType}{/lang}
 												{/if}
 											</small>
 										{/if}
@@ -399,15 +399,15 @@
 								{if $pageType == 'system'}
 									{assign var='__errorFieldName' value='metaDescription_'|concat:$availableLanguage->languageID}
 									<dl{if $errorField == $__errorFieldName} class="formError"{/if}>
-										<dt><label for="metaDescription{@$availableLanguage->languageID}">{lang}wcf.acp.page.metaDescription{/lang}</label></dt>
+										<dt><label for="metaDescription{$availableLanguage->languageID}">{lang}wcf.acp.page.metaDescription{/lang}</label></dt>
 										<dd>
-											<input type="text" class="long" name="metaDescription[{@$availableLanguage->languageID}]" id="metaDescription{@$availableLanguage->languageID}" value="{if !$metaDescription[$availableLanguage->languageID]|empty}{$metaDescription[$availableLanguage->languageID]}{/if}">
+											<input type="text" class="long" name="metaDescription[{$availableLanguage->languageID}]" id="metaDescription{$availableLanguage->languageID}" value="{if !$metaDescription[$availableLanguage->languageID]|empty}{$metaDescription[$availableLanguage->languageID]}{/if}">
 											{if $errorField == $__errorFieldName}
 												<small class="innerError">
 													{if $errorType == 'empty'}
 														{lang}wcf.global.form.error.empty{/lang}
 													{else}
-														{lang}wcf.acp.page.metaDescription.error.{@$errorType}{/lang}
+														{lang}wcf.acp.page.metaDescription.error.{$errorType}{/lang}
 													{/if}
 												</small>
 											{/if}
@@ -422,7 +422,7 @@
 								{if $pageType != 'system'}
 									{assign var='__errorFieldName' value='content_'|concat:$availableLanguage->languageID}
 									<dl{if $errorField == $__errorFieldName} class="formError"{/if}>
-										<dt><label for="content{@$availableLanguage->languageID}">{lang}wcf.acp.page.content{/lang}</label></dt>
+										<dt><label for="content{$availableLanguage->languageID}">{lang}wcf.acp.page.content{/lang}</label></dt>
 										<dd>
 											{include file='__pageAddContent' languageID=$availableLanguage->languageID}
 
@@ -431,7 +431,7 @@
 													{if $errorType == 'empty'}
 														{lang}wcf.global.form.error.empty{/lang}
 													{else}
-														{lang}wcf.acp.page.content.error.{@$errorType}{/lang}
+														{lang}wcf.acp.page.content.error.{$errorType}{/lang}
 													{/if}
 												</small>
 											{/if}
@@ -446,15 +446,15 @@
 
 									{assign var='__errorFieldName' value='metaDescription_'|concat:$availableLanguage->languageID}
 									<dl{if $errorField == $__errorFieldName} class="formError"{/if}>
-										<dt><label for="metaDescription{@$availableLanguage->languageID}">{lang}wcf.acp.page.metaDescription{/lang}</label></dt>
+										<dt><label for="metaDescription{$availableLanguage->languageID}">{lang}wcf.acp.page.metaDescription{/lang}</label></dt>
 										<dd>
-											<input type="text" class="long" name="metaDescription[{@$availableLanguage->languageID}]" id="metaDescription{@$availableLanguage->languageID}" value="{if !$metaDescription[$availableLanguage->languageID]|empty}{$metaDescription[$availableLanguage->languageID]}{/if}">
+											<input type="text" class="long" name="metaDescription[{$availableLanguage->languageID}]" id="metaDescription{$availableLanguage->languageID}" value="{if !$metaDescription[$availableLanguage->languageID]|empty}{$metaDescription[$availableLanguage->languageID]}{/if}">
 											{if $errorField == $__errorFieldName}
 												<small class="innerError">
 													{if $errorType == 'empty'}
 														{lang}wcf.global.form.error.empty{/lang}
 													{else}
-														{lang}wcf.acp.page.metaDescription.error.{@$errorType}{/lang}
+														{lang}wcf.acp.page.metaDescription.error.{$errorType}{/lang}
 													{/if}
 												</small>
 											{/if}
@@ -472,7 +472,7 @@
 
 		<div id="boxes" class="tabMenuContent">
 			<div class="section">
-				<woltlab-core-notice type="info">{lang}wcf.acp.page.boxOrder.page{@$action|ucfirst}{/lang}</woltlab-core-notice>
+				<woltlab-core-notice type="info">{lang}wcf.acp.page.boxOrder.page{$action|ucfirst}{/lang}</woltlab-core-notice>
 				
 				<dl{if $errorField == 'boxIDs'} class="formError"{/if}>
 					<dt>{lang}wcf.acp.page.boxes{/lang}</dt>
@@ -497,7 +497,7 @@
 								{if $errorType == 'empty'}
 									{lang}wcf.global.form.error.empty{/lang}
 								{else}
-									{lang}wcf.acp.page.boxIDs.error.{@$errorType}{/lang}
+									{lang}wcf.acp.page.boxIDs.error.{$errorType}{/lang}
 								{/if}
 							</small>
 						{/if}

--- a/wcfsetup/install/files/acp/templates/pageBoxOrder.tpl
+++ b/wcfsetup/install/files/acp/templates/pageBoxOrder.tpl
@@ -131,7 +131,7 @@
 		const boxes = new Map();
 		{foreach from=$boxes key=position item=boxData}
 			{if $position != 'mainMenu'}
-				boxes.set('{$position}', [{implode from=$boxData item=box}{ boxId: {$box->boxID}, name: '{unsafe:$box->name|encodeJS}', isDisabled: {if $box->isDisabled}true{else}false{/if} }{/implode}]);
+				boxes.set('{unsafe:$position|encodeJS}', [{implode from=$boxData item=box}{ boxId: {$box->boxID}, name: '{unsafe:$box->name|encodeJS}', isDisabled: {if $box->isDisabled}true{else}false{/if} }{/implode}]);
 			{/if}
 		{/foreach}
 		

--- a/wcfsetup/install/files/acp/templates/pageMenu.tpl
+++ b/wcfsetup/install/files/acp/templates/pageMenu.tpl
@@ -6,8 +6,8 @@
 			{foreach from=$__wcf->getACPMenu()->getMenuItems('') item=_sectionMenuItem}
 				<li>
 					<button type="button" class="acpPageMenuLink{if $_sectionMenuItem->menuItem|in_array:$_activeMenuItems} active{/if}" data-menu-item="{$_sectionMenuItem->menuItem}">
-						{@$_sectionMenuItem->getIcon()->toHtml(32)}
-						<span class="acpPageMenuItemLabel">{@$_sectionMenuItem}</span>
+						{unsafe:$_sectionMenuItem->getIcon()->toHtml(32)}
+						<span class="acpPageMenuItemLabel">{$_sectionMenuItem}</span>
 					</button>
 				</li>
 			{/foreach}
@@ -19,27 +19,27 @@
 			<ol class="acpPageSubMenuCategoryList{if $_sectionMenuItem->menuItem|in_array:$_activeMenuItems} active{/if}" data-menu-item="{$_sectionMenuItem->menuItem}">
 				{foreach from=$__wcf->getACPMenu()->getMenuItems($_sectionMenuItem->menuItem) item=_menuItemCategory}
 					<li class="acpPageSubMenuCategory">
-						<span>{@$_menuItemCategory}</span>
+						<span>{$_menuItemCategory}</span>
 						
 						<ol class="acpPageSubMenuItemList">
 							{foreach from=$__wcf->getACPMenu()->getMenuItems($_menuItemCategory->menuItem) item=_menuItem}
 								{assign var=_subMenuItems value=$__wcf->getACPMenu()->getMenuItems($_menuItem->menuItem)}
 								
 								{if $_subMenuItems|empty}
-									<li{if $_menuItem->menuItem|in_array:$_activeMenuItems} class="active"{/if}><a href="{$_menuItem->getLink()}" class="acpPageSubMenuLink">{@$_menuItem}</a></li>
+									<li{if $_menuItem->menuItem|in_array:$_activeMenuItems} class="active"{/if}><a href="{$_menuItem->getLink()}" class="acpPageSubMenuLink">{$_menuItem}</a></li>
 								{else}
 									{if $_menuItem->menuItem === 'wcf.acp.menu.link.option.category'}
 										{* handle special option categories *}
 										{foreach from=$_subMenuItems item=_subMenuItem}
-											<li{if $_subMenuItem->menuItem|in_array:$_activeMenuItems} class="active"{/if}><a href="{$_subMenuItem->getLink()}" class="acpPageSubMenuLink">{@$_subMenuItem}</a></li>
+											<li{if $_subMenuItem->menuItem|in_array:$_activeMenuItems} class="active"{/if}><a href="{$_subMenuItem->getLink()}" class="acpPageSubMenuLink">{$_subMenuItem}</a></li>
 										{/foreach}
 									{else}
 										<li class="acpPageSubMenuLinkWrapper">
-											<a href="{$_menuItem->getLink()}" class="acpPageSubMenuLink{if $_menuItem->menuItem|in_array:$_activeMenuItems && $_activeMenuItems[0] === $_menuItem->menuItem} active{/if}">{@$_menuItem}</a>
+											<a href="{$_menuItem->getLink()}" class="acpPageSubMenuLink{if $_menuItem->menuItem|in_array:$_activeMenuItems && $_activeMenuItems[0] === $_menuItem->menuItem} active{/if}">{$_menuItem}</a>
 											
 											{foreach from=$_subMenuItems item=_subMenuItem}
-												<a href="{$_subMenuItem->getLink()}" class="acpPageSubMenuIcon jsTooltip{if $_subMenuItem->menuItem|in_array:$_activeMenuItems} active{/if}" title="{@$_subMenuItem}">
-													{@$_subMenuItem->getIcon()->toHtml()}
+												<a href="{$_subMenuItem->getLink()}" class="acpPageSubMenuIcon jsTooltip{if $_subMenuItem->menuItem|in_array:$_activeMenuItems} active{/if}" title="{$_subMenuItem}">
+													{unsafe:$_subMenuItem->getIcon()->toHtml()}
 												</a>
 											{/foreach}
 										</li>

--- a/wcfsetup/install/files/acp/templates/paidSubscriptionAdd.tpl
+++ b/wcfsetup/install/files/acp/templates/paidSubscriptionAdd.tpl
@@ -46,7 +46,7 @@
 						{elseif $errorType == 'multilingual'}
 							{lang}wcf.global.form.error.multilingual{/lang}
 						{else}
-							{lang}wcf.acp.paidSubscription.title.error.{@$errorType}{/lang}
+							{lang}wcf.acp.paidSubscription.title.error.{$errorType}{/lang}
 						{/if}
 					</small>
 				{/if}
@@ -66,7 +66,7 @@
 						{if $errorType == 'empty'}
 							{lang}wcf.global.form.error.empty{/lang}
 						{else}
-							{lang}wcf.acp.paidSubscription.description.error.{@$errorType}{/lang}
+							{lang}wcf.acp.paidSubscription.description.error.{$errorType}{/lang}
 						{/if}
 					</small>
 				{/if}
@@ -76,7 +76,7 @@
 		<dl>
 			<dt><label for="showOrder">{lang}wcf.global.showOrder{/lang}</label></dt>
 			<dd>
-				<input type="number" id="showOrder" name="showOrder" value="{if $showOrder}{@$showOrder}{/if}" class="tiny" min="0">
+				<input type="number" id="showOrder" name="showOrder" value="{if $showOrder}{$showOrder}{/if}" class="tiny" min="0">
 				<small>{lang}wcf.acp.paidSubscription.showOrder.description{/lang}</small>
 			</dd>
 		</dl>
@@ -119,7 +119,7 @@
 						{if $errorType == 'empty'}
 							{lang}wcf.global.form.error.empty{/lang}
 						{else}
-							{lang}wcf.acp.paidSubscription.cost.error.{@$errorType}{/lang}
+							{lang}wcf.acp.paidSubscription.cost.error.{$errorType}{/lang}
 						{/if}
 					</small>
 				{/if}
@@ -147,7 +147,7 @@
 						{if $errorType == 'empty'}
 							{lang}wcf.global.form.error.empty{/lang}
 						{else}
-							{lang}wcf.acp.paidSubscription.subscriptionLength.error.{@$errorType}{/lang}
+							{lang}wcf.acp.paidSubscription.subscriptionLength.error.{$errorType}{/lang}
 						{/if}
 					</small>
 				{/if}
@@ -173,7 +173,7 @@
 						{if $errorType == 'empty'}
 							{lang}wcf.global.form.error.empty{/lang}
 						{else}
-							{lang}wcf.acp.paidSubscription.userGroups.error.{@$errorType}{/lang}
+							{lang}wcf.acp.paidSubscription.userGroups.error.{$errorType}{/lang}
 						{/if}
 					</small>
 				{/if}

--- a/wcfsetup/install/files/acp/templates/paidSubscriptionAdd.tpl
+++ b/wcfsetup/install/files/acp/templates/paidSubscriptionAdd.tpl
@@ -1,16 +1,23 @@
 {include file='header' pageTitle='wcf.acp.paidSubscription.'|concat:$action}
 
 <script data-relocate="true">
-	$(function() {
-		$('#subscriptionLengthPermanent').change(function() {
-			if ($('#subscriptionLengthPermanent').is(':checked')) {
-				$('#subscriptionLengthDL, #isRecurringDL').hide();
+	require(['WoltLabSuite/Core/Dom/Util'], ({ show, hide }) => {
+		const subscriptionLengthPermanent = document.getElementById('subscriptionLengthPermanent');
+		const subscriptionLengthDL = document.getElementById('subscriptionLengthDL');
+		const isRecurringDL = document.getElementById('isRecurringDL');
+
+		function toggleSubscriptionElements() {
+			if (subscriptionLengthPermanent.checked) {
+				hide(subscriptionLengthDL);
+				hide(isRecurringDL);
+			} else {
+				show(subscriptionLengthDL);
+				show(isRecurringDL);
 			}
-			else {
-				$('#subscriptionLengthDL, #isRecurringDL').show();
-			}
-		});
-		$('#subscriptionLengthPermanent').change();
+		}
+
+		subscriptionLengthPermanent.addEventListener('change', toggleSubscriptionElements);
+		toggleSubscriptionElements();
 	});
 </script>
 

--- a/wcfsetup/install/files/acp/templates/reactionTypeAdd.tpl
+++ b/wcfsetup/install/files/acp/templates/reactionTypeAdd.tpl
@@ -14,6 +14,6 @@
 	</nav>
 </header>
 
-{@$form->getHtml()}
+{unsafe:$form->getHtml()}
 
 {include file='footer'}

--- a/wcfsetup/install/files/acp/templates/smileyAdd.tpl
+++ b/wcfsetup/install/files/acp/templates/smileyAdd.tpl
@@ -28,7 +28,7 @@
 						{if $errorType == 'empty' || $errorType == 'multilingual'}
 							{lang}wcf.global.form.error.{$errorType}{/lang}
 						{else}
-							{lang}wcf.acp.smiley.smileyTitle.error.{@$errorType}{/lang}
+							{lang}wcf.acp.smiley.smileyTitle.error.{$errorType}{/lang}
 						{/if}
 					</small>
 				{/if}
@@ -49,7 +49,7 @@
 						{if $errorType == 'empty'}
 							{lang}wcf.global.form.error.empty{/lang}
 						{else}
-							{lang}wcf.acp.smiley.categoryID.error.{@$errorType}{/lang}
+							{lang}wcf.acp.smiley.categoryID.error.{$errorType}{/lang}
 						{/if}
 					</small>
 				{/if}
@@ -66,7 +66,7 @@
 						{if $errorType == 'empty'}
 							{lang}wcf.global.form.error.empty{/lang}
 						{else}
-							{lang}wcf.acp.smiley.smileyCode.error.{@$errorType}{/lang}
+							{lang}wcf.acp.smiley.smileyCode.error.{$errorType}{/lang}
 						{/if}
 					</small>
 				{/if}
@@ -80,7 +80,7 @@
 				
 				{if $errorField == 'aliases'}
 					<small class="innerError">
-						{lang}wcf.acp.smiley.aliases.error.{@$errorType}{/lang}
+						{lang}wcf.acp.smiley.aliases.error.{$errorType}{/lang}
 					</small>
 				{/if}
 			</dd>
@@ -93,7 +93,7 @@
 				
 				{if $errorField == 'showOrder'}
 					<small class="innerError">
-						{lang}wcf.acp.smiley.showOrder.error.{@$errorType}{/lang}
+						{lang}wcf.acp.smiley.showOrder.error.{$errorType}{/lang}
 					</small>
 				{/if}
 			</dd>
@@ -119,7 +119,7 @@
 							{if $errorType == 'empty'}
 								{lang}wcf.global.form.error.empty{/lang}
 							{else}
-								{lang}wcf.acp.smiley.fileUpload.error.{@$errorType}{/lang}
+								{lang}wcf.acp.smiley.fileUpload.error.{$errorType}{/lang}
 							{/if}
 						</small>
 					{/if}
@@ -137,7 +137,7 @@
 							{if $errorType == 'empty'}
 								{lang}wcf.global.form.error.empty{/lang}
 							{else}
-								{lang}wcf.acp.smiley.smileyPath.error.{@$errorType}{/lang}
+								{lang}wcf.acp.smiley.smileyPath.error.{$errorType}{/lang}
 							{/if}
 						</small>
 					{/if}
@@ -169,7 +169,7 @@
 							{if $errorType == 'empty'}
 								{lang}wcf.global.form.error.empty{/lang}
 							{else}
-								{lang}wcf.acp.smiley.fileUpload.error.{@$errorType}{/lang}
+								{lang}wcf.acp.smiley.fileUpload.error.{$errorType}{/lang}
 							{/if}
 						</small>
 					{/if}
@@ -187,7 +187,7 @@
 							{if $errorType == 'empty'}
 								{lang}wcf.global.form.error.empty{/lang}
 							{else}
-								{lang}wcf.acp.smiley.smileyPath.error.{@$errorType}{/lang}
+								{lang}wcf.acp.smiley.smileyPath.error.{$errorType}{/lang}
 							{/if}
 						</small>
 					{/if}

--- a/wcfsetup/install/files/acp/templates/smileyCategoryAdd.tpl
+++ b/wcfsetup/install/files/acp/templates/smileyCategoryAdd.tpl
@@ -2,7 +2,7 @@
 
 <header class="contentHeader">
 	<div class="contentHeaderTitle">
-		<h1 class="contentTitle">{@$objectType->getProcessor()->getLanguageVariable($action)}</h1>
+		<h1 class="contentTitle">{unsafe:$objectType->getProcessor()->getLanguageVariable($action)}</h1>
 	</div>
 
 	{hascontent}
@@ -18,7 +18,7 @@
 					{if $action == 'edit' && $categoryNodeList !== null && $categoryNodeList->hasChildren()}
 						<li class="dropdown">
 							<a class="button dropdownToggle">
-								{icon name='sort'} <span>{@$objectType->getProcessor()->getLanguageVariable('button.choose')}</span>
+								{icon name='sort'} <span>{unsafe:$objectType->getProcessor()->getLanguageVariable('button.choose')}</span>
 							</a>
 							<div class="dropdownMenu">
 								<ul class="scrollableDropdownMenu">
@@ -34,7 +34,7 @@
 
 					{if $objectType->getProcessor()->canDeleteCategory() || $objectType->getProcessor()->canEditCategory()}
 						<li>
-							<a href="{link controller=$listController application=$objectType->getProcessor()->getApplication()}{/link}" class="button">{icon name='list'} <span>{@$objectType->getProcessor()->getLanguageVariable('button.list')}</span></a>
+							<a href="{link controller=$listController application=$objectType->getProcessor()->getApplication()}{/link}" class="button">{icon name='list'} <span>{unsafe:$objectType->getProcessor()->getLanguageVariable('button.list')}</span></a>
 						</li>
 					{/if}
 
@@ -45,7 +45,7 @@
 	{/hascontent}
 </header>
 
-{@$form->getHtml()}
+{unsafe:$form->getHtml()}
 
 {if $action == 'edit'}
 	<script data-relocate="true">

--- a/wcfsetup/install/files/acp/templates/styleAdd.tpl
+++ b/wcfsetup/install/files/acp/templates/styleAdd.tpl
@@ -1,6 +1,6 @@
 {include file='header' pageTitle='wcf.acp.style.'|concat:$action}
 
-<link href="{@$__wcf->getPath()}acp/style/acpStyleEditor.css?v={LAST_UPDATE_TIME}" type="text/css" rel="stylesheet">
+<link href="{$__wcf->getPath()}acp/style/acpStyleEditor.css?v={LAST_UPDATE_TIME}" type="text/css" rel="stylesheet">
 
 {include file='shared_colorPickerJavaScript'}
 
@@ -8,7 +8,7 @@
 	require(["WoltLabSuite/Core/Acp/Ui/Style/Editor", "WoltLabSuite/Core/Ui/Color/Picker"], (AcpUiStyleEditor, ColorPicker) => {
 		AcpUiStyleEditor.setup({
 			isTainted: {if $isTainted}true{else}false{/if},
-			styleId: {if $action === 'edit'}{@$style->styleID}{else}0{/if},
+			styleId: {if $action === 'edit'}{$style->styleID}{else}0{/if},
 		});
 
 		ColorPicker.fromSelector(".jsColorPicker");
@@ -226,7 +226,7 @@
 				<dl{if $errorField == 'image'} class="formError"{/if}>
 					<dt><label for="image">{lang}wcf.acp.style.image{/lang}</label></dt>
 					<dd>
-						{@$__wcf->getUploadHandler()->renderField('image')}
+						{unsafe:$__wcf->getUploadHandler()->renderField('image')}
 						{if $errorField == 'image'}
 							<small class="innerError">
 								{if $errorType == 'empty'}
@@ -244,7 +244,7 @@
 				<dl{if $errorField == 'image2x'} class="formError"{/if}>
 					<dt><label for="image2x">{lang}wcf.acp.style.image2x{/lang}</label></dt>
 					<dd>
-						{@$__wcf->getUploadHandler()->renderField('image2x')}
+						{unsafe:$__wcf->getUploadHandler()->renderField('image2x')}
 						{if $errorField == 'image2x'}
 							<small class="innerError">
 								{if $errorType == 'empty'}
@@ -283,7 +283,7 @@
 				<dl{if $errorField == 'customAssets'} class="formError"{/if}>
 					<dt><label for="customAssets">{lang}wcf.acp.style.customAssets{/lang}</label></dt>
 					<dd>
-						{@$__wcf->getUploadHandler()->renderField('customAssets')}
+						{unsafe:$__wcf->getUploadHandler()->renderField('customAssets')}
 						{if $errorField == 'customAssets'}
 							<small class="innerError">
 								{if $errorType == 'empty'}
@@ -306,7 +306,7 @@
 				<dl{if $errorField == 'image'} class="formError"{/if}>
 					<dt><label for="favicon">{lang}wcf.acp.style.favicon{/lang}</label></dt>
 					<dd>
-						{@$__wcf->getUploadHandler()->renderField('favicon')}
+						{unsafe:$__wcf->getUploadHandler()->renderField('favicon')}
 						{if $errorField == 'favicon'}
 							<small class="innerError">
 								{if $errorType == 'empty'}
@@ -336,7 +336,7 @@
 				<dl{if $errorField == 'coverPhoto'} class="formError"{/if}>
 					<dt><label for="coverPhoto">{lang}wcf.acp.style.coverPhoto{/lang}</label></dt>
 					<dd>
-						{@$__wcf->getUploadHandler()->renderField('coverPhoto')}
+						{unsafe:$__wcf->getUploadHandler()->renderField('coverPhoto')}
 						{if $errorField == 'coverPhoto'}
 							<small class="innerError">
 								{if $errorType == 'empty'}
@@ -380,7 +380,7 @@
 						<input type="number" id="wcfLayoutMinWidth" name="wcfLayoutMinWidth" value="{$variables[wcfLayoutMinWidth]}" class="tiny">
 						<select name="wcfLayoutMinWidth_unit" class="jsUnitSelect">
 							{foreach from=$availableUnits item=unit}
-								<option value="{$unit}"{if $variables[wcfLayoutMinWidth_unit] == $unit} selected{/if}>{@$unit}</option>
+								<option value="{$unit}"{if $variables[wcfLayoutMinWidth_unit] == $unit} selected{/if}>{$unit}</option>
 							{/foreach}
 						</select>
 					</dd>
@@ -391,7 +391,7 @@
 						<input type="number" id="wcfLayoutMaxWidth" name="wcfLayoutMaxWidth" value="{$variables[wcfLayoutMaxWidth]}" class="tiny">
 						<select name="wcfLayoutMaxWidth_unit" class="jsUnitSelect">
 							{foreach from=$availableUnits item=unit}
-								<option value="{$unit}"{if $variables[wcfLayoutMaxWidth_unit] == $unit} selected{/if}>{@$unit}</option>
+								<option value="{$unit}"{if $variables[wcfLayoutMaxWidth_unit] == $unit} selected{/if}>{$unit}</option>
 							{/foreach}
 						</select>
 					</dd>
@@ -403,7 +403,7 @@
 						<input type="number" id="wcfLayoutFixedWidth" name="wcfLayoutFixedWidth" value="{$variables[wcfLayoutFixedWidth]}" class="tiny">
 						<select name="wcfLayoutFixedWidth_unit" class="jsUnitSelect">
 							{foreach from=$availableUnits item=unit}
-								<option value="{$unit}"{if $variables[wcfLayoutFixedWidth_unit] == $unit} selected{/if}>{@$unit}</option>
+								<option value="{$unit}"{if $variables[wcfLayoutFixedWidth_unit] == $unit} selected{/if}>{$unit}</option>
 							{/foreach}
 						</select>
 					</dd>
@@ -419,7 +419,7 @@
 				<dl>
 					<dt><label for="pageLogo">{lang}wcf.acp.style.globals.pageLogo{/lang}</label></dt>
 					<dd>
-						{@$__wcf->getUploadHandler()->renderField('pageLogo')}
+						{unsafe:$__wcf->getUploadHandler()->renderField('pageLogo')}
 						<script data-relocate="true">
 						elBySel('#pageLogouploadFileList').addEventListener('change', function (ev) {
 							var img = elBySel('#pageLogouploadFileList img');
@@ -460,7 +460,7 @@
 				<dl>
 					<dt><label for="pageLogoMobile">{lang}wcf.acp.style.globals.pageLogoMobile{/lang}</label></dt>
 					<dd>
-						{@$__wcf->getUploadHandler()->renderField('pageLogoMobile')}
+						{unsafe:$__wcf->getUploadHandler()->renderField('pageLogoMobile')}
 					</dd>
 				</dl>
 				
@@ -478,7 +478,7 @@
 						<select name="wcfFontSizeDefault_unit" class="jsUnitSelect">
 							{foreach from=$availableUnits item=unit}
 								{if $unit == 'px' || $unit == 'pt'}
-									<option value="{$unit}"{if $variables[wcfFontSizeDefault_unit] == $unit} selected{/if}>{@$unit}</option>
+									<option value="{$unit}"{if $variables[wcfFontSizeDefault_unit] == $unit} selected{/if}>{$unit}</option>
 								{/if}
 							{/foreach}
 						</select>
@@ -490,7 +490,7 @@
 						<input type="number" id="wcfFontSizeSmall" name="wcfFontSizeSmall" value="{$variables[wcfFontSizeSmall]}" class="tiny">
 						<select name="wcfFontSizeSmall_unit" class="jsUnitSelect">
 							{foreach from=$availableUnits item=unit}
-								<option value="{$unit}"{if $variables[wcfFontSizeSmall_unit] == $unit} selected{/if}>{@$unit}</option>
+								<option value="{$unit}"{if $variables[wcfFontSizeSmall_unit] == $unit} selected{/if}>{$unit}</option>
 							{/foreach}
 						</select>
 					</dd>
@@ -501,7 +501,7 @@
 						<input type="number" id="wcfFontSizeHeadline" name="wcfFontSizeHeadline" value="{$variables[wcfFontSizeHeadline]}" class="tiny">
 						<select name="wcfFontSizeHeadline_unit" class="jsUnitSelect">
 							{foreach from=$availableUnits item=unit}
-								<option value="{$unit}"{if $variables[wcfFontSizeHeadline_unit] == $unit} selected{/if}>{@$unit}</option>
+								<option value="{$unit}"{if $variables[wcfFontSizeHeadline_unit] == $unit} selected{/if}>{$unit}</option>
 							{/foreach}
 						</select>
 					</dd>
@@ -512,7 +512,7 @@
 						<input type="number" id="wcfFontSizeSection" name="wcfFontSizeSection" value="{$variables[wcfFontSizeSection]}" class="tiny">
 						<select name="wcfFontSizeSection_unit" class="jsUnitSelect">
 							{foreach from=$availableUnits item=unit}
-								<option value="{$unit}"{if $variables[wcfFontSizeSection_unit] == $unit} selected{/if}>{@$unit}</option>
+								<option value="{$unit}"{if $variables[wcfFontSizeSection_unit] == $unit} selected{/if}>{$unit}</option>
 							{/foreach}
 						</select>
 					</dd>
@@ -523,7 +523,7 @@
 						<input type="number" id="wcfFontSizeTitle" name="wcfFontSizeTitle" value="{$variables[wcfFontSizeTitle]}" class="tiny">
 						<select name="wcfFontSizeTitle_unit" class="jsUnitSelect">
 							{foreach from=$availableUnits item=unit}
-								<option value="{$unit}"{if $variables[wcfFontSizeTitle_unit] == $unit} selected{/if}>{@$unit}</option>
+								<option value="{$unit}"{if $variables[wcfFontSizeTitle_unit] == $unit} selected{/if}>{$unit}</option>
 							{/foreach}
 						</select>
 					</dd>
@@ -550,7 +550,7 @@
 					<dd>
 						<select name="wcfFontFamilyFallback" id="wcfFontFamilyFallback">
 							{foreach from=$availableFontFamilies key=fontFamily item=primaryFont}
-								<option value='{@$fontFamily}'{if $variables[wcfFontFamilyFallback] == $fontFamily} selected{/if}>{@$primaryFont}</option>
+								<option value='{$fontFamily}'{if $variables[wcfFontFamilyFallback] == $fontFamily} selected{/if}>{$primaryFont}</option>
 							{/foreach}
 						</select>
 					</dd>
@@ -591,7 +591,7 @@
 						
 						<div id="spHeader" data-region="wcfHeader">
 							<div class="spBoundary">
-								<div id="spLogo"><img src="{@$__wcf->getPath()}acp/images/woltlabSuite.png" height="80" width="562" alt=""></div>
+								<div id="spLogo"><img src="{$__wcf->getPath()}acp/images/woltlabSuite.png" height="80" width="562" alt=""></div>
 								<div id="spSearch"><div class="spInlineWrapper" data-region="wcfHeaderSearchBox"><input type="search" id="spSearchBox" placeholder="{lang}wcf.global.search.enterSearchTerm{/lang}" autocomplete="off"></div></div>
 							</div>
 						</div>

--- a/wcfsetup/install/files/acp/templates/styleImport.tpl
+++ b/wcfsetup/install/files/acp/templates/styleImport.tpl
@@ -35,7 +35,7 @@
 						{elseif $errorType == 'uploadFailed'}
 							{lang}wcf.upload.error.uploadFailed{/lang}
 						{else}
-							{lang}wcf.acp.style.import.source.error.{@$errorType}{/lang}
+							{lang}wcf.acp.style.import.source.error.{$errorType}{/lang}
 						{/if}
 					</small>
 				{/if}

--- a/wcfsetup/install/files/acp/templates/tagInput.tpl
+++ b/wcfsetup/install/files/acp/templates/tagInput.tpl
@@ -1,8 +1,8 @@
 {if $__wcf->session->getPermission('user.tag.canViewTag')}
 	<dl class="jsOnly">
-		<dt><label for="tagSearchInput{if $tagInputSuffix|isset}{@$tagInputSuffix}{/if}">{lang}wcf.tagging.tags{/lang}</label></dt>
+		<dt><label for="tagSearchInput{if $tagInputSuffix|isset}{$tagInputSuffix}{/if}">{lang}wcf.tagging.tags{/lang}</label></dt>
 		<dd>
-			<input id="tagSearchInput{if $tagInputSuffix|isset}{@$tagInputSuffix}{/if}" type="text" value="" class="long">
+			<input id="tagSearchInput{if $tagInputSuffix|isset}{$tagInputSuffix}{/if}" type="text" value="" class="long">
 			<small>{lang}wcf.tagging.tags.description{/lang}</small>
 		</dd>
 	</dl>
@@ -10,15 +10,15 @@
 	<script data-relocate="true">
 		require(['WoltLabSuite/Core/Ui/ItemList'], function(UiItemList) {
 			UiItemList.init(
-				'tagSearchInput{if $tagInputSuffix|isset}{@$tagInputSuffix}{/if}',
-				[{if $tags|isset && $tags|count}{implode from=$tags item=tag}'{@$tag|encodeJS}'{/implode}{/if}],
+				'tagSearchInput{if $tagInputSuffix|isset}{unsafe:$tagInputSuffix|encodeJS}{/if}',
+				[{if $tags|isset && $tags|count}{implode from=$tags item=tag}'{unsafe:$tag|encodeJS}'{/implode}{/if}],
 				{
 					ajax: {
 						className: 'wcf\\data\\tag\\TagAction'
-						{if !$tagLanguageID|empty}, parameters: { languageID: {@$tagLanguageID|encodeJS} }{/if}
+						{if !$tagLanguageID|empty}, parameters: { languageID: {$tagLanguageID} }{/if}
 					},
-					maxLength: {@TAGGING_MAX_TAG_LENGTH},
-					submitFieldName: '{if $tagSubmitFieldName|isset}{@$tagSubmitFieldName}{else}tags[]{/if}'
+					maxLength: {TAGGING_MAX_TAG_LENGTH},
+					submitFieldName: '{if $tagSubmitFieldName|isset}{unsafe:$tagSubmitFieldName|encodeJS}{else}tags[]{/if}'
 				}
 			);
 		});

--- a/wcfsetup/install/files/acp/templates/templateAdd.tpl
+++ b/wcfsetup/install/files/acp/templates/templateAdd.tpl
@@ -9,13 +9,13 @@
 	<nav class="contentHeaderNavigation">
 		<ul>
 			{if $action == 'edit'}<li><a href="{link controller='TemplateDiff' id=$formObject->templateID}{/link}" class="button">{icon name='right-left'} <span>{lang}wcf.acp.template.diff{/lang}</span></a></li>{/if}
-			<li><a href="{link controller='TemplateList'}{if $action == 'edit'}templateGroupID={@$formObject->templateGroupID}{/if}{/link}" class="button">{icon name='list'} <span>{lang}wcf.acp.menu.link.template.list{/lang}</span></a></li>
+			<li><a href="{link controller='TemplateList'}{if $action == 'edit'}templateGroupID={$formObject->templateGroupID}{/if}{/link}" class="button">{icon name='list'} <span>{lang}wcf.acp.menu.link.template.list{/lang}</span></a></li>
 			
 			{event name='contentHeaderNavigation'}
 		</ul>
 	</nav>
 </header>
 
-{@$form->getHtml()}
+{unsafe:$form->getHtml()}
 
 {include file='footer'}

--- a/wcfsetup/install/files/acp/templates/trophyAdd.tpl
+++ b/wcfsetup/install/files/acp/templates/trophyAdd.tpl
@@ -230,7 +230,7 @@
 <div id="trophyIconEditor" style="display: none;">
 	<div class="box128">
 		<span class="jsTrophyIcon trophyIcon" style="color: {$iconColor}; background-color: {$badgeColor}">
-			{@$icon->toHtml(128)}
+			{unsafe:$icon->toHtml(128)}
 		</span>
 		<div>
 			<dl>


### PR DESCRIPTION
- Remove unnecessary `@`
- Use `unsafe:` instead of `@`
- Add missing `{unsafe:…|encodeJS}`
- Replace deprecated `time` template modifier with `{time}`
- Migrate jQuery Code to plain JavaScript