### PR TITLE
Add optional emoji mapping for smileys

### DIFF
--- a/wcfsetup/install/files/acp/database/update_com.woltlab.wcf_6.3_step1.php
+++ b/wcfsetup/install/files/acp/database/update_com.woltlab.wcf_6.3_step1.php
@@ -57,4 +57,9 @@ return [
         ->columns([
             DefaultFalseBooleanDatabaseTableColumn::create('showOnUserCard'),
         ]),
+    PartialDatabaseTable::create('wcf1_smiley')
+        ->columns([
+            NotNullVarchar255DatabaseTableColumn::create('emoji')
+                ->defaultValue(''),
+        ]),
 ];

--- a/wcfsetup/install/files/acp/templates/smileyAdd.tpl
+++ b/wcfsetup/install/files/acp/templates/smileyAdd.tpl
@@ -80,12 +80,26 @@
 			<dt><label for="aliases">{lang}wcf.acp.smiley.aliases{/lang}</label></dt>
 			<dd>
 				<textarea id="aliases" name="aliases" cols="40" rows="10">{$aliases}</textarea>
-				
+
 				{if $errorField == 'aliases'}
 					<small class="innerError">
 						{lang}wcf.acp.smiley.aliases.error.{$errorType}{/lang}
 					</small>
 				{/if}
+			</dd>
+		</dl>
+
+		<dl{if $errorField == 'emoji'} class="formError"{/if}>
+			<dt><label for="emoji">{lang}wcf.acp.smiley.emoji{/lang}</label></dt>
+			<dd>
+				<input type="text" id="emoji" name="emoji" value="{$emoji}" class="short" maxlength="64">
+
+				{if $errorField == 'emoji'}
+					<small class="innerError">
+						{lang}wcf.acp.smiley.emoji.error.{$errorType}{/lang}
+					</small>
+				{/if}
+				<small>{lang}wcf.acp.smiley.emoji.description{/lang}</small>
 			</dd>
 		</dl>
 		

--- a/wcfsetup/install/files/lib/acp/form/SmileyAddForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/SmileyAddForm.class.php
@@ -85,6 +85,11 @@ class SmileyAddForm extends AbstractForm
     public $aliases = '';
 
     /**
+     * unicode emoji that replaces this smiley during message reprocessing
+     */
+    public string $emoji = '';
+
+    /**
      * path to the smiley file
      * @var string
      */
@@ -140,6 +145,7 @@ class SmileyAddForm extends AbstractForm
             'categoryID' => $this->categoryID,
             'smileyCode' => $this->smileyCode,
             'aliases' => $this->aliases,
+            'emoji' => $this->emoji,
             'smileyPath' => $this->smileyPath,
             'smileyPath2x' => $this->smileyPath2x,
             'categoryNodeList' => $this->categoryNodeTree->getIterator(),
@@ -187,6 +193,9 @@ class SmileyAddForm extends AbstractForm
         if (isset($_POST['aliases'])) {
             $this->aliases = StringUtil::unifyNewlines(StringUtil::trim($_POST['aliases']));
         }
+        if (isset($_POST['emoji'])) {
+            $this->emoji = StringUtil::trim($_POST['emoji']);
+        }
         if (isset($_POST['smileyPath'])) {
             $this->smileyPath = FileUtil::removeLeadingSlash(StringUtil::trim($_POST['smileyPath']));
         }
@@ -217,6 +226,7 @@ class SmileyAddForm extends AbstractForm
                 'smileyTitle' => $this->smileyTitle,
                 'smileyCode' => $this->smileyCode,
                 'aliases' => $this->aliases,
+                'emoji' => $this->emoji,
                 'smileyPath' => $this->smileyPath,
                 'smileyPath2x' => $this->smileyPath2x,
                 'showOrder' => $this->showOrder,
@@ -246,6 +256,7 @@ class SmileyAddForm extends AbstractForm
         $this->showOrder = 0;
         $this->smileyPath = $this->smileyPath2x = '';
         $this->aliases = '';
+        $this->emoji = '';
         $this->uploadedFilename = $this->uploadedFilename2x = '';
 
         I18nHandler::getInstance()->reset();

