### PR TITLE
Use the real installation number instead of hardcoded

### DIFF
--- a/wcfsetup/install/files/lib/acp/page/SystemCheckPage.class.php
+++ b/wcfsetup/install/files/lib/acp/page/SystemCheckPage.class.php
@@ -4,6 +4,7 @@ namespace wcf\acp\page;
 
 use wcf\data\application\Application;
 use wcf\page\AbstractPage;
+use wcf\system\application\ApplicationHandler;
 use wcf\system\database\util\PreparedStatementConditionBuilder;
 use wcf\system\Environment;
 use wcf\system\exception\SystemException;
@@ -300,9 +301,13 @@ class SystemCheckPage extends AbstractPage
             foreach ($keys as $column => $reference) {
                 $innerConditionBuilder = new PreparedStatementConditionBuilder(false);
                 $innerConditionBuilder->add('REFERENCED_TABLE_SCHEMA = ?', [WCF::getDB()->getDatabaseName()]);
-                $innerConditionBuilder->add('REFERENCED_TABLE_NAME = ?', [$reference['referenceTable']]);
+                $innerConditionBuilder->add('REFERENCED_TABLE_NAME = ?', [
+                        ApplicationHandler::insertRealDatabaseTableNames($reference['referenceTable'])
+                ]);
                 $innerConditionBuilder->add('REFERENCED_COLUMN_NAME = ?', [$reference['referenceColumn']]);
-                $innerConditionBuilder->add('TABLE_NAME = ?', [$table]);
+                $innerConditionBuilder->add('TABLE_NAME = ?', [
+                        ApplicationHandler::insertRealDatabaseTableNames($table)
+                ]);
                 $innerConditionBuilder->add('COLUMN_NAME = ?', [$column]);
 
                 $conditionBuilder->add('(' . $innerConditionBuilder . ')', $innerConditionBuilder->getParameters());


### PR DESCRIPTION
Currently the validation of MySQL respective the foreign keys are always falsy [in 6.2](https://github.com/WoltLab/WCF/commit/32bd58238b0e9a296c953491b34c8153d41c95d5) if the installation number of the instance is not `1`.

The parameters of the condition builder are not replaced by `WCF::getDB()->prepare()` during statement preparation.

