### PR TITLE
Use commands for Application Actions

### DIFF
--- a/wcfsetup/install/files/lib/acp/action/UninstallPackageAction.class.php
+++ b/wcfsetup/install/files/lib/acp/action/UninstallPackageAction.class.php
@@ -117,7 +117,10 @@ final class UninstallPackageAction extends AbstractSecureAction
 
         // mark package as tainted if it is an app
         if ($package->isApplication) {
-            (new MarkApplicationAsTainted(ApplicationHandler::getInstance()->getApplicationByID($package->packageID)))();
+            $application = ApplicationHandler::getInstance()->getApplicationByID($package->packageID);
+            \assert($application !== null);
+
+            (new MarkApplicationAsTainted($application))();
         }
 
         $this->installation->nodeBuilder->purgeNodes();

--- a/wcfsetup/install/files/lib/acp/action/UninstallPackageAction.class.php
+++ b/wcfsetup/install/files/lib/acp/action/UninstallPackageAction.class.php
@@ -6,10 +6,11 @@ use Laminas\Diactoros\Response\JsonResponse;
 use Psr\Http\Message\ResponseInterface;
 use wcf\acp\page\PackageListPage;
 use wcf\action\AbstractSecureAction;
-use wcf\data\application\ApplicationAction;
+use wcf\command\application\MarkApplicationAsTainted;
 use wcf\data\package\installation\queue\PackageInstallationQueue;
 use wcf\data\package\installation\queue\PackageInstallationQueueEditor;
 use wcf\data\package\Package;
+use wcf\system\application\ApplicationHandler;
 use wcf\system\exception\IllegalLinkException;
 use wcf\system\package\PackageUninstallationDispatcher;
 use wcf\system\request\LinkHandler;
@@ -116,8 +117,7 @@ final class UninstallPackageAction extends AbstractSecureAction
 
         // mark package as tainted if it is an app
         if ($package->isApplication) {
-            $applicationAction = new ApplicationAction([$package->packageID], 'markAsTainted');
-            $applicationAction->executeAction();
+            (new MarkApplicationAsTainted(ApplicationHandler::getInstance()->getApplicationByID($package->packageID)))();
         }
 
         $this->installation->nodeBuilder->purgeNodes();

--- a/wcfsetup/install/files/lib/acp/form/ApplicationManagementForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/ApplicationManagementForm.class.php
@@ -9,9 +9,9 @@ use wcf\data\page\PageNode;
 use wcf\data\page\PageNodeTree;
 use wcf\form\AbstractForm;
 use wcf\system\application\ApplicationHandler;
-use wcf\system\cache\builder\ApplicationCacheBuilder;
 use wcf\system\cache\builder\PageCacheBuilder;
 use wcf\system\cache\builder\RoutingCacheBuilder;
+use wcf\system\cache\eager\ApplicationCache;
 use wcf\system\exception\UserInputException;
 use wcf\system\Regex;
 use wcf\system\style\StyleHandler;
@@ -188,7 +188,7 @@ final class ApplicationManagementForm extends AbstractForm
         ApplicationHandler::rebuild();
 
         // Reset caches to reflect the new landing pages.
-        ApplicationCacheBuilder::getInstance()->reset();
+        (new ApplicationCache())->rebuild();
         PageCacheBuilder::getInstance()->reset();
         RoutingCacheBuilder::getInstance()->reset();
         StyleHandler::resetStylesheets();

--- a/wcfsetup/install/files/lib/acp/form/RescueModeForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/RescueModeForm.class.php
@@ -3,7 +3,7 @@
 namespace wcf\acp\form;
 
 use Laminas\Diactoros\Response\RedirectResponse;
-use wcf\command\application\RebuildApplicationsCookieDomain;
+use wcf\command\application\SynchronizeCookieDomain;
 use wcf\data\application\Application;
 use wcf\data\application\ApplicationEditor;
 use wcf\data\application\ApplicationList;
