### PR TITLE
Fix one-time consent for external media

### DIFF
--- a/ts/WoltLabSuite/Core/Component/Image/Fancybox/ConsentPlugin.ts
+++ b/ts/WoltLabSuite/Core/Component/Image/Fancybox/ConsentPlugin.ts
@@ -67,6 +67,18 @@ export class ConsentPlugin {
     externalURL.href = slide.src!;
     externalURL.innerText = url.host;
 
+    const showOnceButton = clone.querySelector(".jsButtonMessageUserConsentOnce") as HTMLButtonElement;
+    // The Fancybox plugin handles this button because there is no payload for the generic consent handler.
+    showOnceButton.classList.remove("jsButtonMessageUserConsentOnce");
+    showOnceButton.addEventListener("click", () => {
+      slide.type = this.#sliderToType.get(slide);
+      slide.el!.innerHTML = "";
+
+      // refresh current slide content
+      carousel.emit("detachSlideEl", slide);
+      carousel.emit("attachSlideEl", slide);
+    });
+
     const button = clone.querySelector(".jsButtonMessageUserConsentEnable") as HTMLButtonElement;
     button.addEventListener("click", () => {
       this.destroy();

--- a/wcfsetup/install/files/js/WoltLabSuite/Core/Component/Image/Fancybox/ConsentPlugin.js
+++ b/wcfsetup/install/files/js/WoltLabSuite/Core/Component/Image/Fancybox/ConsentPlugin.js
@@ -52,6 +52,16 @@ define(["require", "exports", "WoltLabSuite/Core/Ui/Message/UserConsent", "WoltL
             const url = new URL(slide.src);
             externalURL.href = slide.src;
             externalURL.innerText = url.host;
+            const showOnceButton = clone.querySelector(".jsButtonMessageUserConsentOnce");
+            // The Fancybox plugin handles this button because there is no payload for the generic consent handler.
+            showOnceButton.classList.remove("jsButtonMessageUserConsentOnce");
+            showOnceButton.addEventListener("click", () => {
+                slide.type = this.#sliderToType.get(slide);
+                slide.el.innerHTML = "";
+                // refresh current slide content
+                carousel.emit("detachSlideEl", slide);
+                carousel.emit("attachSlideEl", slide);
+            });
             const button = clone.querySelector(".jsButtonMessageUserConsentEnable");
             button.addEventListener("click", () => {
                 this.destroy();


### PR DESCRIPTION
The Fancybox consent plugin only handles permanently enabling external media. Clicking “Display content once” still invokes the generic user-consent handler, which expects a target or payload and can attempt to insert content relative to an already detached consent element.

This results in an empty Fancybox slide and the following error:

> The reference element has no parent, but the insert position was set to 'before'.

This PR handles one-time consent directly in the Fancybox plugin:

- Restores the original media type for the current slide.
- Refreshes the current slide so the external media is loaded.
- Prevents the generic payload-based consent handler from processing the Fancybox button.
- Leaves permanent consent behavior unchanged.