### PR TITLE
Refactor templates

### DIFF
--- a/com.woltlab.wcf/templates/accountManagement.tpl
+++ b/com.woltlab.wcf/templates/accountManagement.tpl
@@ -107,8 +107,8 @@
 					new PasswordStrength(elById('newPassword'), {
 						relatedInputs: relatedInputs,
 						staticDictionary: [
-							'{$__wcf->user->username|encodeJS}',
-							'{$__wcf->user->email|encodeJS}',
+							'{unsafe:$__wcf->user->username|encodeJS}',
+							'{unsafe:$__wcf->user->email|encodeJS}',
 						]
 					});
 				})

--- a/com.woltlab.wcf/templates/headIncludeJavaScript.tpl
+++ b/com.woltlab.wcf/templates/headIncludeJavaScript.tpl
@@ -102,9 +102,9 @@ window.addEventListener('pageshow', function(event) {
 				],
 			{/if}
 			styleChanger: {if $__wcf->getStyleHandler()->showStyleChanger()}true{else}false{/if},
-			{if $__wcf->user->userID && !$__wcf->getMessageQuoteManager()->getRemoveQuoteIDs()|empty}removeQuotes: [{implode from=$__wcf->getMessageQuoteManager()->getRemoveQuoteIDs() item=uuid}'{$uuid|encodeJS}'{/implode}],{/if}
+			{if $__wcf->user->userID && !$__wcf->getMessageQuoteManager()->getRemoveQuoteIDs()|empty}removeQuotes: [{implode from=$__wcf->getMessageQuoteManager()->getRemoveQuoteIDs() item=uuid}'{unsafe:$uuid|encodeJS}'{/implode}],{/if}
 			{if $__wcf->user->userID && !$__wcf->getMessageQuoteManager()->getUsedQuotes()|empty}usedQuotes: new Map([
-				{foreach from=$__wcf->getMessageQuoteManager()->getUsedQuotes() key=editorID item=uuids}['{$editorID|encodeJS}', [{implode from=$uuids item=uuid}'{$uuid|encodeJS}'{/implode}]]{/foreach}
+				{foreach from=$__wcf->getMessageQuoteManager()->getUsedQuotes() key=editorID item=uuids}['{unsafe:$editorID|encodeJS}', [{implode from=$uuids item=uuid}'{unsafe:$uuid|encodeJS}'{/implode}]]{/foreach}
 			]),
 			{/if}
 		});

--- a/com.woltlab.wcf/templates/shared_uploadFieldComponent.tpl
+++ b/com.woltlab.wcf/templates/shared_uploadFieldComponent.tpl
@@ -52,7 +52,7 @@
 			imagePreview: {if !$uploadField->supportMultipleFiles() && $uploadField->isImageOnly()}true{else}false{/if},
 			{if $uploadField->getAcceptableFiles()}
 				acceptableFiles: [
-					{implode from=$uploadField->getAcceptableFiles() item=accept}'{$accept|encodeJS}'{/implode}
+					{implode from=$uploadField->getAcceptableFiles() item=accept}'{unsafe:$accept|encodeJS}'{/implode}
 				],
 			{/if}
 		});

--- a/com.woltlab.wcf/templates/shared_wysiwyg.tpl
+++ b/com.woltlab.wcf/templates/shared_wysiwyg.tpl
@@ -43,9 +43,9 @@
 
 		{include file='mediaJavaScript'}
 
-		const element = document.getElementById('{$wysiwygSelector|encodeJS}');
+		const element = document.getElementById('{unsafe:$wysiwygSelector|encodeJS}');
 		if (element === null) {
-			throw new Error("Unable to find the source element '{$wysiwygSelector|encodeJS}' for the editor.")
+			throw new Error("Unable to find the source element '{unsafe:$wysiwygSelector|encodeJS}' for the editor.")
 		}
 
 		let enableAttachments = element.dataset.disableAttachments !== "true";

