### PR TITLE
Unify events / CSS in user cards and user profile header

### DIFF
--- a/com.woltlab.wcf/templates/userCard.tpl
+++ b/com.woltlab.wcf/templates/userCard.tpl
@@ -40,18 +40,22 @@
 	</div>
 
 	<div class="userCard__content">
-		<h3 class="userCard__username">
-			<a href="{$user->getLink()}" class="userCard__link">{unsafe:$user->getFormattedUsername()}</a>
+		<div class="userCard__headline">
+			<h3 class="userCard__username">
+				<a href="{$user->getLink()}" class="userCard__link">{unsafe:$user->getFormattedUsername()}</a>
+			</h3>
 			
-			{if $user->banned}
-				<span class="jsTooltip jsUserBanned" title="{lang}wcf.user.banned{/lang}">
-					{icon name='lock'}
-				</span>
-			{/if}
+			<div class="userCard__statusIcons">
+				{if $user->banned}
+					<span class="jsTooltip jsUserBanned" role="status" title="{lang}wcf.user.banned{/lang}">
+						{icon name='lock'}
+					</span>
+				{/if}
 
-			{event name='icons'}
-		</h3>
-
+				{event name='icons'}
+			</div>
+		</div>
+		
 		{event name='afterUsername'}
 
 		{if MODULE_USER_RANK}

--- a/com.woltlab.wcf/templates/userProfileHeader.tpl
+++ b/com.woltlab.wcf/templates/userProfileHeader.tpl
@@ -65,14 +65,24 @@
 			</div>
 		</div>
 		<div class="userProfileHeader__title">
-			<h1 class="userProfileHeader__username">
-				<span class="userProfileUsername">{$view->user->username}</span>
-				{if $view->user->banned}
-					<span class="jsTooltip jsUserBanned" title="{lang}wcf.user.banned{/lang}">
-						{icon name='lock'}
-					</span>
-				{/if}
-			</h1>
+			<div class="userProfileHeader__headline">
+				<h1 class="userProfileHeader__username">
+					<span class="userProfileUsername">{$view->user->username}</span>
+				</h1>
+
+				<div class="userProfileHeader__statusIcons">
+					{if $view->user->banned}
+						<span class="jsTooltip jsUserBanned" role="status" title="{lang}wcf.user.banned{/lang}">
+							{icon name='lock'}
+						</span>
+					{/if}
+
+					{event name='icons'}
+				</div>
+			</div>
+			
+			{event name='afterUsername'}
+
 			<div class="userProfileHeader__rank">
 				{if MODULE_USER_RANK}
 					{if $view->user->getUserTitle()}
@@ -83,7 +93,7 @@
 					{/if}
 				{/if}
 			</div>
-			{event name='afterTitle'}
+			{event name='afterUserTitle'}
 		</div>
 		<div class="userProfileHeader__stats">
 			{foreach from=$view->getStatItems() item='statItem'}

--- a/wcfsetup/install/files/style/ui/userCard.scss
+++ b/wcfsetup/install/files/style/ui/userCard.scss
@@ -126,6 +126,8 @@
 }
 
 .userCard__username {
+	display: inline;
+
 	@include wcfFontHeadline;
 	@include wcfFontBold;
 }
@@ -143,6 +145,12 @@
 	&:focus {
 		color: inherit;
 	}
+}
+
+.userCard__statusIcons {
+	display: inline;
+	position: relative;
+	z-index: 1;
 }
 
 .userCard__footer__stats {

--- a/wcfsetup/install/files/style/ui/userProfileHeader.scss
+++ b/wcfsetup/install/files/style/ui/userProfileHeader.scss
@@ -100,6 +100,7 @@ body[data-page-identifier="com.woltlab.wcf.User"] .userProfileContent:first-chil
 }
 
 .userProfileHeader__username {
+	display: inline;
 	font-size: var(--wcfFontSizeTitle);
 	font-weight: 600;
 	line-height: 1.05;
@@ -107,6 +108,12 @@ body[data-page-identifier="com.woltlab.wcf.User"] .userProfileContent:first-chil
 	@include screen-sm-down {
 		font-size: var(--wcfFontSizeHeadline);
 	}
+}
+
+.userProfileHeader__statusIcons {
+	display: inline;
+	position: relative;
+	z-index: 1;
 }
 
 .userProfileHeader__stats {


### PR DESCRIPTION
The status icons were also moved from the headline tags, as this was not accessible.

ref https://github.com/WoltLab/WCF/pull/6518