### PR TITLE
Add a helper method for infallible API endpoints

### DIFF
--- a/ts/WoltLabSuite/Core/Acp/Controller/ExceptionLog/View.ts
+++ b/ts/WoltLabSuite/Core/Acp/Controller/ExceptionLog/View.ts
@@ -15,12 +15,9 @@ import { wheneverFirstSeen } from "WoltLabSuite/Core/Helper/Selector";
 import { getPhrase } from "WoltLabSuite/Core/Language";
 
 async function showDialog(button: HTMLElement): Promise<void> {
-  const response = await renderException(button.closest("tr")!.dataset.objectId!);
-  if (!response.ok) {
-    return;
-  }
+  const { template } = await renderException(button.closest("tr")!.dataset.objectId!);
 
-  const dialog = dialogFactory().fromHtml(response.value.template).withoutControls();
+  const dialog = dialogFactory().fromHtml(template).withoutControls();
   dialog.content.querySelector(".jsCopyButton")?.addEventListener("click", () => {
     void copyTextToClipboard(dialog.content.querySelector<HTMLTextAreaElement>(".jsCopyException")!.value);
   });

--- a/ts/WoltLabSuite/Core/Acp/Controller/VersionTracker/VersionList.ts
+++ b/ts/WoltLabSuite/Core/Acp/Controller/VersionTracker/VersionList.ts
@@ -19,12 +19,11 @@ function initRevertButtons(container: HTMLElement, objectType: string, objectId:
         return;
       }
 
-      const response = await revertVersion(objectType, objectId, parseInt(button.dataset.objectId!));
-      if (response.ok) {
-        showDefaultSuccessSnackbar().addEventListener("snackbar:close", () => {
-          window.location.reload();
-        });
-      }
+      await revertVersion(objectType, objectId, parseInt(button.dataset.objectId!));
+
+      showDefaultSuccessSnackbar().addEventListener("snackbar:close", () => {
+        window.location.reload();
+      });
     });
   });
 }

--- a/ts/WoltLabSuite/Core/Api/Articles/GetArticlePopover.ts
+++ b/ts/WoltLabSuite/Core/Api/Articles/GetArticlePopover.ts
@@ -8,21 +8,16 @@
  */
 
 import { prepareRequest } from "WoltLabSuite/Core/Ajax/Backend";
-import { ApiResult, apiResultFromError, apiResultFromValue } from "WoltLabSuite/Core/Api/Result";
+import { fromInfallibleApiRequest } from "WoltLabSuite/Core/Api/Result";
 
 type Response = {
   template: string;
 };
 