--- a/com.woltlab.wcf/templates/shared_wysiwygCmsToolbar.tpl
+++ b/com.woltlab.wcf/templates/shared_wysiwygCmsToolbar.tpl
@@ -21,7 +21,7 @@
 		{jsphrase name='wcf.page.search.name'}
 		{jsphrase name='wcf.page.search.results'}
 
-		const element = document.getElementById('{$wysiwygSelector|encodeJS}');
+		const element = document.getElementById('{unsafe:$wysiwygSelector|encodeJS}');
 		setupArticle(element);
 		setupPage(element);
 	});

--- a/com.woltlab.wcf/templates/userException.tpl
+++ b/com.woltlab.wcf/templates/userException.tpl
@@ -30,7 +30,7 @@
 	{$stacktrace}
 	-->
 	<script>
-		console.debug('{$name|encodeJS} thrown in {$file|encodeJS} ({$line})');
+		console.debug('{unsafe:$name|encodeJS} thrown in {unsafe:$file|encodeJS} ({$line})');
 		console.debug('Stacktrace:\n{unsafe:$stacktrace|encodeJS}');
 	</script>
 {/if}

--- a/ts/WoltLabSuite/Core/Component/Option/Enable.ts
+++ b/ts/WoltLabSuite/Core/Component/Option/Enable.ts
@@ -93,13 +93,10 @@ function enableOption(element: HTMLElement, enable: boolean) {
 
     const parentOptionTypeBoolean = element.closest(".optionTypeBoolean");
     if (parentOptionTypeBoolean) {
-      // escape dots so that they are not recognized as class selectors
-      const elementId = element.id.replace(/\./g, "\\.");
-
-      const noElement = document.getElementById(elementId + "_no") as HTMLInputElement;
+      const noElement = document.getElementById(element.id + "_no") as HTMLInputElement;
       noElement.disabled = !enable;
 
-      const neverElement = document.getElementById(elementId + "_never") as HTMLInputElement;
+      const neverElement = document.getElementById(element.id + "_never") as HTMLInputElement;
       if (neverElement) {
         neverElement.disabled = !enable;
       }

--- a/wcfsetup/install/files/acp/templates/__devtoolsProjectInstructionsFormField.tpl
+++ b/wcfsetup/install/files/acp/templates/__devtoolsProjectInstructionsFormField.tpl
@@ -250,7 +250,7 @@
 										],
 										pip: '{$instruction[pip]}',
 										runStandalone: {$instruction[runStandalone]|intval},
-										value: '{$instruction[value]|encodeJS}'
+										value: '{unsafe:$instruction[value]|encodeJS}'
 									}
 								{/implode}
 							{/if}

--- a/wcfsetup/install/files/acp/templates/articleAdd.tpl
+++ b/wcfsetup/install/files/acp/templates/articleAdd.tpl
@@ -4,7 +4,7 @@
 	<div class="contentHeaderTitle">
 		<h1 class="contentTitle">{if $action == 'add'}{lang}wcf.acp.article.add{/lang}{else}{lang}wcf.acp.article.edit{/lang}{/if}</h1>
 	</div>
-	
+
 	<nav class="contentHeaderNavigation">
 		<ul>
 			{if $action == 'edit'}
@@ -12,7 +12,7 @@
 					{unsafe:$interactionContextMenu->render()}
 				</li>
 			{/if}
-			
+
 			{event name='contentHeaderNavigation'}
 		</ul>
 	</nav>

--- a/wcfsetup/install/files/acp/templates/devtoolsMissingLanguageItemList.tpl
+++ b/wcfsetup/install/files/acp/templates/devtoolsMissingLanguageItemList.tpl
@@ -57,7 +57,7 @@
 						<td class="columnID">{$logEntry->getObjectID()}</td>
 						<td class="columnText">{if $logEntry->getLanguage()}{$logEntry->getLanguage()}{else}{$logEntry->languageID}{/if}</td>
 						<td class="columnText">{$logEntry->languageItem}</td>
-						<td class="columnDate">{@$logEntry->lastTime|time}</td>
+						<td class="columnDate">{time time=$logEntry->lastTime}</td>
 					</tr>
 				{/foreach}
 			</tbody>

