### PR TITLE
Show a user-friendly error message when RPC interactions fail

### DIFF
--- a/ts/WoltLabSuite/Core/Api/Result.ts
+++ b/ts/WoltLabSuite/Core/Api/Result.ts
@@ -105,29 +105,36 @@ export async function fromInfallibleApiRequest<T = unknown>(request: () => Promi
 }
 
 function showErrorDialog(apiError: ApiError): void {
-  const code = escapeHTML(apiError.code);
-  const type = escapeHTML(apiError.type);
-  const message = apiError.message ? escapeHTML(apiError.message) : "(not set)";
-  const param = apiError.param ? "<kbd>" + escapeHTML(apiError.param) + "</kbd>" : "(not set)";
+  let html = "";
+  if ((!window.ENABLE_DEBUG_MODE && apiError.code === "permission_denied") || apiError.code === "assertion_failed") {
+    html = getPhrase(
+      apiError.code === "permission_denied" ? "wcf.ajax.error.permissionDenied" : "wcf.ajax.error.illegalLink",
+    );
+  } else {
+    const code = escapeHTML(apiError.code);
+    const type = escapeHTML(apiError.type);
+    const message = apiError.message ? escapeHTML(apiError.message) : "(not set)";
+    const param = apiError.param ? "<kbd>" + escapeHTML(apiError.param) + "</kbd>" : "(not set)";
 
-  const html = `
-    <dl>
-      <dt>Unexpected server error</dt>
-      <dd><kbd>${type}</kbd></dd>
-    </dl>
-    <dl>
-      <dt>Error code</dt>
-      <dd><kbd>${code}</kbd></dd>
-    </dl>
-    <dl>
-      <dt>Parameter</dt>
-      <dd>${param}</dd>
-    </dl>
-    <dl>
-      <dt>Message</dt>
-      <dd>${message}</dd>
-    </dl>
-  `;
+    html = `
+      <dl>
+        <dt>Unexpected server error</dt>
+        <dd><kbd>${type}</kbd></dd>
+      </dl>
+      <dl>
+        <dt>Error code</dt>
+        <dd><kbd>${code}</kbd></dd>
+      </dl>
+      <dl>
+        <dt>Parameter</dt>
+        <dd>${param}</dd>
+      </dl>
+      <dl>
+        <dt>Message</dt>
+        <dd>${message}</dd>
+      </dl>
+    `;
+  }
 
   const dialog = dialogFactory().fromHtml(html).asAlert();
   dialog.show(getPhrase("wcf.global.error.title"));

--- a/ts/WoltLabSuite/Core/Component/Interaction/Rpc.ts
+++ b/ts/WoltLabSuite/Core/Component/Interaction/Rpc.ts
@@ -32,18 +32,11 @@ async function handleRpcInteraction(
   }
 
   if (confirmationType == ConfirmationType.Delete) {
-    const result = await deleteObject(endpoint);
-    if (!result.ok) {
-      return;
-    }
+    (await deleteObject(endpoint)).unwrap();
   } else {
-    const result = await postObject(
-      endpoint,
-      confirmationResult.reason ? { reason: confirmationResult.reason } : undefined,
-    );
-    if (!result.ok) {
-      return;
-    }
+    (
+      await postObject(endpoint, confirmationResult.reason ? { reason: confirmationResult.reason } : undefined)
+    ).unwrap();
   }
 
   if (interactionEffect === InteractionEffect.ReloadItem || interactionEffect === InteractionEffect.ReloadPage) {

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Api/Result.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Api/Result.js
@@ -80,28 +80,34 @@ define(["require", "exports", "../Ajax/Error", "../Component/Dialog", "../Core",
         }
     }
     function showErrorDialog(apiError) {
-        const code = (0, StringUtil_1.escapeHTML)(apiError.code);
-        const type = (0, StringUtil_1.escapeHTML)(apiError.type);
-        const message = apiError.message ? (0, StringUtil_1.escapeHTML)(apiError.message) : "(not set)";
-        const param = apiError.param ? "<kbd>" + (0, StringUtil_1.escapeHTML)(apiError.param) + "</kbd>" : "(not set)";
-        const html = `
-    <dl>
-      <dt>Unexpected server error</dt>
-      <dd><kbd>${type}</kbd></dd>
-    </dl>
-    <dl>
-      <dt>Error code</dt>
-      <dd><kbd>${code}</kbd></dd>
-    </dl>
-    <dl>
-      <dt>Parameter</dt>
-      <dd>${param}</dd>
-    </dl>
-    <dl>
-      <dt>Message</dt>
-      <dd>${message}</dd>
-    </dl>
-  `;
+        let html = "";
+        if ((!window.ENABLE_DEBUG_MODE && apiError.code === "permission_denied") || apiError.code === "assertion_failed") {
+            html = (0, Language_1.getPhrase)(apiError.code === "permission_denied" ? "wcf.ajax.error.permissionDenied" : "wcf.ajax.error.illegalLink");
+        }
+        else {
+            const code = (0, StringUtil_1.escapeHTML)(apiError.code);
+            const type = (0, StringUtil_1.escapeHTML)(apiError.type);
+            const message = apiError.message ? (0, StringUtil_1.escapeHTML)(apiError.message) : "(not set)";
+            const param = apiError.param ? "<kbd>" + (0, StringUtil_1.escapeHTML)(apiError.param) + "</kbd>" : "(not set)";
+            html = `
+      <dl>
+        <dt>Unexpected server error</dt>
+        <dd><kbd>${type}</kbd></dd>
+      </dl>
+      <dl>
+        <dt>Error code</dt>
+        <dd><kbd>${code}</kbd></dd>
+      </dl>
+      <dl>
+        <dt>Parameter</dt>
+        <dd>${param}</dd>
+      </dl>
+      <dl>
+        <dt>Message</dt>
+        <dd>${message}</dd>
+      </dl>
+    `;
+        }
         const dialog = (0, Dialog_1.dialogFactory)().fromHtml(html).asAlert();
         dialog.show((0, Language_1.getPhrase)("wcf.global.error.title"));
     }

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Component/Interaction/Rpc.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Component/Interaction/Rpc.js
@@ -16,16 +16,10 @@ define(["require", "exports", "WoltLabSuite/Core/Api/DeleteObject", "WoltLabSuit
             return;
         }
         if (confirmationType == Confirmation_1.ConfirmationType.Delete) {
-            const result = await (0, DeleteObject_1.deleteObject)(endpoint);
-            if (!result.ok) {
-                return;
-            }
+            (await (0, DeleteObject_1.deleteObject)(endpoint)).unwrap();
         }
         else {
-            const result = await (0, PostObject_1.postObject)(endpoint, confirmationResult.reason ? { reason: confirmationResult.reason } : undefined);
-            if (!result.ok) {
-                return;
-            }
+            (await (0, PostObject_1.postObject)(endpoint, confirmationResult.reason ? { reason: confirmationResult.reason } : undefined)).unwrap();
         }
         if (interactionEffect === InteractionEffect_1.InteractionEffect.ReloadItem || interactionEffect === InteractionEffect_1.InteractionEffect.ReloadPage) {
             element.dispatchEvent(new CustomEvent("interaction:invalidate", {

--- a/wcfsetup/install/files/lib/system/event/listener/PreloadPhrasesCollectingListener.class.php
+++ b/wcfsetup/install/files/lib/system/event/listener/PreloadPhrasesCollectingListener.class.php
@@ -16,6 +16,9 @@ final class PreloadPhrasesCollectingListener
 {
     public function __invoke(PreloadPhrasesCollecting $event): void
     {
+        $event->preload('wcf.ajax.error.illegalLink');
+        $event->preload('wcf.ajax.error.permissionDenied');
+
         $event->preload('wcf.button.delete.confirmMessage');
 
         $event->preload('wcf.clipboard.item.mark');


### PR DESCRIPTION
ref https://www.woltlab.com/community/thread/314577-gridview-interaction-wirft-keine-exception/