### PR TITLE
`ShowOrderFormField` includes edited object in sibling list

### DIFF
--- a/wcfsetup/install/files/lib/acp/form/ContactOptionAddForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/ContactOptionAddForm.class.php
@@ -92,7 +92,7 @@ class ContactOptionAddForm extends AbstractFormOptionAddForm
     /**
      * @return array<int, string>
      */
-    private function getContactOptions(): array
+    protected function getContactOptions(): array
     {
         $optionList = new ContactOptionList();
         $optionList->sqlOrderBy = 'showOrder ASC';

--- a/wcfsetup/install/files/lib/acp/form/ContactOptionEditForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/ContactOptionEditForm.class.php
@@ -70,4 +70,14 @@ class ContactOptionEditForm extends ContactOptionAddForm
             ),
         ]);
     }
+
+    #[\Override]
+    protected function getContactOptions(): array
+    {
+        return \array_filter(
+            parent::getContactOptions(),
+            fn(int $key) => $key !== $this->formObject->getObjectID(),
+            \ARRAY_FILTER_USE_KEY
+        );
+    }
 }

--- a/wcfsetup/install/files/lib/acp/form/ContactRecipientAddForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/ContactRecipientAddForm.class.php
@@ -81,12 +81,12 @@ class ContactRecipientAddForm extends AbstractFormBuilderForm
     /**
      * @return array<int, string>
      */
-    private function getContactRecipient(): array
+    protected function getContactRecipient(): array
     {
         $recipientList = new ContactRecipientList();
         $recipientList->sqlOrderBy = 'showOrder ASC';
         $recipientList->readObjects();
 
-        return \array_map(static fn ($recipient) => $recipient->getName(), $recipientList->getObjects());
+        return \array_map(static fn($recipient) => $recipient->getName(), $recipientList->getObjects());
     }
 }

--- a/wcfsetup/install/files/lib/acp/form/ContactRecipientEditForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/ContactRecipientEditForm.class.php
@@ -67,4 +67,14 @@ class ContactRecipientEditForm extends ContactRecipientAddForm
             ),
         ]);
     }
+
+    #[\Override]
+    protected function getContactRecipient(): array
+    {
+        return \array_filter(
+            parent::getContactRecipient(),
+            fn(int $key) => $key !== $this->formObject->getObjectID(),
+            \ARRAY_FILTER_USE_KEY
+        );
+    }
 }

--- a/wcfsetup/install/files/lib/acp/form/ReactionTypeAddForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/ReactionTypeAddForm.class.php
@@ -71,7 +71,7 @@ class ReactionTypeAddForm extends AbstractFormBuilderForm
                     ->languageItemPattern('wcf.reactionType.title\d+'),
                 ShowOrderFormField::create()
                     ->required()
-                    ->options(new ReactionTypeList()),
+                    ->options($this->getReactionTypes()),
                 BooleanFormField::create('isAssignable')
                     ->label('wcf.acp.reactionType.isAssignable')
                     ->description('wcf.acp.reactionType.isAssignable.description')
@@ -93,5 +93,16 @@ class ReactionTypeAddForm extends AbstractFormBuilderForm
             $dataContainer,
             $iconContainer,
         ]);
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    protected function getReactionTypes(): array
+    {
+        $list = new ReactionTypeList();
+        $list->readObjects();
+
+        return \array_map(static fn($option) => $option->getTitle(), $list->getObjects());
     }
 }

--- a/wcfsetup/install/files/lib/acp/form/ReactionTypeEditForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/ReactionTypeEditForm.class.php
@@ -58,4 +58,16 @@ class ReactionTypeEditForm extends ReactionTypeAddForm
             ),
         ]);
     }
+
+    /**
+     * @return array<int, string>
+     */
+    protected function getReactionTypes(): array
+    {
+        return \array_filter(
+            parent::getReactionTypes(),
+            fn(int $key) => $key !== $this->formObject->getObjectID(),
+            \ARRAY_FILTER_USE_KEY
+        );
+    }
 }

--- a/wcfsetup/install/files/lib/acp/form/UserOptionCategoryAddForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/UserOptionCategoryAddForm.class.php
@@ -61,18 +61,7 @@ class UserOptionCategoryAddForm extends AbstractFormBuilderForm
                         ->i18nRequired()
                         ->languageItemPattern('wcf.user.option.category.(category\d+|[\w\.]+)'),
                     ShowOrderFormField::create()
-                        ->options(function () {
-                            $categoryList = new UserOptionCategoryList();
-                            $categoryList->getConditionBuilder()->add('parentCategoryName = ?', ['profile']);
-                            $categoryList->readObjects();
-                            $categories = [];
-
-                            foreach ($categoryList->getObjects() as $category) {
-                                $categories[$category->categoryID] = $category->getTitle();
-                            }
-
-                            return $categories;
-                        }),
+                        ->options($this->getCategories()),
                 ]),
         ]);
     }
@@ -131,5 +120,20 @@ class UserOptionCategoryAddForm extends AbstractFormBuilderForm
         ]);
 
         parent::saved();
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    protected function getCategories(): array
+    {
+        $categoryList = new UserOptionCategoryList();
+        $categoryList->getConditionBuilder()->add('parentCategoryName = ?', ['profile']);
+        $categoryList->readObjects();
+
+        return \array_map(
+            static fn($category) => $category->getTitle(),
+            $categoryList->getObjects()
+        );
     }
 }

--- a/wcfsetup/install/files/lib/acp/form/UserOptionCategoryEditForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/UserOptionCategoryEditForm.class.php
@@ -63,4 +63,14 @@ class UserOptionCategoryEditForm extends UserOptionCategoryAddForm
 
         AbstractFormBuilderForm::saved();
     }
+
+    #[\Override]
+    protected function getCategories(): array
+    {
+        return \array_filter(
+            parent::getCategories(),
+            fn(int $key) => $key !== $this->formObject->getObjectID(),
+            \ARRAY_FILTER_USE_KEY
+        );
+    }
 }


### PR DESCRIPTION
These methods return ALL items without filtering out the currently edited object. The `ShowOrderFormField` documentation explicitly states the edited object must NOT be in the sibling list, or position calculation will be off-by-one.