### PR TITLE
Fix issues in TypeScript for quote handling

### DIFF
--- a/ts/WoltLabSuite/Core/Component/Quote/Storage.ts
+++ b/ts/WoltLabSuite/Core/Component/Quote/Storage.ts
@@ -171,7 +171,7 @@ export function clearQuotesForEditor(editorId: string): void {
   usedQuotes.get(editorId)?.forEach((uuid) => {
     for (const [key, quotes] of storage.quotes) {
       const quote = quotes.get(uuid);
-      if (quote?.rawMessage !== null) {
+      if (quote !== undefined && quote.rawMessage !== null) {
         fullQuotes.push(key);
       }
 
@@ -207,7 +207,7 @@ function storeQuote(objectType: string, message: Message, quote: Quote): string 
   storage.messages.set(key, message);
 
   for (const [uuid, q] of storage.quotes.get(key)!) {
-    if ((q.rawMessage !== null && q.rawMessage === null) || q.message === quote.message) {
+    if ((q.rawMessage !== null && q.rawMessage === quote.rawMessage) || q.message === quote.message) {
       return uuid;
     }
   }

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Component/Quote/Storage.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Component/Quote/Storage.js
@@ -122,7 +122,7 @@ define(["require", "exports", "tslib", "WoltLabSuite/Core/Core", "WoltLabSuite/C
         usedQuotes.get(editorId)?.forEach((uuid) => {
             for (const [key, quotes] of storage.quotes) {
                 const quote = quotes.get(uuid);
-                if (quote?.rawMessage !== null) {
+                if (quote !== undefined && quote.rawMessage !== null) {
                     fullQuotes.push(key);
                 }
                 quotes.delete(uuid);
@@ -149,7 +149,7 @@ define(["require", "exports", "tslib", "WoltLabSuite/Core/Core", "WoltLabSuite/C
         }
         storage.messages.set(key, message);
         for (const [uuid, q] of storage.quotes.get(key)) {
-            if ((q.rawMessage !== null && q.rawMessage === null) || q.message === quote.message) {
+            if ((q.rawMessage !== null && q.rawMessage === quote.rawMessage) || q.message === quote.message) {
                 return uuid;
             }
         }


### PR DESCRIPTION
* Optional chaining with `!== null` caused false positives in `clearQuotesForEditor`
* Tautological condition broke quote deduplication