### PR TITLE
Refactor acp list/page templates

### DIFF
--- a/wcfsetup/install/files/acp/templates/cacheList.tpl
+++ b/wcfsetup/install/files/acp/templates/cacheList.tpl
@@ -43,7 +43,7 @@
 	{/if}
 	{if $cacheData.size}<dl>
 		<dt>{lang}wcf.acp.cache.data.size{/lang}</dt>
-		<dd>{@$cacheData.size|filesize}</dd>
+		<dd>{$cacheData.size|filesize}</dd>
 	</dl>{/if}
 	{if $cacheData.files}<dl>
 		<dt>{lang}wcf.acp.cache.data.files{/lang}</dt>
@@ -65,7 +65,7 @@
 					<br><kbd>{$cache}</kbd>
 				</summary>
 				
-				<table id="cache{@$cacheIndex}" class="table">
+				<table id="cache{$cacheIndex}" class="table">
 					<thead>
 						<tr>
 							<th class="columnTitle">{lang}wcf.acp.cache.list.name{/lang}</th>
@@ -81,10 +81,10 @@
 						{foreach from=$files item=file}
 							<tr>
 								<td class="columnTitle">{$file.filename}</td>
-								<td class="columnDigits">{@$file.filesize|filesize}</td>
+								<td class="columnDigits">{$file.filesize|filesize}</td>
 								<td class="columnDate">{if $file.mtime > 1}{@$file.mtime|time}{/if}</td>
 								{if $file.perm|isset}
-									<td class="columnDigits"><span{if !$file.writable} class="hot"{/if}>{@$file.perm}</span></td>
+									<td class="columnDigits"><span{if !$file.writable} class="hot"{/if}>{$file.perm}</span></td>
 								{/if}
 							</tr>
 						{/foreach}

--- a/wcfsetup/install/files/acp/templates/cacheList.tpl
+++ b/wcfsetup/install/files/acp/templates/cacheList.tpl
@@ -82,7 +82,7 @@
 							<tr>
 								<td class="columnTitle">{$file.filename}</td>
 								<td class="columnDigits">{$file.filesize|filesize}</td>
-								<td class="columnDate">{if $file.mtime > 1}{@$file.mtime|time}{/if}</td>
+								<td class="columnDate">{if $file.mtime > 1}{time time=$file.mtime}{/if}</td>
 								{if $file.perm|isset}
 									<td class="columnDigits"><span{if !$file.writable} class="hot"{/if}>{$file.perm}</span></td>
 								{/if}

--- a/wcfsetup/install/files/acp/templates/categoryList.tpl
+++ b/wcfsetup/install/files/acp/templates/categoryList.tpl
@@ -14,7 +14,7 @@
 
 <header class="contentHeader">
 	<div class="contentHeaderTitle">
-		<h1 class="contentTitle">{@$objectType->getProcessor()->getLanguageVariable('list')}</h1>
+		<h1 class="contentTitle">{unsafe:$objectType->getProcessor()->getLanguageVariable('list')}</h1>
 	</div>
 	
 	{hascontent}
@@ -22,7 +22,7 @@
 			<ul>
 				{content}
 					{if $objectType->getProcessor()->canAddCategory()}
-						<li><a href="{link controller=$addController application=$objectType->getProcessor()->getApplication()}{/link}" class="button">{icon name='plus'} <span>{@$objectType->getProcessor()->getLanguageVariable('add')}</span></a></li>
+						<li><a href="{link controller=$addController application=$objectType->getProcessor()->getApplication()}{/link}" class="button">{icon name='plus'} <span>{unsafe:$objectType->getProcessor()->getLanguageVariable('add')}</span></a></li>
 					{/if}
 						
 					{event name='contentHeaderNavigation'}
@@ -40,7 +40,7 @@
 				{foreach from=$categoryNodeList item='category'}
 					{section name=i loop=$oldDepth-$categoryNodeList->getDepth()}</ol></li>{/section}
 					
-					<li class="{if $objectType->getProcessor()->canEditCategory()}sortableNode {if $categoryNodeList->getDepth() == $objectType->getProcessor()->getMaximumNestingLevel()}sortableNoNesting {/if}{/if}jsCategory jsObjectActionObject" data-object-id="{@$category->getObjectID()}">
+					<li class="{if $objectType->getProcessor()->canEditCategory()}sortableNode {if $categoryNodeList->getDepth() == $objectType->getProcessor()->getMaximumNestingLevel()}sortableNoNesting {/if}{/if}jsCategory jsObjectActionObject" data-object-id="{$category->getObjectID()}">
 						<span class="sortableNodeLabel">
 							<span class="title">
 								{event name='beforeTitle'}
@@ -68,7 +68,7 @@
 										class="jsObjectAction jsTooltip"
 										title="{lang}wcf.global.button.delete{/lang}"
 										data-object-action="delete"
-										data-confirm-message="{@$objectType->getProcessor()->getLanguageVariable('delete.sure')}"
+										data-confirm-message="{unsafe:$objectType->getProcessor()->getLanguageVariable('delete.sure')}"
 									>
 										{icon name='xmark'}
 									</button>
@@ -78,7 +78,7 @@
 							</span>
 						</span>
 						
-						<ol class="categoryList sortableList jsObjectActionObjectChildren" data-object-id="{@$category->categoryID}">{if !$categoryNodeList->current()->hasChildren()}</ol></li>{/if}
+						<ol class="categoryList sortableList jsObjectActionObjectChildren" data-object-id="{$category->categoryID}">{if !$categoryNodeList->current()->hasChildren()}</ol></li>{/if}
 					{assign var=oldDepth value=$categoryNodeList->getDepth()}
 				{/foreach}
 				{section name=i loop=$oldDepth}</ol></li>{/section}
@@ -90,7 +90,7 @@
 		<button type="button" class="button buttonPrimary" data-type="submit">{lang}wcf.global.button.saveSorting{/lang}</button>
 	</div>
 {hascontentelse}
-	<woltlab-core-notice type="info">{@$objectType->getProcessor()->getLanguageVariable('noneAvailable')}</woltlab-core-notice>
+	<woltlab-core-notice type="info">{unsafe:$objectType->getProcessor()->getLanguageVariable('noneAvailable')}</woltlab-core-notice>
 {/hascontent}
 
 {include file='footer'}

