### PR TITLE
Remove the view transition from list / grid views

### DIFF
--- a/ts/WoltLabSuite/Core/Component/GridView/Selection.ts
+++ b/ts/WoltLabSuite/Core/Component/GridView/Selection.ts
@@ -175,24 +175,11 @@ export class Selection extends EventTarget {
     this.dispatchEvent(new CustomEvent("grid-view:update-selection"));
 
     if (selectedIds.length === 0) {
-      if ("startViewTransition" in document) {
-        document.startViewTransition(() => {
-          this.#selectionBar!.hidden = true;
-        });
-      } else {
-        this.#selectionBar.hidden = true;
-      }
-
+      this.#selectionBar.hidden = true;
       return;
     }
 
-    if ("startViewTransition" in document) {
-      document.startViewTransition(() => {
-        this.#selectionBar!.hidden = false;
-      });
-    } else {
-      this.#selectionBar.hidden = false;
-    }
+    this.#selectionBar.hidden = false;
 
     this.#bulkInteractionButton!.textContent = getPhrase("wcf.clipboard.button.numberOfSelectedItems", {
       numberOfSelectedItems: selectedIds.length,

--- a/ts/WoltLabSuite/Core/Component/ListView/Selection.ts
+++ b/ts/WoltLabSuite/Core/Component/ListView/Selection.ts
@@ -175,24 +175,12 @@ export class Selection extends EventTarget {
     this.dispatchEvent(new CustomEvent("list-view:update-selection"));
 
     if (selectedIds.length === 0) {
-      if ("startViewTransition" in document) {
-        document.startViewTransition(() => {
-          this.#selectionBar!.hidden = true;
-        });
-      } else {
-        this.#selectionBar.hidden = true;
-      }
-
+      this.#selectionBar.hidden = true;
       return;
     }
 
-    if ("startViewTransition" in document) {
-      document.startViewTransition(() => {
-        this.#selectionBar!.hidden = false;
-      });
-    } else {
-      this.#selectionBar.hidden = false;
-    }
+    this.#selectionBar.hidden = false;
+
     this.#bulkInteractionButton!.textContent = getPhrase("wcf.clipboard.button.numberOfSelectedItems", {
       numberOfSelectedItems: selectedIds.length,
     });

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Component/GridView/Selection.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Component/GridView/Selection.js
@@ -147,24 +147,10 @@ define(["require", "exports", "tslib", "WoltLabSuite/Core/Core", "WoltLabSuite/C
             }
             this.dispatchEvent(new CustomEvent("grid-view:update-selection"));
             if (selectedIds.length === 0) {
-                if ("startViewTransition" in document) {
-                    document.startViewTransition(() => {
-                        this.#selectionBar.hidden = true;
-                    });
-                }
-                else {
-                    this.#selectionBar.hidden = true;
-                }
+                this.#selectionBar.hidden = true;
                 return;
             }
-            if ("startViewTransition" in document) {
-                document.startViewTransition(() => {
-                    this.#selectionBar.hidden = false;
-                });
-            }
-            else {
-                this.#selectionBar.hidden = false;
-            }
+            this.#selectionBar.hidden = false;
             this.#bulkInteractionButton.textContent = (0, Language_1.getPhrase)("wcf.clipboard.button.numberOfSelectedItems", {
                 numberOfSelectedItems: selectedIds.length,
             });

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Component/ListView/Selection.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Component/ListView/Selection.js
@@ -147,24 +147,10 @@ define(["require", "exports", "tslib", "WoltLabSuite/Core/Core", "WoltLabSuite/C
             }
             this.dispatchEvent(new CustomEvent("list-view:update-selection"));
             if (selectedIds.length === 0) {
-                if ("startViewTransition" in document) {
-                    document.startViewTransition(() => {
-                        this.#selectionBar.hidden = true;
-                    });
-                }
-                else {
-                    this.#selectionBar.hidden = true;
-                }
+                this.#selectionBar.hidden = true;
                 return;
             }
-            if ("startViewTransition" in document) {
-                document.startViewTransition(() => {
-                    this.#selectionBar.hidden = false;
-                });
-            }
-            else {
-                this.#selectionBar.hidden = false;
-            }
+            this.#selectionBar.hidden = false;
             this.#bulkInteractionButton.textContent = (0, Language_1.getPhrase)("wcf.clipboard.button.numberOfSelectedItems", {
                 numberOfSelectedItems: selectedIds.length,
             });


### PR DESCRIPTION
The transition caused the interface to freeze when executing bulk interactions on multiple entries.