### PR TITLE
Localize the position and type column of `BoxGridView`

### DIFF
--- a/wcfsetup/install/files/lib/system/gridView/admin/BoxGridView.class.php
+++ b/wcfsetup/install/files/lib/system/gridView/admin/BoxGridView.class.php
@@ -5,6 +5,7 @@ namespace wcf\system\gridView\admin;
 use wcf\acp\form\BoxEditForm;
 use wcf\data\box\Box;
 use wcf\data\box\BoxList;
+use wcf\data\DatabaseObject;
 use wcf\data\DatabaseObjectList;
 use wcf\event\gridView\admin\BoxGridViewInitialized;
 use wcf\system\gridView\AbstractGridView;
@@ -12,6 +13,7 @@ use wcf\system\gridView\GridViewColumn;
 use wcf\system\gridView\GridViewRowLink;
 use wcf\system\gridView\renderer\NumberColumnRenderer;
 use wcf\system\gridView\renderer\ObjectIdColumnRenderer;
+use wcf\system\gridView\renderer\PhraseColumnRenderer;
 use wcf\system\interaction\admin\BoxInteractions;
 use wcf\system\interaction\Divider;
 use wcf\system\interaction\EditInteraction;
@@ -48,6 +50,15 @@ final class BoxGridView extends AbstractGridView
                 ->sortable(),
             GridViewColumn::for('boxType')
                 ->label('wcf.acp.box.type')
+                ->renderer(new class extends PhraseColumnRenderer {
+                    #[\Override]
+                    public function render(mixed $value, DatabaseObject $row): string
+                    {
+                        assert($row instanceof Box);
+
+                        return parent::render('wcf.acp.box.type.' . $value, $row);
+                    }
+                })
                 ->filter(
                     new SelectFilter(
                         \array_combine(
@@ -64,6 +75,15 @@ final class BoxGridView extends AbstractGridView
                 ->sortable(),
             GridViewColumn::for('position')
                 ->label('wcf.acp.box.position')
+                ->renderer(new class extends PhraseColumnRenderer {
+                    #[\Override]
+                    public function render(mixed $value, DatabaseObject $row): string
+                    {
+                        assert($row instanceof Box);
+
+                        return parent::render('wcf.acp.box.position.' . $value, $row);
+                    }
+                })
                 ->filter(
                     new SelectFilter(
                         \array_combine(

--- a/wcfsetup/install/files/lib/system/gridView/admin/BoxGridView.class.php
+++ b/wcfsetup/install/files/lib/system/gridView/admin/BoxGridView.class.php
@@ -54,8 +54,6 @@ final class BoxGridView extends AbstractGridView
                     #[\Override]
                     public function render(mixed $value, DatabaseObject $row): string
                     {
-                        assert($row instanceof Box);
-
                         return parent::render('wcf.acp.box.type.' . $value, $row);
                     }
                 })
@@ -79,8 +77,6 @@ final class BoxGridView extends AbstractGridView
                     #[\Override]
                     public function render(mixed $value, DatabaseObject $row): string
                     {
-                        assert($row instanceof Box);
-
                         return parent::render('wcf.acp.box.position.' . $value, $row);
                     }
                 })


### PR DESCRIPTION
In contrast to version 6.1, where the output in the table was localized using language variables, currently only the raw value from the database table is displayed.

This change localizes the output again.

Before:
<img width="1236" height="345" alt="image" src="https://github.com/user-attachments/assets/30e22ce7-d1d6-48ad-b95b-f1c046e79d98" />


After:
<img width="1241" height="331" alt="image" src="https://github.com/user-attachments/assets/83c25539-70f0-4d11-8113-438c3df91d4b" />

Previous (6.1):
<img width="1239" height="228" alt="image" src="https://github.com/user-attachments/assets/977b44d9-c114-45b2-a31f-4384b1afd431" />
