### PR TITLE
Remove permissions for avatar file extensions

### DIFF
--- a/com.woltlab.wcf/userGroupOption.xml
+++ b/com.woltlab.wcf/userGroupOption.xml
@@ -802,19 +802,8 @@ bmp</defaultvalue>
 				<categoryname>user.profile.avatar</categoryname>
 				<optiontype>boolean</optiontype>
 				<defaultvalue>0</defaultvalue>
-				<enableoptions>user.profile.avatar.allowedFileExtensions</enableoptions>
 				<usersonly>1</usersonly>
 				<userdefaultvalue>1</userdefaultvalue>
-			</option>
-			<option name="user.profile.avatar.allowedFileExtensions">
-				<categoryname>user.profile.avatar</categoryname>
-				<optiontype>lineBreakSeparatedText</optiontype>
-				<defaultvalue>gif
-jpg
-jpeg
-png
-webp</defaultvalue>
-				<usersonly>1</usersonly>
 			</option>
 			<option name="user.profile.coverPhoto.canSeeCoverPhotos">
 				<categoryname>user.profile.coverPhoto</categoryname>
@@ -1075,5 +1064,6 @@ webp</defaultvalue>
 	<delete>
 		<option name="user.profile.avatar.maxSize"/>
 		<option name="admin.configuration.package.canUninstallPackage"/>
+		<option name="user.profile.avatar.allowedFileExtensions"/>
 	</delete>
 </data>

--- a/wcfsetup/install/files/lib/system/file/processor/UserAvatarFileProcessor.class.php
+++ b/wcfsetup/install/files/lib/system/file/processor/UserAvatarFileProcessor.class.php
@@ -38,7 +38,13 @@ final class UserAvatarFileProcessor extends AbstractFileProcessor
     #[\Override]
     public function getAllowedFileExtensions(array $context): array
     {
-        return \explode("\n", WCF::getSession()->getPermission('user.profile.avatar.allowedFileExtensions'));
+        return [
+            "png",
+            "jpg",
+            "jpeg",
+            "gif",
+            "webp",
+        ];
     }
 
     #[\Override]

