### PR TITLE
Refactor frontend templates

### DIFF
--- a/com.woltlab.wcf/templates/__labelSelection.tpl
+++ b/com.woltlab.wcf/templates/__labelSelection.tpl
@@ -3,12 +3,12 @@
 		<dt><label>{$labelGroup->getTitle()}</label></dt>
 		<dd>
 			<ul class="labelList jsOnly">
-				<li class="dropdown labelChooser" id="labelGroup{@$labelGroup->groupID}" data-group-id="{@$labelGroup->groupID}">
-					<div class="dropdownToggle" data-toggle="labelGroup{@$labelGroup->groupID}"><span class="badge label">{lang}wcf.label.none{/lang}</span></div>
+				<li class="dropdown labelChooser" id="labelGroup{$labelGroup->groupID}" data-group-id="{$labelGroup->groupID}">
+					<div class="dropdownToggle" data-toggle="labelGroup{$labelGroup->groupID}"><span class="badge label">{lang}wcf.label.none{/lang}</span></div>
 					<div class="dropdownMenu">
 						<ul class="scrollableDropdownMenu">
 							{foreach from=$labelGroup item=label}
-								<li data-label-id="{@$label->labelID}"><span>{@$label->render()}</span></li>
+								<li data-label-id="{$label->labelID}"><span>{unsafe:$label->render()}</span></li>
 							{/foreach}
 						</ul>
 					</div>
@@ -17,7 +17,7 @@
 			{if $noLabelSelectionNoScript|empty}
 				<noscript>
 					{foreach from=$labelGroups item=labelGroup}
-						<select name="labelIDs[{@$labelGroup->groupID}]">
+						<select name="labelIDs[{$labelGroup->groupID}]">
 							<option value="0">{lang}wcf.label.none{/lang}</option>
 							<option value="-1">{lang}wcf.label.withoutSelection{/lang}</option>
 							{foreach from=$labelGroup item=label}

--- a/com.woltlab.wcf/templates/categoryTrophyList.tpl
+++ b/com.woltlab.wcf/templates/categoryTrophyList.tpl
@@ -5,7 +5,7 @@
 		<div class="contentHeaderTitle">
 			<h1 class="contentTitle">{$category->getTitle()}</h1>
 			{if $category && $category->getDescription()}
-				<p class="contentHeaderDescription">{if $category->descriptionUseHtml}{@$category->getDescription()}{else}{$category->getDescription()}{/if}</p>
+				<p class="contentHeaderDescription">{if $category->descriptionUseHtml}{unsafe:$category->getDescription()}{else}{$category->getDescription()}{/if}</p>
 			{/if}
 		</div>
 	</header>
@@ -13,7 +13,7 @@
 
 {capture assign='headContent'}
 	{if $pageNo < $pages}
-		<link rel="next" href="{link controller='CategoryTrophyList' object=$category}pageNo={@$pageNo+1}{/link}">
+		<link rel="next" href="{link controller='CategoryTrophyList' object=$category}pageNo={$pageNo+1}{/link}">
 	{/if}
 	{if $pageNo > 1}
 		<link rel="prev" href="{link controller='CategoryTrophyList' object=$category}{if $pageNo > 2}pageNo={@$pageNo-1}{/if}{/link}">
@@ -31,11 +31,11 @@
 		<ol class="containerList trophyCategoryList doubleColumned">
 			{foreach from=$objects item=trophy}
 				<li class="box64">
-					<div>{@$trophy->renderTrophy(64)}</div>
+					<div>{unsafe:$trophy->renderTrophy(64)}</div>
 					
 					<div class="containerHeadline">
-						<h3><a href="{$trophy->getLink()}">{@$trophy->getTitle()}</a></h3>
-						{if !$trophy->getDescription()|empty}<p><small>{@$trophy->getDescription()}</small></p>{/if}
+						<h3><a href="{$trophy->getLink()}">{unsafe:$trophy->getTitle()}</a></h3>
+						{if !$trophy->getDescription()|empty}<p><small>{unsafe:$trophy->getDescription()}</small></p>{/if}
 						<p><small>{lang items=$trophy->awarded}wcf.user.trophy.trophyAwarded{/lang}</small></p>
 					</div>
 				</li>

--- a/com.woltlab.wcf/templates/categoryTrophyList.tpl
+++ b/com.woltlab.wcf/templates/categoryTrophyList.tpl
@@ -13,15 +13,21 @@
 
 {capture assign='headContent'}
 	{if $pageNo < $pages}
-		<link rel="next" href="{link controller='CategoryTrophyList' object=$category}pageNo={$pageNo+1}{/link}">
+		<link rel="next" href="{link controller='CategoryTrophyList' object=$category pageNo=$pageNo+1}{/link}">
 	{/if}
 	{if $pageNo > 1}
-		<link rel="prev" href="{link controller='CategoryTrophyList' object=$category}{if $pageNo > 2}pageNo={@$pageNo-1}{/if}{/link}">
+		<link rel="prev" href="{link controller='CategoryTrophyList' object=$category}{if $pageNo > 2}pageNo={$pageNo-1}{/if}{/link}">
 	{/if}
 {/capture}
 
 {capture assign='contentInteractionPagination'}
-	{pages print=true assign='pagesLinks' controller='CategoryTrophyList' object=$category link="pageNo=%d"}
+	{if $pages > 1}
+		<woltlab-core-pagination
+			page="{$pageNo}"
+			count="{$pages}"
+			url="{link controller='CategoryTrophyList' object=$category}{/link}"
+		></woltlab-core-pagination>
+	{/if}
 {/capture}
 
 {include file='header'}
@@ -47,11 +53,15 @@
 {/if}
 
 <footer class="contentFooter">
-	{hascontent}
+	{if $pages > 1}
 		<div class="paginationBottom">
-			{content}{@$pagesLinks}{/content}
+			<woltlab-core-pagination
+				page="{$pageNo}"
+				count="{$pages}"
+				url="{link controller='CategoryTrophyList' object=$category}{/link}"
+			></woltlab-core-pagination>
 		</div>
-	{/hascontent}
+	{/if}
 
 	{hascontent}
 		<nav class="contentFooterNavigation">

--- a/com.woltlab.wcf/templates/cms.tpl
+++ b/com.woltlab.wcf/templates/cms.tpl
@@ -47,12 +47,12 @@
 {if $content->content}
 	{if $page->pageType == 'text'}
 		<div class="section cmsContent htmlContent">
-			{@$content->getFormattedContent()}
+			{unsafe:$content->getFormattedContent()}
 		</div>
 	{elseif $page->pageType == 'html'}
-		{@$content->getParsedContent()}
+		{unsafe:$content->getParsedContent()}
 	{elseif $page->pageType == 'tpl'}
-		{@$page->getParsedTemplate($content)}
+		{unsafe:$page->getParsedTemplate($content)}
 	{/if}
 {/if}
 

--- a/com.woltlab.wcf/templates/combinedTagged.tpl
+++ b/com.woltlab.wcf/templates/combinedTagged.tpl
@@ -1,23 +1,23 @@
-{capture assign='pageTitle'}{lang}wcf.tagging.combinedTaggedObjects.{@$objectType}{/lang} {lang}wcf.tagging.combinedTaggedObjects{/lang}{if $pageNo > 1} - {lang}wcf.page.pageNo{/lang}{/if}{/capture}
+{capture assign='pageTitle'}{lang}wcf.tagging.combinedTaggedObjects.{$objectType}{/lang} {lang}wcf.tagging.combinedTaggedObjects{/lang}{if $pageNo > 1} - {lang}wcf.page.pageNo{/lang}{/if}{/capture}
 
 {capture assign='contentHeader'}
 	<header class="contentHeader">
 		<div class="contentHeaderTitle">
-			<h1 class="contentTitle">{lang}wcf.tagging.combinedTaggedObjects.{@$objectType}{/lang} {lang}wcf.tagging.combinedTaggedObjects{/lang}</h1>
+			<h1 class="contentTitle">{lang}wcf.tagging.combinedTaggedObjects.{$objectType}{/lang} {lang}wcf.tagging.combinedTaggedObjects{/lang}</h1>
 		</div>
 	</header>
 {/capture}
 
-{capture assign='linkParameters'}{implode from=$combinedTags item=tag glue='&'}tagIDs[]={@$tag->tagID}{/implode}{/capture}
+{capture assign='linkParameters'}{implode from=$combinedTags item=tag glue='&'}tagIDs[]={$tag->tagID}{/implode}{/capture}
 
 {capture assign='headContent'}
 	{if $pageNo < $pages}
-		<link rel="next" href="{link controller='CombinedTagged'}{@$linkParameters}&objectType={@$objectType}&pageNo={@$pageNo+1}{/link}">
+		<link rel="next" href="{link controller='CombinedTagged' objectType=$objectType pageNo=$pageNo+1}{unsafe:$linkParameters}{/link}">
 	{/if}
 	{if $pageNo > 1}
-		<link rel="prev" href="{link controller='CombinedTagged'}{@$linkParameters}&objectType={@$objectType}{if $pageNo > 2}&pageNo={@$pageNo-1}{/if}{/link}">
+		<link rel="prev" href="{link controller='CombinedTagged' objectType=$objectType}{unsafe:$linkParameters}{if $pageNo > 2}&pageNo={$pageNo-1}{/if}{/link}">
 	{/if}
-	<link rel="canonical" href="{link controller='CombinedTagged'}{@$linkParameters}&objectType={@$objectType}{if $pageNo > 1}&pageNo={@$pageNo}{/if}{/link}">
+	<link rel="canonical" href="{link controller='CombinedTagged' objectType=$objectType}{unsafe:$linkParameters}{if $pageNo > 1}&pageNo={$pageNo}{/if}{/link}">
 {/capture}
 
 {capture assign='sidebarRight'}

--- a/com.woltlab.wcf/templates/combinedTagged.tpl
+++ b/com.woltlab.wcf/templates/combinedTagged.tpl
@@ -48,7 +48,13 @@
 {/capture}
 
 {capture assign='contentInteractionPagination'}
-	{pages print=true assign=pagesLinks controller='CombinedTagged' link="$linkParameters&objectType=$objectType&pageNo=%d"}
+	{if $pages > 1}
+		<woltlab-core-pagination
+			page="{$pageNo}"
+			count="{$pages}"
+			url="{link controller='CombinedTagged' objectType=$objectType}{unsafe:$linkParameters}{/link}"
+		></woltlab-core-pagination>
+	{/if}
 {/capture}
 
 {capture assign='contentInteractionButtons'}
@@ -64,11 +70,15 @@
 {/if}
 
 <footer class="contentFooter">
-	{hascontent}
+	{if $pages > 1}
 		<div class="paginationBottom">
-			{content}{@$pagesLinks}{/content}
+			<woltlab-core-pagination
+				page="{$pageNo}"
+				count="{$pages}"
+				url="{link controller='CombinedTagged' objectType=$objectType}{unsafe:$linkParameters}{/link}"
+			></woltlab-core-pagination>
 		</div>
-	{/hascontent}
+	{/if}
 	
 	{hascontent}
 		<nav class="contentFooterNavigation">

--- a/com.woltlab.wcf/templates/contentInteraction.tpl
+++ b/com.woltlab.wcf/templates/contentInteraction.tpl
@@ -1,28 +1,28 @@
 {if !$beforeContentInteraction|empty}
