### PR TITLE
Remove obsolete CSS declarations

### DIFF
--- a/wcfsetup/install/files/style/layout/gridList.scss
+++ b/wcfsetup/install/files/style/layout/gridList.scss
@@ -66,8 +66,7 @@
 		position: absolute;
 	}
 
-	&:hover,
-	&:focus {
+	&:hover {
 		color: inherit;
 		text-decoration: underline;
 		text-underline-offset: 3px;

--- a/wcfsetup/install/files/style/ui/contentItem.scss
+++ b/wcfsetup/install/files/style/ui/contentItem.scss
@@ -45,8 +45,7 @@
 		top: 0;
 	}
 
-	&:hover,
-	&:focus {
+	&:hover {
 		color: inherit;
 	}
 }

--- a/wcfsetup/install/files/style/ui/discussionList.scss
+++ b/wcfsetup/install/files/style/ui/discussionList.scss
@@ -208,16 +208,11 @@
 		inset: 0;
 		position: absolute;
 	}
-
-	&:hover,
-	&:focus {
-		color: inherit;
-	}
 }
 
 @media (hover: hover) {
-	.discussionList__item__link:hover,
-	.discussionList__item__link:focus {
+	.discussionList__item__link:hover {
+		color: inherit;
 		text-decoration: underline;
 		text-underline-offset: 3px;
 	}
@@ -248,16 +243,11 @@
 		inset: 0;
 		position: absolute;
 	}
-
-	&:hover,
-	&:focus {
-		color: inherit;
-	}
 }
 
 @media (hover: hover) {
-	.discussionList__item__lastPost__link:hover,
-	.discussionList__item__lastPost__link:focus {
+	.discussionList__item__lastPost__link:hover {
+		color: inherit;
 		text-decoration: underline;
 		text-underline-offset: 3px;
 	}

--- a/wcfsetup/install/files/style/ui/embeddedContent.scss
+++ b/wcfsetup/install/files/style/ui/embeddedContent.scss
@@ -48,8 +48,7 @@
 		z-index: 1;
 	}
 
-	&:hover,
-	&:focus {
+	&:hover {
 		color: inherit;
 	}
 }

--- a/wcfsetup/install/files/style/ui/entryCardList.scss
+++ b/wcfsetup/install/files/style/ui/entryCardList.scss
@@ -142,8 +142,7 @@ html:not(.touch) .entryCardList__item:hover .entryCardList__item__image__element
 		position: absolute;
 	}
 
-	&:hover,
-	&:focus {
+	&:hover {
 		color: inherit;
 	}
 }

--- a/wcfsetup/install/files/style/ui/notificationList.scss
+++ b/wcfsetup/install/files/style/ui/notificationList.scss
@@ -52,8 +52,7 @@
 		position: absolute;
 	}
 
-	&:hover,
-	&:focus {
+	&:hover {
 		color: inherit;
 	}
 }

--- a/wcfsetup/install/files/style/ui/recentActivityList.scss
+++ b/wcfsetup/install/files/style/ui/recentActivityList.scss
@@ -134,9 +134,10 @@
 		inset: 0;
 		position: absolute;
 	}
+}
 
-	&:hover,
-	&:focus {
+@media (hover: hover) {
+	.recentActivityListItem__link:hover {
 		color: inherit;
 		text-decoration: underline;
 		text-underline-offset: 3px;

--- a/wcfsetup/install/files/style/ui/sidebarList.scss
+++ b/wcfsetup/install/files/style/ui/sidebarList.scss
@@ -55,9 +55,10 @@
 		inset: 0;
 		position: absolute;
 	}
+}
 
-	&:hover,
-	&:focus {
+@media (hover: hover) {
+	.sidebarListItem .sidebarListItem__link:hover {
 		color: inherit;
 		text-decoration: underline;
 		text-underline-offset: 3px;
@@ -71,8 +72,7 @@
 .sidebarListItem__meta a {
 	color: inherit;
 
-	&:hover,
-	&:focus {
+	&:hover {
 		color: inherit;
 	}
 }

--- a/wcfsetup/install/files/style/ui/unfurlUrl.scss
+++ b/wcfsetup/install/files/style/ui/unfurlUrl.scss
@@ -83,23 +83,17 @@ html[data-color-scheme="dark"] .unfurlUrlCard {
 	-webkit-line-clamp: 2;
 
 	&::before {
-		bottom: 0;
 		content: "";
-		left: 0;
+		inset: 0;
 		position: absolute;
-		right: 0;
-		top: 0;
-	}
-
-	&:hover,
-	&:focus {
-		color: inherit;
 	}
 }
 
-@media (pointer: fine) {
-	.unfurlUrlCard:hover .unfurlUrlTitle {
+@media (hover: hover) {
+	.unfurlUrlTitle:hover {
+		color: inherit;
 		text-decoration: underline;
+		text-underline-offset: 3px;
 	}
 }
 

--- a/wcfsetup/install/files/style/ui/userCard.scss
+++ b/wcfsetup/install/files/style/ui/userCard.scss
@@ -141,8 +141,7 @@
 		position: absolute;
 	}
 
-	&:hover,
-	&:focus {
+	&:hover {
 		color: inherit;
 	}
 }


### PR DESCRIPTION
It is unnecessary to set the focus value explicitly, as it is already set by the base value.