--- a/wcfsetup/install/lang/de.xml
+++ b/wcfsetup/install/lang/de.xml
@@ -811,7 +811,6 @@ Sie erreichen das Fehlerprotokoll unter: {link controller='ExceptionLogView' isE
 		<item name="wcf.acp.group.option.category.user.profile.avatar"><![CDATA[Avatare]]></item>
 		<item name="wcf.acp.group.option.category.admin.user.rank"><![CDATA[Benutzerränge]]></item>
 		<item name="wcf.acp.group.option.category.user.signature"><![CDATA[Signaturen]]></item>
-		<item name="wcf.acp.group.option.user.profile.avatar.allowedFileExtensions"><![CDATA[Erlaubte Dateiendungen]]></item>
 		<item name="wcf.acp.group.option.user.profile.avatar.canSeeAvatars"><![CDATA[Kann Avatare anderer Benutzer sehen]]></item>
 		<item name="wcf.acp.group.option.user.profile.avatar.canUploadAvatar"><![CDATA[Kann eigenen Avatar hochladen]]></item>
 		<item name="wcf.acp.group.option.user.profile.canChangeEmail"><![CDATA[Kann E-Mail-Adresse ändern]]></item>
@@ -5260,7 +5259,7 @@ Sobald {if LANGUAGE_USE_INFORMAL_VARIANT}dein{else}Ihr{/if} Benutzerkonto freige
 		<item name="wcf.user.avatar"><![CDATA[Avatar]]></item>
 		<item name="wcf.user.avatar.edit"><![CDATA[Avatar bearbeiten]]></item>
 		<item name="wcf.user.avatar.error.disabled"><![CDATA[Der Administrator hat{if $__wcf->user->avatarID} {if LANGUAGE_USE_INFORMAL_VARIANT}deinen{else}Ihren{/if} derzeitigen Avatar gesperrt und{/if} {if LANGUAGE_USE_INFORMAL_VARIANT}dir{else}Ihnen{/if} die weitere Nutzungsberechtigung der Avatar-Funktion {if !$__wcf->user->disableAvatarReason}entzogen.{else} aus folgenden Gründen entzogen: {$__wcf->user->disableAvatarReason}{/if}]]></item>
-		<item name="wcf.user.avatar.type.custom.description"><![CDATA[Eigene Avatare dürfen die Dateiendungen {"\n"|str_replace:', ':$__wcf->session->getPermission('user.profile.avatar.allowedFileExtensions')} besitzen.<br>Die Mindestgröße für Avatare liegt bei 128 × 128 Pixel.]]></item>
+		<item name="wcf.user.avatar.type.custom.description"><![CDATA[Eigene Avatare dürfen die Dateiendungen gif, jpg, jpeg, png, webp besitzen.<br>Die Mindestgröße für Avatare liegt bei 128 × 128 Pixel.]]></item>
 	</category>
 	<category name="wcf.user.condition">
 		<item name="wcf.user.condition.activityPoints"><![CDATA[Punkte]]></item>

--- a/wcfsetup/install/lang/en.xml
+++ b/wcfsetup/install/lang/en.xml
@@ -787,7 +787,6 @@ You can access the error log at: {link controller='ExceptionLogView' isEmail=tru
 		<item name="wcf.acp.group.option.category.user.profile.avatar"><![CDATA[Avatars]]></item>
 		<item name="wcf.acp.group.option.category.admin.user.rank"><![CDATA[User Ranks]]></item>
 		<item name="wcf.acp.group.option.category.user.signature"><![CDATA[Signatures]]></item>
-		<item name="wcf.acp.group.option.user.profile.avatar.allowedFileExtensions"><![CDATA[Allowed Image Extensions]]></item>
 		<item name="wcf.acp.group.option.user.profile.avatar.canSeeAvatars"><![CDATA[Can view users’ avatars]]></item>
 		<item name="wcf.acp.group.option.user.profile.avatar.canUploadAvatar"><![CDATA[Can upload their avatar]]></item>
 		<item name="wcf.acp.group.option.user.profile.canChangeEmail"><![CDATA[Can change their email address]]></item>
@@ -5259,7 +5258,7 @@ You also received a list of backup codes to use when your second factor becomes 
 		<item name="wcf.user.avatar"><![CDATA[Avatar]]></item>
 		<item name="wcf.user.avatar.edit"><![CDATA[Edit Avatar]]></item>
 		<item name="wcf.user.avatar.error.disabled"><![CDATA[The administrators {if $__wcf->user->avatarID}have blocked your avatar and {/if}disallowed you from using an avatar{if $__wcf->user->disableAvatarReason}: {$__wcf->user->disableAvatarReason}{/if}.]]></item>
-		<item name="wcf.user.avatar.type.custom.description"><![CDATA[You may use the following file extensions “{"\n"|str_replace:', ':$__wcf->session->getPermission('user.profile.avatar.allowedFileExtensions')}” for your avatar.<br>The minimum dimensions are 128 × 128 pixels.]]></item>
+		<item name="wcf.user.avatar.type.custom.description"><![CDATA[You may use the following file extensions “gif, jpg, jpeg, png, webp” for your avatar.<br>The minimum dimensions are 128 × 128 pixels.]]></item>
 	</category>
 	<category name="wcf.user.condition">
 		<item name="wcf.user.condition.activityPoints"><![CDATA[Points]]></item>


### PR DESCRIPTION
The permission exists for historical reasons, but serves no real purpose. There are no meaningful file extensions that the administrator could add. Incorrect input also causes the upload process to stop working.

ref https://www.woltlab.com/community/thread/315897-fehler-bei-avatar-bearbeiten/