--- a/wcfsetup/install/files/acp/templates/mediaList.tpl
+++ b/wcfsetup/install/files/acp/templates/mediaList.tpl
@@ -149,10 +149,10 @@
 						</div>
 					</td>
 					<td class="columnText columnMediaTitle">{$media->title|tableWordwrap}</td>
-					<td class="columnDate columnUploadTime">{@$media->uploadTime|time}</td>
+					<td class="columnDate columnUploadTime">{time time=$media->uploadTime}</td>
 					<td class="columnDigits columnFilesize">{$media->filesize|filesize}</td>
 					<td class="columnDigits columnDownloads">{#$media->downloads}</td>
-					<td class="columnDate columnLastDownloadTime">{if $media->lastDownloadTime}{@$media->lastDownloadTime|time}{/if}</td>
+					<td class="columnDate columnLastDownloadTime">{if $media->lastDownloadTime}{time time=$media->lastDownloadTime}{/if}</td>
 					
 					{event name='columns'}
 				</tr>

--- a/wcfsetup/install/files/acp/templates/mediaList.tpl
+++ b/wcfsetup/install/files/acp/templates/mediaList.tpl
@@ -11,7 +11,7 @@
 		
 		ControllerMediaList.init({
 			{if $categoryID}
-				categoryId: {@$categoryID},
+				categoryId: {$categoryID},
 			{/if}
 			hasMarkedItems: {if $hasMarkedItems}true{else}false{/if}
 		});
@@ -113,13 +113,13 @@
 		<thead>
 			<tr>
 				<th class="columnMark"><label><input type="checkbox" class="jsClipboardMarkAll"></label></th>
-				<th class="columnID columnMediaID{if $sortField == 'mediaID'} active {@$sortOrder}{/if}" colspan="2"><a href="{link controller='MediaList'}pageNo={@$pageNo}&sortField=mediaID&sortOrder={if $sortField == 'mediaID' && $sortOrder == 'ASC'}DESC{else}ASC{/if}{@$linkParameters}{/link}">{lang}wcf.global.objectID{/lang}</a></th>
-				<th class="columnTitle columnFilename{if $sortField == 'filename'} active {@$sortOrder}{/if}"><a href="{link controller='MediaList'}pageNo={@$pageNo}&sortField=filename&sortOrder={if $sortField == 'filename' && $sortOrder == 'ASC'}DESC{else}ASC{/if}{@$linkParameters}{/link}">{lang}wcf.media.filename{/lang}</a></th>
-				<th class="columnText columnMediaTitle{if $sortField == 'title'} active {@$sortOrder}{/if}"><a href="{link controller='MediaList'}pageNo={@$pageNo}&sortField=title&sortOrder={if $sortField == 'title' && $sortOrder == 'ASC'}DESC{else}ASC{/if}{@$linkParameters}{/link}">{lang}wcf.global.title{/lang}</a></th>
-				<th class="columnDate columnUploadTime{if $sortField == 'uploadTime'} active {@$sortOrder}{/if}"><a href="{link controller='MediaList'}pageNo={@$pageNo}&sortField=uploadTime&sortOrder={if $sortField == 'uploadTime' && $sortOrder == 'ASC'}DESC{else}ASC{/if}{@$linkParameters}{/link}">{lang}wcf.media.uploadTime{/lang}</a></th>
-				<th class="columnDigits columnFilesize{if $sortField == 'filesize'} active {@$sortOrder}{/if}"><a href="{link controller='MediaList'}pageNo={@$pageNo}&sortField=filesize&sortOrder={if $sortField == 'filesize' && $sortOrder == 'ASC'}DESC{else}ASC{/if}{@$linkParameters}{/link}">{lang}wcf.media.filesize{/lang}</a></th>
-				<th class="columnDigits columnDownloads{if $sortField == 'downloads'} active {@$sortOrder}{/if}"><a href="{link controller='MediaList'}pageNo={@$pageNo}&sortField=downloads&sortOrder={if $sortField == 'downloads' && $sortOrder == 'ASC'}DESC{else}ASC{/if}{@$linkParameters}{/link}">{lang}wcf.media.downloads{/lang}</a></th>
-				<th class="columnDate columnLastDownloadTime{if $sortField == 'lastDownloadTime'} active {@$sortOrder}{/if}"><a href="{link controller='MediaList'}pageNo={@$pageNo}&sortField=lastDownloadTime&sortOrder={if $sortField == 'lastDownloadTime' && $sortOrder == 'ASC'}DESC{else}ASC{/if}{@$linkParameters}{/link}">{lang}wcf.media.lastDownloadTime{/lang}</a></th>
+				<th class="columnID columnMediaID{if $sortField == 'mediaID'} active {$sortOrder}{/if}" colspan="2"><a href="{link controller='MediaList'}pageNo={$pageNo}&sortField=mediaID&sortOrder={if $sortField == 'mediaID' && $sortOrder == 'ASC'}DESC{else}ASC{/if}{unsafe:$linkParameters}{/link}">{lang}wcf.global.objectID{/lang}</a></th>
+				<th class="columnTitle columnFilename{if $sortField == 'filename'} active {$sortOrder}{/if}"><a href="{link controller='MediaList'}pageNo={$pageNo}&sortField=filename&sortOrder={if $sortField == 'filename' && $sortOrder == 'ASC'}DESC{else}ASC{/if}{unsafe:$linkParameters}{/link}">{lang}wcf.media.filename{/lang}</a></th>
+				<th class="columnText columnMediaTitle{if $sortField == 'title'} active {$sortOrder}{/if}"><a href="{link controller='MediaList'}pageNo={$pageNo}&sortField=title&sortOrder={if $sortField == 'title' && $sortOrder == 'ASC'}DESC{else}ASC{/if}{unsafe:$linkParameters}{/link}">{lang}wcf.global.title{/lang}</a></th>
+				<th class="columnDate columnUploadTime{if $sortField == 'uploadTime'} active {$sortOrder}{/if}"><a href="{link controller='MediaList'}pageNo={$pageNo}&sortField=uploadTime&sortOrder={if $sortField == 'uploadTime' && $sortOrder == 'ASC'}DESC{else}ASC{/if}{unsafe:$linkParameters}{/link}">{lang}wcf.media.uploadTime{/lang}</a></th>
+				<th class="columnDigits columnFilesize{if $sortField == 'filesize'} active {$sortOrder}{/if}"><a href="{link controller='MediaList'}pageNo={$pageNo}&sortField=filesize&sortOrder={if $sortField == 'filesize' && $sortOrder == 'ASC'}DESC{else}ASC{/if}{unsafe:$linkParameters}{/link}">{lang}wcf.media.filesize{/lang}</a></th>
+				<th class="columnDigits columnDownloads{if $sortField == 'downloads'} active {$sortOrder}{/if}"><a href="{link controller='MediaList'}pageNo={$pageNo}&sortField=downloads&sortOrder={if $sortField == 'downloads' && $sortOrder == 'ASC'}DESC{else}ASC{/if}{unsafe:$linkParameters}{/link}">{lang}wcf.media.downloads{/lang}</a></th>
+				<th class="columnDate columnLastDownloadTime{if $sortField == 'lastDownloadTime'} active {$sortOrder}{/if}"><a href="{link controller='MediaList'}pageNo={$pageNo}&sortField=lastDownloadTime&sortOrder={if $sortField == 'lastDownloadTime' && $sortOrder == 'ASC'}DESC{else}ASC{/if}{unsafe:$linkParameters}{/link}">{lang}wcf.media.lastDownloadTime{/lang}</a></th>
 				
 				{event name='columnHeads'}
 			</tr>
@@ -127,20 +127,20 @@
 		
 		<tbody class="jsReloadPageWhenEmpty" id="mediaListTableBody" data-no-items-info="noItemsInfo">
 			{foreach from=$objects item=media}
-				<tr class="jsMediaRow jsClipboardObject jsObjectActionObject" data-object-id="{@$media->getObjectID()}">
-					<td class="columnMark"><input type="checkbox" class="jsClipboardItem" data-object-id="{@$media->mediaID}"></td>
+				<tr class="jsMediaRow jsClipboardObject jsObjectActionObject" data-object-id="{$media->getObjectID()}">
+					<td class="columnMark"><input type="checkbox" class="jsClipboardItem" data-object-id="{$media->mediaID}"></td>
 					<td class="columnIcon">
-						<button type="button" class="mediaEditButton jsMediaEditButton jsTooltip" title="{lang}wcf.global.button.edit{/lang}" data-object-id="{@$media->mediaID}">
+						<button type="button" class="mediaEditButton jsMediaEditButton jsTooltip" title="{lang}wcf.global.button.edit{/lang}" data-object-id="{$media->mediaID}">
 							{icon name='pencil'}
 						</button>
 						{objectAction action="delete" objectTitle=$media->filename}
 						
 						{event name='rowButtons'}
 					</td>
-					<td class="columnID columnMediaID">{@$media->mediaID}</td>
+					<td class="columnID columnMediaID">{$media->mediaID}</td>
 					<td class="columnTitle columnFilename">
 						<div class="box48">
-							{@$media->getElementTag(48)}
+							{unsafe:$media->getElementTag(48)}
 							
 							<div>
 								<p><a href="{$media->getLink()}">{$media->filename|tableWordwrap}</a></p>
@@ -150,7 +150,7 @@
 					</td>
 					<td class="columnText columnMediaTitle">{$media->title|tableWordwrap}</td>
 					<td class="columnDate columnUploadTime">{@$media->uploadTime|time}</td>
-					<td class="columnDigits columnFilesize">{@$media->filesize|filesize}</td>
+					<td class="columnDigits columnFilesize">{$media->filesize|filesize}</td>
 					<td class="columnDigits columnDownloads">{#$media->downloads}</td>
 					<td class="columnDate columnLastDownloadTime">{if $media->lastDownloadTime}{@$media->lastDownloadTime|time}{/if}</td>
 					

--- a/wcfsetup/install/files/acp/templates/mediaList.tpl
+++ b/wcfsetup/install/files/acp/templates/mediaList.tpl
@@ -95,18 +95,20 @@
 	</section>
 </form>
 
-{hascontent}
+{assign var='linkParameters' value=''}
+{if $username}{capture append=linkParameters}&username={unsafe:$username|rawurlencode}{/capture}{/if}
+{if $q}{capture append=linkParameters}&q={unsafe:$q|rawurlencode}{/capture}{/if}
+{if $categoryID}{capture append=linkParameters}&categoryID={$categoryID}{/capture}{/if}
+
+{if $pages > 1}
 	<div class="paginationTop">
-		{content}
-			{assign var='linkParameters' value=''}
-			{if $username}{capture append=linkParameters}&username={@$username|rawurlencode}{/capture}{/if}
-			{if $q}{capture append=linkParameters}&q={@$q|rawurlencode}{/capture}{/if}
-			{if $categoryID}{capture append=linkParameters}&categoryID={@$categoryID}{/capture}{/if}
-			
-			{pages print=true assign=pagesLinks controller="MediaList" link="pageNo=%d&sortField=$sortField&sortOrder=$sortOrder$linkParameters"}
-		{/content}
+		<woltlab-core-pagination
+			page="{$pageNo}"
+			count="{$pages}"
+			url="{link controller='MediaList' sortField=$sortField sortOrder=$sortOrder}{unsafe:$linkParameters}{/link}"
+		></woltlab-core-pagination>
 	</div>
-{/hascontent}
+{/if}
 
 <div class="section tabularBox"{if !$objects|count} style="display: none;{/if}">
 	<table class="table jsClipboardContainer jsObjectActionContainer" data-object-action-class-name="wcf\data\media\MediaAction" data-type="com.woltlab.wcf.media">
@@ -193,11 +195,15 @@
 
 {if $objects|count}
 	<footer class="contentFooter">
-		{hascontent}
+		{if $pages > 1}
 			<div class="paginationBottom">
-				{content}{@$pagesLinks}{/content}
+				<woltlab-core-pagination
+					page="{$pageNo}"
+					count="{$pages}"
+					url="{link controller='MediaList' sortField=$sortField sortOrder=$sortOrder}{unsafe:$linkParameters}{/link}"
+				></woltlab-core-pagination>
 			</div>
-		{/hascontent}
+		{/if}
 		
 		<nav class="contentFooterNavigation">
 			<ul>

--- a/wcfsetup/install/files/acp/templates/mediaListItems.tpl
+++ b/wcfsetup/install/files/acp/templates/mediaListItems.tpl
@@ -1,7 +1,7 @@
 {foreach from=$mediaList item=media}
-	<li class="jsClipboardObject mediaFile jsObjectActionObject" data-object-id="{@$media->getObjectID()}">
+	<li class="jsClipboardObject mediaFile jsObjectActionObject" data-object-id="{$media->getObjectID()}">
 		<div class="mediaThumbnail">
-			{@$media->getElementTag(144)}
+			{unsafe:$media->getElementTag(144)}
 		</div>
 
 		{assign var='__mediaTitle' value=$media->filename}
@@ -15,10 +15,10 @@
 		<nav class="jsMobileNavigation buttonGroupNavigation">
 			<ul class="buttonList iconList">
 				<li class="mediaCheckbox">
-					<a><label><input type="checkbox" class="jsClipboardItem" data-object-id="{@$media->mediaID}"></label></a>
+					<a><label><input type="checkbox" class="jsClipboardItem" data-object-id="{$media->mediaID}"></label></a>
 				</li>
 				{if $__wcf->session->getPermission('admin.content.cms.canManageMedia')}
-					<li class="jsMediaEditButton" data-object-id="{@$media->mediaID}">
+					<li class="jsMediaEditButton" data-object-id="{$media->mediaID}">
 						<button type="button" class="jsTooltip" title="{lang}wcf.global.button.edit{/lang}">
 							{icon name='pencil'}
 						</button>
@@ -30,13 +30,13 @@
 					</li>
 				{/if}
 				{if $mode == 'editor'}
-					<li class="jsMediaInsertButton" data-object-id="{@$media->mediaID}">
+					<li class="jsMediaInsertButton" data-object-id="{$media->mediaID}">
 						<button type="button" class="jsTooltip" title="{lang}wcf.media.button.insert{/lang}">
 							{icon name='plus'}
 						</button>
 					</li>
 				{elseif $mode == 'select'}
-					<li class="jsMediaSelectButton" data-object-id="{@$media->mediaID}">
+					<li class="jsMediaSelectButton" data-object-id="{$media->mediaID}">
 						<button type="button" class="jsTooltip" title="{lang}wcf.media.button.select{/lang}">
 							{icon name='check'}
 						</button>

--- a/wcfsetup/install/files/acp/templates/menuItemList.tpl
+++ b/wcfsetup/install/files/acp/templates/menuItemList.tpl
@@ -9,7 +9,7 @@
 				protectRoot: true
 			},
 			additionalParameters: {
-				menuID: '{@$menuID}'
+				menuID: {$menuID}
 			}
 		});
 	});