@@ -333,7 +333,7 @@ final class RescueModeForm extends AbstractForm
             ]);
         }
 
-        (new RebuildApplicationsCookieDomain())();
+        (new SynchronizeCookieDomain())();
 
         // reload currently active application to avoid outdated cache data
         $application = ApplicationHandler::getInstance()->getActiveApplication();

--- a/wcfsetup/install/files/lib/acp/form/RescueModeForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/RescueModeForm.class.php
@@ -3,8 +3,8 @@
 namespace wcf\acp\form;
 
 use Laminas\Diactoros\Response\RedirectResponse;
+use wcf\command\application\RebuildApplicationsCookieDomain;
 use wcf\data\application\Application;
-use wcf\data\application\ApplicationAction;
 use wcf\data\application\ApplicationEditor;
 use wcf\data\application\ApplicationList;
 use wcf\data\user\authentication\failure\UserAuthenticationFailure;
@@ -333,9 +333,7 @@ final class RescueModeForm extends AbstractForm
             ]);
         }
 
-        // rebuild cookie domain and paths
-        $applicationAction = new ApplicationAction([], 'rebuild');
-        $applicationAction->executeAction();
+        (new RebuildApplicationsCookieDomain())();
 
         // reload currently active application to avoid outdated cache data
         $application = ApplicationHandler::getInstance()->getActiveApplication();

--- a/wcfsetup/install/files/lib/command/application/MarkApplicationAsTainted.class.php
+++ b/wcfsetup/install/files/lib/command/application/MarkApplicationAsTainted.class.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace wcf\command\application;
+
+use wcf\data\application\Application;
+use wcf\data\application\ApplicationEditor;
+use wcf\system\cache\eager\ApplicationCache;
+
+/**
+ * Marking an application as tainted, prevents it from loading.
+ * This should be called during the uninstallation.
+ *
+ * @author Olaf Braun
+ * @copyright 2001-2025 WoltLab GmbH
+ * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @since 6.3
+ */
+final class MarkApplicationAsTainted
+{
+    public function __construct(public readonly Application $application)
+    {
+    }
+
+    public function __invoke(): void
+    {
+        $applicationEditor = new ApplicationEditor($this->application);
+        $applicationEditor->update(['isTainted' => 1]);
+
+        (new ApplicationCache())->rebuild();
+    }
+}

