### PR TITLE
Show absolute path to WSC installation in path selection overlay on `DevtoolsProjectListPage`

### DIFF
--- a/wcfsetup/install/files/acp/templates/devtoolsProjectList.tpl
+++ b/wcfsetup/install/files/acp/templates/devtoolsProjectList.tpl
@@ -95,7 +95,7 @@
 	<dl>
 		<dt>{lang}wcf.acp.devtools.project.quickSetup.path{/lang}</dt>
 		<dd>
-			<input type="text" name="projectQuickSetupPath" id="projectQuickSetupPath" class="long" />
+			<input type="text" name="projectQuickSetupPath" id="projectQuickSetupPath" class="long" placeholder="{unsafe:$wcfDir}" />
 			<small>{lang}wcf.acp.devtools.project.quickSetup.path.description{/lang}</small>
 		</dd>
 	</dl>

--- a/wcfsetup/install/files/lib/acp/page/DevtoolsProjectListPage.class.php
+++ b/wcfsetup/install/files/lib/acp/page/DevtoolsProjectListPage.class.php
@@ -4,6 +4,7 @@ namespace wcf\acp\page;
 
 use wcf\data\devtools\project\DevtoolsProjectList;
 use wcf\page\SortablePage;
+use wcf\system\WCF;
 
 /**
  * Shows a list of devtools projects.
@@ -51,4 +52,13 @@ class DevtoolsProjectListPage extends SortablePage
      * @inheritDoc
      */
     public $validSortFields = ['projectID', 'name', 'path'];
+    
+    #[\Override]
+    public function assignVariables() {
+	parent::assignVariables();
+		
+	WCF::getTPL()->assign([
+		'wcfDir' => WCF_DIR,
+	]);
+    }
 }

--- a/wcfsetup/install/files/lib/acp/page/DevtoolsProjectListPage.class.php
+++ b/wcfsetup/install/files/lib/acp/page/DevtoolsProjectListPage.class.php
@@ -52,13 +52,14 @@ class DevtoolsProjectListPage extends SortablePage
      * @inheritDoc
      */
     public $validSortFields = ['projectID', 'name', 'path'];
-    
+
     #[\Override]
-    public function assignVariables() {
-	parent::assignVariables();
-		
-	WCF::getTPL()->assign([
-		'wcfDir' => WCF_DIR,
-	]);
+    public function assignVariables()
+    {
+        parent::assignVariables();
+
+        WCF::getTPL()->assign([
+                'wcfDir' => WCF_DIR,
+        ]);
     }
 }


### PR DESCRIPTION
During the test of Suite 6.2 I've discovered, that the path selection overlay does not provide the absolute path to the Suite Core installation on the `DevtoolsProjectListPage`.

Because the path is shown on the `DevtoolsProjectAddForm` it makes sense to unify this behavior.

Note: The usage of `\WCF_DIR` directly in the template is disallowed. Therefore the page-class needs to assign this information through the template engine.