### PR TITLE
Add extension point for custom stored Font Awesome icons

### DIFF
--- a/com.woltlab.wcf/templates/shared_iconFormField.tpl
+++ b/com.woltlab.wcf/templates/shared_iconFormField.tpl
@@ -13,34 +13,43 @@
 	{if $__iconFormFieldIncludeJavaScript}
 		{include file='shared_fontAwesomeJavaScript'}
 	{/if}
-	
+
 	<script data-relocate="true">
 		require(['WoltLabSuite/Core/Ui/Style/FontAwesome'], (UiStyleFontAwesome) => {
 			const iconContainer = document.getElementById('{unsafe:$field->getPrefixedId()|encodeJS}_icon');
 			const input = document.getElementById('{unsafe:$field->getPrefixedId()|encodeJS}');
 			const buttonRemoveIcon = document.getElementById('{unsafe:$field->getPrefixedId()|encodeJS}_removeIcon');
-			
-			const callback = (iconName, forceSolid) => {
-				input.value = `${ iconName };${ forceSolid }`;
 
+			const renderNativePreview = (iconName, forceSolid) => {
 				let icon = iconContainer.querySelector("fa-icon");
-				if (icon) {
-					icon.setIcon(iconName, forceSolid);
-				} else {
+				if (!icon || icon.parentElement !== iconContainer || iconContainer.childElementCount !== 1) {
+					iconContainer.replaceChildren();
+
 					icon = document.createElement("fa-icon");
 					icon.size = 64;
-					icon.setIcon(iconName, forceSolid);
 					iconContainer.append(icon);
+				}
+
+				icon.setIcon(iconName, forceSolid);
+			};
+
+			const callback = (iconName, forceSolid, value, previewHtml) => {
+				input.value = typeof value === 'string' ? value : `${ iconName };${ forceSolid }`;
+
+				if (typeof previewHtml === 'string') {
+					iconContainer.innerHTML = previewHtml;
+				} else {
+					renderNativePreview(iconName, forceSolid);
 				}
 
 				buttonRemoveIcon.hidden = false;
 			};
-			
+
 			const button = document.getElementById('{unsafe:$field->getPrefixedId()|encodeJS}_openIconDialog');
 			button.addEventListener('click', () => UiStyleFontAwesome.open(callback));
 			buttonRemoveIcon.addEventListener("click", () => {
 				input.value = "";
-				iconContainer.querySelector("fa-icon")?.remove();
+				iconContainer.replaceChildren();
 
 				buttonRemoveIcon.hidden = true;
 			});

--- a/ts/WoltLabSuite/Core/Acp/Ui/Trophy/Badge.ts
+++ b/ts/WoltLabSuite/Core/Acp/Ui/Trophy/Badge.ts
@@ -13,16 +13,33 @@ import DomUtil from "../../../Dom/Util";
 
 const badgeContainer = document.getElementById("badgeContainer")!;
 const previewWrapper = badgeContainer.querySelector(".trophyIcon") as HTMLElement;
-const previewIcon = previewWrapper.querySelector("fa-icon")!;
+
+function renderNativePreview(icon: string, forceSolid: boolean): void {
+  let previewIcon = previewWrapper.querySelector("fa-icon");
+  if (!(previewIcon instanceof HTMLElement) || previewIcon.parentElement !== previewWrapper) {
+    previewWrapper.replaceChildren();
+
+    previewIcon = document.createElement("fa-icon");
+    previewIcon.size = 64;
+    previewWrapper.append(previewIcon);
+  }
+
+  previewIcon.setIcon(icon, forceSolid);
+}
 
 function setupChangeIcon(): void {
   const button = badgeContainer.querySelector('.trophyIconEditButton[data-value="icon"]') as HTMLButtonElement;
   const input = badgeContainer.querySelector('input[name="iconName"]') as HTMLInputElement;
 
   button.addEventListener("click", () => {
-    openFontAwesomePicker((icon, forceSolid) => {
-      previewIcon.setIcon(icon, forceSolid);
-      input.value = `${icon};${String(forceSolid)}`;
+    openFontAwesomePicker((icon, forceSolid, value, previewHtml) => {
+      input.value = value ?? `${icon};${String(forceSolid)}`;
+
+      if (typeof previewHtml === "string") {
+        previewWrapper.innerHTML = previewHtml;
+      } else {
+        renderNativePreview(icon, forceSolid);
+      }
     });
   });
 }

--- a/ts/WoltLabSuite/Core/Ui/Style/FontAwesome.ts
+++ b/ts/WoltLabSuite/Core/Ui/Style/FontAwesome.ts
@@ -11,7 +11,7 @@ import { getPhrase } from "WoltLabSuite/Core/Language";
 import UiItemListFilter from "../ItemList/Filter";
 import { dialogFactory } from "WoltLabSuite/Core/Component/Dialog";
 
-type CallbackSelect = (icon: string, forceSolid: boolean) => void;
+type CallbackSelect = (icon: string, forceSolid: boolean, value?: string, previewHtml?: string) => void;
 type IconData = { icon: string; forceSolid: boolean };
 
 function createIconList(): HTMLElement {
@@ -92,7 +92,9 @@ function setupListeners(): void {
 
 /**
  * Shows the FontAwesome selection dialog, supplied callback will be
- * invoked with the selection icon's name as the only argument.
+ * invoked with the selected icon's native data. Replacement
+ * implementations may pass an explicit stored value and preview html
+ * for non-native icons.
  */
 export function open(callback: CallbackSelect): void {
   const dialog = dialogFactory().fromElement(getContent()).asConfirmation();

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Acp/Ui/Trophy/Badge.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Acp/Ui/Trophy/Badge.js
@@ -14,14 +14,28 @@ define(["require", "exports", "tslib", "../../../Ui/Style/FontAwesome", "../../.
     Util_1 = tslib_1.__importDefault(Util_1);
     const badgeContainer = document.getElementById("badgeContainer");
     const previewWrapper = badgeContainer.querySelector(".trophyIcon");
-    const previewIcon = previewWrapper.querySelector("fa-icon");
+    function renderNativePreview(icon, forceSolid) {
+        let previewIcon = previewWrapper.querySelector("fa-icon");
+        if (!(previewIcon instanceof HTMLElement) || previewIcon.parentElement !== previewWrapper) {
+            previewWrapper.replaceChildren();
+            previewIcon = document.createElement("fa-icon");
+            previewIcon.size = 64;
+            previewWrapper.append(previewIcon);
+        }
+        previewIcon.setIcon(icon, forceSolid);
+    }
     function setupChangeIcon() {
         const button = badgeContainer.querySelector('.trophyIconEditButton[data-value="icon"]');
         const input = badgeContainer.querySelector('input[name="iconName"]');
         button.addEventListener("click", () => {
-            (0, FontAwesome_1.open)((icon, forceSolid) => {
-                previewIcon.setIcon(icon, forceSolid);
-                input.value = `${icon};${String(forceSolid)}`;
+            (0, FontAwesome_1.open)((icon, forceSolid, value, previewHtml) => {
+                input.value = value ?? `${icon};${String(forceSolid)}`;
+                if (typeof previewHtml === "string") {
+                    previewWrapper.innerHTML = previewHtml;
+                }
+                else {
+                    renderNativePreview(icon, forceSolid);
+                }
             });
         });
     }

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Style/FontAwesome.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Ui/Style/FontAwesome.js
@@ -74,7 +74,9 @@ define(["require", "exports", "tslib", "WoltLabSuite/Core/Language", "../ItemLis
     }
     /**
      * Shows the FontAwesome selection dialog, supplied callback will be
-     * invoked with the selection icon's name as the only argument.
+     * invoked with the selected icon's native data. Replacement
+     * implementations may pass an explicit stored value and preview html
+     * for non-native icons.
      */
     function open(callback) {
         const dialog = (0, Dialog_1.dialogFactory)().fromElement(getContent()).asConfirmation();

--- a/wcfsetup/install/files/lib/event/style/StoredIconResolving.class.php
+++ b/wcfsetup/install/files/lib/event/style/StoredIconResolving.class.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace wcf\event\style;
+
+use wcf\event\IPsr14Event;
+use wcf\system\style\IFontAwesomeIcon;
+
+/**
+ * Resolves a stored icon string to a renderable icon instance.
+ *
+ * @author      Sascha Greuel
+ * @copyright   2001-2026 WoltLab GmbH
+ * @license     GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
+ * @since       6.2
+ */
+final class StoredIconResolving implements IPsr14Event
+{
+    public ?IFontAwesomeIcon $icon = null;
+
+    public function __construct(
+        public readonly string $iconData
+    ) {
+    }
+}

--- a/wcfsetup/install/files/lib/system/style/FontAwesomeIcon.class.php
+++ b/wcfsetup/install/files/lib/system/style/FontAwesomeIcon.class.php
@@ -2,6 +2,8 @@
 
 namespace wcf\system\style;
 
+use wcf\event\style\StoredIconResolving;
+use wcf\system\event\EventHandler;
 use wcf\system\style\exception\InvalidIconFormat;
 use wcf\system\style\exception\InvalidIconSize;
 use wcf\system\style\exception\UnknownIcon;
@@ -28,9 +30,13 @@ final class FontAwesomeIcon implements IFontAwesomeIcon, \Stringable
 
     private function __construct(
         private readonly string $name,
-        private readonly bool $forceSolid
+        private readonly bool $forceSolid,
+        private readonly ?string $iconData = null,
+        private readonly ?IFontAwesomeIcon $icon = null
     ) {
-        self::validateName($name);
+        if ($this->icon === null) {
+            self::validateName($name);
+        }
     }
 
     /**
@@ -40,6 +46,10 @@ final class FontAwesomeIcon implements IFontAwesomeIcon, \Stringable
     #[\Override]
     public function __toString(): string
     {
+        if ($this->iconData !== null) {
+            return $this->iconData;
+        }
+
         return \sprintf(
             "%s;%s",
             $this->name,
@@ -52,6 +62,10 @@ final class FontAwesomeIcon implements IFontAwesomeIcon, \Stringable
     {
         if (!\in_array($size, self::SIZES)) {
             throw new InvalidIconSize($size);
+        }
+
+        if ($this->icon !== null) {
+            return $this->icon->toHtml($size);
         }
 
         if ($this->forceSolid) {
@@ -78,18 +92,21 @@ final class FontAwesomeIcon implements IFontAwesomeIcon, \Stringable
      */
     public static function fromString(string $iconData): self
     {
-        if (!\str_contains($iconData, ';')) {
+        $icon = self::parseIconData($iconData);
+        if ($icon !== null && self::isValidName($icon['name'])) {
+            return self::fromValues($icon['name'], $icon['forceSolid']);
+        }
+
+        $resolvedIcon = self::resolveStoredIcon($iconData);
+        if ($resolvedIcon !== null) {
+            return new self('question', true, $iconData, $resolvedIcon);
+        }
+
+        if ($icon === null) {
             throw new InvalidIconFormat();
         }
 
-        [$name, $solid] = \explode(';', $iconData, 2);
-        if ($solid !== 'true' && $solid !== 'false') {
-            throw new InvalidIconFormat();
-        }
-
-        $forceSolid = $solid === 'true';
-
-        return self::fromValues($name, $forceSolid);
+        return self::fromValues($icon['name'], $icon['forceSolid']);
     }
 
     public static function fromValues(string $name, bool $forceSolid = false): self
@@ -99,16 +116,40 @@ final class FontAwesomeIcon implements IFontAwesomeIcon, \Stringable
 
     public static function isValidString(string $iconData): bool
     {
+        $icon = self::parseIconData($iconData);
+        if ($icon !== null && self::isValidName($icon['name'])) {
+            return true;
+        }
+
+        return self::resolveStoredIcon($iconData) !== null;
+    }
+
+    /**
+     * @return ?array{name: string, forceSolid: bool}
+     */
+    private static function parseIconData(string $iconData): ?array
+    {
         if (!\str_contains($iconData, ';')) {
-            return false;
+            return null;
         }
 
         [$name, $solid] = \explode(';', $iconData, 2);
         if ($solid !== 'true' && $solid !== 'false') {
-            return false;
+            return null;
         }
 
-        return self::isValidName($name);
+        return [
+            'name' => $name,
+            'forceSolid' => $solid === 'true',
+        ];
+    }
+
+    private static function resolveStoredIcon(string $iconData): ?IFontAwesomeIcon
+    {
+        $event = new StoredIconResolving($iconData);
+        EventHandler::getInstance()->fire($event);
+
+        return $event->icon;
     }
 
     public static function isValidName(string $name): bool


### PR DESCRIPTION
## Current State

WoltLab Suite 6.2 icon fields and rendering are effectively limited to native Font Awesome icon strings in the `name;forceSolid` format.

This means that packages can replace or extend the icon picker UI, but selected values cannot be accepted globally unless they still look like native WSC icon strings. In practice, this blocks package-safe integrations for icons that need additional identity data, for example:

- bundled brand SVG icons,
- externally provided icon packs,
- icons that are not part of WSC's native Font Awesome metadata,
- descriptors that need package-specific rendering.

Without a core extension point, third-party packages must either integrate with each consuming form individually or avoid storing extended icon values.

## Proposed State

This PR adds a small extension point around stored icon resolution:

- `FontAwesomeIcon::isValidString()` first accepts native values as before.
- If a value is not a valid native icon string, WSC fires `wcf\event\style\StoredIconResolving`.
- A package may resolve the stored value to an `IFontAwesomeIcon`.
- `FontAwesomeIcon::fromString()` preserves the original stored string and delegates rendering to the resolved icon.
- Native icon behavior remains unchanged.

The Font Awesome picker callback is also extended in a backwards-compatible way:

```ts
(icon: string, forceSolid: boolean, value?: string, previewHtml?: string) => void
```

Existing picker consumers can continue using only icon and forceSolid. Replacement picker implementations can optionally provide:

- an explicit stored value,
- trusted preview HTML for non-native icon previews.

IconFormField and trophy badge previews now use these optional values when present, while retaining the native <fa-icon> preview path for normal icons.

## Why Accept This?

This gives WSC a narrow, package-safe extension point instead of forcing packages to patch core files or duplicate integrations for every icon field.

Benefits:

- Preserves existing native Font Awesome behavior.
- Enables package-safe support for additional icon sources.
- Allows existing core fields using IconFormField to accept custom stored icons without package-specific field forks.
- Keeps the rendering contract aligned with WSC's existing IFontAwesomeIcon abstraction.
- Avoids hardcoding third-party icon logic into WSC.
- Keeps the implementation small and opt-in: nothing changes unless a package listens to StoredIconResolving.

## Downsides

- FontAwesomeIcon::isValidString() and fromString() now may fire an event for values that are not valid native icon strings.
- StoredIconResolving becomes a public extension point and therefore should be treated as API once released.
- previewHtml is trusted HTML supplied by the picker implementation. This is useful for SVG/custom previews, but the contract should make clear that extensions must not pass unsanitized user input.

## Risks For WSC 6.2

The behavioral risk is low because native icon strings still take the same path as before. Existing callers and picker callbacks remain compatible.

The main 6.2 risk is API commitment: adding StoredIconResolving in a patch release means third-party packages may depend on it immediately. If the event shape should change, that is easier before release than after.

Waiting for 6.3 would reduce that API commitment risk, but it would leave 6.2 without a package-safe way to integrate extended icon sources. For installations already using WSC 6.2, packages would still need brittle field-specific workarounds or core patches.

## Compatibility

This is intended to be backwards-compatible:

- existing native icon values still validate and render as before,
- existing picker callbacks still work,
- existing FontAwesomeIcon::fromString() consumers can render resolved custom icons without code changes,
- packages that do not listen to StoredIconResolving are unaffected.