-export async function getArticlePopover(articleId: number): Promise<ApiResult<string>> {
+export async function getArticlePopover(articleId: number): Promise<string> {
   const url = new URL(`${window.WSC_RPC_API_URL}core/articles/${articleId}/popover`);
 
-  let response: Response;
-  try {
-    response = (await prepareRequest(url).get().fetchAsJson()) as Response;
-  } catch (e) {
-    return apiResultFromError(e);
-  }
-
-  return apiResultFromValue(response.template);
+  return fromInfallibleApiRequest(() => {
+    return prepareRequest(url).get().fetchAsJson();
+  });
 }

--- a/ts/WoltLabSuite/Core/Api/Cronjobs/Logs/ClearLogs.ts
+++ b/ts/WoltLabSuite/Core/Api/Cronjobs/Logs/ClearLogs.ts
@@ -9,14 +9,10 @@
  */
 
 import { prepareRequest } from "WoltLabSuite/Core/Ajax/Backend";
-import { ApiResult, apiResultFromError, apiResultFromValue } from "../../Result";
+import { fromInfallibleApiRequest } from "../../Result";
 
-export async function clearLogs(): Promise<ApiResult<[]>> {
-  try {
-    await prepareRequest(`${window.WSC_RPC_API_URL}core/cronjobs/logs`).delete().fetchAsJson();
-  } catch (e) {
-    return apiResultFromError(e);
-  }
-
-  return apiResultFromValue([]);
+export async function clearLogs(): Promise<[]> {
+  return fromInfallibleApiRequest(() => {
+    return prepareRequest(`${window.WSC_RPC_API_URL}core/cronjobs/logs`).delete().fetchAsJson();
+  });
 }

--- a/ts/WoltLabSuite/Core/Api/Exceptions/RenderException.ts
+++ b/ts/WoltLabSuite/Core/Api/Exceptions/RenderException.ts
@@ -8,21 +8,16 @@
  */
 
 import { prepareRequest } from "WoltLabSuite/Core/Ajax/Backend";
-import { ApiResult, apiResultFromError, apiResultFromValue } from "../Result";
+import { fromInfallibleApiRequest } from "../Result";
 
 type Response = {
   template: string;
 };
 
-export async function renderException(exceptionId: string): Promise<ApiResult<Response>> {
+export async function renderException(exceptionId: string): Promise<Response> {
   const url = new URL(`${window.WSC_RPC_API_URL}core/exceptions/${exceptionId}/render`);
 
-  let response: Response;
-  try {
-    response = (await prepareRequest(url).get().fetchAsJson()) as Response;
-  } catch (e) {
-    return apiResultFromError(e);
-  }
-
-  return apiResultFromValue(response);
+  return fromInfallibleApiRequest(() => {
+    return prepareRequest(url).get().fetchAsJson();
+  });
 }

--- a/ts/WoltLabSuite/Core/Api/Gridviews/GetRow.ts
+++ b/ts/WoltLabSuite/Core/Api/Gridviews/GetRow.ts
@@ -8,7 +8,7 @@
  */
 
 import { prepareRequest } from "WoltLabSuite/Core/Ajax/Backend";
-import { ApiResult, apiResultFromError, apiResultFromValue } from "../Result";
+import { fromInfallibleApiRequest } from "../Result";
 
 type Response = {
   template: string;
@@ -18,7 +18,7 @@ export async function getRow(
   gridViewClass: string,
   objectId: string | number,
   gridViewParameters?: Map<string, string>,
-): Promise<ApiResult<Response>> {
+): Promise<Response> {
   const url = new URL(`${window.WSC_RPC_API_URL}core/grid-views/row`);
   url.searchParams.set("gridView", gridViewClass);
   url.searchParams.set("objectID", objectId.toString());
@@ -34,12 +34,7 @@ export async function getRow(
     });
   }
 
-  let response: Response;
-  try {
-    response = (await prepareRequest(url).get().allowCaching().disableLoadingIndicator().fetchAsJson()) as Response;
-  } catch (e) {
-    return apiResultFromError(e);
-  }
-
-  return apiResultFromValue(response);
+  return fromInfallibleApiRequest(() => {
+    return prepareRequest(url).get().allowCaching().disableLoadingIndicator().fetchAsJson();
+  });
 }

--- a/ts/WoltLabSuite/Core/Api/Gridviews/GetRows.ts
+++ b/ts/WoltLabSuite/Core/Api/Gridviews/GetRows.ts
@@ -8,7 +8,7 @@
  */
 
 import { prepareRequest } from "WoltLabSuite/Core/Ajax/Backend";
-import { ApiResult, apiResultFromError, apiResultFromValue } from "../Result";
+import { fromInfallibleApiRequest } from "../Result";
 
 type Response = {
   template: string;
@@ -24,7 +24,7 @@ export async function getRows(
   sortOrder: string = "ASC",
   filters?: Map<string, string>,
   gridViewParameters?: Map<string, string>,
-): Promise<ApiResult<Response>> {
+): Promise<Response> {
   const url = new URL(`${window.WSC_RPC_API_URL}core/grid-views/rows`);
   url.searchParams.set("gridView", gridViewClass);
   url.searchParams.set("pageNo", pageNo.toString());
@@ -47,12 +47,7 @@ export async function getRows(
     });
   }
 
-  let response: Response;
-  try {
-    response = (await prepareRequest(url).get().allowCaching().disableLoadingIndicator().fetchAsJson()) as Response;
-  } catch (e) {
-    return apiResultFromError(e);
-  }
-
-  return apiResultFromValue(response);
+  return fromInfallibleApiRequest(() => {
+    return prepareRequest(url).get().allowCaching().disableLoadingIndicator().fetchAsJson();
+  });
 }

--- a/ts/WoltLabSuite/Core/Api/Interactions/GetBulkContextMenuOptions.ts
+++ b/ts/WoltLabSuite/Core/Api/Interactions/GetBulkContextMenuOptions.ts
@@ -8,25 +8,17 @@
  */
 
 import { prepareRequest } from "WoltLabSuite/Core/Ajax/Backend";
-import { ApiResult, apiResultFromError, apiResultFromValue } from "../Result";
+import { fromInfallibleApiRequest } from "../Result";
 
 type Response = {
   template: string;
 };
 
-export async function getBulkContextMenuOptions(
-  providerClassName: string,
-  objectIds: number[],
-): Promise<ApiResult<Response>> {
-  let response: Response;
-  try {
-    response = (await prepareRequest(`${window.WSC_RPC_API_URL}core/interactions/bulk-context-menu-options`)
+export async function getBulkContextMenuOptions(providerClassName: string, objectIds: number[]): Promise<Response> {
+  return fromInfallibleApiRequest(() => {
+    return prepareRequest(`${window.WSC_RPC_API_URL}core/interactions/bulk-context-menu-options`)
       .post({ provider: providerClassName, objectIDs: objectIds })
       .disableLoadingIndicator()
-      .fetchAsJson()) as Response;
-  } catch (e) {
-    return apiResultFromError(e);
-  }
-
-  return apiResultFromValue(response);
+      .fetchAsJson();
+  });
 }

--- a/ts/WoltLabSuite/Core/Api/Interactions/GetContextMenuOptions.ts
+++ b/ts/WoltLabSuite/Core/Api/Interactions/GetContextMenuOptions.ts
@@ -8,26 +8,18 @@
  */
 
 import { prepareRequest } from "WoltLabSuite/Core/Ajax/Backend";
-import { ApiResult, apiResultFromError, apiResultFromValue } from "../Result";
+import { fromInfallibleApiRequest } from "../Result";
 
 type Response = {
   template: string;
 };
 
-export async function getContextMenuOptions(
-  providerClassName: string,
-  objectId: number | string,
-): Promise<ApiResult<Response>> {
+export async function getContextMenuOptions(providerClassName: string, objectId: number | string): Promise<Response> {
   const url = new URL(`${window.WSC_RPC_API_URL}core/interactions/context-menu-options`);
   url.searchParams.set("provider", providerClassName);
   url.searchParams.set("objectID", objectId.toString());
 
-  let response: Response;
-  try {
-    response = (await prepareRequest(url).get().allowCaching().disableLoadingIndicator().fetchAsJson()) as Response;
-  } catch (e) {
-    return apiResultFromError(e);
-  }
-
-  return apiResultFromValue(response);
+  return fromInfallibleApiRequest(() => {
+    return prepareRequest(url).get().allowCaching().disableLoadingIndicator().fetchAsJson();
+  });
 }

--- a/ts/WoltLabSuite/Core/Api/ListViews/GetItem.ts
+++ b/ts/WoltLabSuite/Core/Api/ListViews/GetItem.ts
@@ -8,7 +8,7 @@
  */
 
 import { prepareRequest } from "WoltLabSuite/Core/Ajax/Backend";
-import { ApiResult, apiResultFromError, apiResultFromValue } from "../Result";
+import { fromInfallibleApiRequest } from "../Result";
 
 type Response = {
   template: string;
@@ -18,7 +18,7 @@ export async function getItem(
   listViewClass: string,
   objectId: string | number,
   listViewParameters?: Map<string, string>,
-): Promise<ApiResult<Response>> {
+): Promise<Response> {
   const url = new URL(`${window.WSC_RPC_API_URL}core/list-views/item`);
   url.searchParams.set("listView", listViewClass);
   url.searchParams.set("objectID", objectId.toString());
@@ -34,12 +34,7 @@ export async function getItem(
     });
   }
 
-  let response: Response;
-  try {
-    response = (await prepareRequest(url).get().allowCaching().disableLoadingIndicator().fetchAsJson()) as Response;
-  } catch (e) {
-    return apiResultFromError(e);
-  }
-
-  return apiResultFromValue(response);
+  return fromInfallibleApiRequest(() => {
+    return prepareRequest(url).get().allowCaching().disableLoadingIndicator().fetchAsJson();
+  });
 }

--- a/ts/WoltLabSuite/Core/Api/ListViews/GetItems.ts
+++ b/ts/WoltLabSuite/Core/Api/ListViews/GetItems.ts
@@ -8,7 +8,7 @@
  */
 
 import { prepareRequest } from "WoltLabSuite/Core/Ajax/Backend";
-import { ApiResult, apiResultFromError, apiResultFromValue } from "../Result";
+import { fromInfallibleApiRequest } from "../Result";
 
 type Response = {
   template: string;
@@ -24,7 +24,7 @@ export async function getItems(
   sortOrder: string = "ASC",
   filters?: Map<string, string>,
   listViewParameters?: Map<string, string>,
-): Promise<ApiResult<Response>> {
+): Promise<Response> {
   const url = new URL(`${window.WSC_RPC_API_URL}core/list-views/items`);
   url.searchParams.set("listView", listViewClass);
   url.searchParams.set("pageNo", pageNo.toString());
@@ -47,12 +47,7 @@ export async function getItems(
     });
   }
 
-  let response: Response;
-  try {
-    response = (await prepareRequest(url).get().allowCaching().disableLoadingIndicator().fetchAsJson()) as Response;
-  } catch (e) {
-    return apiResultFromError(e);
-  }
-
-  return apiResultFromValue(response);
+  return fromInfallibleApiRequest(() => {
+    return prepareRequest(url).get().allowCaching().disableLoadingIndicator().fetchAsJson();
+  });
 }

--- a/ts/WoltLabSuite/Core/Api/Messages/MentionSuggestions.ts
+++ b/ts/WoltLabSuite/Core/Api/Messages/MentionSuggestions.ts
@@ -9,7 +9,7 @@
  */
 
 import { prepareRequest } from "WoltLabSuite/Core/Ajax/Backend";
-import { ApiResult, apiResultFromError, apiResultFromValue } from "../Result";
+import { fromInfallibleApiRequest } from "../Result";
 
 type Item =
   | {
@@ -25,16 +25,11 @@ type Item =
     };
 type Response = Item[];
 
-export async function mentionSuggestions(query: string): Promise<ApiResult<Response>> {
+export async function mentionSuggestions(query: string): Promise<Response> {
   const url = new URL(window.WSC_RPC_API_URL + "core/messages/mention-suggestions");
   url.searchParams.set("query", query);
 
-  let response: Response;
-  try {
-    response = (await prepareRequest(url).get().allowCaching().disableLoadingIndicator().fetchAsJson()) as Response;
-  } catch (e) {
-    return apiResultFromError(e);
-  }
-
-  return apiResultFromValue(response);
+  return fromInfallibleApiRequest<Response>(() => {
+    return prepareRequest(url).get().allowCaching().disableLoadingIndicator().fetchAsJson();
+  });
 }

--- a/ts/WoltLabSuite/Core/Api/Messages/MentionSuggestions.ts
+++ b/ts/WoltLabSuite/Core/Api/Messages/MentionSuggestions.ts
@@ -29,7 +29,7 @@ export async function mentionSuggestions(query: string): Promise<Response> {
   const url = new URL(window.WSC_RPC_API_URL + "core/messages/mention-suggestions");
   url.searchParams.set("query", query);
 
-  return fromInfallibleApiRequest<Response>(() => {
+  return fromInfallibleApiRequest(() => {
     return prepareRequest(url).get().allowCaching().disableLoadingIndicator().fetchAsJson();
   });
 }

--- a/ts/WoltLabSuite/Core/Api/Messages/RenderQuote.ts
+++ b/ts/WoltLabSuite/Core/Api/Messages/RenderQuote.ts
@@ -9,7 +9,7 @@
  */
 
 import { prepareRequest } from "WoltLabSuite/Core/Ajax/Backend";
-import { ApiResult, apiResultFromError, apiResultFromValue } from "../Result";
+import { fromInfallibleApiRequest } from "../Result";
 
 type Response = {
   objectID: number;
@@ -20,22 +20,13 @@ type Response = {
   rawMessage: string | null;
 };
 
-export async function renderQuote(
-  objectType: string,
-  objectID: number,
-  isFullQuote: boolean,
-): Promise<ApiResult<Response>> {
+export async function renderQuote(objectType: string, objectID: number, isFullQuote: boolean): Promise<Response> {
   const url = new URL(window.WSC_RPC_API_URL + "core/messages/render-quote");
   url.searchParams.set("objectType", objectType);
   url.searchParams.set("isFullQuote", String(isFullQuote));
   url.searchParams.set("objectID", objectID.toString());
 
-  let response: Response;
-  try {
-    response = (await prepareRequest(url).get().fetchAsJson()) as Response;
-  } catch (e) {
-    return apiResultFromError(e);
-  }
-
-  return apiResultFromValue(response);
+  return fromInfallibleApiRequest(() => {
+    return prepareRequest(url).get().fetchAsJson();
+  });
 }

--- a/ts/WoltLabSuite/Core/Api/Messages/ResetRemovalQuotes.ts
+++ b/ts/WoltLabSuite/Core/Api/Messages/ResetRemovalQuotes.ts
@@ -9,16 +9,12 @@
  */
 
 import { prepareRequest } from "WoltLabSuite/Core/Ajax/Backend";
-import { ApiResult, apiResultFromError, apiResultFromValue } from "../Result";
+import { fromInfallibleApiRequest } from "../Result";
 
-export async function resetRemovalQuotes(): Promise<ApiResult<[]>> {
+export async function resetRemovalQuotes(): Promise<[]> {
   const url = new URL(window.WSC_RPC_API_URL + "core/messages/reset-removal-quotes");
 
-  try {
-    await prepareRequest(url).post().fetchAsJson();
-  } catch (e) {
-    return apiResultFromError(e);
-  }
-
-  return apiResultFromValue([]);
+  return fromInfallibleApiRequest(() => {
+    return prepareRequest(url).post().fetchAsJson();
+  });
 }

--- a/ts/WoltLabSuite/Core/Api/ModerationQueues/ChangeJustifiedStatus.ts
+++ b/ts/WoltLabSuite/Core/Api/ModerationQueues/ChangeJustifiedStatus.ts
@@ -9,18 +9,14 @@
  */
 
 import { prepareRequest } from "WoltLabSuite/Core/Ajax/Backend";
-import { ApiResult, apiResultFromError, apiResultFromValue } from "../Result";
+import { fromInfallibleApiRequest } from "../Result";
 
-export async function changeJustifiedStatus(queueId: number, markAsJustified: boolean): Promise<ApiResult<[]>> {
-  try {
-    await prepareRequest(`${window.WSC_RPC_API_URL}core/moderation-queues/${queueId}/change-justified-status`)
+export async function changeJustifiedStatus(queueId: number, markAsJustified: boolean): Promise<[]> {
+  return fromInfallibleApiRequest(() => {
+    return prepareRequest(`${window.WSC_RPC_API_URL}core/moderation-queues/${queueId}/change-justified-status`)
       .post({
         markAsJustified,
       })
       .fetchAsJson();
-  } catch (e) {
-    return apiResultFromError(e);
-  }
-
-  return apiResultFromValue([]);
+  });
 }

--- a/ts/WoltLabSuite/Core/Api/ModerationQueues/CloseReport.ts
+++ b/ts/WoltLabSuite/Core/Api/ModerationQueues/CloseReport.ts
@@ -9,18 +9,14 @@
  */
 
 import { prepareRequest } from "WoltLabSuite/Core/Ajax/Backend";
-import { ApiResult, apiResultFromError, apiResultFromValue } from "../Result";
+import { fromInfallibleApiRequest } from "../Result";
 
-export async function closeReport(queueId: number, markAsJustified: boolean): Promise<ApiResult<[]>> {
-  try {
-    await prepareRequest(`${window.WSC_RPC_API_URL}core/moderation-queues/${queueId}/close`)
+export async function closeReport(queueId: number, markAsJustified: boolean): Promise<[]> {
+  return fromInfallibleApiRequest(() => {
+    return prepareRequest(`${window.WSC_RPC_API_URL}core/moderation-queues/${queueId}/close`)
       .post({
         markAsJustified,
       })
       .fetchAsJson();
-  } catch (e) {
-    return apiResultFromError(e);
-  }
-
-  return apiResultFromValue([]);
+  });
 }

--- a/ts/WoltLabSuite/Core/Api/ModerationQueues/DeleteContent.ts
+++ b/ts/WoltLabSuite/Core/Api/ModerationQueues/DeleteContent.ts
@@ -9,18 +9,14 @@
  */
 
 import { prepareRequest } from "WoltLabSuite/Core/Ajax/Backend";
-import { ApiResult, apiResultFromError, apiResultFromValue } from "../Result";
+import { fromInfallibleApiRequest } from "../Result";
 
-export async function deleteContent(queueId: number, reason: string): Promise<ApiResult<[]>> {
-  try {
-    await prepareRequest(`${window.WSC_RPC_API_URL}core/moderation-queues/${queueId}/delete-content`)
+export async function deleteContent(queueId: number, reason: string): Promise<[]> {
+  return fromInfallibleApiRequest(() => {
+    return prepareRequest(`${window.WSC_RPC_API_URL}core/moderation-queues/${queueId}/delete-content`)
       .post({
         reason,
       })
       .fetchAsJson();
-  } catch (e) {
-    return apiResultFromError(e);
-  }
-
-  return apiResultFromValue([]);
+  });
 }

--- a/ts/WoltLabSuite/Core/Api/ModerationQueues/EnableContent.ts
+++ b/ts/WoltLabSuite/Core/Api/ModerationQueues/EnableContent.ts
@@ -9,16 +9,12 @@
  */
 
 import { prepareRequest } from "WoltLabSuite/Core/Ajax/Backend";
-import { ApiResult, apiResultFromError, apiResultFromValue } from "../Result";
+import { fromInfallibleApiRequest } from "../Result";
 
-export async function enableContent(queueId: number): Promise<ApiResult<[]>> {
-  try {
-    await prepareRequest(`${window.WSC_RPC_API_URL}core/moderation-queues/${queueId}/enable-content`)
+export async function enableContent(queueId: number): Promise<[]> {
+  return fromInfallibleApiRequest(() => {
+    return prepareRequest(`${window.WSC_RPC_API_URL}core/moderation-queues/${queueId}/enable-content`)
       .post()
       .fetchAsJson();
-  } catch (e) {
-    return apiResultFromError(e);
-  }
-
-  return apiResultFromValue([]);
+  });
 }

--- a/ts/WoltLabSuite/Core/Api/Result.ts
+++ b/ts/WoltLabSuite/Core/Api/Result.ts
@@ -10,7 +10,10 @@
  */
 
 import { StatusNotOk } from "../Ajax/Error";
+import { dialogFactory } from "../Component/Dialog";
 import { isPlainObject } from "../Core";
+import { getPhrase } from "../Language";
+import { escapeHTML } from "../StringUtil";
 import { ApiError } from "./Error";
 
 export type ApiResult<T> =
@@ -58,7 +61,7 @@ export async function apiResultFromStatusNotOk(e: StatusNotOk): Promise<ApiResul
 
   let json: unknown;
   try {
-    json = await response.json();
+    json = await response.clone().json();
   } catch {
     throw e;
   }
@@ -77,10 +80,55 @@ export async function apiResultFromStatusNotOk(e: StatusNotOk): Promise<ApiResul
       ok: false,
       error: apiError,
       unwrap() {
+        showErrorDialog(apiError);
+
         throw new Error("Trying to unwrap an erroneous result.", { cause: apiError });
       },
     };
   }
 
   throw e;
+}
+
+/**
+ * Helper method for API requests that are expected to never fail. Infallible
+ * requests are those that should only fail if there is an unexpected server
+ * error or if the request was the result of a bug in the client.
+ */
+export async function fromInfallibleApiRequest<T = unknown>(request: () => Promise<unknown>): Promise<T> {
+  try {
+    return (await request()) as T;
+  } catch (e) {
+    const error = await apiResultFromError(e);
+    return error.unwrap();
+  }
+}
+
+function showErrorDialog(apiError: ApiError): void {
+  const code = escapeHTML(apiError.code);
+  const type = escapeHTML(apiError.type);
+  const message = apiError.message ? escapeHTML(apiError.message) : "(not set)";
+  const param = apiError.param ? "<kbd>" + escapeHTML(apiError.param) + "</kbd>" : "(not set)";
+
+  const html = `
+    <dl>
+      <dt>Unexpected server error</dt>
+      <dd><kbd>${type}</kbd></dd>
+    </dl>
+    <dl>
+      <dt>Error code</dt>
+      <dd><kbd>${code}</kbd></dd>
+    </dl>
+    <dl>
+      <dt>Parameter</dt>
+      <dd>${param}</dd>
+    </dl>
+    <dl>
+      <dt>Message</dt>
+      <dd>${message}</dd>
+    </dl>
+  `;
+
+  const dialog = dialogFactory().fromHtml(html).asAlert();
+  dialog.show(getPhrase("wcf.global.error.title"));
 }

--- a/ts/WoltLabSuite/Core/Api/Sessions/DeleteSession.ts
+++ b/ts/WoltLabSuite/Core/Api/Sessions/DeleteSession.ts
@@ -10,14 +10,10 @@
  */
 
 import { prepareRequest } from "WoltLabSuite/Core/Ajax/Backend";
-import { ApiResult, apiResultFromError, apiResultFromValue } from "../Result";
+import { fromInfallibleApiRequest } from "../Result";
 
-export async function deleteSession(sessionId: string): Promise<ApiResult<[]>> {
-  try {
-    await prepareRequest(`${window.WSC_RPC_API_URL}core/sessions/${sessionId}`).delete().fetchAsJson();
-  } catch (e) {
-    return apiResultFromError(e);
-  }
-
-  return apiResultFromValue([]);
+export async function deleteSession(sessionId: string): Promise<[]> {
+  return fromInfallibleApiRequest(() => {
+    return prepareRequest(`${window.WSC_RPC_API_URL}core/sessions/${sessionId}`).delete().fetchAsJson();
+  });
 }

--- a/ts/WoltLabSuite/Core/Api/VersionTrackers/RevertVersion.ts
+++ b/ts/WoltLabSuite/Core/Api/VersionTrackers/RevertVersion.ts
@@ -9,20 +9,16 @@
  */
 
 import { prepareRequest } from "WoltLabSuite/Core/Ajax/Backend";
-import { ApiResult, apiResultFromError, apiResultFromValue } from "../Result";
+import { fromInfallibleApiRequest } from "../Result";
 
-export async function revertVersion(objectType: string, objectId: number, versionId: number): Promise<ApiResult<[]>> {
-  try {
-    await prepareRequest(`${window.WSC_RPC_API_URL}core/version-trackers/revert`)
+export async function revertVersion(objectType: string, objectId: number, versionId: number): Promise<[]> {
+  return fromInfallibleApiRequest(() => {
+    return prepareRequest(`${window.WSC_RPC_API_URL}core/version-trackers/revert`)
       .post({
         objectType,
         objectId,
         versionId,
       })
       .fetchAsJson();
-  } catch (e) {
-    return apiResultFromError(e);
-  }
-
-  return apiResultFromValue([]);
+  });
 }

--- a/ts/WoltLabSuite/Core/BootstrapFrontend.ts
+++ b/ts/WoltLabSuite/Core/BootstrapFrontend.ts
@@ -64,9 +64,7 @@ function setupArticlePopover(): void {
   whenFirstSeen(".articleLink", () => {
     void import("WoltLabSuite/Core/Component/Popover").then(({ setupFor }) => {
       setupFor({
-        endpoint: async (objectId: number) => {
-          return (await getArticlePopover(objectId)).unwrap();
-        },
+        endpoint: (objectId) => getArticlePopover(objectId),
         identifier: "com.woltlab.wcf.article",
         selector: ".articleLink",
       });

--- a/ts/WoltLabSuite/Core/Component/Ckeditor/Mention.ts
+++ b/ts/WoltLabSuite/Core/Component/Ckeditor/Mention.ts
@@ -25,7 +25,7 @@ async function getPossibleMentions(query: string): Promise<Mention[]> {
     return [];
   }
 
-  return (await mentionSuggestions(query)).unwrap().map((item) => {
+  return (await mentionSuggestions(query)).map((item) => {
     if (item.type === "user") {
       return {
         id: `@${item.username}`,

--- a/ts/WoltLabSuite/Core/Component/GridView.ts
+++ b/ts/WoltLabSuite/Core/Component/GridView.ts
@@ -46,16 +46,14 @@ export class GridView {
   }
 
   async #loadRows(cause: StateChangeCause): Promise<void> {
-    const response = (
-      await getRows(
-        this.#gridClassName,
-        this.#state.getPageNo(),
-        this.#state.getSortField(),
-        this.#state.getSortOrder(),
-        this.#state.getActiveFilters(),
-        this.#gridViewParameters,
-      )
-    ).unwrap();
+    const response = await getRows(
+      this.#gridClassName,
+      this.#state.getPageNo(),
+      this.#state.getSortField(),
+      this.#state.getSortOrder(),
+      this.#state.getActiveFilters(),
+      this.#gridViewParameters,
+    );
     DomUtil.setInnerHtml(this.#table.querySelector("tbody")!, response.template);
 
     this.#table.hidden = response.totalRows == 0;
@@ -66,8 +64,9 @@ export class GridView {
   }
 
   async #refreshRow(row: HTMLElement): Promise<void> {
-    const response = (await getRow(this.#gridClassName, row.dataset.objectId!, this.#gridViewParameters)).unwrap();
-    row.replaceWith(DomUtil.createFragmentFromHtml(response.template));
+    const { template } = await getRow(this.#gridClassName, row.dataset.objectId!, this.#gridViewParameters);
+
+    row.replaceWith(DomUtil.createFragmentFromHtml(template));
     this.#state.refreshSelection();
     DomChangeListener.trigger();
   }
@@ -126,8 +125,8 @@ export class GridView {
   }
 
   async #loadBulkInteractions(objectIds: number[]): Promise<void> {
-    const response = await getBulkContextMenuOptions(this.#bulkInteractionProviderClassName, objectIds);
-    this.#state.setBulkInteractionContextMenuOptions(response.unwrap().template);
+    const { template } = await getBulkContextMenuOptions(this.#bulkInteractionProviderClassName, objectIds);
+    this.#state.setBulkInteractionContextMenuOptions(template);
   }
 
   #checkEmptyTable(): void {

--- a/ts/WoltLabSuite/Core/Component/Interaction/StandaloneButton.ts
+++ b/ts/WoltLabSuite/Core/Component/Interaction/StandaloneButton.ts
@@ -42,14 +42,14 @@ export class StandaloneButton {
   }
 
   async #refreshContextMenu(): Promise<void> {
-    const response = (await getContextMenuOptions(this.#providerClassName, this.#objectId)).unwrap();
+    const { template } = await getContextMenuOptions(this.#providerClassName, this.#objectId);
 
     const dropdown = this.#getDropdownMenu();
     if (!dropdown) {
       return;
     }
 
-    dropdown.innerHTML = response.template;
+    dropdown.innerHTML = template;
 
     this.#initInteractions();
   }

--- a/ts/WoltLabSuite/Core/Component/ListView.ts
+++ b/ts/WoltLabSuite/Core/Component/ListView.ts
@@ -47,16 +47,14 @@ export class ListView {
   }
 
   async #loadItems(cause: StateChangeCause): Promise<void> {
-    const response = (
-      await getItems(
-        this.#viewClassName,
-        this.#state.getPageNo(),
-        this.#state.getSortField(),
-        this.#state.getSortOrder(),
-        this.#state.getActiveFilters(),
-        this.#listViewParameters,
-      )
-    ).unwrap();
+    const response = await getItems(
+      this.#viewClassName,
+      this.#state.getPageNo(),
+      this.#state.getSortField(),
+      this.#state.getSortOrder(),
+      this.#state.getActiveFilters(),
+      this.#listViewParameters,
+    );
     setInnerHtml(this.#viewElement, response.template);
 
     this.#viewElement.hidden = response.totalItems === 0;
@@ -70,8 +68,8 @@ export class ListView {
   }
 
   async #refreshItem(item: HTMLElement): Promise<void> {
-    const response = (await getItem(this.#viewClassName, item.dataset.objectId!, this.#listViewParameters)).unwrap();
-    item.replaceWith(createFragmentFromHtml(response.template));
+    const { template } = await getItem(this.#viewClassName, item.dataset.objectId!, this.#listViewParameters);
+    item.replaceWith(createFragmentFromHtml(template));
     this.#state.refreshSelection();
     triggerDomChange();
   }
@@ -130,8 +128,8 @@ export class ListView {
   }
 
   async #loadBulkInteractions(objectIds: number[]): Promise<void> {
-    const response = await getBulkContextMenuOptions(this.#bulkInteractionProviderClassName, objectIds);
-    this.#state.setBulkInteractionContextMenuOptions(response.unwrap().template);
+    const { template } = await getBulkContextMenuOptions(this.#bulkInteractionProviderClassName, objectIds);
+    this.#state.setBulkInteractionContextMenuOptions(template);
   }
 
   #checkEmptyList(): void {

--- a/ts/WoltLabSuite/Core/Component/Quote/Storage.ts
+++ b/ts/WoltLabSuite/Core/Component/Quote/Storage.ts
@@ -60,12 +60,7 @@ export async function saveQuote(
       .dispatch()) as LegacyQuoteData;
     quote = result.renderedQuote;
   } else {
-    const result = await renderQuote(objectType, objectId, false);
-    if (!result.ok) {
-      throw new Error("Error fetching quote data");
-    }
-
-    quote = result.value;
+    quote = await renderQuote(objectType, objectId, false);
   }
 
   const uuid = storeQuote(objectType, quote, {
@@ -94,12 +89,7 @@ export async function saveFullQuote(
     const result = (await dboAction("saveFullQuote", className).objectIds([objectId]).dispatch()) as LegacyQuoteData;
     message = result.renderedQuote;
   } else {
-    const result = await renderQuote(objectType, objectId, true);
-    if (!result.ok) {
-      throw new Error("Error fetching quote data");
-    }
-
-    message = result.value;
+    message = await renderQuote(objectType, objectId, true);
   }
 
   const uuid = storeQuote(objectType, message, message);

--- a/ts/WoltLabSuite/Core/Controller/Moderation/Activation.ts
+++ b/ts/WoltLabSuite/Core/Controller/Moderation/Activation.ts
@@ -21,12 +21,11 @@ async function handleEnableContent(queueId: number, redirectUrl: string): Promis
     .withoutMessage();
 
   if (result) {
-    const response = await enableContent(queueId);
-    if (response.ok) {
-      showDefaultSuccessSnackbar().addEventListener("snackbar:close", () => {
-        window.location.href = redirectUrl;
-      });
-    }
+    await enableContent(queueId);
+
+    showDefaultSuccessSnackbar().addEventListener("snackbar:close", () => {
+      window.location.href = redirectUrl;
+    });
   }
 }
 
@@ -34,12 +33,11 @@ async function handleRemoveContent(queueId: number, objectName: string, redirect
   const { result, reason } = await confirmationFactory().softDelete(objectName, true);
 
   if (result) {
-    const response = await deleteContent(queueId, reason);
-    if (response.ok) {
-      showDefaultSuccessSnackbar().addEventListener("snackbar:close", () => {
-        window.location.href = redirectUrl;
-      });
-    }
+    await deleteContent(queueId, reason);
+
+    showDefaultSuccessSnackbar().addEventListener("snackbar:close", () => {
+      window.location.href = redirectUrl;
+    });
   }
 }
 

--- a/ts/WoltLabSuite/Core/Controller/Moderation/Report.ts
+++ b/ts/WoltLabSuite/Core/Controller/Moderation/Report.ts
@@ -20,12 +20,11 @@ async function handleRemoveContent(queueId: number, objectName: string, redirect
   const { result, reason } = await confirmationFactory().softDelete(objectName, true);
 
   if (result) {
-    const response = await deleteContent(queueId, reason);
-    if (response.ok) {
-      showDefaultSuccessSnackbar().addEventListener("snackbar:close", () => {
-        window.location.href = redirectUrl;
-      });
-    }
+    await deleteContent(queueId, reason);
+
+    showDefaultSuccessSnackbar().addEventListener("snackbar:close", () => {
+      window.location.href = redirectUrl;
+    });
   }
 }
 
@@ -42,12 +41,11 @@ async function handleCloseReport(queueId: number, redirectUrl: string): Promise<
     });
 
   if (result) {
-    const response = await closeReport(queueId, dialog.content.querySelector("input")!.checked);
-    if (response.ok) {
-      showDefaultSuccessSnackbar().addEventListener("snackbar:close", () => {
-        window.location.href = redirectUrl;
-      });
-    }
+    await closeReport(queueId, dialog.content.querySelector("input")!.checked);
+
+    showDefaultSuccessSnackbar().addEventListener("snackbar:close", () => {
+      window.location.href = redirectUrl;
+    });
   }
 }
 
@@ -65,12 +63,11 @@ async function handleChangeJustifiedStatus(queueId: number, justified: boolean, 
     });
 
   if (result) {
-    const response = await changeJustifiedStatus(queueId, dialog.content.querySelector("input")!.checked);
-    if (response.ok) {
-      showDefaultSuccessSnackbar().addEventListener("snackbar:close", () => {
-        window.location.href = redirectUrl;
-      });
-    }
+    await changeJustifiedStatus(queueId, dialog.content.querySelector("input")!.checked);
+
+    showDefaultSuccessSnackbar().addEventListener("snackbar:close", () => {
+      window.location.href = redirectUrl;
+    });
   }
 }
 

--- a/ts/WoltLabSuite/Core/Ui/User/Session/Delete.ts
+++ b/ts/WoltLabSuite/Core/Ui/User/Session/Delete.ts
@@ -16,7 +16,7 @@ function onClick(button: HTMLElement): void {
   UiConfirmation.show({
     message: Language.get("wcf.user.security.deleteSession.confirmMessage"),
     confirm: async (_parameters) => {
-      (await deleteSession(button.dataset.sessionId!)).unwrap();
+      await deleteSession(button.dataset.sessionId!);
 
       button.closest("li")?.remove();
 

--- a/wcfsetup/install/files/acp/templates/cronjobLogList.tpl
+++ b/wcfsetup/install/files/acp/templates/cronjobLogList.tpl
@@ -9,12 +9,11 @@
 					.withoutMessage();
 					
 				if (result) {
-					const response = await clearLogs();
-					if (response.ok) {
-						showDefaultSuccessSnackbar().addEventListener("snackbar:close", () => {
-							window.location.reload();
-						});
-					}
+					await clearLogs();
+
+					showDefaultSuccessSnackbar().addEventListener("snackbar:close", () => {
+						window.location.reload();
+					});
 				}
 			});
 		});

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Acp/Controller/ExceptionLog/View.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Acp/Controller/ExceptionLog/View.js
@@ -11,11 +11,8 @@ define(["require", "exports", "WoltLabSuite/Core/Api/Exceptions/RenderException"
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.setup = setup;
     async function showDialog(button) {
-        const response = await (0, RenderException_1.renderException)(button.closest("tr").dataset.objectId);
-        if (!response.ok) {
-            return;
-        }
-        const dialog = (0, Dialog_1.dialogFactory)().fromHtml(response.value.template).withoutControls();
+        const { template } = await (0, RenderException_1.renderException)(button.closest("tr").dataset.objectId);
+        const dialog = (0, Dialog_1.dialogFactory)().fromHtml(template).withoutControls();
         dialog.content.querySelector(".jsCopyButton")?.addEventListener("click", () => {
             void (0, Clipboard_1.copyTextToClipboard)(dialog.content.querySelector(".jsCopyException").value);
         });

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Acp/Controller/VersionTracker/VersionList.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Acp/Controller/VersionTracker/VersionList.js
@@ -17,12 +17,10 @@ define(["require", "exports", "WoltLabSuite/Core/Api/VersionTrackers/RevertVersi
                 if (!result) {
                     return;
                 }
-                const response = await (0, RevertVersion_1.revertVersion)(objectType, objectId, parseInt(button.dataset.objectId));
-                if (response.ok) {
-                    (0, Snackbar_1.showDefaultSuccessSnackbar)().addEventListener("snackbar:close", () => {
-                        window.location.reload();
-                    });
-                }
+                await (0, RevertVersion_1.revertVersion)(objectType, objectId, parseInt(button.dataset.objectId));
+                (0, Snackbar_1.showDefaultSuccessSnackbar)().addEventListener("snackbar:close", () => {
+                    window.location.reload();
+                });
             });
         });
     }

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Api/Articles/GetArticlePopover.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Api/Articles/GetArticlePopover.js
@@ -12,13 +12,8 @@ define(["require", "exports", "WoltLabSuite/Core/Ajax/Backend", "WoltLabSuite/Co
     exports.getArticlePopover = getArticlePopover;
     async function getArticlePopover(articleId) {
         const url = new URL(`${window.WSC_RPC_API_URL}core/articles/${articleId}/popover`);
-        let response;
-        try {
-            response = (await (0, Backend_1.prepareRequest)(url).get().fetchAsJson());
-        }
-        catch (e) {
-            return (0, Result_1.apiResultFromError)(e);
-        }
-        return (0, Result_1.apiResultFromValue)(response.template);
+        return (0, Result_1.fromInfallibleApiRequest)(() => {
+            return (0, Backend_1.prepareRequest)(url).get().fetchAsJson();
+        });
     }
 });

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Api/Cronjobs/Logs/ClearLogs.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Api/Cronjobs/Logs/ClearLogs.js
@@ -12,12 +12,8 @@ define(["require", "exports", "WoltLabSuite/Core/Ajax/Backend", "../../Result"],
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.clearLogs = clearLogs;
     async function clearLogs() {
-        try {
-            await (0, Backend_1.prepareRequest)(`${window.WSC_RPC_API_URL}core/cronjobs/logs`).delete().fetchAsJson();
-        }
-        catch (e) {
-            return (0, Result_1.apiResultFromError)(e);
-        }
-        return (0, Result_1.apiResultFromValue)([]);
+        return (0, Result_1.fromInfallibleApiRequest)(() => {
+            return (0, Backend_1.prepareRequest)(`${window.WSC_RPC_API_URL}core/cronjobs/logs`).delete().fetchAsJson();
+        });
     }
 });

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Api/Exceptions/RenderException.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Api/Exceptions/RenderException.js
@@ -12,13 +12,8 @@ define(["require", "exports", "WoltLabSuite/Core/Ajax/Backend", "../Result"], fu
     exports.renderException = renderException;
     async function renderException(exceptionId) {
         const url = new URL(`${window.WSC_RPC_API_URL}core/exceptions/${exceptionId}/render`);
-        let response;
-        try {
-            response = (await (0, Backend_1.prepareRequest)(url).get().fetchAsJson());
-        }
-        catch (e) {
-            return (0, Result_1.apiResultFromError)(e);
-        }
-        return (0, Result_1.apiResultFromValue)(response);
+        return (0, Result_1.fromInfallibleApiRequest)(() => {
+            return (0, Backend_1.prepareRequest)(url).get().fetchAsJson();
+        });
     }
 });

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Api/Gridviews/GetRow.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Api/Gridviews/GetRow.js
@@ -26,13 +26,8 @@ define(["require", "exports", "WoltLabSuite/Core/Ajax/Backend", "../Result"], fu
                 }
             });
         }
-        let response;
-        try {
-            response = (await (0, Backend_1.prepareRequest)(url).get().allowCaching().disableLoadingIndicator().fetchAsJson());
-        }
-        catch (e) {
-            return (0, Result_1.apiResultFromError)(e);
-        }
-        return (0, Result_1.apiResultFromValue)(response);
+        return (0, Result_1.fromInfallibleApiRequest)(() => {
+            return (0, Backend_1.prepareRequest)(url).get().allowCaching().disableLoadingIndicator().fetchAsJson();
+        });
     }
 });

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Api/Gridviews/GetRows.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Api/Gridviews/GetRows.js
@@ -33,13 +33,8 @@ define(["require", "exports", "WoltLabSuite/Core/Ajax/Backend", "../Result"], fu
                 }
             });
         }
-        let response;
-        try {
-            response = (await (0, Backend_1.prepareRequest)(url).get().allowCaching().disableLoadingIndicator().fetchAsJson());
-        }
-        catch (e) {
-            return (0, Result_1.apiResultFromError)(e);
-        }
-        return (0, Result_1.apiResultFromValue)(response);
+        return (0, Result_1.fromInfallibleApiRequest)(() => {
+            return (0, Backend_1.prepareRequest)(url).get().allowCaching().disableLoadingIndicator().fetchAsJson();
+        });
     }
 });

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Api/Interactions/GetBulkContextMenuOptions.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Api/Interactions/GetBulkContextMenuOptions.js
@@ -11,16 +11,11 @@ define(["require", "exports", "WoltLabSuite/Core/Ajax/Backend", "../Result"], fu
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.getBulkContextMenuOptions = getBulkContextMenuOptions;
     async function getBulkContextMenuOptions(providerClassName, objectIds) {
-        let response;
-        try {
-            response = (await (0, Backend_1.prepareRequest)(`${window.WSC_RPC_API_URL}core/interactions/bulk-context-menu-options`)
+        return (0, Result_1.fromInfallibleApiRequest)(() => {
+            return (0, Backend_1.prepareRequest)(`${window.WSC_RPC_API_URL}core/interactions/bulk-context-menu-options`)
                 .post({ provider: providerClassName, objectIDs: objectIds })
                 .disableLoadingIndicator()
-                .fetchAsJson());
-        }
-        catch (e) {
-            return (0, Result_1.apiResultFromError)(e);
-        }
-        return (0, Result_1.apiResultFromValue)(response);
+                .fetchAsJson();
+        });
     }
 });

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Api/Interactions/GetContextMenuOptions.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Api/Interactions/GetContextMenuOptions.js
@@ -14,13 +14,8 @@ define(["require", "exports", "WoltLabSuite/Core/Ajax/Backend", "../Result"], fu
         const url = new URL(`${window.WSC_RPC_API_URL}core/interactions/context-menu-options`);
         url.searchParams.set("provider", providerClassName);
         url.searchParams.set("objectID", objectId.toString());
-        let response;
-        try {
-            response = (await (0, Backend_1.prepareRequest)(url).get().allowCaching().disableLoadingIndicator().fetchAsJson());
-        }
-        catch (e) {
-            return (0, Result_1.apiResultFromError)(e);
-        }
-        return (0, Result_1.apiResultFromValue)(response);
+        return (0, Result_1.fromInfallibleApiRequest)(() => {
+            return (0, Backend_1.prepareRequest)(url).get().allowCaching().disableLoadingIndicator().fetchAsJson();
+        });
     }
 });

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Api/ListViews/GetItem.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Api/ListViews/GetItem.js
@@ -26,13 +26,8 @@ define(["require", "exports", "WoltLabSuite/Core/Ajax/Backend", "../Result"], fu
                 }
             });
         }
-        let response;
-        try {
-            response = (await (0, Backend_1.prepareRequest)(url).get().allowCaching().disableLoadingIndicator().fetchAsJson());
-        }
-        catch (e) {
-            return (0, Result_1.apiResultFromError)(e);
-        }
-        return (0, Result_1.apiResultFromValue)(response);
+        return (0, Result_1.fromInfallibleApiRequest)(() => {
+            return (0, Backend_1.prepareRequest)(url).get().allowCaching().disableLoadingIndicator().fetchAsJson();
+        });
     }
 });

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Api/ListViews/GetItems.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Api/ListViews/GetItems.js
@@ -33,13 +33,8 @@ define(["require", "exports", "WoltLabSuite/Core/Ajax/Backend", "../Result"], fu
                 }
             });
         }
