### PR TITLE
Smart URL Rewriting

### DIFF
--- a/wcfsetup/install/files/global.php
+++ b/wcfsetup/install/files/global.php
@@ -10,11 +10,16 @@
 require_once(__DIR__ . '/app.config.inc.php');
 
 // Make the frontend inaccessible until WCFSetup completes.
+/*
+
+TODO: This is currently not possible, find a solution!
+
 if (!PACKAGE_ID) {
     \http_response_code(500);
 
     exit;
 }
+*/
 
 // initiate wcf core
 require_once(WCF_DIR . 'lib/system/WCF.class.php');

--- a/wcfsetup/install/files/lib/data/package/Package.class.php
+++ b/wcfsetup/install/files/lib/data/package/Package.class.php
@@ -447,9 +447,9 @@ class Package extends DatabaseObject implements ILinkableObject, IRouteControlle
         $content = "<?php\n";
         $content .= "// {$package->package} (packageID {$packageID})\n";
         $content .= "if (!defined('{$prefix}_DIR')) define('{$prefix}_DIR', __DIR__.'/');\n";
-        $content .= "if (!defined('PACKAGE_ID')) define('PACKAGE_ID', {$packageID});\n";
 
         if ($packageID != 1) {
+            $content .= "if (!defined('PACKAGE_ID')) define('PACKAGE_ID', {$packageID});\n";
             $content .= "\n";
             $content .= "// helper constants for applications\n";
             $content .= "if (!defined('RELATIVE_{$prefix}_DIR')) define('RELATIVE_{$prefix}_DIR', '');\n";

--- a/wcfsetup/install/files/lib/system/WCF.class.php
+++ b/wcfsetup/install/files/lib/system/WCF.class.php
@@ -495,7 +495,22 @@ class WCF
             $prefix = \mb_substr($app->domainPath, \mb_strlen($rootApp->domainPath));
             RouteHandler::ltrimPathInfo($prefix);
         } else {
-            \wcfDebug(RouteHandler::getPath(), $pathInfo);
+            // The path info is relative to the root app, therefore we need to
+            // resolve the invoked app by examining the start of it.
+            $lengthOfRootPath = \mb_strlen($rootApp->domainPath);
+            foreach ($sortedPaths as $packageID => $pathname) {
+                $pathname = \mb_substr($pathname, $lengthOfRootPath);
+                if (\str_starts_with($pathInfo, $pathname)) {
+                    $candidate = $packageID;
+
+                    // Trim the path info to strip the invoekd app from it.
+                    RouteHandler::ltrimPathInfo($pathname);
+
+                    break;
+                }
+            }
+
+            \assert($candidate !== null);
         }
 
         if ($candidate === null) {

--- a/wcfsetup/install/files/lib/system/WCF.class.php
+++ b/wcfsetup/install/files/lib/system/WCF.class.php
@@ -24,6 +24,7 @@ use wcf\system\package\PackageInstallationDispatcher;
 use wcf\system\registry\RegistryHandler;
 use wcf\system\request\Request;
 use wcf\system\request\RequestHandler;
+use wcf\system\request\RouteHandler;
 use wcf\system\session\SessionFactory;
 use wcf\system\session\SessionHandler;
 use wcf\system\style\StyleHandler;
@@ -194,6 +195,7 @@ class WCF
         // start initialization
         $this->initDB();
         $this->loadOptions();
+        $this->resolveActiveApplication();
         $this->initSession();
         $this->initLanguage();
         $this->initTPL();
@@ -418,7 +420,7 @@ class WCF
         require($filename);
 
         // check if option file is complete and writable
-        if (PACKAGE_ID) {
+        if (!\defined('\\PACKAGE_ID')) {
             if (!\is_writable($filename)) {
                 FileUtil::makeWritable($filename);
 
@@ -447,6 +449,66 @@ class WCF
                 \spl_autoload_unregister([self::class, 'autoload']);
                 \spl_autoload_register([self::class, 'autoloadDebug'], true, true);
             }
+        }
+    }
+
+    protected function resolveActiveApplication(): void
+    {
+        if (\defined('PACKAGE_ID')) {
+            return;
+        }
+
+        $applications = ApplicationHandler::getInstance()->getApplications();
+        if (!\URL_OMIT_INDEX_PHP || \count($applications) === 1) {
+            \define('PACKAGE_ID', 1);
+            return;
+        }
+
+        // We do not support smart rewrites for setups where apps are installed
+        // in different directory where the only shared ancestor is not an app.
+        $rootApp = ApplicationHandler::getInstance()->getRootApplication();
+        if ($rootApp === null) {
+            \define('PACKAGE_ID', 1);
+            return;
+        }
+
+        $sortedPaths = ApplicationHandler::getInstance()->getSortedPaths();
+
+        // When the core is the root app we can simply check the path info for
+        // any apps appearing at the start of it.
+        $coreIsAtRoot = ($rootApp === ApplicationHandler::getInstance()->getWCF());
+
+        /** @var ?int */
+        $candidate = null;
+        $pathInfo = RouteHandler::getPathInfo();
+        if ($coreIsAtRoot) {
+            foreach ($sortedPaths as $packageID => $pathname) {
+                if (\str_starts_with($pathInfo, \mb_substr($pathname, \mb_strlen($rootApp->domainPath)))) {
+                    $candidate = $packageID;
+                    break;
+                }
+            }
+
+            \assert($candidate !== null);
+
+            $app = ApplicationHandler::getInstance()->getApplicationByID($candidate);
+            $prefix = \mb_substr($app->domainPath, \mb_strlen($rootApp->domainPath));
+            RouteHandler::ltrimPathInfo($prefix);
+        } else {
+            \wcfDebug(RouteHandler::getPath(), $pathInfo);
+        }
+
+        if ($candidate === null) {
+            \define('PACKAGE_ID', 1);
+        } else {
+            $application = ApplicationHandler::getInstance()->getApplicationByID($candidate);
+            \assert($application !== null);
+
+            \define('PACKAGE_ID', $candidate);
+
+            // Include the `app.config.inc.php` of the primary app.
+            $pathname = FileUtil::addTrailingSlash(FileUtil::getRealPath(\WCF_DIR . $application->getPackage()->packageDir)) . 'app.config.inc.php';
+            require_once $pathname;
         }
     }
 

--- a/wcfsetup/install/files/lib/system/WCFACP.class.php
+++ b/wcfsetup/install/files/lib/system/WCFACP.class.php
@@ -47,6 +47,7 @@ class WCFACP extends WCF
         // start initialization
         $this->initDB();
         $this->loadOptions();
+        $this->resolveActiveApplication();
         $this->initSession();
         $this->initLanguage();
         $this->initTPL();

--- a/wcfsetup/install/files/lib/system/application/ApplicationHandler.class.php
+++ b/wcfsetup/install/files/lib/system/application/ApplicationHandler.class.php
@@ -26,16 +26,20 @@ use wcf\util\Url;
 final class ApplicationHandler extends SingletonFactory
 {
     /**
-     * application cache
-     * @var mixed[][]
+     * @var array{
+     *  abbreviation: array<string, int>,
+     *  application: array<int, Application>,
+     *  sortedPaths: array<int, string>,
+     *  rootApplication: ?int,
+     * }
      */
-    protected $cache;
+    private array $cache;
 
     /**
      * list of page URLs
      * @var string[]
      */
-    protected array $pageURLs = [];
+    private array $pageURLs;
 
     /**
      * Initializes cache.
@@ -185,7 +189,7 @@ final class ApplicationHandler extends SingletonFactory
      */
     public function isInternalURL(string $url): bool
     {
-        if (empty($this->pageURLs)) {
+        if (!isset($this->pageURLs)) {
             $internalHostnames = ArrayUtil::trim(\explode("\n", StringUtil::unifyNewlines(\INTERNAL_HOSTNAMES)));
 
             $this->pageURLs = \array_unique([
@@ -219,9 +223,7 @@ final class ApplicationHandler extends SingletonFactory
      * @since 5.2
      * @deprecated 5.5 - This function is a noop. The 'active' status is determined live.
      */
-    public function rebuildActiveApplication(): void
-    {
-    }
+    public function rebuildActiveApplication(): void {}
 
     /**
      * @since 6.0
@@ -229,6 +231,37 @@ final class ApplicationHandler extends SingletonFactory
     public function getDomainName(): string
     {
         return $this->getApplicationByID(1)->domainName;
+    }
+
+    /**
+     * Returns a list of the domain paths of all apps sorted by their length
+     * with the longest value appearing first. The key of each path is the
+     * package id of the corresponding app.
+     *
+     * @return array<int, string>
+     * @since 6.2
+     */
+    public function getSortedPaths(): array
+    {
+        return $this->cache['sortedPaths'];
+    }
+
+    /**
+     * Returns the app that is the root of all other apps. This is the case when
+     * all other apps installed in a direct or indirect subdirectory.
+     *
+     * @since 6.2
+     */
+    public function getRootApplication(): ?Application
+    {
+        if ($this->cache['rootApplication'] === null) {
+            return null;
+        }
+
+        $rootApp = $this->getApplicationByID($this->cache['rootApplication']);
+        \assert($rootApp !== null);
+
+        return $rootApp;
     }
 
     /**
@@ -263,7 +296,7 @@ final class ApplicationHandler extends SingletonFactory
         }
 
         if ($skipCache) {
-            $sql = "SELECT package 
+            $sql = "SELECT package
                     FROM   wcf" . WCF_N . "_package
                     WHERE  isApplication = ?";
             $statement = WCF::getDB()->prepareUnmanaged($sql);

--- a/wcfsetup/install/files/lib/system/cache/builder/ApplicationCacheBuilder.class.php
+++ b/wcfsetup/install/files/lib/system/cache/builder/ApplicationCacheBuilder.class.php
@@ -9,20 +9,20 @@ use wcf\system\WCF;
 /**
  * Caches applications.
  *
- * @author  Alexander Ebert
- * @copyright   2001-2019 WoltLab GmbH
- * @license GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @author      Alexander Ebert
+ * @copyright   2001-2025 WoltLab GmbH
+ * @license     GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
  */
-class ApplicationCacheBuilder extends AbstractCacheBuilder
+final class ApplicationCacheBuilder extends AbstractCacheBuilder
 {
-    /**
-     * @inheritDoc
-     */
+    #[\Override]
     public function rebuild(array $parameters)
     {
         $data = [
             'abbreviation' => [],
             'application' => [],
+            'sortedPaths' => [],
+            'rootApplication' => null,
         ];
 
         // fetch applications
@@ -34,7 +34,11 @@ class ApplicationCacheBuilder extends AbstractCacheBuilder
 
         foreach ($applications as $application) {
             $data['application'][$application->packageID] = $application;
+            $data['sortedPaths'][$application->packageID] = $application->domainPath;
         }
+
+        \uasort($data['sortedPaths'], static fn($a, $b) => \mb_strlen($b) - \mb_strlen($a));
+        $data['rootApplication'] = $this->getRootApplication($data['sortedPaths']);
 
         // fetch abbreviations
         $sql = "SELECT packageID, package
@@ -48,5 +52,23 @@ class ApplicationCacheBuilder extends AbstractCacheBuilder
         }
 
         return $data;
+    }
+
+    /**
+     * @param array<int, string> $sortedPaths
+     * @since 6.2
+     */
+    private function getRootApplication(array $sortedPaths): ?int
+    {
+        $candidate = \array_key_last($sortedPaths);
+        $shortestPath = $sortedPaths[$candidate];
+
+        foreach ($sortedPaths as $path) {
+            if (!\str_starts_with($path, $shortestPath)) {
+                return null;
+            }
+        }
+
+        return $candidate;
     }
 }

--- a/wcfsetup/install/files/lib/system/request/RequestHandler.class.php
+++ b/wcfsetup/install/files/lib/system/request/RequestHandler.class.php
@@ -89,6 +89,15 @@ final class RequestHandler extends SingletonFactory
      */
     public function handle(string $application = 'wcf', bool $isACPRequest = false): void
     {
+        // Override the application when this request was the result of a smart
+        // rewrite.
+        if ($application === 'wcf' && \PACKAGE_ID > 1) {
+            $app = ApplicationHandler::getInstance()->getApplicationByID(\PACKAGE_ID);
+            \assert($app !== null);
+
+            $application = $app->getAbbreviation();
+        }
+
         try {
             $this->isACPRequest = $isACPRequest;
 

--- a/wcfsetup/install/files/lib/system/request/RouteHandler.class.php
+++ b/wcfsetup/install/files/lib/system/request/RouteHandler.class.php
@@ -384,4 +384,17 @@ final class RouteHandler extends SingletonFactory
 
         return self::$pathInfo;
     }
+
+    /**
+     * TODO: This is merely a helper to get this working for the time being.
+     *
+     * @since 6.2
+     */
+    public static function ltrimPathInfo(string $prefix): void
+    {
+        \assert(isset(self::$pathInfo));
+        \assert(\str_starts_with(self::$pathInfo, $prefix));
+
+        self::$pathInfo = \mb_substr(self::$pathInfo, \mb_strlen($prefix));
+    }
 }


### PR DESCRIPTION
URL rewriting is a feature that causes quite some friction because it requires exact rules that must be adjusted whenever apps are added or removed. This forces users more often than not to reach out for help because their newly installed app is dysfunctional when the real reason is that the rewrite rules are simply outdated. Even tricks like predefining a set typical values falls short when custom directory names are being used.

# Smart URL Rewriting

We can solve this issue by directing all rewritten requests to the core and take care of the application mapping ourselves. This requires that all apps are a direct or indirect child of a single app (“single root”) which allows us to require only a single rewrite rule while simultaneously avoiding any conflicts with other content on the same website.

## Core at Root

Setup:

- Core installed at `/`.
- Forum installed at `/forum/`.

```nginx
rewrite ^/([^.]*)$ /index.php?$1;
```

| Request for | `getPath()` | `getPathInfo()` |
|---|---|---|
| `/members-list/` | `/` | `members-list/` |
| `/forum/board/2-default-forum/` | `/` | `forum/board/2-default-forum/` |

## Core in a Subdirectory

Setup:

- Forum installed at `/`.
- Core installed at `/core/`.

```nginx
rewrite ^/([^.]*)$ /core/index.php?$1;
```

| Request for | `getPath()` | `getPathInfo()` |
|---|---|---|
| `/core/members-list/` | `/core/` | `core/members-list/` |
| `/board/2-default-forum/` | `/core/` | `board/2-default-forum/` |