### PR TITLE
Overhaul sorting of label groups in the admin panel

### DIFF
--- a/wcfsetup/install/files/lib/acp/form/LabelAddForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/LabelAddForm.class.php
@@ -54,9 +54,8 @@ class LabelAddForm extends AbstractFormBuilderForm
     {
         parent::createForm();
 
-        $labelGroupList = new LabelGroupList();
-        $labelGroupList->readObjects();
-        if ($labelGroupList->count() === 0) {
+        $labelGroups = $this->getAvailableLabelGroups();
+        if ($labelGroups === []) {
             throw new NamedUserException(
                 HtmlString::fromSafeHtml(WCF::getLanguage()->getDynamicVariable('wcf.acp.label.error.noGroups'))
             );
@@ -67,7 +66,7 @@ class LabelAddForm extends AbstractFormBuilderForm
                 ->appendChildren([
                     SelectFormField::create('groupID')
                         ->label('wcf.acp.label.group')
-                        ->options($labelGroupList)
+                        ->options($labelGroups, labelLanguageItems: false)
                         ->immutable($this->formAction !== 'create')
                         ->description('wcf.acp.label.group.permanentSelection')
                         ->required(),
@@ -82,6 +81,24 @@ class LabelAddForm extends AbstractFormBuilderForm
                         ->textReferenceNodeId('label')
                 ])
         ]);
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    protected function getAvailableLabelGroups(): array
+    {
+        $labelGroupList = new LabelGroupList();
+        $labelGroupList->readObjects();
+        $labelGroups = \array_map(static fn($group) => $group->getExtendedTitle(), $labelGroupList->getObjects());
+
+        $collator = new \Collator(WCF::getLanguage()->getLocale());
+        \uasort(
+            $labelGroups,
+            static fn(string $groupA, string $groupB) => $collator->compare($groupA, $groupB)
+        );
+
+        return $labelGroups;
     }
 
     protected function getShowOrderField(): IFormField

--- a/wcfsetup/install/files/lib/data/label/group/LabelGroup.class.php
+++ b/wcfsetup/install/files/lib/data/label/group/LabelGroup.class.php
@@ -38,6 +38,24 @@ class LabelGroup extends DatabaseObject implements IRouteController
     }
 
     /**
+     * Returns the title and, if available, the description as a combined string.
+     *
+     * @since 6.2
+     */
+    public function getExtendedTitle(): string
+    {
+        if (!$this->groupDescription) {
+            return $this->getTitle();
+        }
+
+        return \sprintf(
+            "%s / %s",
+            $this->getTitle(),
+            $this->groupDescription
+        );
+    }
+
+    /**
      * Callback for uasort() to sort label groups by show order and (if equal) group id.
      *
      * @param LabelGroup $groupA

--- a/wcfsetup/install/files/lib/system/gridView/admin/LabelGridView.class.php
+++ b/wcfsetup/install/files/lib/system/gridView/admin/LabelGridView.class.php
@@ -4,6 +4,7 @@ namespace wcf\system\gridView\admin;
 
 use wcf\acp\form\LabelEditForm;
 use wcf\data\DatabaseObject;
+use wcf\data\label\group\LabelGroupList;
 use wcf\data\label\group\ViewableLabelGroup;
 use wcf\data\label\I18nLabelList;
 use wcf\data\label\Label;
@@ -77,25 +78,16 @@ final class LabelGridView extends AbstractGridView
                             $group = $groups[$row->groupID];
                             \assert($group instanceof ViewableLabelGroup);
 
-                            if (empty($group->groupDescription)) {
-                                return StringUtil::encodeHTML($group->getTitle());
-                            }
-                            return \sprintf(
-                                "%s / %s",
-                                StringUtil::encodeHTML($group->getTitle()),
-                                StringUtil::encodeHTML($group->groupDescription)
-                            );
+                            return StringUtil::encodeHTML($group->getExtendedTitle());
                         }
                     }
                 )
                 ->filter(
                     new SelectFilter(
-                        \array_map(
-                            static fn(ViewableLabelGroup $group) => $group->getTitle(),
-                            LabelCacheBuilder::getInstance()->getData(arrayIndex: "groups"),
-                        ),
+                        $this->getAvailableLabelGroups(),
                         'groupID',
-                        'wcf.acp.label.group'
+                        'wcf.acp.label.group',
+                        labelLanguageItems: false
                     )
                 )
                 ->sortable(),
@@ -134,5 +126,23 @@ final class LabelGridView extends AbstractGridView
     protected function getInitializedEvent(): LabelGridViewInitialized
     {
         return new LabelGridViewInitialized($this);
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    protected function getAvailableLabelGroups(): array
+    {
+        $labelGroupList = new LabelGroupList();
+        $labelGroupList->readObjects();
+        $labelGroups = \array_map(static fn($group) => $group->getExtendedTitle(), $labelGroupList->getObjects());
+
+        $collator = new \Collator(WCF::getLanguage()->getLocale());
+        \uasort(
+            $labelGroups,
+            static fn(string $groupA, string $groupB) => $collator->compare($groupA, $groupB)
+        );
+
+        return $labelGroups;
     }
 }


### PR DESCRIPTION
Previously, `showOrder` was used for sorting in the admin panel. However, `showOrder` was only intended for sorting in the frontend and could led to chaotic sorting in the admin panel when you have a larger number of label groups in your installation.

Instead, alphabetical sorting is now used consistently and the description is always displayed to make the label groups easier to distinguish.