--- a/wcfsetup/install/files/lib/acp/form/SmileyEditForm.class.php
+++ b/wcfsetup/install/files/lib/acp/form/SmileyEditForm.class.php
@@ -77,6 +77,7 @@ class SmileyEditForm extends SmileyAddForm
                 'smileyTitle' => $this->smileyTitle,
                 'smileyCode' => $this->smileyCode,
                 'aliases' => $this->aliases,
+                'emoji' => $this->emoji,
                 'smileyPath' => $this->smileyPath,
                 'smileyPath2x' => $this->smileyPath2x,
                 'showOrder' => $this->showOrder,
@@ -106,6 +107,7 @@ class SmileyEditForm extends SmileyAddForm
 
             $this->smileyCode = $this->smiley->smileyCode;
             $this->aliases = $this->smiley->aliases;
+            $this->emoji = $this->smiley->emoji;
             $this->smileyPath = $this->smiley->smileyPath;
             $this->smileyPath2x = $this->smiley->smileyPath2x;
             $this->showOrder = $this->smiley->showOrder;

--- a/wcfsetup/install/files/lib/data/smiley/Smiley.class.php
+++ b/wcfsetup/install/files/lib/data/smiley/Smiley.class.php
@@ -23,6 +23,7 @@ use wcf\util\StringUtil;
  * @property-read   string  $smileyCode     code used for displaying the smiley
  * @property-read   string  $aliases        alternative codes used for displaying the smiley
  * @property-read   int     $showOrder      position of the smiley in relation to the other smileys in the same category