@@ -24,7 +24,7 @@
 	<nav class="contentHeaderNavigation">
 		<ul>
 			<li><a href="{link controller='MenuEdit' id=$menuID}{/link}" class="button">{icon name='pencil'} <span>{lang}wcf.acp.menu.edit{/lang}</span></a></li>
-			<li><a href="{link controller='MenuItemAdd'}menuID={@$menuID}{/link}" class="button">{icon name='plus'} <span>{lang}wcf.acp.menu.item.add{/lang}</span></a></li>
+			<li><a href="{link controller='MenuItemAdd'}menuID={$menuID}{/link}" class="button">{icon name='plus'} <span>{lang}wcf.acp.menu.item.add{/lang}</span></a></li>
 			
 			{event name='contentHeaderNavigation'}
 		</ul>
@@ -36,7 +36,7 @@
 		<ol class="sortableList jsReloadPageWhenEmpty jsObjectActionContainer" data-object-action-class-name="wcf\data\menu\item\MenuItemAction" data-object-id="0">
 			{content}
 				{foreach from=$menuItemNodeList item=menuItemNode}
-					<li class="sortableNode jsObjectActionObject" data-object-id="{@$menuItemNode->getObjectID()}">
+					<li class="sortableNode jsObjectActionObject" data-object-id="{$menuItemNode->getObjectID()}">
 						<span class="sortableNodeLabel">
 							<a href="{link controller='MenuItemEdit' id=$menuItemNode->itemID}{/link}">{$menuItemNode->getTitle()}</a>
 							<span class="statusDisplay sortableButtonContainer">