--- a/wcfsetup/install/files/lib/command/application/MarkApplicationAsTainted.class.php
+++ b/wcfsetup/install/files/lib/command/application/MarkApplicationAsTainted.class.php
@@ -7,8 +7,8 @@ use wcf\data\application\ApplicationEditor;
 use wcf\system\cache\eager\ApplicationCache;
 
 /**
- * Marking an application as tainted, prevents it from loading.
- * This should be called during the uninstallation.
+ * Marking an application as tainted prevents it from being loaded during its
+ * uninstallation. This MUST NOT be called outside of an active uninstallation.
  *
  * @author Olaf Braun
  * @copyright 2001-2025 WoltLab GmbH
@@ -17,9 +17,9 @@ use wcf\system\cache\eager\ApplicationCache;
  */
 final class MarkApplicationAsTainted
 {
-    public function __construct(public readonly Application $application)
-    {
-    }
+    public function __construct(
+        public readonly Application $application
+    ) {}
 
     public function __invoke(): void
     {

--- a/wcfsetup/install/files/lib/command/application/RebuildApplicationsCookieDomain.class.php
+++ b/wcfsetup/install/files/lib/command/application/RebuildApplicationsCookieDomain.class.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace wcf\command\application;
+
+use wcf\data\application\Application;
+use wcf\data\application\ApplicationList;
+use wcf\system\cache\eager\ApplicationCache;
+use wcf\system\language\LanguageFactory;
+use wcf\system\Regex;
+use wcf\system\WCF;
+
+/**
+ * Rebuilds application cookie domains.
+ *
+ * @author Olaf Braun
+ * @copyright 2001-2025 WoltLab GmbH
+ * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @since 6.3
+ */
+final class RebuildApplicationsCookieDomain
+{
+    public function __construct()
+    {
+    }
+
+    public function __invoke(): void
+    {
+        $sql = "UPDATE  wcf1_application
+                SET     cookieDomain = ?
+                WHERE   packageID = ?";
+        $statement = WCF::getDB()->prepare($sql);
+
+        $regex = new Regex(':[0-9]+');
+
+        WCF::getDB()->beginTransaction();
+        foreach ($this->getApplications() as $application) {
+            $domainName = $application->domainName;
+            if (\str_ends_with($regex->replace($domainName, ''), $application->cookieDomain)) {
+                $domainName = $application->cookieDomain;
+            }
+
+            $statement->execute([
+                $domainName,
+                $application->packageID,
+            ]);
+        }
+        WCF::getDB()->commitTransaction();
+
+        $this->resetCache();
+    }
+
+    /**
+     * @return Application[]
+     */
+    private function getApplications(): array
+    {
+        $applicationList = new ApplicationList();
+        $applicationList->readObjects();
+
+        return $applicationList->getObjects();
+    }
+
+    private function resetCache(): void
+    {
+        LanguageFactory::getInstance()->deleteLanguageCache();
+        (new ApplicationCache())->rebuild();
+    }
+}

--- a/wcfsetup/install/files/lib/command/application/SynchronizeCookieDomain.class.php
+++ b/wcfsetup/install/files/lib/command/application/SynchronizeCookieDomain.class.php
@@ -10,19 +10,15 @@ use wcf\system\Regex;
 use wcf\system\WCF;
 
 /**
- * Rebuilds application cookie domains.
+ * Synchronizes the cookie domain for all installed apps.
  *
  * @author Olaf Braun
  * @copyright 2001-2025 WoltLab GmbH
  * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
  * @since 6.3
  */
-final class RebuildApplicationsCookieDomain
+final class SynchronizeCookieDomain
 {
-    public function __construct()
-    {
-    }
-
     public function __invoke(): void
     {
         $sql = "UPDATE  wcf1_application

--- a/wcfsetup/install/files/lib/data/application/ApplicationAction.class.php
+++ b/wcfsetup/install/files/lib/data/application/ApplicationAction.class.php
@@ -2,11 +2,9 @@
 
 namespace wcf\data\application;
 
+use wcf\command\application\MarkApplicationAsTainted;
+use wcf\command\application\RebuildApplicationsCookieDomain;
 use wcf\data\AbstractDatabaseObjectAction;
-use wcf\system\cache\builder\ApplicationCacheBuilder;
-use wcf\system\language\LanguageFactory;
-use wcf\system\Regex;
-use wcf\system\WCF;
 
 /**
  * Executes application-related actions.
@@ -25,60 +23,26 @@ class ApplicationAction extends AbstractDatabaseObjectAction
     protected $className = ApplicationEditor::class;
 
     /**
-     * application editor object
-     * @var ApplicationEditor
-     */
-    public $applicationEditor;
-
-    /**
      * Assigns a list of applications to a group and computes cookie domain.
      *
      * @return void
+     *
+     * @deprecated 6.3 use `RebuildApplicationsCookieDomain`
      */
     public function rebuild()
     {
-        if (empty($this->objects)) {
-            $this->readObjects();
-        }
-
-        $sql = "UPDATE  wcf1_application
-                SET     cookieDomain = ?
-                WHERE   packageID = ?";
-        $statement = WCF::getDB()->prepare($sql);
-
-        // calculate cookie domain
-        $regex = new Regex(':[0-9]+');
-        WCF::getDB()->beginTransaction();
-        foreach ($this->getObjects() as $application) {
-            $domainName = $application->domainName;
-            if (\str_ends_with($regex->replace($domainName, ''), $application->cookieDomain)) {
-                $domainName = $application->cookieDomain;
-            }
-
-            $statement->execute([
-                $domainName,
-                $application->packageID,
-            ]);
-        }
-        WCF::getDB()->commitTransaction();
-
-        // rebuild templates
-        LanguageFactory::getInstance()->deleteLanguageCache();
-
-        // reset application cache
-        ApplicationCacheBuilder::getInstance()->reset();
+        (new RebuildApplicationsCookieDomain())();
     }
 
     /**
      * Marks an application as tainted, prevents loading it during uninstallation.
      *
      * @return void
+     *
+     * @deprecated 6.3 use `MarkApplicationAsTainted`
      */
     public function markAsTainted()
     {
-        $applicationEditor = $this->getSingleObject();
-        $applicationEditor->update(['isTainted' => 1]);
-
-        ApplicationCacheBuilder::getInstance()->reset();
+        (new MarkApplicationAsTainted($this->getSingleObject()->getDecoratedObject()))();
     }
 }

--- a/wcfsetup/install/files/lib/data/application/ApplicationAction.class.php
+++ b/wcfsetup/install/files/lib/data/application/ApplicationAction.class.php
@@ -3,7 +3,7 @@
 namespace wcf\data\application;
 
 use wcf\command\application\MarkApplicationAsTainted;
-use wcf\command\application\RebuildApplicationsCookieDomain;
+use wcf\command\application\SynchronizeCookieDomain;
 use wcf\data\AbstractDatabaseObjectAction;
 
 /**
@@ -27,11 +27,11 @@ class ApplicationAction extends AbstractDatabaseObjectAction
      *
      * @return void
      *
-     * @deprecated 6.3 use `RebuildApplicationsCookieDomain`
+     * @deprecated 6.3 use `SynchronizeCookieDomain`
      */
     public function rebuild()
     {
-        (new RebuildApplicationsCookieDomain())();
+        (new SynchronizeCookieDomain())();
     }
 
     /**

--- a/wcfsetup/install/files/lib/data/application/ApplicationEditor.class.php
+++ b/wcfsetup/install/files/lib/data/application/ApplicationEditor.class.php
@@ -4,7 +4,7 @@ namespace wcf\data\application;
 
 use wcf\data\DatabaseObjectEditor;
 use wcf\data\IEditableCachedObject;
-use wcf\system\cache\builder\ApplicationCacheBuilder;
+use wcf\system\cache\eager\ApplicationCache;
 
 /**
  * Provides functions to edit applications.
@@ -29,6 +29,6 @@ class ApplicationEditor extends DatabaseObjectEditor implements IEditableCachedO
      */
     public static function resetCache()
     {
-        ApplicationCacheBuilder::getInstance()->reset();
+        (new ApplicationCache())->rebuild();
     }
 }

--- a/wcfsetup/install/files/lib/data/page/Page.class.php
+++ b/wcfsetup/install/files/lib/data/page/Page.class.php
@@ -12,8 +12,8 @@ use wcf\data\TDatabaseObjectPermissions;
 use wcf\data\user\User;
 use wcf\system\acl\simple\SimpleAclResolver;
 use wcf\system\application\ApplicationHandler;
-use wcf\system\cache\builder\ApplicationCacheBuilder;
 use wcf\system\cache\builder\RoutingCacheBuilder;
+use wcf\system\cache\eager\ApplicationCache;
 use wcf\system\database\util\PreparedStatementConditionBuilder;
 use wcf\system\exception\SystemException;
 use wcf\system\language\LanguageFactory;
@@ -297,7 +297,7 @@ class Page extends DatabaseObject implements ILinkableObject, ITitledObject
         WCF::getDB()->commitTransaction();
 
         // reset caches to reflect new landing page
-        ApplicationCacheBuilder::getInstance()->reset();
+        (new ApplicationCache())->rebuild();
         RoutingCacheBuilder::getInstance()->reset();
     }
 

--- a/wcfsetup/install/files/lib/system/application/ApplicationHandler.class.php
+++ b/wcfsetup/install/files/lib/system/application/ApplicationHandler.class.php
@@ -2,11 +2,11 @@
 
 namespace wcf\system\application;
 
+use wcf\command\application\RebuildApplicationsCookieDomain;
 use wcf\data\application\Application;
-use wcf\data\application\ApplicationAction;
-use wcf\data\application\ApplicationList;
 use wcf\data\package\Package;
-use wcf\system\cache\builder\ApplicationCacheBuilder;
+use wcf\system\cache\eager\ApplicationCache;
+use wcf\system\cache\eager\data\ApplicationCacheData;
 use wcf\system\request\RequestHandler;
 use wcf\system\request\RouteHandler;
 use wcf\system\SingletonFactory;
@@ -27,9 +27,8 @@ final class ApplicationHandler extends SingletonFactory
 {
     /**
      * application cache
-     * @var mixed[][]
      */
-    protected $cache;
+    protected ApplicationCacheData $cache;
 
     /**
      * list of page URLs
@@ -42,7 +41,7 @@ final class ApplicationHandler extends SingletonFactory
      */
     protected function init()
     {
-        $this->cache = ApplicationCacheBuilder::getInstance()->getData();
+        $this->cache = (new ApplicationCache())->getCache();
     }
 
     /**
@@ -54,15 +53,7 @@ final class ApplicationHandler extends SingletonFactory
      */
     public function getApplication(string $abbreviation): ?Application
     {
-        if (isset($this->cache['abbreviation'][$abbreviation])) {
-            $packageID = $this->cache['abbreviation'][$abbreviation];
-
-            if (isset($this->cache['application'][$packageID])) {
-                return $this->cache['application'][$packageID];
-            }
-        }
-
-        return null;
+        return $this->cache->getApplicationByAbbreviation($abbreviation);
     }
 
     /**
@@ -73,7 +64,7 @@ final class ApplicationHandler extends SingletonFactory
      */
     public function getApplicationByID(int $packageID): ?Application
     {
-        return $this->cache['application'][$packageID] ?? null;
+        return $this->cache->getApplication($packageID);
     }
 
     /**
@@ -120,11 +111,7 @@ final class ApplicationHandler extends SingletonFactory
             return $this->getApplication($abbreviation);
         }
 
-        if (isset($this->cache['application'][PACKAGE_ID])) {
-            return $this->cache['application'][PACKAGE_ID];
-        }
-
-        return $this->getWCF();
+        return $this->cache->getApplication(PACKAGE_ID) ?? $this->getWCF();
     }
 
     /**
@@ -152,7 +139,7 @@ final class ApplicationHandler extends SingletonFactory
      */
     public function getApplications(): array
     {
-        return $this->cache['application'];
+        return $this->cache->application;
     }
 
     /**
@@ -160,13 +147,7 @@ final class ApplicationHandler extends SingletonFactory
      */
     public function getAbbreviation(int $packageID): ?string
     {
-        foreach ($this->cache['abbreviation'] as $abbreviation => $applicationID) {
-            if ($packageID == $applicationID) {
-                return $abbreviation;
-            }
-        }
-
-        return null;
+        return $this->cache->getAbbreviationByPackageID($packageID);
     }
 
     /**
@@ -177,7 +158,7 @@ final class ApplicationHandler extends SingletonFactory
      */
     public function getAbbreviations(): array
     {
-        return \array_keys($this->cache['abbreviation']);
+        return \array_keys($this->cache->abbreviation);
     }
 
     /**
@@ -236,11 +217,7 @@ final class ApplicationHandler extends SingletonFactory
      */
     public static function rebuild(): void
     {
-        $applicationList = new ApplicationList();
-        $applicationList->readObjects();
-
-        $applicationAction = new ApplicationAction($applicationList->getObjects(), 'rebuild');
-        $applicationAction->executeAction();
+        (new RebuildApplicationsCookieDomain())();
     }
 
     /**

--- a/wcfsetup/install/files/lib/system/application/ApplicationHandler.class.php
+++ b/wcfsetup/install/files/lib/system/application/ApplicationHandler.class.php
@@ -2,7 +2,7 @@
 
 namespace wcf\system\application;
 
-use wcf\command\application\RebuildApplicationsCookieDomain;
+use wcf\command\application\SynchronizeCookieDomain;
 use wcf\data\application\Application;
 use wcf\data\package\Package;
 use wcf\system\cache\eager\ApplicationCache;
@@ -19,22 +19,18 @@ use wcf\util\Url;
 /**
  * Handles multi-application environments.
  *
- * @author  Alexander Ebert
- * @copyright   2001-2019 WoltLab GmbH
+ * @author Alexander Ebert
+ * @copyright 2001-2019 WoltLab GmbH
  * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
  */
 final class ApplicationHandler extends SingletonFactory
 {
-    /**
-     * application cache
-     */
-    protected ApplicationCacheData $cache;
+    private ApplicationCacheData $cache;
 
     /**
-     * list of page URLs
      * @var string[]
      */
-    protected array $pageURLs = [];
+    private array $pageURLs = [];
 
     /**
      * Initializes cache.
@@ -59,8 +55,6 @@ final class ApplicationHandler extends SingletonFactory
     /**
      * Returns an application delivered by the package with the given id or `null`
      * if no such application exists.
-     *
-     * @since   3.0
      */
     public function getApplicationByID(int $packageID): ?Application
     {
@@ -117,7 +111,7 @@ final class ApplicationHandler extends SingletonFactory
     /**
      * Returns a list of dependent applications.
      *
-     * @return  Application[]
+     * @return Application[]
      */
     public function getDependentApplications(): array
     {
@@ -135,11 +129,11 @@ final class ApplicationHandler extends SingletonFactory
     /**
      * Returns a list of all active applications.
      *
-     * @return  Application[]
+     * @return Application[]
      */
     public function getApplications(): array
     {
-        return $this->cache->application;
+        return $this->cache->applications;
     }
 
     /**
@@ -153,12 +147,11 @@ final class ApplicationHandler extends SingletonFactory
     /**
      * Returns the list of application abbreviations.
      *
-     * @return      string[]
-     * @since       3.1
+     * @return string[]
      */
     public function getAbbreviations(): array
     {
-        return \array_keys($this->cache->abbreviation);
+        return \array_keys($this->cache->abbreviations);
     }
 
     /**
@@ -188,7 +181,6 @@ final class ApplicationHandler extends SingletonFactory
     /**
      * Always returns false.
      *
-     * @since       3.1
      * @deprecated  5.4
      */
     public function isMultiDomainSetup(): bool
@@ -197,12 +189,9 @@ final class ApplicationHandler extends SingletonFactory
     }
 
     /**
-     * @since 5.2
      * @deprecated 5.5 - This function is a noop. The 'active' status is determined live.
      */
-    public function rebuildActiveApplication(): void
-    {
-    }
+    public function rebuildActiveApplication(): void {}
 
     /**
      * @since 6.0
@@ -217,7 +206,7 @@ final class ApplicationHandler extends SingletonFactory
      */
     public static function rebuild(): void
     {
-        (new RebuildApplicationsCookieDomain())();
+        (new SynchronizeCookieDomain())();
     }
 
     /**
@@ -228,7 +217,6 @@ final class ApplicationHandler extends SingletonFactory
      * queries, for example.
      *
      * @param $skipCache if `true`, no caches will be used and relevant application packages will be read from database directly
-     * @since   5.2
      */
     public static function insertRealDatabaseTableNames(string $string, bool $skipCache = false): string
     {
@@ -240,7 +228,7 @@ final class ApplicationHandler extends SingletonFactory
         }
 
         if ($skipCache) {
-            $sql = "SELECT package 
+            $sql = "SELECT package
                     FROM   wcf" . WCF_N . "_package
                     WHERE  isApplication = ?";
             $statement = WCF::getDB()->prepareUnmanaged($sql);

--- a/wcfsetup/install/files/lib/system/cache/builder/ApplicationCacheBuilder.class.php
+++ b/wcfsetup/install/files/lib/system/cache/builder/ApplicationCacheBuilder.class.php
@@ -2,9 +2,7 @@
 
 namespace wcf\system\cache\builder;
 
-use wcf\data\application\Application;
-use wcf\data\package\Package;
-use wcf\system\WCF;
+use wcf\system\cache\eager\ApplicationCache;
 
 /**
  * Caches applications.
@@ -12,41 +10,25 @@ use wcf\system\WCF;
  * @author  Alexander Ebert
  * @copyright   2001-2019 WoltLab GmbH
  * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ *
+ * @deprecated 6.3 Use `ApplicationCache` instead.
  */
-class ApplicationCacheBuilder extends AbstractCacheBuilder
+class ApplicationCacheBuilder extends AbstractLegacyCacheBuilder
 {
-    /**
-     * @inheritDoc
-     */
-    public function rebuild(array $parameters)
+    #[\Override]
+    protected function rebuild(array $parameters): array
     {
-        $data = [
-            'abbreviation' => [],
-            'application' => [],
+        $cache = (new ApplicationCache())->getCache();
+
+        return [
+            'application' => $cache->application,
+            'abbreviation' => $cache->abbreviation,
         ];
+    }
 
-        // fetch applications
-        $sql = "SELECT *
-                FROM   wcf" . WCF_N . "_application";
-        $statement = WCF::getDB()->prepareUnmanaged($sql);
-        $statement->execute();
-        $applications = $statement->fetchObjects(Application::class);
-
-        foreach ($applications as $application) {
-            $data['application'][$application->packageID] = $application;
-        }
-
-        // fetch abbreviations
-        $sql = "SELECT packageID, package
-                FROM   wcf" . WCF_N . "_package
-                WHERE  isApplication = ?";
-        $statement = WCF::getDB()->prepareUnmanaged($sql);
-        $statement->execute([1]);
-        $packages = $statement->fetchMap('packageID', 'package');
-        foreach ($packages as $packageID => $package) {
-            $data['abbreviation'][Package::getAbbreviation($package)] = $packageID;
-        }
-
-        return $data;
+    #[\Override]
+    public function reset(array $parameters = [])
+    {
+        (new ApplicationCache())->rebuild();
     }
 }

--- a/wcfsetup/install/files/lib/system/cache/builder/ApplicationCacheBuilder.class.php
+++ b/wcfsetup/install/files/lib/system/cache/builder/ApplicationCacheBuilder.class.php
@@ -21,8 +21,8 @@ class ApplicationCacheBuilder extends AbstractLegacyCacheBuilder
         $cache = (new ApplicationCache())->getCache();
 
         return [
-            'application' => $cache->application,
-            'abbreviation' => $cache->abbreviation,
+            'application' => $cache->applications,
+            'abbreviation' => $cache->abbreviations,
         ];
     }
 

--- a/wcfsetup/install/files/lib/system/cache/eager/ApplicationCache.class.php
+++ b/wcfsetup/install/files/lib/system/cache/eager/ApplicationCache.class.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace wcf\system\cache\eager;
+
+use wcf\data\application\Application;
+use wcf\data\package\Package;
+use wcf\system\cache\eager\data\ApplicationCacheData;
+use wcf\system\WCF;
+
+/**
+ * Eager cache for applications.
+ *
+ * @author Olaf Braun
+ * @copyright 2001-2025 WoltLab GmbH
+ * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @since 6.3
+ *
+ * @extends AbstractEagerCache<ApplicationCacheData>
+ */
+final class ApplicationCache extends AbstractEagerCache
+{
+    #[\Override]
+    protected function getCacheData(): ApplicationCacheData
+    {
+        $sql = "SELECT *
+                FROM   wcf" . WCF_N . "_application";
+        $statement = WCF::getDB()->prepareUnmanaged($sql);
+        $statement->execute();
+        $applications = $statement->fetchObjects(Application::class, 'packageID');
+
+
+        $sql = "SELECT packageID, package
+                FROM   wcf" . WCF_N . "_package
+                WHERE  isApplication = ?";
+        $statement = WCF::getDB()->prepareUnmanaged($sql);
+        $statement->execute([1]);
+        $packages = $statement->fetchMap('packageID', 'package');
+
+        $abbreviation = [];
+        foreach ($packages as $packageID => $package) {
+            $abbreviation[Package::getAbbreviation($package)] = $packageID;
+        }
+
+        return new ApplicationCacheData(
+            $applications,
+            $abbreviation,
+        );
+    }
+}

--- a/wcfsetup/install/files/lib/system/cache/eager/data/ApplicationCacheData.class.php
+++ b/wcfsetup/install/files/lib/system/cache/eager/data/ApplicationCacheData.class.php
@@ -14,20 +14,20 @@ final class ApplicationCacheData
 {
     public function __construct(
         /** @var array<int, Application> */
-        public readonly array $application,
+        public readonly array $applications,
         /** @var array<string, int> */
-        public readonly array $abbreviation,
+        public readonly array $abbreviations,
     ) {
     }
 
     public function getApplication(int $packageID): ?Application
     {
-        return $this->application[$packageID] ?? null;
+        return $this->applications[$packageID] ?? null;
     }
 
     public function getApplicationByAbbreviation(string $abbreviation): ?Application
     {
-        $packageID = $this->abbreviation[$abbreviation] ?? null;
+        $packageID = $this->abbreviations[$abbreviation] ?? null;
         if ($packageID === null) {
             return null;
         }
@@ -37,6 +37,6 @@ final class ApplicationCacheData
 
     public function getAbbreviationByPackageID(int $packageID): ?string
     {
-        return \array_search($packageID, $this->abbreviation) ?: null;
+        return \array_search($packageID, $this->abbreviations) ?: null;
     }
 }

--- a/wcfsetup/install/files/lib/system/cache/eager/data/ApplicationCacheData.class.php
+++ b/wcfsetup/install/files/lib/system/cache/eager/data/ApplicationCacheData.class.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace wcf\system\cache\eager\data;
+
+use wcf\data\application\Application;
+
+/**
+ * @author Olaf Braun
+ * @copyright 2001-2025 WoltLab GmbH
+ * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @since 6.3
+ */
+final class ApplicationCacheData
+{
+    public function __construct(
+        /** @var array<int, Application> */
+        public readonly array $application,
+        /** @var array<string, int> */
+        public readonly array $abbreviation,
+    ) {
+    }
+
+    public function getApplication(int $packageID): ?Application
+    {
+        return $this->application[$packageID] ?? null;
+    }
+
+    public function getApplicationByAbbreviation(string $abbreviation): ?Application
+    {
+        $packageID = $this->abbreviation[$abbreviation] ?? null;
+        if ($packageID === null) {
+            return null;
+        }
+
+        return $this->getApplication($packageID);
+    }
+
+    public function getAbbreviationByPackageID(int $packageID): ?string
+    {
+        return \array_search($packageID, $this->abbreviation) ?: null;
+    }
+}


### PR DESCRIPTION
- Implement an `ApplicationCache` as an eager cache
  - Deprecate `ApplicationCacheBuilder`
- Introduce commands to mark an application as tainted
- Introduce commands to rebuild the cookie domains for the applications