### PR TITLE
Image cropper provides no dimensions in error for single-size configs

### DIFF
--- a/ts/WoltLabSuite/Core/Component/Image/Cropper.ts
+++ b/ts/WoltLabSuite/Core/Component/Image/Cropper.ts
@@ -357,7 +357,7 @@ class ExactImageCropper extends ImageCropper {
 
     if (sizes.length === 0) {
       const smallestSize =
-        this.configuration.sizes.length > 1 ? this.configuration.sizes[this.configuration.sizes.length - 1] : undefined;
+        this.configuration.sizes.length > 0 ? this.configuration.sizes[this.configuration.sizes.length - 1] : undefined;
       throw new Error(
         getPhrase("wcf.upload.error.image.tooSmall", {
           width: smallestSize?.width,

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Component/Image/Cropper.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Component/Image/Cropper.js
@@ -267,7 +267,7 @@ define(["require", "exports", "tslib", "WoltLabSuite/Core/Image/Resizer", "WoltL
                 }
             });
             if (sizes.length === 0) {
-                const smallestSize = this.configuration.sizes.length > 1 ? this.configuration.sizes[this.configuration.sizes.length - 1] : undefined;
+                const smallestSize = this.configuration.sizes.length > 0 ? this.configuration.sizes[this.configuration.sizes.length - 1] : undefined;
                 throw new Error((0, Language_1.getPhrase)("wcf.upload.error.image.tooSmall", {
                     width: smallestSize?.width,
                     height: smallestSize?.height,


### PR DESCRIPTION
When only one size is configured, `smallestSize` is undefined, showing the user an error with blank dimensions.