### PR TITLE
Improve poll meter bar contrast in dark mode

### DIFF
--- a/wcfsetup/install/files/style/ui/poll.scss
+++ b/wcfsetup/install/files/style/ui/poll.scss
@@ -97,5 +97,5 @@
 }
 
 html[data-color-scheme="dark"] .pollMeterValue {
-	background-color: rgb(255 255 255 / 34%);
+	background-color: var(--wcfContentLink);
 }


### PR DESCRIPTION
## What

In dark mode the poll result bar (`.pollMeterValue`) was filled with a
faint translucent white (`rgb(255 255 255 / 34%)`), which is hard to
distinguish from the underlying track. This makes it difficult to read
the relative share of votes at a glance.

This changes the dark mode fill to the accent color (`--wcfContentLink`),
so the filled portion is clearly visible and consistent with the
appearance of the bar in light mode.

## Why

Reported in #5925 with before/after screenshots.

## Notes

Single-line style change in `wcfsetup/install/files/style/ui/poll.scss`.
Using the `--wcfContentLink` variable keeps the color in sync with the
active style's accent instead of hardcoding a value.