+ * @property-read   string  $emoji          unicode emoji that replaces this smiley when content is reprocessed
  */
 class Smiley extends DatabaseObject implements ITitledObject
 {

--- a/wcfsetup/install/files/lib/system/html/input/node/HtmlInputNodeImg.class.php
+++ b/wcfsetup/install/files/lib/system/html/input/node/HtmlInputNodeImg.class.php
@@ -255,6 +255,18 @@ class HtmlInputNodeImg extends AbstractHtmlInputNode
         $code = $element->getAttribute('alt');
 
         $smiley = SmileyCache::getInstance()->getSmileyByCode($code);
+
+        // Migrate legacy smiley element to the mapped unicode emoji.
+        if ($smiley !== null && $smiley->emoji !== '') {
+            $element->parentNode->insertBefore(
+                $element->ownerDocument->createTextNode($smiley->emoji),
+                $element
+            );
+            $element->parentNode->removeChild($element);
+
+            return;
+        }
+
         if ($smiley === null || $this->smiliesFound === 50) {
             $element->parentNode->insertBefore($element->ownerDocument->createTextNode($code), $element);
             $element->parentNode->removeChild($element);

--- a/wcfsetup/install/files/lib/system/html/input/node/HtmlInputNodeTextParser.class.php
+++ b/wcfsetup/install/files/lib/system/html/input/node/HtmlInputNodeTextParser.class.php
@@ -607,12 +607,19 @@ class HtmlInputNodeTextParser
         foreach ($smileyPatterns as $smileyPattern) {
             $value = \preg_replace_callback($smileyPattern, function ($matches) use ($text) {
                 $smileyCode = $matches[0];
+                $smiley = self::$smilies[$smileyCode];
+
+                // Replace smiley with mapped unicode emoji so legacy smiley codes
+                // get migrated to native emojis whenever a message is reprocessed.
+                if ($smiley->emoji !== '') {
+                    return $smiley->emoji;
+                }
+
                 if ($this->smileyCount === 50) {
                     return $smileyCode;
                 }
 
                 $this->smileyCount++;
-                $smiley = self::$smilies[$smileyCode];
                 $element = $text->ownerDocument->createElement('img');
                 $element->setAttribute('src', $smiley->getURL());
                 $element->setAttribute('class', 'smiley');

--- a/wcfsetup/install/files/lib/system/html/output/node/HtmlOutputNodeImg.class.php
+++ b/wcfsetup/install/files/lib/system/html/output/node/HtmlOutputNodeImg.class.php
@@ -41,6 +41,13 @@ class HtmlOutputNodeImg extends AbstractHtmlOutputNode
                 $code = $element->getAttribute('alt');
 
                 $smiley = SmileyCache::getInstance()->getSmileyByCode($code);
+
+                // Render the mapped unicode emoji instead of the legacy smiley image.
+                if ($smiley !== null && $smiley->emoji !== '') {
+                    $htmlNodeProcessor->replaceElementWithText($element, $smiley->emoji, false);
+                    continue;
+                }
+
                 if ($smiley === null || $this->outputType === 'text/plain') {
                     // output as raw code instead
                     $htmlNodeProcessor->replaceElementWithText($element, ' ' . $code . ' ', false);

--- a/wcfsetup/install/lang/de.xml
+++ b/wcfsetup/install/lang/de.xml
@@ -2855,6 +2855,8 @@ Abschnitte dürfen nicht leer sein und nur folgende Zeichen enthalten: <kbd>[a-z
 		<item name="wcf.acp.smiley.smileyCode.error.notUnique"><![CDATA[Dieser Smiley-Code wird bereits von einem anderen Smiley verwendet]]></item>
 		<item name="wcf.acp.smiley.aliases"><![CDATA[Alternative Smiley-Codes]]></item>
 		<item name="wcf.acp.smiley.aliases.error.notUnique"><![CDATA[Mindestens ein alternativer Smiley-Code wird bereits von einem anderen Smiley verwendet]]></item>
+		<item name="wcf.acp.smiley.emoji"><![CDATA[Emoji]]></item>
+		<item name="wcf.acp.smiley.emoji.description"><![CDATA[Optionales Emoji, das diesen Smiley ersetzt, sobald eine bestehende Nachricht aktualisiert wird. Leer lassen, um den Smiley nicht zu ersetzen.]]></item>
 		<item name="wcf.acp.smiley.smileyPath"><![CDATA[Smiley-Pfad]]></item>
 		<item name="wcf.acp.smiley.smileyPath.description"><![CDATA[Der Smiley-Pfad wird relativ zu „{$__wcf->getPath()}“ interpretiert.]]></item>
 		<item name="wcf.acp.smiley.smileyPath.error.notFound"><![CDATA[Es wurde keine Datei unter dem angegebenen Pfad gefunden]]></item>

--- a/wcfsetup/install/lang/en.xml
+++ b/wcfsetup/install/lang/en.xml
@@ -2784,6 +2784,8 @@ If you have <strong>already bought the licenses for the listed apps</strong>, th
 		<item name="wcf.acp.smiley.smileyCode.error.notUnique"><![CDATA[This smiley code is already in use by another smiley.]]></item>
 		<item name="wcf.acp.smiley.aliases"><![CDATA[Alternative Smiley Codes]]></item>
 		<item name="wcf.acp.smiley.aliases.error.notUnique"><![CDATA[At least one alternative smiley code is already in use by another smiley.]]></item>
+		<item name="wcf.acp.smiley.emoji"><![CDATA[Emoji]]></item>
+		<item name="wcf.acp.smiley.emoji.description"><![CDATA[Optional emoji that replaces this smiley when an existing message is updated. Leave empty to keep the smiley unchanged.]]></item>
 		<item name="wcf.acp.smiley.smileyPath"><![CDATA[Smiley Path]]></item>
 		<item name="wcf.acp.smiley.smileyPath.description"><![CDATA[The smiley path is relative to “{$__wcf->getPath()}”.]]></item>
 		<item name="wcf.acp.smiley.smileyPath.error.notFound"><![CDATA[Unable to find a file on entered path.]]></item>

--- a/wcfsetup/setup/db/install_com.woltlab.wcf.php
+++ b/wcfsetup/setup/db/install_com.woltlab.wcf.php
@@ -3293,6 +3293,8 @@ return [
                 ->notNull(),
             NotNullInt10DatabaseTableColumn::create('showOrder')
                 ->defaultValue(0),
+            NotNullVarchar255DatabaseTableColumn::create('emoji')
+                ->defaultValue(''),
         ])
         ->indices([
             DatabaseTablePrimaryIndex::create()


### PR DESCRIPTION
Allow administrators to map a smiley to a unicode emoji. When set, the input and output processors replace the smiley image with the configured emoji so that legacy smiley codes are migrated to native emojis whenever a message is reprocessed.

ref https://www.woltlab.com/community/thread/318318-smilies-zu-emojis-migrieren/