--- a/wcfsetup/install/files/acp/templates/optionFieldList.tpl
+++ b/wcfsetup/install/files/acp/templates/optionFieldList.tpl
@@ -27,7 +27,7 @@
 				</label>
 			{/if}
 		</dt>
-		<dd>{@$optionData[html]}
+		<dd>{unsafe:$optionData[html]}
 			{if $error}
 				<small class="innerError">
 					{if $error == 'empty'}

--- a/wcfsetup/install/files/acp/templates/package.tpl
+++ b/wcfsetup/install/files/acp/templates/package.tpl
@@ -56,15 +56,15 @@
 			</dl>
 			<dl>
 				<dt>{lang}wcf.acp.package.packageDate{/lang}</dt>
-				<dd>{@$package->packageDate|date}</dd>
+				<dd>{time time=$package->packageDate type='plainDate'}</dd>
 			</dl>
 			<dl>
 				<dt>{lang}wcf.acp.package.installDate{/lang}</dt>
-				<dd>{@$package->installDate|time}</dd>
+				<dd>{time time=$package->installDate}</dd>
 			</dl>
 			<dl>
 				<dt>{lang}wcf.acp.package.updateDate{/lang}</dt>
-				<dd>{@$package->updateDate|time}</dd>
+				<dd>{time time=$package->updateDate}</dd>
 			</dl>
 			{if $package->packageURL != ''}
 				<dl>

--- a/wcfsetup/install/files/acp/templates/packageEnableUpgradeOverride.tpl
+++ b/wcfsetup/install/files/acp/templates/packageEnableUpgradeOverride.tpl
@@ -15,6 +15,6 @@
 	</nav>
 </header>
 
-{@$form->getHtml()}
+{unsafe:$form->getHtml()}
 
 {include file='footer'}

--- a/wcfsetup/install/files/acp/templates/packageEnableUpgradeOverrideIssues.tpl
+++ b/wcfsetup/install/files/acp/templates/packageEnableUpgradeOverrideIssues.tpl
@@ -2,8 +2,8 @@
 <ul class="nativeList">
 	{foreach from=$issues item='issue'}
 		<li>
-			<strong>{@$issue['title']}</strong><br>
-			{@$issue['description']}
+			<strong>{unsafe:$issue['title']}</strong><br>
+			{unsafe:$issue['description']}
 		</li>
 	{/foreach}
 </ul>

--- a/wcfsetup/install/files/acp/templates/packageInstallationConfirm.tpl
+++ b/wcfsetup/install/files/acp/templates/packageInstallationConfirm.tpl
@@ -1,4 +1,4 @@
-{capture assign='pageTitle'}{lang}wcf.acp.package.{@$queue->action}.title{/lang}: {$archive->getLocalizedPackageInfo('packageName')}{/capture}
+{capture assign='pageTitle'}{lang}wcf.acp.package.{$queue->action}.title{/lang}: {$archive->getLocalizedPackageInfo('packageName')}{/capture}
 {include file='header'}
 
 <script data-relocate="true">
@@ -10,15 +10,15 @@
 			'wcf.acp.package.update.title': '{jslang}wcf.acp.package.update.title{/jslang}'
 		});
 		
-		new WCF.ACP.Package.Installation({@$queue->queueID}, undefined, {if $queue->action == 'install'}{if $queue->isApplication}false{else}true{/if}, false{else}false, true{/if});
+		new WCF.ACP.Package.Installation({$queue->queueID}, undefined, {if $queue->action == 'install'}{if $queue->isApplication}false{else}true{/if}, false{else}false, true{/if});
 		
-		new WCF.ACP.Package.Installation.Cancel({@$queue->queueID});
+		new WCF.ACP.Package.Installation.Cancel({$queue->queueID});
 	});
 </script>
 
 <header class="contentHeader">
 	<div class="contentHeaderTitle">
