### PR TITLE
Prevent layout shifts on loading caused by the sort indicator

### DIFF
--- a/com.woltlab.wcf/templates/shared_gridView.tpl
+++ b/com.woltlab.wcf/templates/shared_gridView.tpl
@@ -29,7 +29,7 @@
 					{/if}
 					{foreach from=$view->getVisibleColumns() item='column'}
 						<th
-							class="gridView__headerColumn {$column->getClasses()}"
+							class="gridView__headerColumn {$column->getClasses()} {if $view->isSortedBy($column)}active {$view->getSortOrder()}{/if}"
 							data-id="{$column->getID()}"
 							data-sortable="{$column->isSortable()}"
 						>

--- a/wcfsetup/install/files/lib/system/gridView/AbstractGridView.class.php
+++ b/wcfsetup/install/files/lib/system/gridView/AbstractGridView.class.php
@@ -726,6 +726,14 @@ abstract class AbstractGridView
     }
 
     /**
+     * Returns true if the rows are currently sorted by the provided column.
+     */
+    public function isSortedBy(GridViewColumn $column): bool
+    {
+        return $this->getSortField() === $column->getID();
+    }
+
+    /**
      * Initializes the database object list.
      */
     protected function initObjectList(): void


### PR DESCRIPTION
The arrow indicating the active column that the rows are sorted by are added on runtime. This causes a layout shift because no such marking exist at the page load.

This is particularly noticeable on the package list of any other view that is sorted by a narrow column.