### PR TITLE
Ignore missing values for selections

### DIFF
--- a/wcfsetup/install/files/lib/system/form/builder/field/MultipleSelectionFormField.class.php
+++ b/wcfsetup/install/files/lib/system/form/builder/field/MultipleSelectionFormField.class.php
@@ -44,6 +44,11 @@ class MultipleSelectionFormField extends AbstractFormField implements
     protected $value = [];
 
     /**
+     * @since 6.2
+     */
+    private bool $ignoreInvalidValues = false;
+
+    /**
      * @inheritDoc
      */
     public function hasSaveValue()
@@ -130,13 +135,30 @@ class MultipleSelectionFormField extends AbstractFormField implements
             throw new InvalidFormFieldValue($this, 'array', \gettype($value));
         }
 
-        $unknownValues = \array_diff($value, \array_keys($this->getOptions()));
-        if (!empty($unknownValues)) {
-            throw new \InvalidArgumentException(
-                "Unknown values '" . \implode("', '", $unknownValues) . "' for field '{$this->getId()}'."
-            );
+        $validKeys = \array_keys($this->getOptions());
+        $unknownValues = \array_diff($value, $validKeys);
+        if ($unknownValues !== []) {
+            if ($this->ignoreInvalidValues) {
+                $value = \array_intersect($value, $validKeys);
+            } else {
+                throw new \InvalidArgumentException(
+                    "Unknown values '" . \implode("', '", $unknownValues) . "' for field '{$this->getId()}'."
+                );
+            }
         }
 
         return parent::value($value);
+    }
+
+    /**
+     * Ignores invalid values when reading them from data.
+     *
+     * @since 6.2
+     */
+    public function ignoreInvalidValues(bool $ignoreInvalidValues = true): self
+    {
+        $this->ignoreInvalidValues = $ignoreInvalidValues;
+
+        return $this;
     }
 }

--- a/wcfsetup/install/files/lib/system/form/builder/field/SelectFormField.class.php
+++ b/wcfsetup/install/files/lib/system/form/builder/field/SelectFormField.class.php
@@ -32,6 +32,11 @@ final class SelectFormField extends AbstractFormField implements
     protected $templateName = 'shared_selectFormField';
 
     /**
+     * @since 6.2
+     */
+    private bool $ignoreInvalidValues = false;
+
+    /**
      * @inheritDoc
      */
     public function readValue()
@@ -75,10 +80,26 @@ final class SelectFormField extends AbstractFormField implements
     {
         if ($value !== null && $value !== '') {
             if (!isset($this->getOptions()[$value])) {
-                throw new \InvalidArgumentException("Unknown value '{$value}' for field '{$this->getId()}'.");
+                if ($this->ignoreInvalidValues) {
+                    $value = null;
+                } else {
+                    throw new \InvalidArgumentException("Unknown value '{$value}' for field '{$this->getId()}'.");
+                }
             }
         }
 
         return parent::value($value);
+    }
+
+    /**
+     * Ignores invalid values when reading them from data.
+     *
+     * @since 6.2
+     */
+    public function ignoreInvalidValues(bool $ignoreInvalidValues = true): self
+    {
+        $this->ignoreInvalidValues = $ignoreInvalidValues;
+
+        return $this;
     }
 }

--- a/wcfsetup/install/files/lib/system/form/option/CheckboxesFormOption.class.php
+++ b/wcfsetup/install/files/lib/system/form/option/CheckboxesFormOption.class.php
@@ -30,7 +30,8 @@ class CheckboxesFormOption extends AbstractFormOption
     #[\Override]
     public function getFormField(string $id, array $configuration = []): AbstractFormField
     {
-        $formField = MultipleSelectionFormField::create($id);
+        $formField = MultipleSelectionFormField::create($id)
+            ->ignoreInvalidValues();
         $this->setSelectOptions($formField, $configuration);
 
         return $formField;

--- a/wcfsetup/install/files/lib/system/form/option/SelectFormOption.class.php
+++ b/wcfsetup/install/files/lib/system/form/option/SelectFormOption.class.php
@@ -30,7 +30,8 @@ class SelectFormOption extends AbstractFormOption
     #[\Override]
     public function getFormField(string $id, array $configuration = []): AbstractFormField
     {
-        $formField = SelectFormField::create($id);
+        $formField = SelectFormField::create($id)
+            ->ignoreInvalidValues();
         $this->setSelectOptions($formField, $configuration);
 
         return $formField;


### PR DESCRIPTION
Scenario: An option with the keys A and B is created. An item is created setting the option to option A. The key A is now deleted, attempting to edit it will yield an exception because A is not valid anymore.

This changes the behavior by explicitly discarding invalid values without changing the behavior of the form fields in general.

See https://www.woltlab.com/community/thread/315658/