-		<h1 class="contentTitle">{lang}wcf.acp.package.{@$queue->action}.title{/lang}: {$archive->getLocalizedPackageInfo('packageName')}</h1>
+		<h1 class="contentTitle">{lang}wcf.acp.package.{$queue->action}.title{/lang}: {$archive->getLocalizedPackageInfo('packageName')}</h1>
 		<p class="contentHeaderDescription">{$archive->getLocalizedPackageInfo('packageDescription')}</p>
 	</div>
 </header>
@@ -46,7 +46,7 @@
 	
 	<dl>
 		<dt>{lang}wcf.acp.package.packageDate{/lang}</dt>
-		<dd>{@$archive->getPackageInfo('date')|date}</dd>
+		<dd>{time time=$archive->getPackageInfo('date') type='plainDate'}</dd>
 	</dl>
 	
 	{if $archive->getPackageInfo('packageURL') != ''}
@@ -82,7 +82,7 @@
 				{foreach from=$packageValidationArchives item=packageValidationArchive}
 					{assign var=exceptionMessage value=$packageValidationArchive->getExceptionMessage()}
 					<tr>
-						<td class="columnTitle columnPackageName"><span{if $packageValidationArchive->getDepth()} style="padding-left: {@$packageValidationArchive->getDepth() * 14}px"{/if}>{$packageValidationArchive->getArchive()->getLocalizedPackageInfo('packageName')}</span></td>
+						<td class="columnTitle columnPackageName"><span{if $packageValidationArchive->getDepth()} style="padding-left: {$packageValidationArchive->getDepth() * 14}px"{/if}>{$packageValidationArchive->getArchive()->getLocalizedPackageInfo('packageName')}</span></td>
 						<td class="columnText columnPackage">{$packageValidationArchive->getArchive()->getPackageInfo('name')}</td>
 						<td class="columnIcon columnStatus">
 							{if $exceptionMessage}
@@ -95,7 +95,7 @@
 					
 					{if $exceptionMessage}
 						<tr>
-							<td colspan="3"><span{if $packageValidationArchive->getDepth()} style="padding-left: {@$packageValidationArchive->getDepth() * 14}px"{/if}>{@$exceptionMessage}</span></td>
+							<td colspan="3"><span{if $packageValidationArchive->getDepth()} style="padding-left: {$packageValidationArchive->getDepth() * 14}px"{/if}>{unsafe:$exceptionMessage}</span></td>
 						</tr>
 					{/if}
 				{/foreach}

--- a/wcfsetup/install/files/acp/templates/packageInstallationSetup.tpl
+++ b/wcfsetup/install/files/acp/templates/packageInstallationSetup.tpl
@@ -10,7 +10,7 @@
 	$(function() {
 		WCF.Language.add('wcf.acp.package.install.title', '{jslang}wcf.acp.package.install.title{/jslang}');
 		
-		var $installation = new WCF.ACP.Package.Installation({@$queueID});
+		var $installation = new WCF.ACP.Package.Installation({$queueID});
 		$installation.prepareInstallation();
 	});
 </script>

--- a/wcfsetup/install/files/acp/templates/packageInstallationStepPrepare.tpl
+++ b/wcfsetup/install/files/acp/templates/packageInstallationStepPrepare.tpl
@@ -5,8 +5,8 @@
 		</span>
 		
 		<div>
-			<h1 class="contentTitle">{lang}wcf.acp.package.{@$installationType}.title{/lang}</h1>
-			<p id="packageInstallationAction">{lang}wcf.acp.package.{@$installationType}.step.prepare{/lang}</span></p>
+			<h1 class="contentTitle">{lang}wcf.acp.package.{$installationType}.title{/lang}</h1>
+			<p id="packageInstallationAction">{lang}wcf.acp.package.{$installationType}.step.prepare{/lang}</span></p>
 			<small><progress id="packageInstallationProgress" value="0" max="100">0%</progress> <span id="packageInstallationProgressLabel">0%</span></small>
 		</div>
 	</header>

