### PR TITLE
Only load the file to the attachments if it is actually needed

### DIFF
--- a/wcfsetup/install/files/lib/data/attachment/Attachment.class.php
+++ b/wcfsetup/install/files/lib/data/attachment/Attachment.class.php
@@ -3,10 +3,10 @@
 namespace wcf\data\attachment;
 
 use wcf\data\DatabaseObject;
-use wcf\data\ILinkableObject;
-use wcf\data\IThumbnailFile;
 use wcf\data\file\File;
 use wcf\data\file\thumbnail\FileThumbnailList;
+use wcf\data\ILinkableObject;
+use wcf\data\IThumbnailFile;
 use wcf\data\object\type\ObjectTypeCache;
 use wcf\system\request\IRouteController;
 use wcf\system\request\LinkHandler;
@@ -390,7 +390,7 @@ class Attachment extends DatabaseObject implements ILinkableObject, IRouteContro
 
     public function setFile(File $file): void
     {
-        if ($this->file->fileID === $file->fileID) {
+        if ($this->fileID === $file->fileID) {
             $this->file = $file;
         }
     }
@@ -398,11 +398,6 @@ class Attachment extends DatabaseObject implements ILinkableObject, IRouteContro
     #[\Override]
     public function __get($name)
     {
-        $file = $this->getFile();
-        if ($file === null) {
-            return parent::__get($name);
-        }
-
         if ($name === 'downloads' || $name === 'lastDownloadTime') {
             // Static files are no longer served through PHP but the web server
             // instead, therefore we can no longer report any meaningful numbers.
@@ -410,26 +405,47 @@ class Attachment extends DatabaseObject implements ILinkableObject, IRouteContro
             // For existing files the stored value is suppressed because it is
             // not going to be increased ever, possibly creating a false
             // impression when the historic stored value is being reported.
-            if ($file->isStaticFile()) {
+            if ($this->getFile()?->isStaticFile()) {
                 return 0;
             }
         }
 
-        return match ($name) {
-            'filename' => $file->filename,
-            'filesize' => $file->fileSize,
-            'fileType' => $file->mimeType,
-            'isImage' => $file->isImage() ? 1 : 0,
-            'height' => $file->height ?: 0,
-            'width' => $file->width ?: 0,
-            'thumbnailType' => $file->getThumbnail('')?->getMimeType() ?: '',
-            'thumbnailWidth' => $file->getThumbnail('')?->width ?: 0,
-            'thumbnailHeight' => $file->getThumbnail('')?->height ?: 0,
-            'tinyThumbnailType' => $file->getThumbnail('tiny')?->getMimeType() ?: '',
-            'tinyThumbnailWidth' => $file->getThumbnail('tiny')?->width ?: 0,
-            'tinyThumbnailHeight' => $file->getThumbnail('tiny')?->height ?: 0,
-            default => parent::__get($name),
-        };
+        if (\in_array($name, [
+            'filename',
+            'filesize',
+            'fileType',
+            'isImage',
+            'height',
+            'width',
+            'thumbnailType',
+            'thumbnailWidth',
+            'thumbnailHeight',
+            'tinyThumbnailType',
+            'tinyThumbnailWidth',
+            'tinyThumbnailHeight',
+        ])) {
+            $file = $this->getFile();
+            if ($file === null) {
+                return parent::__get($name);
+            }
+
+            return match ($name) {
+                'filename' => $file->filename,
+                'filesize' => $file->fileSize,
+                'fileType' => $file->mimeType,
+                'isImage' => $file->isImage() ? 1 : 0,
+                'height' => $file->height ?: 0,
+                'width' => $file->width ?: 0,
+                'thumbnailType' => $file->getThumbnail('')?->getMimeType() ?: '',
+                'thumbnailWidth' => $file->getThumbnail('')?->width ?: 0,
+                'thumbnailHeight' => $file->getThumbnail('')?->height ?: 0,
+                'tinyThumbnailType' => $file->getThumbnail('tiny')?->getMimeType() ?: '',
+                'tinyThumbnailWidth' => $file->getThumbnail('tiny')?->width ?: 0,
+                'tinyThumbnailHeight' => $file->getThumbnail('tiny')?->height ?: 0,
+            };
+        }
+
+        return parent::__get($name);
     }
 
     public function toHtmlElement(): ?string


### PR DESCRIPTION
This ensures that when `AttachmentList::loadFiles()` is called, the files are not loaded individually from the database. This happens by calling `$attachment->fileID`, which corresponds to `$attachment->__get('fileID')`.

https://github.com/WoltLab/WCF/blob/948bdbfa380001ae8ac82739870bb91309b680a8/wcfsetup/install/files/lib/data/attachment/AttachmentList.class.php#L41-L72