-	{@$beforeContentInteraction}
+	{unsafe:$beforeContentInteraction}
 {/if}
 
 {capture assign='__contentInteractionPagination'}
-	{if $contentInteractionPagination|isset}{@$contentInteractionPagination}{/if}
+	{if $contentInteractionPagination|isset}{unsafe:$contentInteractionPagination}{/if}
 {/capture}
 {assign var='__contentInteractionPagination' value=$__contentInteractionPagination|trim}
 
 {capture assign='__contentInteractionButtons'}
 	{event name='beforeButtons'}
-	{if $contentInteractionButtons|isset}{@$contentInteractionButtons}{/if}
+	{if $contentInteractionButtons|isset}{unsafe:$contentInteractionButtons}{/if}
 	{event name='afterButtons'}
 {/capture}
 {assign var='__contentInteractionButtons' value=$__contentInteractionButtons|trim}
 
 {capture assign='__contentInteractionDropdownItems'}
 	{event name='beforeDropdownItems'}
-	{if $contentInteractionDropdownItems|isset}{@$contentInteractionDropdownItems}{/if}
+	{if $contentInteractionDropdownItems|isset}{unsafe:$contentInteractionDropdownItems}{/if}
 	{event name='afterDropdownItems'}
 {/capture}
 {assign var='__contentInteractionDropdownItems' value=$__contentInteractionDropdownItems|trim}
 
 {capture assign='__contentInteractionShareButton'}
-	{if $contentInteractionShareButton|isset}{@$contentInteractionShareButton}{/if}
+	{if $contentInteractionShareButton|isset}{unsafe:$contentInteractionShareButton}{/if}
 {/capture}
 {assign var='__contentInteractionShareButton' value=$__contentInteractionShareButton|trim}
 
@@ -32,7 +32,7 @@
 			{unsafe:$contentInteractionTabsComponent->render()}
 		{elseif $__contentInteractionPagination}
 			<div class="contentInteractionPagination paginationTop">
-				{@$__contentInteractionPagination}
+				{unsafe:$__contentInteractionPagination}
 			</div>
 		{/if}
 
@@ -40,13 +40,13 @@
 			<div class="contentInteractionButtonContainer">
 				{if $__contentInteractionButtons}
 					<div class="contentInteractionButtons">
-						{@$__contentInteractionButtons}
+						{unsafe:$__contentInteractionButtons}
 					</div>
 				{/if}
 
 				{if $__contentInteractionShareButton}
 					 <div class="contentInteractionShareButton">
-						{@$__contentInteractionShareButton}
+						{unsafe:$__contentInteractionShareButton}
 					</div>
 				{/if}
 
@@ -55,7 +55,7 @@
 						<button type="button" class="button small dropdownToggle" aria-label="{lang}wcf.global.button.more{/lang}">{icon name='ellipsis-vertical'}</button>
 
 						<ul class="contentInteractionDropdownItems dropdownMenu">
-							{@$__contentInteractionDropdownItems}
+							{unsafe:$__contentInteractionDropdownItems}
 						</ul>
 					</div>
 				{/if}

--- a/com.woltlab.wcf/templates/customOptionFieldList.tpl
+++ b/com.woltlab.wcf/templates/customOptionFieldList.tpl
@@ -2,7 +2,7 @@
 	{assign var=option value=$optionData[object]}
 	<dl class="{if $errorType|is_array && $errorType[$option->optionName]|isset} formError{/if}">
 		<dt{if $optionData[cssClassName]} class="{$optionData[cssClassName]}"{/if}><label for="{$option->optionName}">{$option->getTitle()}</label>{if $option->required} <span class="customOptionRequired">*</span>{/if}</dt>
-		<dd>{@$optionData[html]}
+		<dd>{unsafe:$optionData[html]}
 			<small>{$option->getDescription()}</small>
 			
 			{if $errorType|is_array && $errorType[$option->optionName]|isset}

--- a/com.woltlab.wcf/templates/deletedContentList.tpl
+++ b/com.woltlab.wcf/templates/deletedContentList.tpl
@@ -1,4 +1,4 @@
-{capture assign='pageTitle'}{lang}wcf.moderation.deletedContent.{@$objectType}{/lang}{/capture}
+{capture assign='pageTitle'}{lang}wcf.moderation.deletedContent.{$objectType}{/lang}{/capture}
 
 {capture assign='sidebarRight'}
 	<section class="box" data-static-box-identifier="com.woltlab.wcf.DeletedContentListMenu">
@@ -18,7 +18,7 @@
 	</section>
 {/capture}
 
-{capture assign='contentTitle'}{lang}wcf.moderation.deletedContent.{@$objectType}{/lang}{/capture}
+{capture assign='contentTitle'}{lang}wcf.moderation.deletedContent.{$objectType}{/lang}{/capture}
 
 {capture assign='contentInteractionPagination'}
 	{pages print=true assign=pagesLinks controller='DeletedContentList' link="objectType=$objectType&pageNo=%d"}

--- a/com.woltlab.wcf/templates/deletedContentList.tpl
+++ b/com.woltlab.wcf/templates/deletedContentList.tpl
@@ -21,7 +21,13 @@
 {capture assign='contentTitle'}{lang}wcf.moderation.deletedContent.{$objectType}{/lang}{/capture}
 
 {capture assign='contentInteractionPagination'}
-	{pages print=true assign=pagesLinks controller='DeletedContentList' link="objectType=$objectType&pageNo=%d"}
+	{if $pages > 1}
+		<woltlab-core-pagination
+			page="{$pageNo}"
+			count="{$pages}"
+			url="{link controller='DeletedContentList' objectType=$objectType}{/link}"
+		></woltlab-core-pagination>
+	{/if}
 {/capture}
 
 {include file='header'}
@@ -33,11 +39,15 @@
 {/if}
 
 <footer class="contentFooter">
-	{hascontent}
+	{if $pages > 1}
 		<div class="paginationBottom">
-			{content}{@$pagesLinks}{/content}
+			<woltlab-core-pagination
+				page="{$pageNo}"
+				count="{$pages}"
+				url="{link controller='DeletedContentList' objectType=$objectType}{/link}"
+			></woltlab-core-pagination>
 		</div>
-	{/hascontent}
+	{/if}
 	
 	{hascontent}
 		<nav class="contentFooterNavigation">

--- a/com.woltlab.wcf/templates/editHistory.tpl
+++ b/com.woltlab.wcf/templates/editHistory.tpl
@@ -62,9 +62,9 @@
 					{/if}
 					<td{if $line[0] === '+'} class="diffAdded"{elseif $line[0] === '-'} class="diffRemoved"{/if}{if $colspan} colspan="2"{assign var='colspan' value=false}{/if}>
 				{/if}
-				{if $line[0] === ' '}{@$line[1]}<br>{/if}
-				{if $line[0] === '-'}{@$line[1]}<br>{/if}
-				{if $line[0] === '+'}{@$line[1]}<br>{/if}
+				{if $line[0] === ' '}{unsafe:$line[1]}<br>{/if}
+				{if $line[0] === '-'}{unsafe:$line[1]}<br>{/if}
+				{if $line[0] === '+'}{unsafe:$line[1]}<br>{/if}
 				{assign var='prevType' value=$line[0]}
 			{/foreach}
 		</tbody>
@@ -110,7 +110,7 @@
 				{foreach from=$objects item=edit name=edit}
 					<tr class="jsEditRow">
 						<td class="columnIcon">
-							<button type="button" class="jsRevertButton jsTooltip" title="{lang}wcf.edit.revert{/lang}" data-object-id="{@$edit->entryID}" data-confirm-message="{lang __encode=true}wcf.edit.revert.confirmMessage{/lang}">
+							<button type="button" class="jsRevertButton jsTooltip" title="{lang}wcf.edit.revert{/lang}" data-object-id="{$edit->entryID}" data-confirm-message="{lang __encode=true}wcf.edit.revert.confirmMessage{/lang}">
 								{icon name='rotate-left'}
 							</button>
 							<input type="radio" name="oldID" value="{$edit->entryID}"{if $oldID == $edit->entryID} checked{/if}> <input type="radio" name="newID" value="{$edit->entryID}"{if $newID == $edit->entryID} checked{/if}>

--- a/com.woltlab.wcf/templates/emailActivation.tpl
+++ b/com.woltlab.wcf/templates/emailActivation.tpl
@@ -1,5 +1,5 @@
 {include file='authFlowHeader'}
 
-{@$form->getHtml()}
+{unsafe:$form->getHtml()}
 
 {include file='authFlowFooter'}

--- a/com.woltlab.wcf/templates/emailNewActivationCode.tpl
+++ b/com.woltlab.wcf/templates/emailNewActivationCode.tpl
@@ -1,5 +1,5 @@
 {include file='authFlowHeader'}
 
-{@$form->getHtml()}
+{unsafe:$form->getHtml()}
 
 {include file='authFlowFooter'}

--- a/com.woltlab.wcf/templates/following.tpl
+++ b/com.woltlab.wcf/templates/following.tpl
@@ -12,7 +12,7 @@
 	<div class="section sectionContainerList">
 		<ol class="containerList userList jsReloadPageWhenEmpty jsObjectActionContainer" data-object-action-class-name="wcf\data\user\follow\UserFollowAction">
 			{foreach from=$objects item=user}
-				<li class="jsFollowing jsObjectActionObject" data-object-id="{@$user->getObjectID()}">
+				<li class="jsFollowing jsObjectActionObject" data-object-id="{$user->getObjectID()}">
 					<div class="box48">
 						{user object=$user type='avatar48' ariaHidden='true' tabindex='-1'}
 						
@@ -21,7 +21,7 @@
 							
 							<nav class="jsMobileNavigation buttonGroupNavigation">
 								<ul class="buttonList iconList jsOnly">
-									<li><a class="pointer jsTooltip jsObjectAction" data-object-action="delete" title="{lang}wcf.user.button.unfollow{/lang}" data-object-id="{@$user->followID}">{icon name='xmark'} <span class="invisible">{lang}wcf.user.button.unfollow{/lang}</span></a></li>
+									<li><a class="pointer jsTooltip jsObjectAction" data-object-action="delete" title="{lang}wcf.user.button.unfollow{/lang}" data-object-id="{$user->followID}">{icon name='xmark'} <span class="invisible">{lang}wcf.user.button.unfollow{/lang}</span></a></li>
 									{event name='userButtons'}
 								</ul>
 							</nav>