--- a/wcfsetup/install/files/acp/templates/packageSearchResultListItems.tpl
+++ b/wcfsetup/install/files/acp/templates/packageSearchResultListItems.tpl
@@ -8,11 +8,11 @@
 			<div class="packageSearchDescription small">{$package->packageDescription}</div>
 			<span class="packageSearchPackage small">{$package->package}</span>
 			{if $package->pluginStoreFileID}
-				<span class="packageSearchPluginStorePage separatorLeft small"><a href="https://pluginstore.woltlab.com/file/{@$package->pluginStoreFileID}/" class="externalURL jsTooltip" title="{lang}wcf.acp.package.pluginStore.file.link{/lang}"{if EXTERNAL_LINK_TARGET_BLANK} target="_blank" rel="noopener"{/if}>{lang}wcf.acp.package.pluginStore.file{/lang}</a></span>
+				<span class="packageSearchPluginStorePage separatorLeft small"><a href="https://pluginstore.woltlab.com/file/{$package->pluginStoreFileID}/" class="externalURL jsTooltip" title="{lang}wcf.acp.package.pluginStore.file.link{/lang}"{if EXTERNAL_LINK_TARGET_BLANK} target="_blank" rel="noopener"{/if}>{lang}wcf.acp.package.pluginStore.file{/lang}</a></span>
 			{/if}
 		</td>
 		<td class="columnText small packageSearchAuthor{if $package->getUpdateServer()->isWoltLabUpdateServer()} packageSearchAuthorWoltlab{/if}" title="{$package->author}">{if $package->authorURL}<a href="{$package->authorURL}" class="externalURL"{if EXTERNAL_LINK_TARGET_BLANK} target="_blank" rel="noopener"{/if}>{$package->author|truncate:30}</a>{else}{$package->author|truncate:30}{/if}</td>
 		<td class="columnText small packageSearchLicense" title="{$package->getAccessibleVersion()->license}">{if $package->getAccessibleVersion()->licenseURL}<a href="{$package->getAccessibleVersion()->licenseURL}" class="externalURL"{if EXTERNAL_LINK_TARGET_BLANK} target="_blank" rel="noopener"{/if}>{$package->getAccessibleVersion()->license|truncate:30}</a>{else}{$package->getAccessibleVersion()->license|truncate:30}{/if}</td>
-		<td class="columnDate packageSearchDate">{@$package->getAccessibleVersion()->packageDate|time}</td>
+		<td class="columnDate packageSearchDate">{time time=$package->getAccessibleVersion()->packageDate}</td>
 	</tr>
 {/foreach}

--- a/wcfsetup/install/files/acp/templates/packageStartInstall.tpl
+++ b/wcfsetup/install/files/acp/templates/packageStartInstall.tpl
@@ -28,7 +28,7 @@
 
 <header class="contentHeader">
 	<div class="contentHeaderTitle">
-		<h1 class="contentTitle">{lang}{@$pageTitle}{/lang}</h1>
+		<h1 class="contentTitle">{lang}{$pageTitle}{/lang}</h1>
 	</div>
 	
 	<nav class="contentHeaderNavigation">
@@ -112,7 +112,7 @@
 								{if $errorType == 'empty'}
 									{lang}wcf.global.form.error.empty{/lang}
 								{else}
-									{lang}wcf.acp.package.error.{@$errorType}{/lang}
+									{lang}wcf.acp.package.error.{$errorType}{/lang}
 								{/if}
 							</small>
 						{/if}

--- a/wcfsetup/install/files/acp/templates/packageUpdateServerAdd.tpl
+++ b/wcfsetup/install/files/acp/templates/packageUpdateServerAdd.tpl
@@ -36,7 +36,7 @@
 						{elseif $errorType[duplicate]|isset}
 							{lang}wcf.acp.updateServer.serverURL.error.duplicate{/lang}
 						{else}
-							{lang}wcf.acp.updateServer.serverURL.error.{@$errorType}{/lang}
+							{lang}wcf.acp.updateServer.serverURL.error.{$errorType}{/lang}
 						{/if}
 					</small>
 				{/if}

