### PR TITLE
Fix regex pattern for bbcode attachment matches

### DIFF
--- a/ts/WoltLabSuite/Core/Component/Attachment/List.ts
+++ b/ts/WoltLabSuite/Core/Component/Attachment/List.ts
@@ -172,7 +172,7 @@ function observeInsertedAttachments(element: HTMLElement, files: HTMLCollectionO
     embeddedAttachments.add(attachmentId);
   });
 
-  const bbcodeMatches = editor.element.innerText.matchAll(/\[attach=('\d+'|"\d+"|\d+)(?:,[^]]+?)?\]\[\/attach\]/g);
+  const bbcodeMatches = editor.element.innerText.matchAll(/\[attach=(?:'|")?(\d+)(?:'|")?(?:,[^]]+?)?]\[\/attach]/g);
   for (const match of bbcodeMatches) {
     const attachmentId = parseInt(match[1]);
     embeddedAttachments.add(attachmentId);


### PR DESCRIPTION
After saving, attachment BBCodes may be normalized from `[attach=1612][/attach]` to `[attach='1612'][/attach]` (or double-quoted), which caused inserted-attachment detection to fail on edit.

This change updates the BBCode matcher to capture numeric IDs regardless of optional single/double quotes around the ID, so previously inserted attachments are correctly recognized in all formats.

- before: matched quoted IDs but parsed NaN
- after: captures digits only and parses reliably