### PR TITLE
Fix Sass mixed declaration deprecations

### DIFF
--- a/wcfsetup/install/files/acp/style/layout.scss
+++ b/wcfsetup/install/files/acp/style/layout.scss
@@ -674,8 +674,7 @@ html[data-color-scheme="dark"] {
 }
 
 .packageSearchName {
-	@include wcfFontHeadline;
-	@include wcfFontBold;
+	@include wcfFontHeadlineBold;
 }
 
 .packageSearchVersion {

--- a/wcfsetup/install/files/style/bootstrap/mixin/font.scss
+++ b/wcfsetup/install/files/style/bootstrap/mixin/font.scss
@@ -37,6 +37,19 @@
 	}
 }
 
+@mixin wcfFontHeadlineBold {
+	font-weight: 600;
+	line-height: 1.28;
+
+	@include screen-md-up {
+		font-size: var(--wcfFontSizeHeadline);
+	}
+
+	@include screen-sm-down {
+		font-size: 18px;
+	}
+}
+
 @mixin wcfFontSection {
 	font-weight: 600;
 	line-height: 1.28;

--- a/wcfsetup/install/files/style/ui/button.scss
+++ b/wcfsetup/install/files/style/ui/button.scss
@@ -39,13 +39,13 @@ a.button {
 
 	// input elements do not inherit font family, size and line-height from body
 	font-family: var(--wcfFontFamily);
-	@include wcfFontDefault;
 	@include wcfLineHeight;
 
 	// removes UA styling enforced by Safari on iOS
 	-webkit-appearance: none;
 
 	@include userSelectNone;
+	@include wcfFontDefault;
 
 	&.active {
 		background-color: var(--wcfButtonBackgroundActive);

--- a/wcfsetup/install/files/style/ui/contentItem.scss
+++ b/wcfsetup/install/files/style/ui/contentItem.scss
@@ -178,8 +178,7 @@
 .contentItemTitle {
 	color: var(--wcfContentHeadlineLink);
 
-	@include wcfFontHeadline;
-	@include wcfFontBold;
+	@include wcfFontHeadlineBold;
 
 	&:hover {
 		color: var(--wcfContentHeadlineLinkActive);

--- a/wcfsetup/install/files/style/ui/dialog.scss
+++ b/wcfsetup/install/files/style/ui/dialog.scss
@@ -98,9 +98,7 @@
 		> span {
 			flex: 1 auto;
 
-			@include wcfFontHeadline;
-
-			font-weight: 600;
+			@include wcfFontHeadlineBold;
 		}
 
 		> .dialogCloseButton {
@@ -344,9 +342,7 @@ html[data-color-scheme="dark"] .dialog::backdrop {
 	text-overflow: ellipsis;
 	white-space: nowrap;
 
-	@include wcfFontHeadline;
-
-	font-weight: 600;
+	@include wcfFontHeadlineBold;
 }
 
 .dialog__closeButton {
@@ -446,11 +442,11 @@ html[data-color-scheme="dark"] .dialog::backdrop {
 .dialogContent,
 .dialog__content {
 	.section .sectionTitle {
-		@include wcfFontDefault;
-
 		border-bottom-width: 0;
 		font-weight: 600;
 		padding-bottom: 0;
+
+		@include wcfFontDefault;
 	}
 
 	> .section:first-child,

--- a/wcfsetup/install/files/style/ui/discussionList.scss
+++ b/wcfsetup/install/files/style/ui/discussionList.scss
@@ -149,8 +149,7 @@
 .discussionList__item__title {
 	grid-area: title;
 
-	@include wcfFontHeadline;
-	@include wcfFontBold;
+	@include wcfFontHeadlineBold;
 }
 
 @include screen-xs {

--- a/wcfsetup/install/files/style/ui/dropdown.scss
+++ b/wcfsetup/install/files/style/ui/dropdown.scss
@@ -95,10 +95,10 @@
 	}
 
 	.userObjectWatchSelectDescription {
-		@include wcfFontSmall;
-
 		color: var(--wcfContentDimmedText);
 		padding-top: 0;
 		white-space: normal;
+
+		@include wcfFontSmall;
 	}
 }

--- a/wcfsetup/install/files/style/ui/embeddedContent.scss
+++ b/wcfsetup/install/files/style/ui/embeddedContent.scss
@@ -81,8 +81,7 @@
 	-webkit-line-clamp: 2;
 	-webkit-box-orient: vertical;
 
-	@include wcfFontHeadline;
-	@include wcfFontBold;
+	@include wcfFontHeadlineBold;
 }
 
 .embeddedContentDetails {

--- a/wcfsetup/install/files/style/ui/entry.scss
+++ b/wcfsetup/install/files/style/ui/entry.scss
@@ -41,8 +41,7 @@
 .entry__attachments__title {
 	margin-bottom: 10px;
 
-	@include wcfFontHeadline;
-	@include wcfFontBold;
+	@include wcfFontHeadlineBold;
 }
 
 .entry__footer {

--- a/wcfsetup/install/files/style/ui/entryCardList.scss
+++ b/wcfsetup/install/files/style/ui/entryCardList.scss
@@ -124,8 +124,7 @@ html:not(.touch) .entryCardList__item:hover .entryCardList__item__image__element
 	color: var(--wcfContentHeadlineLink);
 	display: flex;
 
-	@include wcfFontHeadline;
-	@include wcfFontBold;
+	@include wcfFontHeadlineBold;
 }
 
 .entryCardList__item .listView__item__markAsRead {

--- a/wcfsetup/install/files/style/ui/itemListInput.scss
+++ b/wcfsetup/install/files/style/ui/itemListInput.scss
@@ -1,10 +1,12 @@
 .inputItemList {
 	@include input;
 
-	display: flex;
-	flex-wrap: wrap;
-	padding-bottom: 0;
-	padding-top: 5px;
+	& {
+		display: flex;
+		flex-wrap: wrap;
+		padding-bottom: 0;
+		padding-top: 5px;
+	}
 
 	&[data-accepts-new-items="true"] {
 		cursor: text;

--- a/wcfsetup/install/files/style/ui/messageEditHistory.scss
+++ b/wcfsetup/install/files/style/ui/messageEditHistory.scss
@@ -16,11 +16,11 @@
 	}
 
 	.table {
+		width: 100%;
+
 		@include screen-lg {
 			table-layout: fixed;
 		}
-
-		width: 100%;
 
 		th {
 			text-align: center;

--- a/wcfsetup/install/files/style/ui/reactions.scss
+++ b/wcfsetup/install/files/style/ui/reactions.scss
@@ -45,9 +45,9 @@ html[data-color-scheme="dark"] .reactionPopover {
 }
 
 .reactionCount {
-	@include wcfFontSmall;
-
 	vertical-align: middle;
+
+	@include wcfFontSmall;
 
 	&::before {
 		content: "\202f×\202f";

--- a/wcfsetup/install/files/style/ui/unfurlUrl.scss
+++ b/wcfsetup/install/files/style/ui/unfurlUrl.scss
@@ -72,15 +72,14 @@ html[data-color-scheme="dark"] .unfurlUrlCard {
 }
 
 .unfurlUrlTitle {
-	@include wcfFontHeadline;
-	@include wcfFontBold;
-
 	color: inherit;
 	display: -webkit-box;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	-webkit-box-orient: vertical;
 	-webkit-line-clamp: 2;
+
+	@include wcfFontHeadlineBold;
 
 	&::before {
 		content: "";
@@ -103,12 +102,12 @@ html[data-color-scheme="dark"] .unfurlUrlCard {
 }
 
 .unfurlUrlHost {
-	@include wcfFontSmall;
-
 	bottom: 5px;
 	color: var(--wcfContentDimmedText);
 	position: absolute;
 	right: 5px;
+
+	@include wcfFontSmall;
 
 	img {
 		height: 12px !important;

--- a/wcfsetup/install/files/style/ui/userCard.scss
+++ b/wcfsetup/install/files/style/ui/userCard.scss
@@ -128,8 +128,7 @@
 .userCard__username {
 	display: inline;
 
-	@include wcfFontHeadline;
-	@include wcfFontBold;
+	@include wcfFontHeadlineBold;
 }
 
 .userCard__link {
@@ -175,11 +174,12 @@
 }
 
 .userCard__footer__statsItem__key {
-	@include wcfFontSmall;
 	color: var(--wcfContentDimmedText);
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
+
+	@include wcfFontSmall;
 }
 
 .userCard__buttons {
@@ -203,8 +203,9 @@
 }
 
 .userCard__details {
-	@include wcfFontSmall;
 	margin-top: 15px;
+
+	@include wcfFontSmall;
 }
 
 .userCard__details .dataList dd {

--- a/wcfsetup/install/files/style/ui/userMenu.scss
+++ b/wcfsetup/install/files/style/ui/userMenu.scss
@@ -47,9 +47,7 @@
 	text-overflow: ellipsis;
 	white-space: nowrap;
 
-	@include wcfFontHeadline;
-
-	font-weight: 600;
+	@include wcfFontHeadlineBold;
 }
 
 .userMenuButtons {


### PR DESCRIPTION
Fix Sass mixed-decls deprecation warnings in WCF core and ACP styles by avoiding declarations after nested media-producing mixins.

- Add `wcfFontHeadlineBold` for bold headline text without chaining `wcfFontHeadline` and `wcfFontBold`
- Reorder declarations around `wcfFontDefault`, `wcfFontSmall`, `screen-lg`, and related nested mixins
- Wrap the intentional post-input overrides in `itemListInput.scss` with `& {}`

Even after fixing, there are Sass warnings remaining. These are from WSF, etc. where these fixes need to be applied as well.

See also https://www.woltlab.com/community/thread/318717-style-compilation-schl%C3%A4gt-unter-windows-fehlt