--- a/wcfsetup/install/files/acp/templates/permissionDenied.tpl
+++ b/wcfsetup/install/files/acp/templates/permissionDenied.tpl
@@ -4,7 +4,7 @@
 
 {if ENABLE_DEBUG_MODE}
 	<!-- 
-	{$name} thrown in {$file} ({@$line})
+	{$name} thrown in {$file} ({$line})
 	Stacktrace:
 	{$stacktrace}
 	-->

--- a/wcfsetup/install/files/acp/templates/reauthentication.tpl
+++ b/wcfsetup/install/files/acp/templates/reauthentication.tpl
@@ -6,6 +6,6 @@
 	</div>
 </header>
 
-{@$form->getHtml()}
+{unsafe:$form->getHtml()}
 
 {include file='footer'}

--- a/wcfsetup/install/files/acp/templates/userAdd.tpl
+++ b/wcfsetup/install/files/acp/templates/userAdd.tpl
@@ -261,11 +261,11 @@
 							new PasswordStrength(elById('password'), {
 								relatedInputs: relatedInputs,
 								staticDictionary: [
-									'{$__wcf->user->username|encodeJS}',
-									'{$__wcf->user->email|encodeJS}',
+									'{unsafe:$__wcf->user->username|encodeJS}',
+									'{unsafe:$__wcf->user->email|encodeJS}',
 									{if $user|isset}
-										'{$user->username|encodeJS}',
-										'{$user->email|encodeJS}',
+										'{unsafe:$user->username|encodeJS}',
+										'{unsafe:$user->email|encodeJS}',
 									{/if}
 								]
 							});

--- a/wcfsetup/install/files/acp/templates/userException.tpl
+++ b/wcfsetup/install/files/acp/templates/userException.tpl
@@ -28,7 +28,7 @@
 	{$stacktrace}
 	-->
 	<script>
-		console.debug('{$name|encodeJS} thrown in {$file|encodeJS} ({$line})');
+		console.debug('{unsafe:$name|encodeJS} thrown in {unsafe:$file|encodeJS} ({$line})');
 		console.debug('Stacktrace:\n{unsafe:$stacktrace|encodeJS}');
 	</script>
 {/if}

--- a/wcfsetup/install/files/acp/templates/userGroupAdd.tpl
+++ b/wcfsetup/install/files/acp/templates/userGroupAdd.tpl
@@ -237,7 +237,7 @@
 					input.disabled = true;
 				});
 				
-				var permissions = [{implode from=$ownerGroupPermissions item=$_ownerPermission}'{$_ownerPermission|encodeJS}'{/implode}];
+				var permissions = [{implode from=$ownerGroupPermissions item=$_ownerPermission}'{unsafe:$_ownerPermission|encodeJS}'{/implode}];
 				permissions.forEach(function(permission) {
 					elBySelAll('input[name="values[' + permission + ']"]', undefined, function (input) {
 						if (input.value === '1') {

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Component/Option/Enable.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Component/Option/Enable.js
@@ -83,11 +83,9 @@ define(["require", "exports", "WoltLabSuite/Core/Helper/Selector"], function (re
             }
             const parentOptionTypeBoolean = element.closest(".optionTypeBoolean");
             if (parentOptionTypeBoolean) {
-                // escape dots so that they are not recognized as class selectors
-                const elementId = element.id.replace(/\./g, "\\.");
-                const noElement = document.getElementById(elementId + "_no");
+                const noElement = document.getElementById(element.id + "_no");
                 noElement.disabled = !enable;
-                const neverElement = document.getElementById(elementId + "_never");
+                const neverElement = document.getElementById(element.id + "_never");
                 if (neverElement) {
                     neverElement.disabled = !enable;
                 }


### PR DESCRIPTION
- Remove unnecessary `@`
- Use `unsafe:` instead of `@`
- Use the `time` TemplatePlugin and no longer the deprecated `time` or `date` TemplateModifier.
- Ensure that `unsafe:` is always used when the `encodeJS` modifier is used.
- Remove unnecessary escaping of dots in the elementID to enable/disable Boolean options.