-        let response;
-        try {
-            response = (await (0, Backend_1.prepareRequest)(url).get().allowCaching().disableLoadingIndicator().fetchAsJson());
-        }
-        catch (e) {
-            return (0, Result_1.apiResultFromError)(e);
-        }
-        return (0, Result_1.apiResultFromValue)(response);
+        return (0, Result_1.fromInfallibleApiRequest)(() => {
+            return (0, Backend_1.prepareRequest)(url).get().allowCaching().disableLoadingIndicator().fetchAsJson();
+        });
     }
 });

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Api/Messages/MentionSuggestions.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Api/Messages/MentionSuggestions.js
@@ -14,13 +14,8 @@ define(["require", "exports", "WoltLabSuite/Core/Ajax/Backend", "../Result"], fu
     async function mentionSuggestions(query) {
         const url = new URL(window.WSC_RPC_API_URL + "core/messages/mention-suggestions");
         url.searchParams.set("query", query);
-        let response;
-        try {
-            response = (await (0, Backend_1.prepareRequest)(url).get().allowCaching().disableLoadingIndicator().fetchAsJson());
-        }
-        catch (e) {
-            return (0, Result_1.apiResultFromError)(e);
-        }
-        return (0, Result_1.apiResultFromValue)(response);
+        return (0, Result_1.fromInfallibleApiRequest)(() => {
+            return (0, Backend_1.prepareRequest)(url).get().allowCaching().disableLoadingIndicator().fetchAsJson();
+        });
     }
 });

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Api/Messages/RenderQuote.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Api/Messages/RenderQuote.js
@@ -16,13 +16,8 @@ define(["require", "exports", "WoltLabSuite/Core/Ajax/Backend", "../Result"], fu
         url.searchParams.set("objectType", objectType);
         url.searchParams.set("isFullQuote", String(isFullQuote));
         url.searchParams.set("objectID", objectID.toString());
-        let response;
-        try {
-            response = (await (0, Backend_1.prepareRequest)(url).get().fetchAsJson());
-        }
-        catch (e) {
-            return (0, Result_1.apiResultFromError)(e);
-        }
-        return (0, Result_1.apiResultFromValue)(response);
+        return (0, Result_1.fromInfallibleApiRequest)(() => {
+            return (0, Backend_1.prepareRequest)(url).get().fetchAsJson();
+        });
     }
 });

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Api/Messages/ResetRemovalQuotes.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Api/Messages/ResetRemovalQuotes.js
@@ -13,12 +13,8 @@ define(["require", "exports", "WoltLabSuite/Core/Ajax/Backend", "../Result"], fu
     exports.resetRemovalQuotes = resetRemovalQuotes;
     async function resetRemovalQuotes() {
         const url = new URL(window.WSC_RPC_API_URL + "core/messages/reset-removal-quotes");
-        try {
-            await (0, Backend_1.prepareRequest)(url).post().fetchAsJson();
-        }
-        catch (e) {
-            return (0, Result_1.apiResultFromError)(e);
-        }
-        return (0, Result_1.apiResultFromValue)([]);
+        return (0, Result_1.fromInfallibleApiRequest)(() => {
+            return (0, Backend_1.prepareRequest)(url).post().fetchAsJson();
+        });
     }
 });

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Api/ModerationQueues/ChangeJustifiedStatus.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Api/ModerationQueues/ChangeJustifiedStatus.js
@@ -12,16 +12,12 @@ define(["require", "exports", "WoltLabSuite/Core/Ajax/Backend", "../Result"], fu
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.changeJustifiedStatus = changeJustifiedStatus;
     async function changeJustifiedStatus(queueId, markAsJustified) {
-        try {
-            await (0, Backend_1.prepareRequest)(`${window.WSC_RPC_API_URL}core/moderation-queues/${queueId}/change-justified-status`)
+        return (0, Result_1.fromInfallibleApiRequest)(() => {
+            return (0, Backend_1.prepareRequest)(`${window.WSC_RPC_API_URL}core/moderation-queues/${queueId}/change-justified-status`)
                 .post({
                 markAsJustified,
             })
                 .fetchAsJson();
-        }
-        catch (e) {
-            return (0, Result_1.apiResultFromError)(e);
-        }
-        return (0, Result_1.apiResultFromValue)([]);
+        });
     }
 });

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Api/ModerationQueues/CloseReport.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Api/ModerationQueues/CloseReport.js
@@ -12,16 +12,12 @@ define(["require", "exports", "WoltLabSuite/Core/Ajax/Backend", "../Result"], fu
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.closeReport = closeReport;
     async function closeReport(queueId, markAsJustified) {
-        try {
-            await (0, Backend_1.prepareRequest)(`${window.WSC_RPC_API_URL}core/moderation-queues/${queueId}/close`)
+        return (0, Result_1.fromInfallibleApiRequest)(() => {
+            return (0, Backend_1.prepareRequest)(`${window.WSC_RPC_API_URL}core/moderation-queues/${queueId}/close`)
                 .post({
                 markAsJustified,
             })
                 .fetchAsJson();
-        }
-        catch (e) {
-            return (0, Result_1.apiResultFromError)(e);
-        }
-        return (0, Result_1.apiResultFromValue)([]);
+        });
     }
 });

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Api/ModerationQueues/DeleteContent.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Api/ModerationQueues/DeleteContent.js
@@ -12,16 +12,12 @@ define(["require", "exports", "WoltLabSuite/Core/Ajax/Backend", "../Result"], fu
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.deleteContent = deleteContent;
     async function deleteContent(queueId, reason) {
-        try {
-            await (0, Backend_1.prepareRequest)(`${window.WSC_RPC_API_URL}core/moderation-queues/${queueId}/delete-content`)
+        return (0, Result_1.fromInfallibleApiRequest)(() => {
+            return (0, Backend_1.prepareRequest)(`${window.WSC_RPC_API_URL}core/moderation-queues/${queueId}/delete-content`)
                 .post({
                 reason,
             })
                 .fetchAsJson();
-        }
-        catch (e) {
-            return (0, Result_1.apiResultFromError)(e);
-        }
-        return (0, Result_1.apiResultFromValue)([]);
+        });
     }
 });

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Api/ModerationQueues/EnableContent.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Api/ModerationQueues/EnableContent.js
@@ -12,14 +12,10 @@ define(["require", "exports", "WoltLabSuite/Core/Ajax/Backend", "../Result"], fu
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.enableContent = enableContent;
     async function enableContent(queueId) {
-        try {
-            await (0, Backend_1.prepareRequest)(`${window.WSC_RPC_API_URL}core/moderation-queues/${queueId}/enable-content`)
+        return (0, Result_1.fromInfallibleApiRequest)(() => {
+            return (0, Backend_1.prepareRequest)(`${window.WSC_RPC_API_URL}core/moderation-queues/${queueId}/enable-content`)
                 .post()
                 .fetchAsJson();
-        }
-        catch (e) {
-            return (0, Result_1.apiResultFromError)(e);
-        }
-        return (0, Result_1.apiResultFromValue)([]);
+        });
     }
 });

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Api/Result.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Api/Result.js
@@ -8,12 +8,13 @@
  * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
  * @since 6.1
  */
