### PR TITLE
Make properties public in Grid View Page

### DIFF
--- a/wcfsetup/install/files/lib/page/AbstractGridViewPage.class.php
+++ b/wcfsetup/install/files/lib/page/AbstractGridViewPage.class.php
@@ -24,9 +24,9 @@ abstract class AbstractGridViewPage extends AbstractPage
      * @var TGridView
      */
     protected AbstractGridView $gridView;
-    protected int $pageNo = 1;
-    protected string $sortField = '';
-    protected string $sortOrder = '';
+    public int $pageNo = 1;
+    public string $sortField = '';
+    public string $sortOrder = '';
 
     /**
      * @var mixed[]


### PR DESCRIPTION
Properties such as **`pageNo`**, **`sortField`**, and **`sortOrder`** are available in **`MultipleLinkPage`**, but they are not exposed in the new **`AbstractGridViewPage`** implementation. There’s no clear justification for limiting access to these attributes.

As a developer, I may need direct access to these properties, for example, to persist user preferences, implement custom pagination or sorting behavior, or synchronize state between the frontend and backend. Therefore, it would be beneficial to make these properties accessible (e.g., through protected or public getters), ensuring greater flexibility and consistency with the previous implementation.