### PR TITLE
Fix `messageID=0` in message embedded objects

### DIFF
--- a/wcfsetup/install/files/acp/update_com.woltlab.wcf_6.3_embeddedObjects.php
+++ b/wcfsetup/install/files/acp/update_com.woltlab.wcf_6.3_embeddedObjects.php
@@ -1,0 +1,8 @@
+<?php
+
+use wcf\system\WCF;
+
+// Remove orphaned entries associated with `messageID=0`.
+$sql = "DELETE FROM wcf1_message_embedded_object WHERE messageID = ?";
+$statement = WCF::getDB()->prepare($sql);
+$statement->execute([0]);

--- a/wcfsetup/install/files/lib/system/message/embedded/object/MessageEmbeddedObjectManager.class.php
+++ b/wcfsetup/install/files/lib/system/message/embedded/object/MessageEmbeddedObjectManager.class.php
@@ -100,6 +100,10 @@ class MessageEmbeddedObjectManager extends SingletonFactory
         $messageObjectTypeID = $context['objectTypeID'];
         $messageID = $context['objectID'];
 
+        if (!$messageID) {
+            throw new \BadMethodCallException("No 'messageID' was set.");
+        }
+
         // delete existing assignments
         if ($removeExistingObjects) {
             if ($isBulk) {
@@ -195,6 +199,10 @@ class MessageEmbeddedObjectManager extends SingletonFactory
      */
     public function registerSimpleObjects($messageObjectType, $messageID, array $embeddedContent)
     {
+        if (!$messageID) {
+            throw new \BadMethodCallException("No 'messageID' was given.");
+        }
+
         $messageObjectTypeID = ObjectTypeCache::getInstance()
             ->getObjectTypeIDByName('com.woltlab.wcf.message', $messageObjectType);
 


### PR DESCRIPTION
The `messageID` has not been validated, which may have resulted in orphaned entries in existing installations.