### PR TITLE
Add traits for typical dbo collection methods

### DIFF
--- a/wcfsetup/install/files/lib/data/TCollectionEmbeddedObjects.class.php
+++ b/wcfsetup/install/files/lib/data/TCollectionEmbeddedObjects.class.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace wcf\data;
+
+use wcf\system\message\embedded\object\MessageEmbeddedObjectManager;
+
+/**
+ * Trait for dbo collections with message embedded objects.
+ *
+ * @author      Marcel Werk
+ * @copyright   2001-2025 WoltLab GmbH
+ * @license     GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @since       6.2
+ */
+trait TCollectionEmbeddedObjects
+{
+    private bool $embeddedObjectsLoaded = false;
+
+    public function loadEmbeddedObjects(string $messageObjectType): void
+    {
+        if ($this->embeddedObjectsLoaded) {
+            return;
+        }
+
+        $this->embeddedObjectsLoaded = true;
+
+        $objectIDs = $this->getEmbeddedObjectIDs();
+        if ($objectIDs === []) {
+            return;
+        }
+
+        MessageEmbeddedObjectManager::getInstance()->loadObjects(
+            $messageObjectType,
+            $objectIDs
+        );
+    }
+
+    /**
+     * @return int[]
+     */
+    private function getEmbeddedObjectIDs(): array
+    {
+        \assert($this instanceof DatabaseObjectCollection);
+
+        return \array_map(
+            static fn($object) => $object->getObjectID(),
+            \array_filter($this->getObjects(), fn($object) => $object->hasEmbeddedObjects === 1)
+        );
+    }
+}

--- a/wcfsetup/install/files/lib/data/TCollectionUserProfiles.class.php
+++ b/wcfsetup/install/files/lib/data/TCollectionUserProfiles.class.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace wcf\data;
+
+use wcf\data\user\UserProfile;
+use wcf\system\cache\runtime\UserProfileRuntimeCache;
+
+/**
+ * Trait for dbo collections with user profiles.
+ *
+ * @author      Marcel Werk
+ * @copyright   2001-2025 WoltLab GmbH
+ * @license     GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @since       6.2
+ */
+trait TCollectionUserProfiles
+{
+    private bool $userProfilesLoaded = false;
+
+    public function getUserProfile(
+        DatabaseObject $object,
+        string $userIdProperty = 'userID',
+        string $usernameProperty = 'username'
+    ): UserProfile {
+        $this->loadUserProfiles($userIdProperty);
+
+        if ($object->{$userIdProperty}) {
+            return UserProfileRuntimeCache::getInstance()->getObject($object->{$userIdProperty});
+        } else {
+            return UserProfile::getGuestUserProfile($object->{$usernameProperty});
+        }
+    }
+
+    private function loadUserProfiles(string $userIdProperty): void
+    {
+        if ($this->userProfilesLoaded) {
+            return;
+        }
+
+        \assert($this instanceof DatabaseObjectCollection);
+
+        $this->userProfilesLoaded = true;
+
+        $userIDs = [];
+        foreach ($this->getObjects() as $object) {
+            if ($object->{$userIdProperty}) {
+                $userIDs[] = $object->{$userIdProperty};
+            }
+        }
+
+        if ($userIDs !== []) {
+            UserProfileRuntimeCache::getInstance()->cacheObjectIDs($userIDs);
+        }
+    }
+}


### PR DESCRIPTION
Actually, the PHPDoc `@mixin DatabaseObjectCollection` is required here, but in the IDE this causes `getObjects()` to not be resolved correctly because the generic is unknown.