@@ -67,10 +67,10 @@
 							</span>
 						</span>
 					
-						<ol class="sortableList jsObjectActionObjectChildren" data-object-id="{@$menuItemNode->itemID}">{if !$menuItemNode->hasChildren()}</ol></li>{/if}
+						<ol class="sortableList jsObjectActionObjectChildren" data-object-id="{$menuItemNode->itemID}">{if !$menuItemNode->hasChildren()}</ol></li>{/if}
 						
 						{if !$menuItemNode->hasChildren() && $menuItemNode->isLastSibling()}
-							{@"</ol></li>"|str_repeat:$menuItemNode->getOpenParentNodes()}
+							{unsafe:"</ol></li>"|str_repeat:$menuItemNode->getOpenParentNodes()}
 						{/if}
 				{/foreach}
 			{/content}

--- a/wcfsetup/install/files/acp/templates/menuItemList.tpl
+++ b/wcfsetup/install/files/acp/templates/menuItemList.tpl
@@ -24,7 +24,7 @@
 	<nav class="contentHeaderNavigation">
 		<ul>
 			<li><a href="{link controller='MenuEdit' id=$menuID}{/link}" class="button">{icon name='pencil'} <span>{lang}wcf.acp.menu.edit{/lang}</span></a></li>
-			<li><a href="{link controller='MenuItemAdd'}menuID={$menuID}{/link}" class="button">{icon name='plus'} <span>{lang}wcf.acp.menu.item.add{/lang}</span></a></li>
+			<li><a href="{link controller='MenuItemAdd' menuID=$menuID}{/link}" class="button">{icon name='plus'} <span>{lang}wcf.acp.menu.item.add{/lang}</span></a></li>
 			
 			{event name='contentHeaderNavigation'}
 		</ul>

--- a/wcfsetup/install/files/acp/templates/paidSubscriptionTransactionLog.tpl
+++ b/wcfsetup/install/files/acp/templates/paidSubscriptionTransactionLog.tpl
@@ -1,9 +1,9 @@
-{capture assign='pageTitle'}{lang}wcf.acp.paidSubscription.transactionLog{/lang}: {@$log->logID}{/capture}
+{capture assign='pageTitle'}{lang}wcf.acp.paidSubscription.transactionLog{/lang}: {$log->logID}{/capture}
 {include file='header'}
 
 <header class="contentHeader">
 	<div class="contentHeaderTitle">