-define(["require", "exports", "../Ajax/Error", "../Core", "./Error"], function (require, exports, Error_1, Core_1, Error_2) {
+define(["require", "exports", "../Ajax/Error", "../Component/Dialog", "../Core", "../Language", "../StringUtil", "./Error"], function (require, exports, Error_1, Dialog_1, Core_1, Language_1, StringUtil_1, Error_2) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.apiResultFromValue = apiResultFromValue;
     exports.apiResultFromError = apiResultFromError;
     exports.apiResultFromStatusNotOk = apiResultFromStatusNotOk;
+    exports.fromInfallibleApiRequest = fromInfallibleApiRequest;
     function apiResultFromValue(value) {
         return {
             ok: true,
@@ -41,7 +42,7 @@ define(["require", "exports", "../Ajax/Error", "../Core", "./Error"], function (
         }
         let json;
         try {
-            json = await response.json();
+            json = await response.clone().json();
         }
         catch {
             throw e;
@@ -57,10 +58,51 @@ define(["require", "exports", "../Ajax/Error", "../Core", "./Error"], function (
                 ok: false,
                 error: apiError,
                 unwrap() {
+                    showErrorDialog(apiError);
                     throw new Error("Trying to unwrap an erroneous result.", { cause: apiError });
                 },
             };
         }
         throw e;
+    }
+    /**
+     * Helper method for API requests that are expected to never fail. Infallible
+     * requests are those that should only fail if there is an unexpected server
+     * error or if the request was the result of a bug in the client.
+     */
+    async function fromInfallibleApiRequest(request) {
+        try {
+            return (await request());
+        }
+        catch (e) {
+            const error = await apiResultFromError(e);
+            return error.unwrap();
+        }
+    }
+    function showErrorDialog(apiError) {
+        const code = (0, StringUtil_1.escapeHTML)(apiError.code);
+        const type = (0, StringUtil_1.escapeHTML)(apiError.type);
+        const message = apiError.message ? (0, StringUtil_1.escapeHTML)(apiError.message) : "(not set)";
+        const param = apiError.param ? "<kbd>" + (0, StringUtil_1.escapeHTML)(apiError.param) + "</kbd>" : "(not set)";
+        const html = `
+    <dl>
+      <dt>Unexpected server error</dt>
+      <dd><kbd>${type}</kbd></dd>
+    </dl>
+    <dl>
+      <dt>Error code</dt>
+      <dd><kbd>${code}</kbd></dd>
+    </dl>
+    <dl>
+      <dt>Parameter</dt>
+      <dd>${param}</dd>
+    </dl>
+    <dl>
+      <dt>Message</dt>
+      <dd>${message}</dd>
+    </dl>
+  `;
+        const dialog = (0, Dialog_1.dialogFactory)().fromHtml(html).asAlert();
+        dialog.show((0, Language_1.getPhrase)("wcf.global.error.title"));
     }
 });

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Api/Sessions/DeleteSession.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Api/Sessions/DeleteSession.js
@@ -13,12 +13,8 @@ define(["require", "exports", "WoltLabSuite/Core/Ajax/Backend", "../Result"], fu
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.deleteSession = deleteSession;
     async function deleteSession(sessionId) {
-        try {
-            await (0, Backend_1.prepareRequest)(`${window.WSC_RPC_API_URL}core/sessions/${sessionId}`).delete().fetchAsJson();
-        }
-        catch (e) {
-            return (0, Result_1.apiResultFromError)(e);
-        }
-        return (0, Result_1.apiResultFromValue)([]);
+        return (0, Result_1.fromInfallibleApiRequest)(() => {
+            return (0, Backend_1.prepareRequest)(`${window.WSC_RPC_API_URL}core/sessions/${sessionId}`).delete().fetchAsJson();
+        });
     }
 });

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Api/VersionTrackers/RevertVersion.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Api/VersionTrackers/RevertVersion.js
@@ -12,18 +12,14 @@ define(["require", "exports", "WoltLabSuite/Core/Ajax/Backend", "../Result"], fu
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.revertVersion = revertVersion;
     async function revertVersion(objectType, objectId, versionId) {
-        try {
-            await (0, Backend_1.prepareRequest)(`${window.WSC_RPC_API_URL}core/version-trackers/revert`)
+        return (0, Result_1.fromInfallibleApiRequest)(() => {
+            return (0, Backend_1.prepareRequest)(`${window.WSC_RPC_API_URL}core/version-trackers/revert`)
                 .post({
                 objectType,
                 objectId,
                 versionId,
             })
                 .fetchAsJson();
-        }
-        catch (e) {
-            return (0, Result_1.apiResultFromError)(e);
-        }
-        return (0, Result_1.apiResultFromValue)([]);
+        });
     }
 });

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/BootstrapFrontend.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/BootstrapFrontend.js
@@ -39,9 +39,7 @@ define(["require", "exports", "tslib", "./BackgroundQueue", "./Bootstrap", "./Ui
         (0, LazyLoader_1.whenFirstSeen)(".articleLink", () => {
             void new Promise((resolve_2, reject_2) => { require(["WoltLabSuite/Core/Component/Popover"], resolve_2, reject_2); }).then(tslib_1.__importStar).then(({ setupFor }) => {
                 setupFor({
-                    endpoint: async (objectId) => {
-                        return (await (0, GetArticlePopover_1.getArticlePopover)(objectId)).unwrap();
-                    },
+                    endpoint: (objectId) => (0, GetArticlePopover_1.getArticlePopover)(objectId),
                     identifier: "com.woltlab.wcf.article",
                     selector: ".articleLink",
                 });

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Component/Ckeditor/Mention.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Component/Ckeditor/Mention.js
@@ -16,7 +16,7 @@ define(["require", "exports", "../../Dom/Util", "./Event", "WoltLabSuite/Core/Ap
         if (query.length > 24) {
             return [];
         }
-        return (await (0, MentionSuggestions_1.mentionSuggestions)(query)).unwrap().map((item) => {
+        return (await (0, MentionSuggestions_1.mentionSuggestions)(query)).map((item) => {
             if (item.type === "user") {
                 return {
                     id: `@${item.username}`,

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Component/GridView.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Component/GridView.js
@@ -31,7 +31,7 @@ define(["require", "exports", "tslib", "../Api/Gridviews/GetRow", "../Api/Gridvi
             this.#initEventListeners();
         }
         async #loadRows(cause) {
-            const response = (await (0, GetRows_1.getRows)(this.#gridClassName, this.#state.getPageNo(), this.#state.getSortField(), this.#state.getSortOrder(), this.#state.getActiveFilters(), this.#gridViewParameters)).unwrap();
+            const response = await (0, GetRows_1.getRows)(this.#gridClassName, this.#state.getPageNo(), this.#state.getSortField(), this.#state.getSortOrder(), this.#state.getActiveFilters(), this.#gridViewParameters);
             Util_1.default.setInnerHtml(this.#table.querySelector("tbody"), response.template);
             this.#table.hidden = response.totalRows == 0;
             this.#noItemsNotice.hidden = response.totalRows != 0;
@@ -39,8 +39,8 @@ define(["require", "exports", "tslib", "../Api/Gridviews/GetRow", "../Api/Gridvi
             Listener_1.default.trigger();
         }
         async #refreshRow(row) {
-            const response = (await (0, GetRow_1.getRow)(this.#gridClassName, row.dataset.objectId, this.#gridViewParameters)).unwrap();
-            row.replaceWith(Util_1.default.createFragmentFromHtml(response.template));
+            const { template } = await (0, GetRow_1.getRow)(this.#gridClassName, row.dataset.objectId, this.#gridViewParameters);
+            row.replaceWith(Util_1.default.createFragmentFromHtml(template));
             this.#state.refreshSelection();
             Listener_1.default.trigger();
         }
@@ -88,8 +88,8 @@ define(["require", "exports", "tslib", "../Api/Gridviews/GetRow", "../Api/Gridvi
             return state;
         }
         async #loadBulkInteractions(objectIds) {
-            const response = await (0, GetBulkContextMenuOptions_1.getBulkContextMenuOptions)(this.#bulkInteractionProviderClassName, objectIds);
-            this.#state.setBulkInteractionContextMenuOptions(response.unwrap().template);
+            const { template } = await (0, GetBulkContextMenuOptions_1.getBulkContextMenuOptions)(this.#bulkInteractionProviderClassName, objectIds);
+            this.#state.setBulkInteractionContextMenuOptions(template);
         }
         #checkEmptyTable() {
             if (this.#table.querySelectorAll("tbody tr").length > 0) {

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Component/Interaction/StandaloneButton.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Component/Interaction/StandaloneButton.js
@@ -27,12 +27,12 @@ define(["require", "exports", "tslib", "WoltLabSuite/Core/Api/GetObject", "WoltL
             this.#initEventListeners();
         }
         async #refreshContextMenu() {
-            const response = (await (0, GetContextMenuOptions_1.getContextMenuOptions)(this.#providerClassName, this.#objectId)).unwrap();
+            const { template } = await (0, GetContextMenuOptions_1.getContextMenuOptions)(this.#providerClassName, this.#objectId);
             const dropdown = this.#getDropdownMenu();
             if (!dropdown) {
                 return;
             }
-            dropdown.innerHTML = response.template;
+            dropdown.innerHTML = template;
             this.#initInteractions();
         }
         async #refreshHeader() {

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Component/ListView.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Component/ListView.js
@@ -30,7 +30,7 @@ define(["require", "exports", "tslib", "./ListView/State", "../Dom/Change/Listen
             this.#initEventListeners();
         }
         async #loadItems(cause) {
-            const response = (await (0, GetItems_1.getItems)(this.#viewClassName, this.#state.getPageNo(), this.#state.getSortField(), this.#state.getSortOrder(), this.#state.getActiveFilters(), this.#listViewParameters)).unwrap();
+            const response = await (0, GetItems_1.getItems)(this.#viewClassName, this.#state.getPageNo(), this.#state.getSortField(), this.#state.getSortOrder(), this.#state.getActiveFilters(), this.#listViewParameters);
             (0, Util_1.setInnerHtml)(this.#viewElement, response.template);
             this.#viewElement.hidden = response.totalItems === 0;
             this.#noItemsNotice.hidden = response.totalItems !== 0;
@@ -41,8 +41,8 @@ define(["require", "exports", "tslib", "./ListView/State", "../Dom/Change/Listen
             (0, Listener_1.trigger)();
         }
         async #refreshItem(item) {
-            const response = (await (0, GetItem_1.getItem)(this.#viewClassName, item.dataset.objectId, this.#listViewParameters)).unwrap();
-            item.replaceWith((0, Util_1.createFragmentFromHtml)(response.template));
+            const { template } = await (0, GetItem_1.getItem)(this.#viewClassName, item.dataset.objectId, this.#listViewParameters);
+            item.replaceWith((0, Util_1.createFragmentFromHtml)(template));
             this.#state.refreshSelection();
             (0, Listener_1.trigger)();
         }
@@ -90,8 +90,8 @@ define(["require", "exports", "tslib", "./ListView/State", "../Dom/Change/Listen
             return state;
         }
         async #loadBulkInteractions(objectIds) {
-            const response = await (0, GetBulkContextMenuOptions_1.getBulkContextMenuOptions)(this.#bulkInteractionProviderClassName, objectIds);
-            this.#state.setBulkInteractionContextMenuOptions(response.unwrap().template);
+            const { template } = await (0, GetBulkContextMenuOptions_1.getBulkContextMenuOptions)(this.#bulkInteractionProviderClassName, objectIds);
+            this.#state.setBulkInteractionContextMenuOptions(template);
         }
         #checkEmptyList() {
             if (this.#viewElement.querySelectorAll(".listView__item").length > 0) {

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Component/Quote/Storage.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Component/Quote/Storage.js
@@ -39,11 +39,7 @@ define(["require", "exports", "tslib", "WoltLabSuite/Core/Core", "WoltLabSuite/C
             quote = result.renderedQuote;
         }
         else {
-            const result = await (0, RenderQuote_1.renderQuote)(objectType, objectId, false);
-            if (!result.ok) {
-                throw new Error("Error fetching quote data");
-            }
-            quote = result.value;
+            quote = await (0, RenderQuote_1.renderQuote)(objectType, objectId, false);
         }
         const uuid = storeQuote(objectType, quote, {
             message,
@@ -65,11 +61,7 @@ define(["require", "exports", "tslib", "WoltLabSuite/Core/Core", "WoltLabSuite/C
             message = result.renderedQuote;
         }
         else {
-            const result = await (0, RenderQuote_1.renderQuote)(objectType, objectId, true);
-            if (!result.ok) {
-                throw new Error("Error fetching quote data");
-            }
-            message = result.value;
+            message = await (0, RenderQuote_1.renderQuote)(objectType, objectId, true);
         }
         const uuid = storeQuote(objectType, message, message);
         (0, List_1.refreshQuoteLists)();

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Controller/Moderation/Activation.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Controller/Moderation/Activation.js
@@ -16,23 +16,19 @@ define(["require", "exports", "WoltLabSuite/Core/Api/ModerationQueues/DeleteCont
             .custom((0, Language_1.getPhrase)("wcf.moderation.activation.enableContent.confirmMessage"))
             .withoutMessage();
         if (result) {
-            const response = await (0, EnableContent_1.enableContent)(queueId);
-            if (response.ok) {
-                (0, Snackbar_1.showDefaultSuccessSnackbar)().addEventListener("snackbar:close", () => {
-                    window.location.href = redirectUrl;
-                });
-            }
+            await (0, EnableContent_1.enableContent)(queueId);
+            (0, Snackbar_1.showDefaultSuccessSnackbar)().addEventListener("snackbar:close", () => {
+                window.location.href = redirectUrl;
+            });
         }
     }
     async function handleRemoveContent(queueId, objectName, redirectUrl) {
         const { result, reason } = await (0, Confirmation_1.confirmationFactory)().softDelete(objectName, true);
         if (result) {
-            const response = await (0, DeleteContent_1.deleteContent)(queueId, reason);
-            if (response.ok) {
-                (0, Snackbar_1.showDefaultSuccessSnackbar)().addEventListener("snackbar:close", () => {
-                    window.location.href = redirectUrl;
-                });
-            }
+            await (0, DeleteContent_1.deleteContent)(queueId, reason);
+            (0, Snackbar_1.showDefaultSuccessSnackbar)().addEventListener("snackbar:close", () => {
+                window.location.href = redirectUrl;
+            });
         }
     }
     function setup(enableContentButton, removeContentButton) {

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Controller/Moderation/Report.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Controller/Moderation/Report.js
@@ -14,12 +14,10 @@ define(["require", "exports", "WoltLabSuite/Core/Api/ModerationQueues/ChangeJust
     async function handleRemoveContent(queueId, objectName, redirectUrl) {
         const { result, reason } = await (0, Confirmation_1.confirmationFactory)().softDelete(objectName, true);
         if (result) {
-            const response = await (0, DeleteContent_1.deleteContent)(queueId, reason);
-            if (response.ok) {
-                (0, Snackbar_1.showDefaultSuccessSnackbar)().addEventListener("snackbar:close", () => {
-                    window.location.href = redirectUrl;
-                });
-            }
+            await (0, DeleteContent_1.deleteContent)(queueId, reason);
+            (0, Snackbar_1.showDefaultSuccessSnackbar)().addEventListener("snackbar:close", () => {
+                window.location.href = redirectUrl;
+            });
         }
     }
     async function handleCloseReport(queueId, redirectUrl) {
@@ -33,12 +31,10 @@ define(["require", "exports", "WoltLabSuite/Core/Api/ModerationQueues/ChangeJust
             label.append(input, " ", (0, Language_1.getPhrase)("wcf.moderation.report.removeReport.markAsJustified"));
         });
         if (result) {
-            const response = await (0, CloseReport_1.closeReport)(queueId, dialog.content.querySelector("input").checked);
-            if (response.ok) {
-                (0, Snackbar_1.showDefaultSuccessSnackbar)().addEventListener("snackbar:close", () => {
-                    window.location.href = redirectUrl;
-                });
-            }
+            await (0, CloseReport_1.closeReport)(queueId, dialog.content.querySelector("input").checked);
+            (0, Snackbar_1.showDefaultSuccessSnackbar)().addEventListener("snackbar:close", () => {
+                window.location.href = redirectUrl;
+            });
         }
     }
     async function handleChangeJustifiedStatus(queueId, justified, redirectUrl) {
@@ -53,12 +49,10 @@ define(["require", "exports", "WoltLabSuite/Core/Api/ModerationQueues/ChangeJust
             label.append(input, " ", (0, Language_1.getPhrase)("wcf.moderation.report.changeJustifiedStatus.markAsJustified"));
         });
         if (result) {
-            const response = await (0, ChangeJustifiedStatus_1.changeJustifiedStatus)(queueId, dialog.content.querySelector("input").checked);
-            if (response.ok) {
-                (0, Snackbar_1.showDefaultSuccessSnackbar)().addEventListener("snackbar:close", () => {
-                    window.location.href = redirectUrl;
-                });
-            }
+            await (0, ChangeJustifiedStatus_1.changeJustifiedStatus)(queueId, dialog.content.querySelector("input").checked);
+            (0, Snackbar_1.showDefaultSuccessSnackbar)().addEventListener("snackbar:close", () => {
+                window.location.href = redirectUrl;
+            });
         }
     }
     function setup(removeContentButton, closeReportButton, changeJustifiedStatusButton) {

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/User/Session/Delete.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/User/Session/Delete.js
@@ -16,7 +16,7 @@ define(["require", "exports", "tslib", "../../Confirmation", "../../../Language"
         UiConfirmation.show({
             message: Language.get("wcf.user.security.deleteSession.confirmMessage"),
             confirm: async (_parameters) => {
-                (await (0, DeleteSession_1.deleteSession)(button.dataset.sessionId)).unwrap();
+                await (0, DeleteSession_1.deleteSession)(button.dataset.sessionId);
                 button.closest("li")?.remove();
                 (0, Snackbar_1.showDefaultSuccessSnackbar)();
             },


### PR DESCRIPTION
A lot of RPC endpoints have turned out to be infallible, which means that they do not return an error under normal circumstances. Any error is the result of either an unexpected server error or a bug in the client code that makes the call thus all instances where such a request fails it should fail hard and loud.

This PR introduces a new alert dialog that is raised whenever such an unexpected error case is hit. This is strictly meant to be a fall-back case and should not be relied on as an expected behavior.

Example of the code before and after:

https://github.com/WoltLab/WCF/blob/3245fcd4e56050be89cc279d2a06b48637c37df4/ts/WoltLabSuite/Core/Api/ModerationQueues/CloseReport.ts#L14-L26

After the PR:

https://github.com/WoltLab/WCF/blob/dccb5956dd5ee37c11adc452b2fbee25e1afaca0/ts/WoltLabSuite/Core/Api/ModerationQueues/CloseReport.ts#L14-L22