--- a/com.woltlab.wcf/templates/following.tpl
+++ b/com.woltlab.wcf/templates/following.tpl
@@ -3,7 +3,13 @@
 {capture assign='contentTitleBadge'}<span class="badge">{#$items}</span>{/capture}
 
 {capture assign='contentInteractionPagination'}
-	{pages print=true assign=pagesLinks controller='Following' link="pageNo=%d"}
+	{if $pages > 1}
+		<woltlab-core-pagination
+			page="{$pageNo}"
+			count="{$pages}"
+			url="{link controller='Following'}{/link}"
+		></woltlab-core-pagination>
+	{/if}
 {/capture}
 
 {include file='header' __sidebarLeftHasMenu=true}
@@ -37,11 +43,15 @@
 	</div>
 	
 	<footer class="contentFooter">
-		{hascontent}
+		{if $pages > 1}
 			<div class="paginationBottom">
-				{content}{@$pagesLinks}{/content}
+				<woltlab-core-pagination
+					page="{$pageNo}"
+					count="{$pages}"
+					url="{link controller='Following'}{/link}"
+				></woltlab-core-pagination>
 			</div>
-		{/hascontent}
+		{/if}
 		
 		{hascontent}
 			<nav class="contentFooterNavigation">

--- a/com.woltlab.wcf/templates/mediaEditor.tpl
+++ b/com.woltlab.wcf/templates/mediaEditor.tpl
@@ -35,7 +35,7 @@
 		
 		{if $media->downloads}
 			<dt>{lang}wcf.media.lastDownloadTime{/lang}</dt>
-			<dd id="mediaDownloads">{@$media->lastDownloadTime|time}</dd>
+			<dd id="mediaDownloads">{time time=$media->lastDownloadTime}</dd>
 		{/if}
 	</dl>
 </div>

--- a/com.woltlab.wcf/templates/mediaEditor.tpl
+++ b/com.woltlab.wcf/templates/mediaEditor.tpl
@@ -4,7 +4,7 @@
 
 {if $media->isImage && $media->hasThumbnail('small')}
 	<div class="mediaThumbnail">
-		{@$media->getThumbnailTag('small')}
+		{unsafe:$media->getThumbnailTag('small')}
 	</div>
 {/if}
 
@@ -12,7 +12,7 @@
 	{if $media->isImage}
 		{icon size=48 name='file-image'}
 	{else}
-		{@$media->getElementTag(48)}
+		{unsafe:$media->getElementTag(48)}
 	{/if}
 	
 	<dl class="plain dataList">
@@ -20,7 +20,7 @@
 		<dd id="mediaFilename">{$media->filename}</dd>
 		
 		<dt>{lang}wcf.media.filesize{/lang}</dt>
-		<dd id="mediaFilesize">{@$media->filesize|filesize}</dd>
+		<dd id="mediaFilesize">{$media->filesize|filesize}</dd>
 		
 		{if $media->isImage}
 			<dt>{lang}wcf.media.imageDimensions{/lang}</dt>
@@ -45,9 +45,9 @@
 	
 	{hascontent}
 		<dl>
-			<dt><label for="categoryID_{@$media->mediaID}">{lang}wcf.global.category{/lang}</label></dt>
+			<dt><label for="categoryID_{$media->mediaID}">{lang}wcf.global.category{/lang}</label></dt>
 			<dd>
-				<select id="categoryID_{@$media->mediaID}" name="categoryID">
+				<select id="categoryID_{$media->mediaID}" name="categoryID">
 					<option value="0">{lang}wcf.global.noSelection{/lang}</option>
 					
 					{content}
@@ -86,9 +86,9 @@
 	{/if}
 	
 	<dl>
-		<dt><label for="title_{@$media->mediaID}">{lang}wcf.global.title{/lang}</label></dt>
+		<dt><label for="title_{$media->mediaID}">{lang}wcf.global.title{/lang}</label></dt>
 		<dd>
-			<input type="text" id="title_{@$media->mediaID}" name="title" class="long">
+			<input type="text" id="title_{$media->mediaID}" name="title" class="long">
 		</dd>
 	</dl>
 	{if $availableLanguages|count > 1}
@@ -97,9 +97,9 @@
 	
 	{if $media->isImage}
 		<dl>
-			<dt><label for="caption_{@$media->mediaID}">{lang}wcf.media.caption{/lang}</label></dt>
+			<dt><label for="caption_{$media->mediaID}">{lang}wcf.media.caption{/lang}</label></dt>
 			<dd>
-				<textarea id="caption_{@$media->mediaID}" name="caption" cols="40" rows="3"></textarea>
+				<textarea id="caption_{$media->mediaID}" name="caption" cols="40" rows="3"></textarea>
 			</dd>
 		</dl>
 		{if $availableLanguages|count > 1}
@@ -117,9 +117,9 @@
 		</dl>
 		
 		<dl>
-			<dt><label for="altText_{@$media->mediaID}">{lang}wcf.media.altText{/lang}</label></dt>
+			<dt><label for="altText_{$media->mediaID}">{lang}wcf.media.altText{/lang}</label></dt>
 			<dd>
-				<input type="text" id="altText_{@$media->mediaID}" name="altText" class="long">
+				<input type="text" id="altText_{$media->mediaID}" name="altText" class="long">
 			</dd>
 		</dl>
 		{if $availableLanguages|count > 1}

--- a/com.woltlab.wcf/templates/mediaListItems.tpl
+++ b/com.woltlab.wcf/templates/mediaListItems.tpl
@@ -1,7 +1,7 @@
 {foreach from=$mediaList item=media}
-	<li class="jsClipboardObject mediaFile jsObjectActionObject" data-object-id="{@$media->getObjectID()}">
+	<li class="jsClipboardObject mediaFile jsObjectActionObject" data-object-id="{$media->getObjectID()}">
 		<div class="mediaThumbnail">
-			{@$media->getElementTag(144)}
+			{unsafe:$media->getElementTag(144)}
 		</div>
 
 		{assign var='__mediaTitle' value=$media->filename}
@@ -15,10 +15,10 @@
 		<nav class="jsMobileNavigation buttonGroupNavigation">
 			<ul class="buttonList iconList">
 				<li class="mediaCheckbox">
-					<a><label><input type="checkbox" class="jsClipboardItem" data-object-id="{@$media->mediaID}"></label></a>
+					<a><label><input type="checkbox" class="jsClipboardItem" data-object-id="{$media->mediaID}"></label></a>
 				</li>
 				{if $__wcf->session->getPermission('admin.content.cms.canManageMedia')}
-					<li class="jsMediaEditButton" data-object-id="{@$media->mediaID}">
+					<li class="jsMediaEditButton" data-object-id="{$media->mediaID}">
 						<button type="button" class="jsTooltip" title="{lang}wcf.global.button.edit{/lang}">
 							{icon name='pencil'}
 						</button>
@@ -30,13 +30,13 @@
 					</li>
 				{/if}
 				{if $mode == 'editor'}
-					<li class="jsMediaInsertButton" data-object-id="{@$media->mediaID}">
+					<li class="jsMediaInsertButton" data-object-id="{$media->mediaID}">
 						<button type="button" class="jsTooltip" title="{lang}wcf.media.button.insert{/lang}">
 							{icon name='plus'}
 						</button>
 					</li>
 				{elseif $mode == 'select'}
-					<li class="jsMediaSelectButton" data-object-id="{@$media->mediaID}">
+					<li class="jsMediaSelectButton" data-object-id="{$media->mediaID}">
 						<button type="button" class="jsTooltip" title="{lang}wcf.media.button.select{/lang}">
 							{icon name='check'}
 						</button>

--- a/com.woltlab.wcf/templates/membersList.tpl
+++ b/com.woltlab.wcf/templates/membersList.tpl
@@ -6,7 +6,7 @@
 
 {capture assign='headContent'}
 	{if $pageNo < $pages}
-		<link rel="next" href="{link controller='MembersList'}pageNo={$pageNo+1}&{unsafe:$canonicalURLParameters}{/link}">
+		<link rel="next" href="{link controller='MembersList' pageNo=$pageNo+1}{unsafe:$canonicalURLParameters}{/link}">
 	{/if}
 	{if $pageNo > 1}
 		<link rel="prev" href="{link controller='MembersList'}{if $pageNo > 2}pageNo={$pageNo-1}&{/if}{unsafe:$canonicalURLParameters}{/link}">
@@ -34,11 +34,21 @@
 {/capture}
 
 {capture assign='contentInteractionPagination'}
-	{if $searchID}
-			{pages print=true assign=pagesLinks controller='MembersList' id=$searchID link="pageNo=%d&sortField=$sortField&sortOrder=$sortOrder&letter=$encodedLetter"}
+	{if $pages > 1}
+		{if $searchID}
+			<woltlab-core-pagination
+				page="{$pageNo}"
+				count="{$pages}"
+				url="{link controller='MembersList' id=$searchID sortField=$sortField sortOrder=$sortOrder letter=$encodedLetter}{/link}"
+			></woltlab-core-pagination>
 		{else}
-			{pages print=true assign=pagesLinks controller='MembersList' link="pageNo=%d&sortField=$sortField&sortOrder=$sortOrder&letter=$encodedLetter"}
+			<woltlab-core-pagination
+				page="{$pageNo}"
+				count="{$pages}"
+				url="{link controller='MembersList' sortField=$sortField sortOrder=$sortOrder letter=$encodedLetter}{/link}"
+			></woltlab-core-pagination>
 		{/if}
+	{/if}
 {/capture}
 
 {include file='header'}
@@ -50,7 +60,7 @@
 				<a
 					rel="nofollow"
 					class="jsTooltip"
-					href="{link controller='MembersList' id=$searchID}pageNo={$pageNo}&sortField={$sortField}&sortOrder={if $sortOrder == 'ASC'}DESC{else}ASC{/if}{if $letter}&letter={$letter}{/if}{/link}"
+					href="{link controller='MembersList' id=$searchID pageNo=$pageNo sortField=$sortField}sortOrder={if $sortOrder == 'ASC'}DESC{else}ASC{/if}{if $letter}&letter={$letter}{/if}{/link}"
 					title="{lang}wcf.global.sorting{/lang} ({lang}wcf.global.sortOrder.{if $sortOrder === 'ASC'}ascending{else}descending{/if}{/lang})"
 				>
 					{if $sortOrder === 'ASC'}
@@ -64,7 +74,7 @@
 					
 					<ul class="dropdownMenu">
 						{foreach from=$validSortFields item=_sortField}
-							<li{if $_sortField === $sortField} class="active"{/if}><a rel="nofollow" href="{link controller='MembersList' id=$searchID}pageNo={$pageNo}&sortField={$_sortField}&sortOrder={if $sortField === $_sortField}{if $sortOrder === 'DESC'}ASC{else}DESC{/if}{else}{$sortOrder}{/if}{if $letter}&letter={$letter}{/if}{/link}">{lang}wcf.user.sortField.{$_sortField}{/lang}</a></li>
+							<li{if $_sortField === $sortField} class="active"{/if}><a rel="nofollow" href="{link controller='MembersList' id=$searchID pageNo=$pageNo sortField=$_sortField}sortOrder={if $sortField === $_sortField}{if $sortOrder === 'DESC'}ASC{else}DESC{/if}{else}{$sortOrder}{/if}{if $letter}&letter={$letter}{/if}{/link}">{lang}wcf.user.sortField.{$_sortField}{/lang}</a></li>
 						{/foreach}
 					</ul>
 				</div>
@@ -121,11 +131,23 @@
 {/if}
 
 <footer class="contentFooter">
-	{hascontent}
+	{if $pages > 1}
 		<div class="paginationBottom">
-			{content}{@$pagesLinks}{/content}
+			{if $searchID}
+				<woltlab-core-pagination
+					page="{$pageNo}"
+					count="{$pages}"
+					url="{link controller='MembersList' id=$searchID sortField=$sortField sortOrder=$sortOrder letter=$encodedLetter}{/link}"
+				></woltlab-core-pagination>
+		{else}
+			<woltlab-core-pagination
+				page="{$pageNo}"
+				count="{$pages}"
+				url="{link controller='MembersList' sortField=$sortField sortOrder=$sortOrder letter=$encodedLetter}{/link}"
+			></woltlab-core-pagination>
+			{/if}
 		</div>
-	{/hascontent}
+	{/if}
 	
 	{hascontent}
 		<nav class="contentFooterNavigation">

--- a/com.woltlab.wcf/templates/membersList.tpl
+++ b/com.woltlab.wcf/templates/membersList.tpl
@@ -2,16 +2,16 @@
 
 {capture assign='contentTitle'}{if $searchID}{lang}wcf.user.search.results{/lang}{else}{$__wcf->getActivePage()->getTitle()}{/if} <span class="badge">{#$items}</span>{/capture}
 
-{capture assign='canonicalURLParameters'}sortField={@$sortField}&sortOrder={@$sortOrder}{if $letter}&letter={@$letter|rawurlencode}{/if}{/capture}
+{capture assign='canonicalURLParameters'}sortField={$sortField}&sortOrder={$sortOrder}{if $letter}&letter={unsafe:$letter|rawurlencode}{/if}{/capture}
 
 {capture assign='headContent'}
 	{if $pageNo < $pages}
-		<link rel="next" href="{link controller='MembersList'}pageNo={@$pageNo+1}&{@$canonicalURLParameters}{/link}">
+		<link rel="next" href="{link controller='MembersList'}pageNo={$pageNo+1}&{unsafe:$canonicalURLParameters}{/link}">
 	{/if}
 	{if $pageNo > 1}
-		<link rel="prev" href="{link controller='MembersList'}{if $pageNo > 2}pageNo={@$pageNo-1}&{/if}{@$canonicalURLParameters}{/link}">
+		<link rel="prev" href="{link controller='MembersList'}{if $pageNo > 2}pageNo={$pageNo-1}&{/if}{unsafe:$canonicalURLParameters}{/link}">
 	{/if}
-	<link rel="canonical" href="{link controller='MembersList'}{if $pageNo > 1}pageNo={@$pageNo}&{/if}{@$canonicalURLParameters}{/link}">
+	<link rel="canonical" href="{link controller='MembersList'}{if $pageNo > 1}pageNo={$pageNo}&{/if}{unsafe:$canonicalURLParameters}{/link}">
 {/capture}
 
 {capture assign='sidebarRight'}
@@ -50,7 +50,7 @@
 				<a
 					rel="nofollow"
 					class="jsTooltip"
-					href="{link controller='MembersList' id=$searchID}pageNo={@$pageNo}&sortField={$sortField}&sortOrder={if $sortOrder == 'ASC'}DESC{else}ASC{/if}{if $letter}&letter={$letter}{/if}{/link}"
+					href="{link controller='MembersList' id=$searchID}pageNo={$pageNo}&sortField={$sortField}&sortOrder={if $sortOrder == 'ASC'}DESC{else}ASC{/if}{if $letter}&letter={$letter}{/if}{/link}"
 					title="{lang}wcf.global.sorting{/lang} ({lang}wcf.global.sortOrder.{if $sortOrder === 'ASC'}ascending{else}descending{/if}{/lang})"
 				>
 					{if $sortOrder === 'ASC'}
@@ -64,7 +64,7 @@
 					
 					<ul class="dropdownMenu">
 						{foreach from=$validSortFields item=_sortField}
-							<li{if $_sortField === $sortField} class="active"{/if}><a rel="nofollow" href="{link controller='MembersList' id=$searchID}pageNo={@$pageNo}&sortField={$_sortField}&sortOrder={if $sortField === $_sortField}{if $sortOrder === 'DESC'}ASC{else}DESC{/if}{else}{$sortOrder}{/if}{if $letter}&letter={$letter}{/if}{/link}">{lang}wcf.user.sortField.{$_sortField}{/lang}</a></li>
+							<li{if $_sortField === $sortField} class="active"{/if}><a rel="nofollow" href="{link controller='MembersList' id=$searchID}pageNo={$pageNo}&sortField={$_sortField}&sortOrder={if $sortField === $_sortField}{if $sortOrder === 'DESC'}ASC{else}DESC{/if}{else}{$sortOrder}{/if}{if $letter}&letter={$letter}{/if}{/link}">{lang}wcf.user.sortField.{$_sortField}{/lang}</a></li>
 						{/foreach}
 					</ul>
 				</div>

--- a/com.woltlab.wcf/templates/multifactorManageBackup.tpl
+++ b/com.woltlab.wcf/templates/multifactorManageBackup.tpl
@@ -9,7 +9,7 @@
 		{foreach from=$codes item='code'}
 			<li>
 				<span class="multifactorBackupCode{if $code[useTime]} used{/if}">{foreach from=$code[chunks] item='chunk'}<span class="chunk">{$chunk}</span>{/foreach}</span>
-				{if $code[useTime]}({$code[useTime]|plainTime}){/if}
+				{if $code[useTime]}({time time=$code[useTime] type='plainTime'}){/if}
 			</li>
 		{/foreach}
 	</ol>

--- a/com.woltlab.wcf/templates/optionFieldList.tpl
+++ b/com.woltlab.wcf/templates/optionFieldList.tpl
@@ -19,7 +19,7 @@
 				</label>
 			{/if}
 		</dt>
-		<dd>{@$optionData[html]}
+		<dd>{unsafe:$optionData[html]}
 			{if $error}
 				<small class="innerError">
 					{if $error == 'empty'}

--- a/com.woltlab.wcf/templates/reactionTypeImage.tpl
+++ b/com.woltlab.wcf/templates/reactionTypeImage.tpl
@@ -1,5 +1,5 @@
 <img
-	src="{@$__wcf->getPath()}images/reaction/{$reactionType->iconFile}"
+	src="{$__wcf->getPath()}images/reaction/{$reactionType->iconFile}"
 	alt="{$reactionType->getTitle()}"
 	class="reactionType"
 	data-reaction-type-id="{$reactionType->reactionTypeID}"

--- a/com.woltlab.wcf/templates/recentActivityList.tpl
+++ b/com.woltlab.wcf/templates/recentActivityList.tpl
@@ -1,7 +1,7 @@
 {include file='header'}
 
 {if $eventList|count}
-	<div id="recentActivities" class="section recentActivityList" data-last-event-time="{@$lastEventTime}">
+	<div id="recentActivities" class="section recentActivityList" data-last-event-time="{$lastEventTime}">
 		{include file='recentActivityListItem'}
 	</div>
 	

--- a/com.woltlab.wcf/templates/rssFeed.tpl
+++ b/com.woltlab.wcf/templates/rssFeed.tpl
@@ -6,42 +6,42 @@
 	xmlns:slash="http://purl.org/rss/1.0/modules/slash/"
 >
 	<channel>
-		<title><![CDATA[{if $title}{@$title|escapeCDATA} - {/if}{@PAGE_TITLE|phrase|escapeCDATA}]]></title>
-		<link><![CDATA[{@$__wcf->getPath()|escapeCDATA}]]></link>
-		<description><![CDATA[{@PAGE_DESCRIPTION|phrase|escapeCDATA}]]></description>
-		<language>{@$__wcf->language->getFixedLanguageCode()}</language>
+		<title><![CDATA[{if $title}{unsafe:$title|escapeCDATA} - {/if}{unsafe:PAGE_TITLE|phrase|escapeCDATA}]]></title>
+		<link><![CDATA[{unsafe:$__wcf->getPath()|escapeCDATA}]]></link>
+		<description><![CDATA[{unsafe:PAGE_DESCRIPTION|phrase|escapeCDATA}]]></description>
+		<language>{$__wcf->language->getFixedLanguageCode()}</language>
 		<pubDate>{'r'|gmdate:TIME_NOW}</pubDate>
 {assign var='dummy' value=$items->rewind()}
 		<lastBuildDate>{if $items->valid()}{'r'|gmdate:$items->current()->getTime()}{else}{'r'|gmdate:TIME_NOW}{/if}</lastBuildDate>
 		<ttl>60</ttl>
-		<generator><![CDATA[WoltLab Suite{if SHOW_VERSION_NUMBER} {@WCF_VERSION}{/if}]]></generator>
+		<generator><![CDATA[WoltLab Suite{if SHOW_VERSION_NUMBER} {WCF_VERSION}{/if}]]></generator>
 		<atom:link href="{$__wcf->getRequestURI()}" rel="self" type="application/rss+xml" />{*
 		*}{event name='channelFields'}
 {*		*}{foreach from=$items item='item'}
 		<item>
-			<title><![CDATA[{@$item->getTitle()|escapeCDATA}]]></title>
-			<link><![CDATA[{@$item->getLink()|escapeCDATA}]]></link>
-			{hascontent}<description><![CDATA[{content}{@$item->getExcerpt()|escapeCDATA}{/content}]]></description>{/hascontent}
+			<title><![CDATA[{unsafe:$item->getTitle()|escapeCDATA}]]></title>
+			<link><![CDATA[{unsafe:$item->getLink()|escapeCDATA}]]></link>
+			{hascontent}<description><![CDATA[{content}{unsafe:$item->getExcerpt()|escapeCDATA}{/content}]]></description>{/hascontent}
 			<pubDate>{'r'|gmdate:$item->getTime()}</pubDate>
-			<dc:creator><![CDATA[{@$item->getUsername()|escapeCDATA}]]></dc:creator>
-			<guid><![CDATA[{@$item->getLink()|escapeCDATA}]]></guid>
+			<dc:creator><![CDATA[{unsafe:$item->getUsername()|escapeCDATA}]]></dc:creator>
+			<guid><![CDATA[{unsafe:$item->getLink()|escapeCDATA}]]></guid>
 			{foreach from=$item->getCategories() item='category'}
-				<category><![CDATA[{@$category|escapeCDATA}]]></category>
+				<category><![CDATA[{unsafe:$category|escapeCDATA}]]></category>
 			{/foreach}
-			{hascontent}<content:encoded><![CDATA[{content}{@$item->getFormattedMessage()|escapeCDATA}{/content}]]></content:encoded>{/hascontent}
-			{if $supportsEnclosure && $item->getEnclosure()}<enclosure length="{@$item->getEnclosure()->getLength()}" type="{$item->getEnclosure()->getType()}" url="{$item->getEnclosure()->getURL()}" />{/if}
-			<slash:comments><![CDATA[{@$item->getComments()|escapeCDATA}]]></slash:comments>{*
+			{hascontent}<content:encoded><![CDATA[{content}{unsafe:$item->getFormattedMessage()|escapeCDATA}{/content}]]></content:encoded>{/hascontent}
+			{if $supportsEnclosure && $item->getEnclosure()}<enclosure length="{$item->getEnclosure()->getLength()}" type="{$item->getEnclosure()->getType()}" url="{$item->getEnclosure()->getURL()}" />{/if}
+			<slash:comments><![CDATA[{unsafe:$item->getComments()|escapeCDATA}]]></slash:comments>{*
 			*}{event name='itemFields'}
 		</item>
 {*		*}{/foreach}
 	</channel>
 {if ENABLE_BENCHMARK}
 	<!-- 
-		Execution time: {@$__wcf->getBenchmark()->getExecutionTime()}s ({#($__wcf->getBenchmark()->getExecutionTime()-$__wcf->getBenchmark()->getQueryExecutionTime())/$__wcf->getBenchmark()->getExecutionTime()*100}% PHP, {#$__wcf->getBenchmark()->getQueryExecutionTime()/$__wcf->getBenchmark()->getExecutionTime()*100}% SQL) | SQL queries: {#$__wcf->getBenchmark()->getQueryCount()} | Memory-Usage: {$__wcf->getBenchmark()->getMemoryUsage()}
+		Execution time: {$__wcf->getBenchmark()->getExecutionTime()}s ({#($__wcf->getBenchmark()->getExecutionTime()-$__wcf->getBenchmark()->getQueryExecutionTime())/$__wcf->getBenchmark()->getExecutionTime()*100}% PHP, {#$__wcf->getBenchmark()->getQueryExecutionTime()/$__wcf->getBenchmark()->getExecutionTime()*100}% SQL) | SQL queries: {#$__wcf->getBenchmark()->getQueryCount()} | Memory-Usage: {$__wcf->getBenchmark()->getMemoryUsage()}
 	
 {*	*}{if ENABLE_DEBUG_MODE}
 {*		*}{foreach from=$__wcf->getBenchmark()->getItems() item=item}
-{*	*}			{if $item.type == 1}(SQL Query) {/if}{$item.text} ({@$item.use}s)
+{*	*}			{if $item.type == 1}(SQL Query) {/if}{$item.text} ({$item.use}s)
 {*		*}{/foreach}
 {*	*}{/if}
 	-->

--- a/com.woltlab.wcf/templates/search.tpl
+++ b/com.woltlab.wcf/templates/search.tpl
@@ -8,7 +8,7 @@
 				<option value="">{lang}wcf.search.type.everywhere{/lang}</option>
 				{foreach from=$objectTypes key=objectTypeName item=objectType}
 					{if $objectType->isAccessible()}
-						<option value="{$objectTypeName}">{lang}wcf.search.type.{@$objectTypeName}{/lang}</option>
+						<option value="{$objectTypeName}">{lang}wcf.search.type.{$objectTypeName}{/lang}</option>
 					{/if}
 				{/foreach}
 			</select>

--- a/com.woltlab.wcf/templates/searchResultList.tpl
+++ b/com.woltlab.wcf/templates/searchResultList.tpl
@@ -34,9 +34,9 @@
 				</div>
 				{/hascontent}
 
-				<small class="gridListItemType">{lang}wcf.search.object.{@$message->getObjectTypeName()}{/lang}</small>
+				<small class="gridListItemType">{lang}wcf.search.object.{$message->getObjectTypeName()}{/lang}</small>
 				
-				<div class="gridListItemContent">{@$message->getFormattedMessage()}</div>
+				<div class="gridListItemContent">{unsafe:$message->getFormattedMessage()}</div>
 			</li>
 		{/foreach}
 	</ul>

--- a/com.woltlab.wcf/templates/searchResultList.tpl
+++ b/com.woltlab.wcf/templates/searchResultList.tpl
@@ -24,7 +24,7 @@
 								<li>{user object=$message->getUserProfile()}</li>
 							{/if}
 							{if $message->getTime()}
-								<li><small>{@$message->getTime()|time}</small></li>
+								<li><small>{time time=$message->getTime()}</small></li>
 							{/if}
 							{if $message->getContainerTitle()}
 								<li><small><a href="{$message->getContainerLink()}">{$message->getContainerTitle()}</a></small></li>

--- a/com.woltlab.wcf/templates/shared_aclPermissionJavaScript.tpl
+++ b/com.woltlab.wcf/templates/shared_aclPermissionJavaScript.tpl
@@ -11,17 +11,17 @@
 							{assign var='__optionCategoryName' value=$__optionData[categoryName]}
 							
 							{if !$categoryName|isset || ($__categoryNameStart|isset && $__optionCategoryName|str_starts_with:$__categoryNameStart) || (!$__categoryNameStart|isset && $__optionCategoryName == $categoryName)}
-								{@$__optionID}: {
-									categoryName: '{@$__optionData[categoryName]|encodeJS}',
-									label: '{@$__optionData[label]|encodeJS}',
-									optionName: '{@$__optionData[optionName]|encodeJS}'
+								{$__optionID}: {
+									categoryName: '{unsafe:$__optionData[categoryName]|encodeJS}',
+									label: '{unsafe:$__optionData[label]|encodeJS}',
+									optionName: '{unsafe:$__optionData[optionName]|encodeJS}'
 								},
 							{/if}
 						{/foreach}
 					},
 					categories: {
 						{implode from=$aclValues[$objectTypeID][categories] key='__category' item='__categoryName'}
-							'{@$__category|encodeJS}': '{@$__categoryName|encodeJS}'
+							'{unsafe:$__category|encodeJS}': '{unsafe:$__categoryName|encodeJS}'
 						{/implode}
 					},
 					user: {
@@ -29,13 +29,13 @@
 							option: {
 								{foreach from=$aclValues[$objectTypeID][user][option] key='__userID' item='__optionData'}
 									{hascontent}
-										{@$__userID}: {
+										{$__userID}: {
 											{content}
 												{foreach from=$__optionData key='__optionID' item='__optionValue'}
 													{assign var='__optionCategoryName' value=$aclValues[$objectTypeID][options][$__optionID][categoryName]}
 													
 													{if !$categoryName|isset || ($__categoryNameStart|isset && $__optionCategoryName|str_starts_with:$__categoryNameStart) || (!$__categoryNameStart|isset && $__optionCategoryName == $categoryName)}
-														{@$__optionID}: {@$__optionValue},
+														{$__optionID}: {$__optionValue},
 													{/if}
 												{/foreach}
 											{/content}
@@ -51,13 +51,13 @@
 							option: {
 								{foreach from=$aclValues[$objectTypeID][group][option] key='__groupID' item='__optionData'}
 									{hascontent}
-										{@$__groupID}: {
+										{$__groupID}: {
 											{content}
 												{foreach from=$__optionData key='__optionID' item='__optionValue'}
 													{assign var='__optionCategoryName' value=$aclValues[$objectTypeID][options][$__optionID][categoryName]}
 													
 													{if !$categoryName|isset || ($__categoryNameStart|isset && $__optionCategoryName|str_starts_with:$__categoryNameStart) || (!$__categoryNameStart|isset && $__optionCategoryName == $categoryName)}
-														{@$__optionID}: {@$__optionValue},
+														{$__optionID}: {$__optionValue},
 													{/if}
 												{/foreach}
 											{/content}
@@ -73,36 +73,36 @@
 			
 			{if $aclValues[$objectTypeID][user]|isset}
 				{foreach from=$aclValues[$objectTypeID][user][label] key='__userID' item='__label'}
-					if (initialPermissions.returnValues.user.option[{@$__userID}]) {
-						initialPermissions.returnValues.user.label[{@$__userID}] = '{@$__label|encodeJS}';
+					if (initialPermissions.returnValues.user.option[{$__userID}]) {
+						initialPermissions.returnValues.user.label[{$__userID}] = '{unsafe:$__label|encodeJS}';
 					}
 				{/foreach}
 			{/if}
 			
 			{if $aclValues[$objectTypeID][group]|isset}
 				{foreach from=$aclValues[$objectTypeID][group][label] key='__groupID' item='__label'}
-					if (initialPermissions.returnValues.group.option[{@$__groupID}]) {
-						initialPermissions.returnValues.group.label[{@$__groupID}] = '{@$__label|encodeJS}';
+					if (initialPermissions.returnValues.group.option[{$__groupID}]) {
+						initialPermissions.returnValues.group.label[{$__groupID}] = '{unsafe:$__label|encodeJS}';
 					}
 				{/foreach}
 			{/if}
 		{/if}
 
 		var aclList = new AclList(
-			'#{@$containerID}',
-			{@$objectTypeID},
-			{if $categoryName|isset}'{@$categoryName}'{else}null{/if},
-			{if $objectID|isset}{@$objectID}{else}0{/if},
+			'#{unsafe:$containerID|encodeJS}',
+			{$objectTypeID},
+			{if $categoryName|isset}'{unsafe:$categoryName|encodeJS}'{else}null{/if},
+			{if $objectID|isset}{$objectID}{else}0{/if},
 			{if !$includeUserGroups|isset || $includeUserGroups}true{else}false{/if},
 			{if $aclValues[$objectTypeID]|isset}initialPermissions{else}undefined{/if},
-			{if $aclValuesFieldName|isset}'{@$aclValuesFieldName}'{else}undefined{/if}
+			{if $aclValuesFieldName|isset}'{unsafe:$aclValuesFieldName|encodeJS}'{else}undefined{/if}
 		);
 		
 		{if !$aclFormBuilderMode|empty}
 			require(['WoltLabSuite/Core/Form/Builder/Manager'], function(FormBuilderManager) {
 				FormBuilderManager.getField(
-					'{@$field->getDocument()->getId()|encodeJS}',
-					'{@$field->getPrefixedId()|encodeJS}'
+					'{unsafe:$field->getDocument()->getId()|encodeJS}',
+					'{unsafe:$field->getPrefixedId()|encodeJS}'
 				).setAclList(aclList);
 			});
 		{/if}

--- a/com.woltlab.wcf/templates/shared_aclSimple.tpl
+++ b/com.woltlab.wcf/templates/shared_aclSimple.tpl
@@ -87,6 +87,6 @@
 			'wcf.acl.access.denied': '{jslang}wcf.acl.access.denied{/jslang}',
 		});
 
-		new UiAclSimple('{$__aclSimplePrefix}', '{@$__aclInputName|encodeJS}');
+		new UiAclSimple('{$__aclSimplePrefix}', '{unsafe:$__aclInputName|encodeJS}');
 	});
 </script>

--- a/com.woltlab.wcf/templates/shared_bbcode_attach_audio.tpl
+++ b/com.woltlab.wcf/templates/shared_bbcode_attach_audio.tpl
@@ -9,8 +9,8 @@
 <script data-relocate="true">
 	(function () {
 		{* try to determine if browser might be able to play audio *}
-		var audio = elById('attachmentAudio_{@$attachmentIdentifier}');
-		var canPlayType = audio.canPlayType('{$attachment->fileType}');
+		var audio = elById('attachmentAudio_{unsafe:$attachmentIdentifier|encodeJS}');
+		var canPlayType = audio.canPlayType('{unsafe:$attachment->fileType|encodeJS}');
 		
 		if (canPlayType === '') {
 			elRemove(audio);

--- a/com.woltlab.wcf/templates/shared_bbcode_attach_video.tpl
+++ b/com.woltlab.wcf/templates/shared_bbcode_attach_video.tpl
@@ -9,8 +9,8 @@
 <script data-relocate="true">
 	(function () {
 		{* try to determine if browser might be able to play video *}
-		var video = elById('attachmentVideo_{@$attachmentIdentifier}');
-		var canPlayType = video.canPlayType('{$attachment->fileType}');
+		var video = elById('attachmentVideo_{unsafe:$attachmentIdentifier|encodeJS}');
+		var canPlayType = video.canPlayType('{unsafe:$attachment->fileType|encodeJS}');
 		
 		if (canPlayType === '') {
 			elRemove(video);

--- a/com.woltlab.wcf/templates/shared_bbcode_wsa.tpl
+++ b/com.woltlab.wcf/templates/shared_bbcode_wsa.tpl
@@ -15,18 +15,18 @@
 		</h3>
 		
 		<div class="embeddedContentDescription">
-			{@$article->getFormattedTeaser()}
+			{unsafe:$article->getFormattedTeaser()}
 		</div>
 	</div>
 	
 	<div class="embeddedContentMeta">
 		<div class="embeddedContentMetaImage">
-			{@$article->getUserProfile()->getAvatar()->getImageTag(32)}
+			{unsafe:$article->getUserProfile()->getAvatar()->getImageTag(32)}
 		</div>
 		
 		<div class="embeddedContentMetaContent">
 			<div class="embeddedContentMetaAuthor">
-				{@$article->getUserProfile()->getFormattedUsername()}
+				{unsafe:$article->getUserProfile()->getFormattedUsername()}
 			</div>
 			
 			<div class="embeddedContentMetaTime">

--- a/com.woltlab.wcf/templates/shared_bbcode_wsm.tpl
+++ b/com.woltlab.wcf/templates/shared_bbcode_wsm.tpl
@@ -6,7 +6,7 @@
 			{if !$removeLinks}
 				<a href="{$mediaLink}" data-caption="{$media->title}" class="embeddedAttachmentLink" data-fancybox="message-{$activeMessageObjectType}-{$activeMessageID}">
 			{/if}
-					<img src="{$thumbnailLink}" alt="{$media->altText}" title="{$media->title}" width="{@$media->getThumbnailWidth($thumbnailSize)}" height="{@$media->getThumbnailHeight($thumbnailSize)}" loading="lazy">
+					<img src="{$thumbnailLink}" alt="{$media->altText}" title="{$media->title}" width="{$media->getThumbnailWidth($thumbnailSize)}" height="{$media->getThumbnailHeight($thumbnailSize)}" loading="lazy">
 			{if !$removeLinks}
 					<span class="embeddedAttachmentLinkEnlarge">
 						{icon size=24 name='magnifying-glass'}
@@ -14,7 +14,7 @@
 				</a>
 			{/if}
 		{else}
-			<img src="{$mediaLink}" alt="{$media->altText}" title="{$media->title}" width="{@$media->width}" height="{@$media->height}" loading="lazy">
+			<img src="{$mediaLink}" alt="{$media->altText}" title="{$media->title}" width="{$media->width}" height="{$media->height}" loading="lazy">
 		{/if}
 	{elseif $media->isVideo()}
 		<video src="{$mediaLink}" controls></video>
@@ -26,7 +26,7 @@
 		<span class="mediaBBCodeCaption">
 			<span class="mediaBBCodeCaptionAlignment">
 				{if $media->captionEnableHtml}
-					{@$media->caption}
+					{unsafe:$media->caption}
 				{else}
 					{$media->caption}
 				{/if}

--- a/com.woltlab.wcf/templates/shared_benchmark.tpl
+++ b/com.woltlab.wcf/templates/shared_benchmark.tpl
@@ -1,6 +1,6 @@
 <div class="benchmark">
 	{if ENABLE_DEBUG_MODE}<button class="benchmarkDetailsButton">{/if}
-		Execution time: {@$__wcf->getBenchmark()->getExecutionTime()}s ({#($__wcf->getBenchmark()->getExecutionTime()-$__wcf->getBenchmark()->getQueryExecutionTime())/$__wcf->getBenchmark()->getExecutionTime()*100}% PHP, {#$__wcf->getBenchmark()->getQueryExecutionTime()/$__wcf->getBenchmark()->getExecutionTime()*100}% SQL) | SQL queries: {#$__wcf->getBenchmark()->getQueryCount()} | Memory-Usage: {$__wcf->getBenchmark()->getMemoryUsage()}
+		Execution time: {$__wcf->getBenchmark()->getExecutionTime()}s ({#($__wcf->getBenchmark()->getExecutionTime()-$__wcf->getBenchmark()->getQueryExecutionTime())/$__wcf->getBenchmark()->getExecutionTime()*100}% PHP, {#$__wcf->getBenchmark()->getQueryExecutionTime()/$__wcf->getBenchmark()->getExecutionTime()*100}% SQL) | SQL queries: {#$__wcf->getBenchmark()->getQueryCount()} | Memory-Usage: {$__wcf->getBenchmark()->getMemoryUsage()}
 	{if ENABLE_DEBUG_MODE}</button>{/if}
 	
 	{if ENABLE_DEBUG_MODE}
@@ -18,7 +18,7 @@
 						<details>
 							<summary>
 								<span>{if $item.type == 1}(SQL Query) {/if}{$item.text}</span><br>
-								<small style="font-size: .85em">Execution time: <kbd>{@$item.use}s</kbd></small>
+								<small style="font-size: .85em">Execution time: <kbd>{$item.use}s</kbd></small>
 							</summary>
 					
 							<ol class="nativeList" start="0">

--- a/com.woltlab.wcf/templates/shared_captcha.tpl
+++ b/com.woltlab.wcf/templates/shared_captcha.tpl
@@ -1,3 +1,3 @@
 {if $captchaObjectType}
-	{@$captchaObjectType->getProcessor()->getFormElement()}
+	{unsafe:$captchaObjectType->getProcessor()->getFormElement()}
 {/if}

--- a/com.woltlab.wcf/templates/shared_codeMetaCode.tpl
+++ b/com.woltlab.wcf/templates/shared_codeMetaCode.tpl
@@ -11,7 +11,7 @@
 	
 	{assign var='lineNumber' value=$startLineNumber}
 	<pre class="codeBoxCode collapsibleBbcodeOverflow"><code{if $language} class="language-{$language}"{/if}>{foreach from=$content item=line}{*
-		*}<span class="codeBoxLine" id="#codeLine_{$lineNumber}_{$codeID}"><a href="#codeLine_{$lineNumber}_{$codeID|rawurlencode}" class="lineAnchor" title="{@$lineNumber}" tabindex="-1" aria-hidden="true"></a><span>{$line}</span></span>{*
+		*}<span class="codeBoxLine" id="#codeLine_{$lineNumber}_{$codeID}"><a href="#codeLine_{$lineNumber}_{unsafe:$codeID|rawurlencode}" class="lineAnchor" title="{$lineNumber}" tabindex="-1" aria-hidden="true"></a><span>{$line}</span></span>{*
 		*}{assign var='lineNumber' value=$lineNumber+1}{*
 	*}{/foreach}</code></pre>
 	

--- a/com.woltlab.wcf/templates/shared_codemirror.tpl
+++ b/com.woltlab.wcf/templates/shared_codemirror.tpl
@@ -12,7 +12,7 @@
 			{elseif $codemirrorMode === 'text/x-scss'}
 				'codemirror/mode/css/css',
 			{else}
-				'codemirror/mode/{@$codemirrorMode}/{@$codemirrorMode}',
+				'codemirror/mode/{unsafe:$codemirrorMode|encodeJS}/{unsafe:$codemirrorMode|encodeJS}',
 			{/if}
 		{/if}
 		'codemirror/addon/search/search',
@@ -36,7 +36,7 @@
 			function addStylesheet(name) {
 				const link = document.createElement('link');
 				link.rel = 'stylesheet';
-				link.href = `{@$__wcf->getPath()}js/3rdParty/codemirror/${ name }.css`;
+				link.href = `{$__wcf->getPath()}js/3rdParty/codemirror/${ name }.css`;
 				document.head.append(link);
 			}
 
@@ -57,7 +57,7 @@
 						version: 3
 					},
 				{else}
-					mode: '{@$codemirrorMode|encodeJS}',
+					mode: '{unsafe:$codemirrorMode|encodeJS}',
 				{/if}
 			{/if}
 			lineWrapping: true,
@@ -71,7 +71,7 @@
 			config.theme = "material-darker";
 		}
 		
-		document.querySelectorAll('{@$codemirrorSelector|encodeJS}').forEach((element) => {
+		document.querySelectorAll('{unsafe:$codemirrorSelector|encodeJS}').forEach((element) => {
 			{event name='javascriptInit'}
 			
 			if (element.codemirror) {

--- a/com.woltlab.wcf/templates/shared_exceptionLogDetails.tpl
+++ b/com.woltlab.wcf/templates/shared_exceptionLogDetails.tpl
@@ -11,7 +11,7 @@
 </dl>
 <dl>
 	<dt>{lang}wcf.acp.exceptionLog.exception.date{/lang}</dt>
-	<dd>{$exception[date]|plainTime}</dd>
+	<dd>{time time=$exception[date] type='plainTime'}</dd>
 </dl>
 <dl>
 	<dt>{lang}wcf.acp.exceptionLog.exception.requestURI{/lang}</dt>

--- a/com.woltlab.wcf/templates/shared_multiPageCondition.tpl
+++ b/com.woltlab.wcf/templates/shared_multiPageCondition.tpl
@@ -6,4 +6,4 @@
 	</dd>
 </dl>
 
-{@$conditionHtml}
+{unsafe:$conditionHtml}

--- a/com.woltlab.wcf/templates/shared_quoteMetaCode.tpl
+++ b/com.woltlab.wcf/templates/shared_quoteMetaCode.tpl
@@ -1,7 +1,7 @@
 <blockquote class="quoteBox collapsibleBbcode jsCollapsibleBbcode{if $collapseQuote} collapsed{/if}{if !$quoteAuthorObject} quoteBoxSimple{/if}"{if $quoteLink} cite="{$quoteLink}"{/if}>
 	<div class="quoteBoxIcon">
 		{if $quoteAuthorObject}
-			<a href="{$quoteAuthorObject->getLink()}" class="userLink" data-object-id="{@$quoteAuthorObject->userID}" aria-hidden="true">{@$quoteAuthorObject->getAvatar()->getImageTag(24)}</a>
+			<a href="{$quoteAuthorObject->getLink()}" class="userLink" data-object-id="{$quoteAuthorObject->userID}" aria-hidden="true">{unsafe:$quoteAuthorObject->getAvatar()->getImageTag(24)}</a>
 		{else}
 			{icon name='quote-left' size=24}
 		{/if}

--- a/com.woltlab.wcf/templates/shared_scrollablePageCheckboxList.tpl
+++ b/com.woltlab.wcf/templates/shared_scrollablePageCheckboxList.tpl
@@ -10,14 +10,14 @@
 			'wcf.global.filter.visibility.showAll': '{jslang}wcf.global.filter.visibility.showAll{/jslang}'
 		});
 		
-		new UiItemListFilter('{@$pageCheckboxListContainerID}');
+		new UiItemListFilter('{unsafe:$pageCheckboxListContainerID|encodeJS}');
 	});
 </script>
 
-<ul class="scrollableCheckboxList" id="{@$pageCheckboxListContainerID}">
+<ul class="scrollableCheckboxList" id="{$pageCheckboxListContainerID}">
 	{foreach from=$pageNodeList item=pageNode}
 		<li{if $pageNode->getDepth() > 1} style="padding-left: {$pageNode->getDepth()*20-20}px"{/if}>
-			<label><input type="checkbox" name="{@$pageCheckboxID}[]" value="{$pageNode->pageID}" data-identifier="{@$pageNode->identifier}"{if $pageNode->pageID|in_array:$pageIDs} checked{/if}> {$pageNode->name}</label>
+			<label><input type="checkbox" name="{$pageCheckboxID}[]" value="{$pageNode->pageID}" data-identifier="{$pageNode->identifier}"{if $pageNode->pageID|in_array:$pageIDs} checked{/if}> {$pageNode->name}</label>
 		</li>
 	{/foreach}
 </ul>

--- a/com.woltlab.wcf/templates/shared_topReaction.tpl
+++ b/com.woltlab.wcf/templates/shared_topReaction.tpl
@@ -2,17 +2,17 @@
 {if $topReaction}
 	{if $render === 'tiny'}
 		<span class="topReactionTiny jsTooltip" title="{lang reaction=$topReaction[reaction] count=$topReaction[count] other=$topReaction[other]}wcf.like.reaction.topReaction{/lang}">
-			{@$topReaction[reaction]->renderIcon()}
+			{unsafe:$topReaction[reaction]->renderIcon()}
 			<span class="reactionCount">{$topReaction[count]|shortUnit}</span>
 		</span>
 	{elseif $render === 'short'}
 		<span class="topReactionShort jsTooltip" title="{lang reaction=$topReaction[reaction] count=$topReaction[count] other=$topReaction[other]}wcf.like.reaction.topReaction{/lang}">
-			{@$topReaction[reaction]->renderIcon()}
+			{unsafe:$topReaction[reaction]->renderIcon()}
 			<span class="reactionCount">{$topReaction[count]|shortUnit}</span>
 		</span>
 	{elseif $render === 'full'}
 		<span class="topReactionFull">
-			{@$topReaction[reaction]->renderIcon()} {lang reaction=$topReaction[reaction] count=$topReaction[count] other=$topReaction[other]}wcf.like.reaction.topReaction{/lang}
+			{unsafe:$topReaction[reaction]->renderIcon()} {lang reaction=$topReaction[reaction] count=$topReaction[count] other=$topReaction[other]}wcf.like.reaction.topReaction{/lang}
 		</span>
 	{/if}
 {/if}

--- a/com.woltlab.wcf/templates/shared_trophyBadge.tpl
+++ b/com.woltlab.wcf/templates/shared_trophyBadge.tpl
@@ -4,5 +4,5 @@
 	data-trophy-id="{$trophy->trophyID}"
 	{if $showTooltip}title="{$trophy->getTitle()}"{/if}
 >
-	{@$trophy->getIcon()->toHtml($size)}
+	{unsafe:$trophy->getIcon()->toHtml($size)}
 </span>

--- a/com.woltlab.wcf/templates/shared_trophyImage.tpl
+++ b/com.woltlab.wcf/templates/shared_trophyImage.tpl
@@ -1,5 +1,5 @@
 <img
-	src="{@$__wcf->getPath()}images/trophy/{$trophy->iconFile}"
+	src="{$__wcf->getPath()}images/trophy/{$trophy->iconFile}"
 	width="{$size}"
 	height="{$size}"
 	{if $showTooltip}title="{$trophy->getTitle()}"{/if}

--- a/com.woltlab.wcf/templates/shared_uploadFieldComponent.tpl
+++ b/com.woltlab.wcf/templates/shared_uploadFieldComponent.tpl
@@ -23,7 +23,7 @@
 					<div>
 						<div>
 							<p>{$file->getFilename()}</p>
-							<small>{@$file->filesize|filesize}</small>
+							<small>{$file->filesize|filesize}</small>
 						</div>
 						
 						<ul class="buttonGroup"></ul>

--- a/com.woltlab.wcf/templates/shared_wysiwyg.tpl
+++ b/com.woltlab.wcf/templates/shared_wysiwyg.tpl
@@ -20,7 +20,7 @@
 	require([
 		"WoltLabSuite/Core/Component/Ckeditor",
 		"WoltLabSuite/Core/prism-meta",
-		{@$__wcf->getBBCodeHandler()->getEditorLocalization()}
+		{unsafe:$__wcf->getBBCodeHandler()->getEditorLocalization()}
 	], (
 		{ setupCkeditor },
 		PrismMeta
@@ -84,9 +84,9 @@
 		const bbcodes = [
 			{foreach from=$__wcf->getBBCodeHandler()->getButtonBBCodes(true) item=__bbcode}
 				{
-					icon: '{@$__bbcode->getIcon()|encodeJS}',
-					name: '{@$__bbcode->bbcodeTag|encodeJS}',
-					label: '{@$__bbcode->getButtonLabel()|encodeJS}',
+					icon: '{unsafe:$__bbcode->getIcon()|encodeJS}',
+					name: '{unsafe:$__bbcode->bbcodeTag|encodeJS}',
+					label: '{unsafe:$__bbcode->getButtonLabel()|encodeJS}',
 				},
 			{/foreach}
 		];
@@ -100,8 +100,8 @@
 		const smileys = [
 			{foreach from=$__wcf->getSmileyCache()->getEmojis() key=__code item=__smiley}
 			{
-				code: '{@$__code|encodeJS}',
-				html: '{@$__smiley->getHtml()|encodeJS}',
+				code: '{unsafe:$__code|encodeJS}',
+				html: '{unsafe:$__smiley->getHtml()|encodeJS}',
 			},
 			{/foreach}
 		];
@@ -110,10 +110,10 @@
 			{ language: "", label: '{jslang}wcf.editor.code.highlighter.detect{/jslang}' },
 			{ language: "plain", label: '{jslang}wcf.editor.code.highlighter.plain{/jslang}' },
 			{foreach from=$__wcf->getBBCodeHandler()->getCodeBlockLanguages() item=__codeBlockLanguage}
-				{ language: '{@$__codeBlockLanguage|encodeJS}', label: PrismMeta.default['{@$__codeBlockLanguage|encodeJS}'].title },
+				{ language: '{unsafe:$__codeBlockLanguage|encodeJS}', label: PrismMeta.default['{unsafe:$__codeBlockLanguage|encodeJS}'].title },
 			{/foreach}
 		];
 
-		void setupCkeditor(element, features, bbcodes, smileys, codeBlockLanguages, '{@$__wcf->getBBCodeHandler()->getCkeditorLicenseKey()|encodeJS}');
+		void setupCkeditor(element, features, bbcodes, smileys, codeBlockLanguages, '{unsafe:$__wcf->getBBCodeHandler()->getCkeditorLicenseKey()|encodeJS}');
 	});
 </script>

--- a/com.woltlab.wcf/templates/styleChooser.tpl
+++ b/com.woltlab.wcf/templates/styleChooser.tpl
@@ -1,9 +1,9 @@
 <ol class="containerList styleList{if $styleList|count > 4} doubleColumned{/if}">
 	{foreach from=$styleList item=style}
-		<li data-style-id="{@$style->styleID}">
+		<li data-style-id="{$style->styleID}">
 			<div class="box128">
 				<span class="styleListPreviewImage">
-					<img src="{@$style->getPreviewImage()}" srcset="{@$style->getPreviewImage2x()} 2x" height="64" alt="">
+					<img src="{$style->getPreviewImage()}" srcset="{$style->getPreviewImage2x()} 2x" height="64" alt="">
 				</span>
 				<div class="details">
 					<div class="containerHeadline">
@@ -16,7 +16,7 @@
 							{/if}
 						</h3>
 					</div>
-					{if $style->styleDescription}<small>{lang __optional=true}{@$style->styleDescription}{/lang}</small>{/if}
+					{if $style->styleDescription}<small>{lang __optional=true}{$style->styleDescription}{/lang}</small>{/if}
 				</div>
 			</div>
 		</li>

--- a/com.woltlab.wcf/templates/tagInput.tpl
+++ b/com.woltlab.wcf/templates/tagInput.tpl
@@ -1,8 +1,8 @@
 {if $__wcf->session->getPermission('user.tag.canViewTag')}
 	<dl class="jsOnly">
-		<dt><label for="tagSearchInput{if $tagInputSuffix|isset}{@$tagInputSuffix}{/if}">{lang}wcf.tagging.tags{/lang}</label></dt>
+		<dt><label for="tagSearchInput{if $tagInputSuffix|isset}{$tagInputSuffix}{/if}">{lang}wcf.tagging.tags{/lang}</label></dt>
 		<dd>
-			<input id="tagSearchInput{if $tagInputSuffix|isset}{@$tagInputSuffix}{/if}" type="text" value="" class="long">
+			<input id="tagSearchInput{if $tagInputSuffix|isset}{$tagInputSuffix}{/if}" type="text" value="" class="long">
 			<small>{lang}wcf.tagging.tags.description{/lang}</small>
 		</dd>
 	</dl>
@@ -10,15 +10,15 @@
 	<script data-relocate="true">
 		require(['WoltLabSuite/Core/Ui/ItemList'], function(UiItemList) {
 			UiItemList.init(
-				'tagSearchInput{if $tagInputSuffix|isset}{@$tagInputSuffix}{/if}',
-				[{if $tags|isset && $tags|count}{implode from=$tags item=tag}'{@$tag|encodeJS}'{/implode}{/if}],
+				'tagSearchInput{if $tagInputSuffix|isset}{unsafe:$tagInputSuffix|encodeJS}{/if}',
+				[{if $tags|isset && $tags|count}{implode from=$tags item=tag}'{unsafe:$tag|encodeJS}'{/implode}{/if}],
 				{
 					ajax: {
 						className: 'wcf\\data\\tag\\TagAction'
-						{if !$tagLanguageID|empty}, parameters: { languageID: {@$tagLanguageID|encodeJS} }{/if}
+						{if !$tagLanguageID|empty}, parameters: { languageID: {$tagLanguageID} }{/if}
 					},
-					maxLength: {@TAGGING_MAX_TAG_LENGTH},
-					submitFieldName: '{if $tagSubmitFieldName|isset}{@$tagSubmitFieldName}{else}tags[]{/if}'
+					maxLength: {TAGGING_MAX_TAG_LENGTH},
+					submitFieldName: '{if $tagSubmitFieldName|isset}{unsafe:$tagSubmitFieldName|encodeJS}{else}tags[]{/if}'
 				}
 			);
 		});

--- a/com.woltlab.wcf/templates/tagSearch.tpl
+++ b/com.woltlab.wcf/templates/tagSearch.tpl
@@ -3,7 +3,7 @@
 {include file='shared_formError'}
 
 {if $errorMessage|isset}
-	<woltlab-core-notice type="error">{@$errorMessage}</woltlab-core-notice>
+	<woltlab-core-notice type="error">{unsafe:$errorMessage}</woltlab-core-notice>
 {/if}
 
 <form method="post" action="{link controller='TagSearch'}{/link}">
@@ -30,12 +30,12 @@
 			require(['WoltLabSuite/Core/Ui/ItemList'], function(UiItemList) {
 				UiItemList.init(
 					'tagSearchInput',
-					[{if !$tagNames|empty}{implode from=$tagNames item=tagName}'{@$tagName|encodeJS}'{/implode}{/if}],
+					[{if !$tagNames|empty}{implode from=$tagNames item=tagName}'{unsafe:$tagName|encodeJS}'{/implode}{/if}],
 					{
 						ajax: {
 							className: 'wcf\\data\\tag\\TagAction'
 						},
-						maxItems: {@SEARCH_MAX_COMBINED_TAGS},
+						maxItems: {SEARCH_MAX_COMBINED_TAGS},
 						restricted: true,
 						submitFieldName: 'tagNames[]'
 					}

--- a/com.woltlab.wcf/templates/tagged.tpl
+++ b/com.woltlab.wcf/templates/tagged.tpl
@@ -1,15 +1,15 @@
-{capture assign='pageTitle'}{lang}wcf.tagging.taggedObjects.{@$objectType}{/lang}{if $pageNo > 1} - {lang}wcf.page.pageNo{/lang}{/if}{/capture}
+{capture assign='pageTitle'}{lang}wcf.tagging.taggedObjects.{$objectType}{/lang}{if $pageNo > 1} - {lang}wcf.page.pageNo{/lang}{/if}{/capture}
 
-{capture assign='contentTitle'}{lang}wcf.tagging.taggedObjects.{@$objectType}{/lang}{/capture}
+{capture assign='contentTitle'}{lang}wcf.tagging.taggedObjects.{$objectType}{/lang}{/capture}
 
 {capture assign='headContent'}
 	{if $pageNo < $pages}
-		<link rel="next" href="{link controller='Tagged' object=$tag}objectType={@$objectType}&pageNo={@$pageNo+1}{/link}">
+		<link rel="next" href="{link controller='Tagged' object=$tag objectType=$objectType pageNo=$pageNo+1}{/link}">
 	{/if}
 	{if $pageNo > 1}
-		<link rel="prev" href="{link controller='Tagged' object=$tag}objectType={@$objectType}{if $pageNo > 2}&pageNo={@$pageNo-1}{/if}{/link}">
+		<link rel="prev" href="{link controller='Tagged' object=$tag objectType=$objectType}{if $pageNo > 2}&pageNo={$pageNo-1}{/if}{/link}">
 	{/if}
-	<link rel="canonical" href="{link controller='Tagged' object=$tag}objectType={@$objectType}{if $pageNo > 1}&pageNo={@$pageNo}{/if}{/link}">
+	<link rel="canonical" href="{link controller='Tagged' object=$tag objectType=$objectType}{if $pageNo > 1}&pageNo={$pageNo}{/if}{/link}">
 {/capture}
 
 {capture assign='sidebarRight'}

--- a/com.woltlab.wcf/templates/tagged.tpl
+++ b/com.woltlab.wcf/templates/tagged.tpl
@@ -42,7 +42,13 @@
 {/capture}
 
 {capture assign='contentInteractionPagination'}
-	{pages print=true assign=pagesLinks controller='Tagged' object=$tag link="objectType=$objectType&pageNo=%d"}
+	{if $pages > 1}
+		<woltlab-core-pagination
+			page="{$pageNo}"
+			count="{$pages}"
+			url="{link controller='Tagged' object=$tag objectType=$objectType}{/link}"
+		></woltlab-core-pagination>
+	{/if}
 {/capture}
 
 {capture assign='contentInteractionButtons'}
@@ -58,11 +64,15 @@
 {/if}
 
 <footer class="contentFooter">
-	{hascontent}
+	{if $pages > 1}
 		<div class="paginationBottom">
-			{content}{@$pagesLinks}{/content}
+			<woltlab-core-pagination
+				page="{$pageNo}"
+				count="{$pages}"
+				url="{link controller='Tagged' object=$tag objectType=$objectType}{/link}"
+			></woltlab-core-pagination>
 		</div>
-	{/hascontent}
+	{/if}
 	
 	{hascontent}
 		<nav class="contentFooterNavigation">

--- a/com.woltlab.wcf/templates/team.tpl
+++ b/com.woltlab.wcf/templates/team.tpl
@@ -3,7 +3,7 @@
 {foreach from=$objects->getTeams() item=team}
 	<section class="section sectionContainerList">
 		<header class="sectionHeader">
-			<h2 class="sectionTitle" id="group{@$team->groupID}">{$team->getTitle()} <span class="badge">{#$team->getMembers()|count}</span></h2>
+			<h2 class="sectionTitle" id="group{$team->groupID}">{$team->getTitle()} <span class="badge">{#$team->getMembers()|count}</span></h2>
 			<p class="sectionDescription">{$team->getDescription()}</p>
 		</header>
 			

--- a/com.woltlab.wcf/templates/trophy.tpl
+++ b/com.woltlab.wcf/templates/trophy.tpl
@@ -49,7 +49,7 @@
 	
 					<div class="containerHeadline">
 						<h3>{user object=$userTrophy->getUserProfile()}</h3>
-						<small>{if !$userTrophy->getDescription()|empty}<span class="separatorRight">{unsafe:$userTrophy->getDescription()}</span> {/if}{@$userTrophy->time|time}</small>
+						<small>{if !$userTrophy->getDescription()|empty}<span class="separatorRight">{unsafe:$userTrophy->getDescription()}</span> {/if}{time time=$userTrophy->time}</small>
 					</div>
 				</li>
 			{/foreach}

--- a/com.woltlab.wcf/templates/trophy.tpl
+++ b/com.woltlab.wcf/templates/trophy.tpl
@@ -2,10 +2,10 @@
 
 {capture assign='headContent'}
 	{if $pageNo < $pages}
-		<link rel="next" href="{link controller='Trophy' object=$trophy}pageNo={$pageNo+1}{/link}">
+		<link rel="next" href="{link controller='Trophy' object=$trophy pageNo=$pageNo+1}{/link}">
 	{/if}
 	{if $pageNo > 1}
-		<link rel="prev" href="{link controller='Trophy' object=$trophy}{if $pageNo > 2}pageNo={@$pageNo-1}{/if}{/link}">
+		<link rel="prev" href="{link controller='Trophy' object=$trophy}{if $pageNo > 2}pageNo={$pageNo-1}{/if}{/link}">
 	{/if}
 {/capture}
 
@@ -29,7 +29,13 @@
 {/capture}
 
 {capture assign='contentInteractionPagination'}
-	{pages print=true assign='pagesLinks' controller='Trophy' object=$trophy link="pageNo=%d"}
+	{if $pages > 1}
+		<woltlab-core-pagination
+			page="{$pageNo}"
+			count="{$pages}"
+			url="{link controller='Trophy' object=$trophy}{/link}"
+		></woltlab-core-pagination>
+	{/if}
 {/capture}
 
 {include file='header'}
@@ -54,11 +60,15 @@
 {/if}
 
 <footer class="contentFooter">
-	{hascontent}
+	{if $pages > 1}
 		<div class="paginationBottom">
-			{content}{@$pagesLinks}{/content}
+			<woltlab-core-pagination
+				page="{$pageNo}"
+				count="{$pages}"
+				url="{link controller='Trophy' object=$trophy}{/link}"
+			></woltlab-core-pagination>
 		</div>
-	{/hascontent}
+	{/if}
 
 	{hascontent}
 		<nav class="contentFooterNavigation">

--- a/com.woltlab.wcf/templates/trophy.tpl
+++ b/com.woltlab.wcf/templates/trophy.tpl
@@ -2,7 +2,7 @@
 
 {capture assign='headContent'}
 	{if $pageNo < $pages}
-		<link rel="next" href="{link controller='Trophy' object=$trophy}pageNo={@$pageNo+1}{/link}">
+		<link rel="next" href="{link controller='Trophy' object=$trophy}pageNo={$pageNo+1}{/link}">
 	{/if}
 	{if $pageNo > 1}
 		<link rel="prev" href="{link controller='Trophy' object=$trophy}{if $pageNo > 2}pageNo={@$pageNo-1}{/if}{/link}">
@@ -12,13 +12,13 @@
 {capture assign='contentHeader'}
 	<header class="contentHeader messageGroupContentHeader">
 		<div class="contentHeaderIcon">
-			{@$trophy->renderTrophy(64)}
+			{unsafe:$trophy->renderTrophy(64)}
 		</div>
 
 		<div class="contentHeaderTitle">
 			<h1 class="contentTitle">{$trophy->getTitle()}</h1>
 			<ul class="inlineList contentHeaderMetaData">
-				{if !$trophy->getDescription()|empty}<li>{@$trophy->getDescription()}</li>{/if}
+				{if !$trophy->getDescription()|empty}<li>{unsafe:$trophy->getDescription()}</li>{/if}
 				<li>
 					{icon name='users'}
 					<span>{lang}wcf.user.trophy.trophyAwarded{/lang}</span>
@@ -39,11 +39,11 @@
 		<ol class="containerList trophyCategoryList doubleColumned">
 			{foreach from=$objects item=userTrophy}
 				<li class="box64">
-					<div>{@$userTrophy->getUserProfile()->getAvatar()->getImageTag(64)}</div>
+					<div>{unsafe:$userTrophy->getUserProfile()->getAvatar()->getImageTag(64)}</div>
 	
 					<div class="containerHeadline">
 						<h3>{user object=$userTrophy->getUserProfile()}</h3>
-						<small>{if !$userTrophy->getDescription()|empty}<span class="separatorRight">{@$userTrophy->getDescription()}</span> {/if}{@$userTrophy->time|time}</small>
+						<small>{if !$userTrophy->getDescription()|empty}<span class="separatorRight">{unsafe:$userTrophy->getDescription()}</span> {/if}{@$userTrophy->time|time}</small>
 					</div>
 				</li>
 			{/foreach}

--- a/com.woltlab.wcf/templates/trophyList.tpl
+++ b/com.woltlab.wcf/templates/trophyList.tpl
@@ -8,10 +8,10 @@
 
 {capture assign='headContent'}
 	{if $pageNo < $pages}
-		<link rel="next" href="{link controller='TrophyList'}pageNo={@$pageNo+1}{/link}">
+		<link rel="next" href="{link controller='TrophyList' pageNo=$pageNo+1}{/link}">
 	{/if}
 	{if $pageNo > 1}
-		<link rel="prev" href="{link controller='TrophyList'}{if $pageNo > 2}pageNo={@$pageNo-1}{/if}{/link}">
+		<link rel="prev" href="{link controller='TrophyList'}{if $pageNo > 2}pageNo={$pageNo-1}{/if}{/link}">
 	{/if}
 {/capture}
 
@@ -26,11 +26,11 @@
 		<ol class="containerList trophyCategoryList doubleColumned">
 			{foreach from=$objects item=trophy}
 				<li class="box64">
-					<div>{@$trophy->renderTrophy(64)}</div>
+					<div>{unsafe:$trophy->renderTrophy(64)}</div>
 					
 					<div class="containerHeadline">
-						<h3><a href="{$trophy->getLink()}">{@$trophy->getTitle()}</a></h3>
-						{if !$trophy->getDescription()|empty}<p><small>{@$trophy->getDescription()}</small></p>{/if}
+						<h3><a href="{$trophy->getLink()}">{unsafe:$trophy->getTitle()}</a></h3>
+						{if !$trophy->getDescription()|empty}<p><small>{unsafe:$trophy->getDescription()}</small></p>{/if}
 						<p><small>{lang items=$trophy->awarded}wcf.user.trophy.trophyAwarded{/lang}</small></p>
 					</div>
 				</li>

--- a/com.woltlab.wcf/templates/trophyList.tpl
+++ b/com.woltlab.wcf/templates/trophyList.tpl
@@ -16,7 +16,13 @@
 {/capture}
 
 {capture assign='contentInteractionPagination'}
-	{pages print=true assign='pagesLinks' controller='TrophyList' link="pageNo=%d"}
+	{if $pages > 1}
+		<woltlab-core-pagination
+			page="{$pageNo}"
+			count="{$pages}"
+			url="{link controller='TrophyList'}{/link}"
+		></woltlab-core-pagination>
+	{/if}
 {/capture}
 
 {include file='header'}
@@ -42,11 +48,15 @@
 {/if}
 
 <footer class="contentFooter">
-	{hascontent}
+	{if $pages > 1}
 		<div class="paginationBottom">
-			{content}{@$pagesLinks}{/content}
+			<woltlab-core-pagination
+				page="{$pageNo}"
+				count="{$pages}"
+				url="{link controller='TrophyList'}{/link}"
+			></woltlab-core-pagination>
 		</div>
-	{/hascontent}
+	{/if}
 
 	{hascontent}
 		<nav class="contentFooterNavigation">


### PR DESCRIPTION
- Remove unnecessary `@`
- Use `unsafe:` instead of `@`
- Replace deprecated `time` template modifier with `{time}`
- Replace deprecated `{pages}` with `<woltlab-core-pagination>`