-		<h1 class="contentTitle">{lang}wcf.acp.paidSubscription.transactionLog{/lang}: {@$log->logID}</h1>
+		<h1 class="contentTitle">{lang}wcf.acp.paidSubscription.transactionLog{/lang}: {$log->logID}</h1>
 	</div>
 	
 	<nav class="contentHeaderNavigation">
@@ -16,7 +16,7 @@
 </header>
 
 <section class="section">
-	<h2 class="sectionTitle">{lang}wcf.acp.paidSubscription.transactionLog{/lang}: {@$log->logID}</h2>
+	<h2 class="sectionTitle">{lang}wcf.acp.paidSubscription.transactionLog{/lang}: {$log->logID}</h2>
 	
 	<dl>
 		<dt>{lang}wcf.acp.paidSubscription.transactionLog.logMessage{/lang}</dt>
@@ -33,7 +33,7 @@
 		{/if}
 		
 		<dt>{lang}wcf.acp.paidSubscription.transactionLog.paymentMethod{/lang}</dt>
-		<dd>{lang}wcf.payment.{@$log->getPaymentMethodName()}{/lang}</dd>
+		<dd>{lang}wcf.payment.{$log->getPaymentMethodName()}{/lang}</dd>
 		
 		<dt>{lang}wcf.acp.paidSubscription.transactionLog.transactionID{/lang}</dt>
 		<dd>{$log->transactionID}</dd>

--- a/wcfsetup/install/files/acp/templates/paidSubscriptionTransactionLog.tpl
+++ b/wcfsetup/install/files/acp/templates/paidSubscriptionTransactionLog.tpl
@@ -39,7 +39,7 @@
 		<dd>{$log->transactionID}</dd>
 		
 		<dt>{lang}wcf.acp.paidSubscription.transactionLog.logTime{/lang}</dt>
-		<dd>{@$log->logTime|time}</dd>
+		<dd>{time time=$log->logTime}</dd>
 	</dl>
 </section>
 

--- a/wcfsetup/install/files/acp/templates/reactionTypeImage.tpl
+++ b/wcfsetup/install/files/acp/templates/reactionTypeImage.tpl
@@ -1,5 +1,5 @@
 <img
-	src="{@$__wcf->getPath()}images/reaction/{$reactionType->iconFile}"
+	src="{$__wcf->getPath()}images/reaction/{$reactionType->iconFile}"
 	style="width:24px;height:24px"
 	class="reactionType"
 	data-reaction-type-id="{$reactionType->reactionTypeID}"

--- a/wcfsetup/install/files/acp/templates/sitemapList.tpl
+++ b/wcfsetup/install/files/acp/templates/sitemapList.tpl
@@ -34,7 +34,7 @@
 			
 			<tbody>
 				{foreach from=$sitemapObjectTypes item=object}
-					<tr class="sitemapObjectRow jsObjectActionObject" data-object-id="{@$object->getObjectID()}">
+					<tr class="sitemapObjectRow jsObjectActionObject" data-object-id="{$object->getObjectID()}">
 						<td class="columnIcon">
 							{if $sitemapData[$object->objectType]['isDisabled']}
 								{objectAction action="toggle" isDisabled=true}

--- a/wcfsetup/install/files/acp/templates/stat.tpl
+++ b/wcfsetup/install/files/acp/templates/stat.tpl
@@ -1,8 +1,8 @@
 {include file='header' pageTitle='wcf.acp.stat'}
 
-<script data-relocate="true" src="{@$__wcf->getPath()}js/3rdParty/flot/jquery.flot.js"></script>
-<script data-relocate="true" src="{@$__wcf->getPath()}js/3rdParty/flot/jquery.flot.time.js"></script>
-<script data-relocate="true" src="{@$__wcf->getPath()}js/3rdParty/flot/jquery.flot.resize.js"></script>
+<script data-relocate="true" src="{$__wcf->getPath()}js/3rdParty/flot/jquery.flot.js"></script>
+<script data-relocate="true" src="{$__wcf->getPath()}js/3rdParty/flot/jquery.flot.time.js"></script>
+<script data-relocate="true" src="{$__wcf->getPath()}js/3rdParty/flot/jquery.flot.resize.js"></script>
 <script data-relocate="true">
 	$(function() {
 		WCF.Language.addObject({
@@ -62,10 +62,10 @@
 	
 	{foreach from=$availableObjectTypes key=categoryName item=objectTypes}
 		<dl>
-			<dt><label>{lang}wcf.acp.stat.category.{@$categoryName}{/lang}</label></dt>
+			<dt><label>{lang}wcf.acp.stat.category.{$categoryName}{/lang}</label></dt>
 			<dd>
 				{foreach from=$objectTypes item=objectType}
-					<label><input type="checkbox" name="objectTypeID" value="{$objectType->objectTypeID}"{if $objectType->default} checked{/if}> {lang}wcf.acp.stat.{@$objectType->objectType}{/lang}</label>
+					<label><input type="checkbox" name="objectTypeID" value="{$objectType->objectTypeID}"{if $objectType->default} checked{/if}> {lang}wcf.acp.stat.{$objectType->objectType}{/lang}</label>
 				{/foreach}
 			</dd>
 		</dl>

--- a/wcfsetup/install/files/acp/templates/systemCheck.tpl
+++ b/wcfsetup/install/files/acp/templates/systemCheck.tpl
@@ -17,9 +17,9 @@
 		<dt>{lang}wcf.acp.systemCheck.web{/lang}</dt>
 		<dd>
 			{if $results[status][web]}
-				{@$statusOk} {lang}wcf.acp.systemCheck.pass{/lang}
+				{unsafe:$statusOk} {lang}wcf.acp.systemCheck.pass{/lang}
 			{else}
-				{@$statusInsufficient} {lang}wcf.acp.systemCheck.insufficient{/lang}
+				{unsafe:$statusInsufficient} {lang}wcf.acp.systemCheck.insufficient{/lang}
 			{/if}
 		</dd>
 	</dl>
@@ -29,12 +29,12 @@
 		<dd>
 			{if $results[status][php]}
 				{if $results[php][version][result] === 'sufficient'}
-					{@$statusSufficient} {lang}wcf.acp.systemCheck.sufficient{/lang}
+					{unsafe:$statusSufficient} {lang}wcf.acp.systemCheck.sufficient{/lang}
 				{else}
-					{@$statusOk} {lang}wcf.acp.systemCheck.pass{/lang}
+					{unsafe:$statusOk} {lang}wcf.acp.systemCheck.pass{/lang}
 				{/if}
 			{else}
-				{@$statusInsufficient} {lang}wcf.acp.systemCheck.insufficient{/lang}
+				{unsafe:$statusInsufficient} {lang}wcf.acp.systemCheck.insufficient{/lang}
 			{/if}
 		</dd>
 	</dl>
@@ -43,9 +43,9 @@
 		<dt>{lang}wcf.acp.systemCheck.mysql{/lang}</dt>
 		<dd>
 			{if $results[status][mysql]}
-				{@$statusOk} {lang}wcf.acp.systemCheck.pass{/lang}
+				{unsafe:$statusOk} {lang}wcf.acp.systemCheck.pass{/lang}
 			{else}
-				{@$statusInsufficient} {lang}wcf.acp.systemCheck.insufficient{/lang}
+				{unsafe:$statusInsufficient} {lang}wcf.acp.systemCheck.insufficient{/lang}
 			{/if}
 		</dd>
 	</dl>
@@ -54,9 +54,9 @@
 		<dt>{lang}wcf.acp.systemCheck.directories{/lang}</dt>
 		<dd>
 			{if $results[status][directories]}
-				{@$statusOk} {lang}wcf.acp.systemCheck.pass{/lang}
+				{unsafe:$statusOk} {lang}wcf.acp.systemCheck.pass{/lang}
 			{else}
-				{@$statusInsufficient} {lang}wcf.acp.systemCheck.insufficient{/lang}
+				{unsafe:$statusInsufficient} {lang}wcf.acp.systemCheck.insufficient{/lang}
 			{/if}
 		</dd>
 	</dl>
@@ -69,9 +69,9 @@
 		<dt>{lang}wcf.acp.systemCheck.web.https{/lang}</dt>
 		<dd>
 			{if $results[web][https]}
-				{@$statusOk} {lang}wcf.acp.systemCheck.pass{/lang}
+				{unsafe:$statusOk} {lang}wcf.acp.systemCheck.pass{/lang}
 			{else}
-				{@$statusInsufficient} {lang}wcf.acp.systemCheck.notSupported{/lang}
+				{unsafe:$statusInsufficient} {lang}wcf.acp.systemCheck.notSupported{/lang}
 			{/if}
 			<small>{lang}wcf.acp.systemCheck.web.https.description{/lang}</small>
 		</dd>
@@ -85,15 +85,15 @@
 		<dt>{lang}wcf.acp.systemCheck.php.version{/lang}</dt>
 		<dd>
 			{if $results[php][version][result] === 'recommended'}
-				{@$statusOk} {$results[php][version][value]}
+				{unsafe:$statusOk} {$results[php][version][value]}
 			{elseif $results[php][version][result] === 'sufficient'}
-				{@$statusSufficient} {$results[php][version][value]}
+				{unsafe:$statusSufficient} {$results[php][version][value]}
 			{elseif $results[php][version][result] === 'deprecated'}
-				{@$statusSufficient} {$results[php][version][value]}
+				{unsafe:$statusSufficient} {$results[php][version][value]}
 
 				<woltlab-core-notice type="warning">{lang}wcf.acp.systemCheck.php.version.deprecated{/lang}</woltlab-core-notice>
 			{else}
-				{@$statusInsufficient} {$results[php][version][value]}
+				{unsafe:$statusInsufficient} {$results[php][version][value]}
 			{/if}
 			
 			<small>{lang}wcf.acp.systemCheck.php.version.description{/lang}</small>
@@ -104,9 +104,9 @@
 		<dt>{lang}wcf.acp.systemCheck.php.x64{/lang}</dt>
 		<dd>
 			{if $results[php][x64]}
-				{@$statusOk} {lang}wcf.acp.systemCheck.pass{/lang}
+				{unsafe:$statusOk} {lang}wcf.acp.systemCheck.pass{/lang}
 			{else}
-				{@$statusInsufficient} {lang}wcf.acp.systemCheck.notSupported{/lang}
+				{unsafe:$statusInsufficient} {lang}wcf.acp.systemCheck.notSupported{/lang}
 			{/if}
 			<small>{lang}wcf.acp.systemCheck.php.x64.description{/lang}</small>
 		</dd>
@@ -116,11 +116,11 @@
 		<dt>{lang}wcf.acp.systemCheck.php.extension{/lang}</dt>
 		<dd>
 			{if $results[php][extension]|empty}
-				{@$statusOk} {lang}wcf.acp.systemCheck.pass{/lang}
+				{unsafe:$statusOk} {lang}wcf.acp.systemCheck.pass{/lang}
 			{else}
 				<ul class="nativeList">
 					{foreach from=$results[php][extension] item=extension}
-						<li>{@$statusInsufficient} <kbd>{$extension}</kbd></li>
+						<li>{unsafe:$statusInsufficient} <kbd>{$extension}</kbd></li>
 					{/foreach}
 				</ul>
 			{/if}
@@ -131,7 +131,7 @@
 	<dl{if !$results[php][memoryLimit][result]} class="formError"{/if}>
 		<dt>{lang}wcf.acp.systemCheck.php.memoryLimit{/lang}</dt>
 		<dd>
-			{if $results[php][memoryLimit][result]}{@$statusOk}{else}{@$statusInsufficient}{/if} {$results[php][memoryLimit][value]}
+			{if $results[php][memoryLimit][result]}{unsafe:$statusOk}{else}{unsafe:$statusInsufficient}{/if} {$results[php][memoryLimit][value]}
 			<small>{lang}wcf.acp.systemCheck.php.memoryLimit.description{/lang}</small>
 		</dd>
 	</dl>
@@ -140,11 +140,11 @@
 		<dt>{lang}wcf.acp.systemCheck.php.opcache{/lang}</dt>
 		<dd>
 			{if $results[php][opcache] === true}
-				{@$statusOk} {lang}wcf.acp.systemCheck.pass{/lang}
+				{unsafe:$statusOk} {lang}wcf.acp.systemCheck.pass{/lang}
 			{elseif $results[php][opcache] === null}
-				{@$statusSufficient} {lang}wcf.acp.systemCheck.notSupported{/lang}
+				{unsafe:$statusSufficient} {lang}wcf.acp.systemCheck.notSupported{/lang}
 			{else}
-				{@$statusInsufficient} {lang}wcf.acp.systemCheck.php.opcache.broken{/lang}
+				{unsafe:$statusInsufficient} {lang}wcf.acp.systemCheck.php.opcache.broken{/lang}
 			{/if}
 			<small>{lang}wcf.acp.systemCheck.php.opcache.description{/lang}</small>
 		</dd>
@@ -154,17 +154,17 @@
 		<dt>{lang}wcf.acp.systemCheck.php.gd{/lang}</dt>
 		<dd>
 			{if $results[php][gd][result]}
-				{@$statusOk} {lang}wcf.acp.systemCheck.pass{/lang}
+				{unsafe:$statusOk} {lang}wcf.acp.systemCheck.pass{/lang}
 			{else}
 				<ul class="nativeList">
 					{if !$results[php][gd][jpeg]}
-						<li>{@$statusInsufficient} <kbd>jpeg</kbd></li>
+						<li>{unsafe:$statusInsufficient} <kbd>jpeg</kbd></li>
 					{/if}
 					{if !$results[php][gd][png]}
-						<li>{@$statusInsufficient} <kbd>png</kbd></li>
+						<li>{unsafe:$statusInsufficient} <kbd>png</kbd></li>
 					{/if}
 					{if !$results[php][gd][webp]}
-						<li>{@$statusInsufficient} <kbd>webp</kbd></li>
+						<li>{unsafe:$statusInsufficient} <kbd>webp</kbd></li>
 					{/if}
 				</ul>
 			{/if}
@@ -179,7 +179,7 @@
 	<dl{if !$results[mysql][result]} class="formError"{/if}>
 		<dt>{lang}wcf.acp.systemCheck.mysql.version{/lang}</dt>
 		<dd>
-			{if $results[mysql][result]}{@$statusOk}{else}{@$statusInsufficient}{/if}
+			{if $results[mysql][result]}{unsafe:$statusOk}{else}{unsafe:$statusInsufficient}{/if}
 			{if $results[mysql][mariadb]}MariaDB{else}MySQL{/if} {$results[mysql][version]}
 			<small>{lang}wcf.acp.systemCheck.mysql.version.description{/lang}</small>
 		</dd>
@@ -189,9 +189,9 @@
 		<dt>{lang}wcf.acp.systemCheck.mysql.mysqlnd{/lang}</dt>
 		<dd>
 			{if $results[mysql][mysqlnd]}
-				{@$statusOk} {lang}wcf.acp.systemCheck.pass{/lang}
+				{unsafe:$statusOk} {lang}wcf.acp.systemCheck.pass{/lang}
 			{else}
-				{@$statusInsufficient} {lang}wcf.acp.systemCheck.notSupported{/lang}
+				{unsafe:$statusInsufficient} {lang}wcf.acp.systemCheck.notSupported{/lang}
 			{/if}
 			<small>{lang}wcf.acp.systemCheck.mysql.mysqlnd.description{/lang}</small>
 		</dd>
@@ -201,9 +201,9 @@
 		<dt>{lang}wcf.acp.systemCheck.mysql.innodb{/lang}</dt>
 		<dd>
 			{if $results[mysql][innodb]}
-				{@$statusOk} {lang}wcf.acp.systemCheck.pass{/lang}
+				{unsafe:$statusOk} {lang}wcf.acp.systemCheck.pass{/lang}
 			{else}
-				{@$statusInsufficient} {lang}wcf.acp.systemCheck.notSupported{/lang}
+				{unsafe:$statusInsufficient} {lang}wcf.acp.systemCheck.notSupported{/lang}
 			{/if}
 			<small>{lang}wcf.acp.systemCheck.mysql.innodb.description{/lang}</small>
 		</dd>
@@ -213,9 +213,9 @@
 		<dt>{lang}wcf.acp.systemCheck.mysql.foreignKeys{/lang}</dt>
 		<dd>
 			{if $results[mysql][foreignKeys]}
-				{@$statusOk} {lang}wcf.acp.systemCheck.pass{/lang}
+				{unsafe:$statusOk} {lang}wcf.acp.systemCheck.pass{/lang}
 			{else}
-				{@$statusInsufficient} {lang}wcf.acp.systemCheck.notFound{/lang}
+				{unsafe:$statusInsufficient} {lang}wcf.acp.systemCheck.notFound{/lang}
 			{/if}
 			<small>{lang}wcf.acp.systemCheck.mysql.foreignKeys.description{/lang}</small>
 		</dd>
@@ -225,11 +225,11 @@
 		<dt>{lang}wcf.acp.systemCheck.mysql.bufferPool{/lang}</dt>
 		<dd>
 			{if $results[mysql][bufferPool][result] === 'recommended'}
-				{@$statusOk}
+				{unsafe:$statusOk}
 			{elseif $results[mysql][bufferPool][result] === 'sufficient'}
-				{@$statusSufficient}
+				{unsafe:$statusSufficient}
 			{else}
-				{@$statusInsufficient}
+				{unsafe:$statusInsufficient}
 			{/if} {$results[mysql][bufferPool][value]|filesizeBinary}
 			<small>{lang}wcf.acp.systemCheck.mysql.bufferPool.description{/lang}</small>
 		</dd>
@@ -243,11 +243,11 @@
 		<dt>{lang}wcf.acp.systemCheck.directories.writable{/lang}</dt>
 		<dd>
 			{if $results[directories]|empty}
-				{@$statusOk} {lang}wcf.acp.systemCheck.pass{/lang}
+				{unsafe:$statusOk} {lang}wcf.acp.systemCheck.pass{/lang}
 			{else}
 				<ul class="nativeList">
 					{foreach from=$results[directories] item=directory}
-						<li>{@$statusInsufficient} <kbd>{$directory}</kbd></li>
+						<li>{unsafe:$statusInsufficient} <kbd>{$directory}</kbd></li>
 					{/foreach}
 				</ul>
 			{/if}

--- a/wcfsetup/install/files/acp/templates/templateDiff.tpl
+++ b/wcfsetup/install/files/acp/templates/templateDiff.tpl
@@ -58,7 +58,7 @@
 					<h2 class="sectionTitle">
 						{if $parent->templateGroupID}{$templateGroupHierarchy[$parent->templateGroupID][group]->getName()}{else}{lang}wcf.acp.template.group.default{/lang}{/if}
 					</h2>
-					<p class="sectionDescription">{lang}wcf.acp.template.lastModificationTime{/lang}: {@$parent->lastModificationTime|time}</p>
+					<p class="sectionDescription">{lang}wcf.acp.template.lastModificationTime{/lang}: {time time=$parent->lastModificationTime}</p>
 				</header>
 				
 				{assign var=removeOffset value=0}
@@ -87,7 +87,7 @@
 					<h2 class="sectionTitle">
 						{if $template->templateGroupID}{$templateGroupHierarchy[$template->templateGroupID][group]->getName()}{else}{lang}wcf.acp.template.group.default{/lang}{/if}
 					</h2>
-					<p class="sectionDescription">{lang}wcf.acp.template.lastModificationTime{/lang}: {@$template->lastModificationTime|time}</p>
+					<p class="sectionDescription">{lang}wcf.acp.template.lastModificationTime{/lang}: {time time=$template->lastModificationTime}</p>
 				</header>
 				{assign var=removeOffset value=0}
 				{assign var=lineNo value=0}

--- a/wcfsetup/install/files/acp/templates/templateDiff.tpl
+++ b/wcfsetup/install/files/acp/templates/templateDiff.tpl
@@ -36,7 +36,7 @@
 					<option value="0"></option>
 					{assign var=depth value=0}
 					{foreach from=$templateGroupHierarchy item='templateGroup' key='templateGroupID'}
-						<option{if $templateGroup[hasTemplate] !== false && $templateGroup[hasTemplate] != $templateID} value="{$templateGroup[hasTemplate]}"{if $parent->templateID == $templateGroup[hasTemplate]} selected{/if}{else} disabled{/if}>{@'&nbsp;'|str_repeat:$depth * 4}{if $templateGroupID}{$templateGroup[group]->getName()}{else}{lang}wcf.acp.template.group.default{/lang}{/if}</option>
+						<option{if $templateGroup[hasTemplate] !== false && $templateGroup[hasTemplate] != $templateID} value="{$templateGroup[hasTemplate]}"{if $parent->templateID == $templateGroup[hasTemplate]} selected{/if}{else} disabled{/if}>{unsafe:'&nbsp;'|str_repeat:$depth * 4}{if $templateGroupID}{$templateGroup[group]->getName()}{else}{lang}wcf.acp.template.group.default{/lang}{/if}</option>
 						{assign var=depth value=$depth + 1}
 					{/foreach}
 				</select>
@@ -97,7 +97,7 @@
 							*}{foreach from=$diff item='line'}{*
 								*}{if $line[0] == ' '}{*
 									*}{if $removeOffset > 0}{*
-										*}{@'<li style="list-style-type: none">&nbsp;</li>'|str_repeat:$removeOffset}{*
+										*}{unsafe:'<li style="list-style-type: none">&nbsp;</li>'|str_repeat:$removeOffset}{*
 									*}{/if}{*
 									*}{assign var=removeOffset value=0}{assign var=lineNo value=$lineNo + 1}{*
 									*}<li value="{$lineNo}">{$line[1]}</li>{*

--- a/wcfsetup/install/files/acp/templates/versionTrackerList.tpl
+++ b/wcfsetup/install/files/acp/templates/versionTrackerList.tpl
@@ -23,13 +23,13 @@
 	<nav class="tabMenu">
 		<ul>
 			{foreach from=$languages item=language}
-				<li data-name="language{@$language->languageID}"><a href="#">{$language}</a></li>
+				<li data-name="language{$language->languageID}"><a href="#">{$language}</a></li>
 			{/foreach}
 		</ul>
 	</nav>
 {/if}
 {foreach from=$diffs key=languageID item=properties}
-{if $languageID}<div class="tabMenuContent" data-name="language{@$languageID}">{/if}
+{if $languageID}<div class="tabMenuContent" data-name="language{$languageID}">{/if}
 <div class="section editHistoryDiff">
 	<table class="table">
 		<thead>
@@ -73,9 +73,9 @@
 					{/if}
 					<td{if $line[0] === '+'} class="diffAdded"{elseif $line[0] === '-'} class="diffRemoved"{/if}{if $colspan} colspan="2"{assign var='colspan' value=false}{/if}>
 				{/if}
-				{if $line[0] === ' '}{@$line[1]}<br>{/if}
-				{if $line[0] === '-'}{@$line[1]}<br>{/if}
-				{if $line[0] === '+'}{@$line[1]}<br>{/if}
+				{if $line[0] === ' '}{unsafe:$line[1]}<br>{/if}
+				{if $line[0] === '-'}{unsafe:$line[1]}<br>{/if}
+				{if $line[0] === '+'}{unsafe:$line[1]}<br>{/if}
 				{assign var='prevType' value=$line[0]}
 			{/foreach}
 		{/foreach}
@@ -123,7 +123,7 @@
 				{foreach from=$versions item=edit name=edit}
 					<tr class="jsEditRow">
 						<td class="columnIcon">
-							<button type="button" class="jsRevertButton jsTooltip" title="{lang}wcf.edit.revert{/lang}" data-object-id="{@$edit->versionID}" data-confirm-message="{lang __encode=true}wcf.edit.revert.confirmMessage{/lang}">
+							<button type="button" class="jsRevertButton jsTooltip" title="{lang}wcf.edit.revert{/lang}" data-object-id="{$edit->versionID}" data-confirm-message="{lang __encode=true}wcf.edit.revert.confirmMessage{/lang}">
 								{icon name='arrow-rotate-left'}
 							</button>
 							<input type="radio" name="oldID" value="{$edit->versionID}"{if $oldID == $edit->versionID} checked{/if}> <input type="radio" name="newID" value="{$edit->versionID}"{if $newID == $edit->versionID} checked{/if}>


### PR DESCRIPTION
- Remove unnecessary `@`
- Use `unsafe:` instead of `@`
- Replace deprecated `time` template modifier with `{time}`
- Replace deprecated `{pages}` with `<woltlab-core-pagination>`