### PR TITLE
Validate constructor parameters for dynamically instantiated list views

### DIFF
--- a/wcfsetup/install/files/lib/action/ListViewFilterAction.class.php
+++ b/wcfsetup/install/files/lib/action/ListViewFilterAction.class.php
@@ -47,7 +47,10 @@ final class ListViewFilterAction implements RequestHandlerInterface
 
         try {
             /** @var AbstractListView<DatabaseObject, DatabaseObjectList<DatabaseObject>> $view */
-            $view = new $parameters['listView'](...$parameters['listViewParameters']);
+            $view = Helper::mapQueryParametersToClass(
+                $parameters['listViewParameters'],
+                $parameters['listView']
+            );
             // @phpstan-ignore catch.neverThrown
         } catch (\ArgumentCountError | \TypeError $e) {
             if (\ENABLE_DEBUG_MODE) {
@@ -93,7 +96,7 @@ final class ListViewFilterAction implements RequestHandlerInterface
             }
 
             return new JsonResponse([
-                'result' => $data
+                'result' => $data,
             ]);
         } else {
             throw new \LogicException('Unreachable');

--- a/wcfsetup/install/files/lib/http/Helper.class.php
+++ b/wcfsetup/install/files/lib/http/Helper.class.php
@@ -113,16 +113,59 @@ final class Helper
      */
     public static function mapQueryParameters(array $queryParameters, string $schema): mixed
     {
-        $mapper = (new MapperBuilder())
-            ->allowSuperfluousKeys()
-            ->allowScalarValueCasting()
-            ->allowUndefinedValues()
-            ->mapper();
+        $mapper = self::getQueryParameterMapperBuilder()->mapper();
 
         return $mapper->map(
             $schema,
             Source::array($queryParameters)
         );
+    }
+
+    /**
+     * Validates query parameters against the constructor signature of the
+     * provided class and invokes the constructor with the mapped arguments.
+     * No other properties of the class are mapped.
+     *
+     * @template T of object
+     * @param mixed[] $queryParameters
+     * @param class-string<T> $className
+     * @return T
+     * @throws MappingError
+     */
+    public static function mapQueryParametersToClass(array $queryParameters, string $className): object
+    {
+        $reflectionClass = new \ReflectionClass($className);
+        if (!$reflectionClass->isInstantiable()) {
+            throw new \InvalidArgumentException("Class '{$className}' is not instantiable.");
+        }
+
+        $constructor = $reflectionClass->getConstructor();
+        if ($constructor === null) {
+            return $reflectionClass->newInstance();
+        }
+
+        $object = $reflectionClass->newInstanceWithoutConstructor();
+        $constructorClosure = $constructor->getClosure($object);
+        \assert($constructorClosure !== null);
+
+        $arguments = self::getQueryParameterMapperBuilder()
+            ->argumentsMapper()
+            ->mapArguments(
+                $constructorClosure,
+                Source::array($queryParameters)
+            );
+
+        $constructorClosure(...$arguments);
+
+        return $object;
+    }
+
+    private static function getQueryParameterMapperBuilder(): MapperBuilder
+    {
+        return (new MapperBuilder())
+            ->allowSuperfluousKeys()
+            ->allowScalarValueCasting()
+            ->allowUndefinedValues();
     }
 
     /**

--- a/wcfsetup/install/files/lib/system/endpoint/controller/core/listViews/GetItem.class.php
+++ b/wcfsetup/install/files/lib/system/endpoint/controller/core/listViews/GetItem.class.php
@@ -32,7 +32,10 @@ final class GetItem implements IController
             throw new UserInputException('listView', 'invalid');
         }
 
-        $view = new $parameters->listView(...$parameters->listViewParameters);
+        $view = Helper::mapQueryParametersToClass(
+            $parameters->listViewParameters,
+            $parameters->listView
+        );
         // @phpstan-ignore function.alreadyNarrowedType, instanceof.alwaysTrue
         \assert($view instanceof AbstractListView);
 
@@ -68,5 +71,6 @@ final class GetItemParameters
         public readonly array $listViewParameters,
         public readonly bool $allowInteractions = true,
         public readonly bool $allowBulkInteractions = true,
-    ) {}
+    ) {
+    }
 }

--- a/wcfsetup/install/files/lib/system/endpoint/controller/core/listViews/GetItems.class.php
+++ b/wcfsetup/install/files/lib/system/endpoint/controller/core/listViews/GetItems.class.php
@@ -32,7 +32,10 @@ final class GetItems implements IController
             throw new UserInputException('listView', 'invalid');
         }
 
-        $view = new $parameters->listView(...$parameters->listViewParameters);
+        $view = Helper::mapQueryParametersToClass(
+            $parameters->listViewParameters,
+            $parameters->listView
+        );
         // @phpstan-ignore function.alreadyNarrowedType, instanceof.alwaysTrue
         \assert($view instanceof AbstractListView);
 
@@ -98,5 +101,6 @@ final class GetItemsParameters
         public readonly bool $allowSorting = true,
         public readonly bool $allowInteractions = true,
         public readonly bool $allowBulkInteractions = true,
-    ) {}
+    ) {
+    }
 }

--- a/wcfsetup/install/files/lib/system/listView/user/TaggedArticleListView.class.php
+++ b/wcfsetup/install/files/lib/system/listView/user/TaggedArticleListView.class.php
@@ -16,7 +16,7 @@ use wcf\system\tagging\TagEngine;
 class TaggedArticleListView extends ArticleListView
 {
     public function __construct(
-        /** @var list<int> */
+        /** @var non-empty-list<positive-int> */
         public readonly array $tagIDs,
     ) {
         parent::__construct();


### PR DESCRIPTION
List views were instantiated by unpacking unvalidated query parameters directly into their constructors. Scalar values could therefore reach constructor properties and downstream methods with incorrect types.

This caused malformed `tagIDs` parameters to reach `TagEngine::getSubselectForObjectsByTagIDs()`, resulting in a `TypeError`:

```
<<<<<<<<bdc8ad84657e8ab54d7ad351e478815665280f18<<<<
Wed, 02 Sep 2026 06:40:25 +0000
Message: wcf\system\tagging\TagEngine::{closure:wcf\system\tagging\TagEngine::getSubselectForObjectsByTagIDs():341}(): Argument #1 ($tagID) must be of type int, string given
PHP version: 8.4.25
WoltLab Suite version: 6.2.6
Request URI: GET /list-view-filter/?listView=wcf%5Csystem%5ClistView%5Cuser%5CTaggedArticleListView&listViewParameters%5BtagIDs%5D%5B0%5D=14%22%27%2C%28.%29abcd
Referrer: 
User Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36
Peak Memory Usage: 5617872/536870912
======
Error Class: TypeError
Error Message: wcf\system\tagging\TagEngine::{closure:wcf\system\tagging\TagEngine::getSubselectForObjectsByTagIDs():341}(): Argument #1 ($tagID) must be of type int, string given
Error Code: 0
File: /lib/system/tagging/TagEngine.class.php (341)
Extra Information: -
Stack Trace: [{"function":"{closure:wcf\\system\\tagging\\TagEngine::getSubselectForObjectsByTagIDs():341}","class":"wcf\\system\\tagging\\TagEngine","type":"::","args":["[error_during_sanitization]"],"file":"[internal function]","line":"?"},{"file":"\/lib\/system\/tagging\/TagEngine.class.php","line":341,"function":"array_map","args":["Closure",["[redacted]"]],"class":"","type":""},{"file":"\/lib\/system\/listView\/user\/TaggedArticleListView.class.php","line":30,"function":"getSubselectForObjectsByTagIDs","class":"wcf\\system\\tagging\\TagEngine","type":"->","args":["com.woltlab.wcf.article",["[redacted]"]]},{"file":"\/lib\/system\/listView\/AbstractListView.class.php","line":250,"function":"createObjectList","class":"wcf\\system\\listView\\user\\TaggedArticleListView","type":"->","args":[]},{"file":"\/lib\/system\/listView\/AbstractListView.class.php","line":826,"function":"initObjectList","class":"wcf\\system\\listView\\AbstractListView","type":"->","args":[]},{"file":"\/lib\/system\/listView\/AbstractListView.class.php","line":519,"function":"init","class":"wcf\\system\\listView\\AbstractListView","type":"->","args":[]},{"file":"\/lib\/system\/listView\/AbstractListView.class.php","line":432,"function":"getAvailableFilters","class":"wcf\\system\\listView\\AbstractListView","type":"->","args":[]},{"file":"\/lib\/action\/ListViewFilterAction.class.php","line":64,"function":"isFilterable","class":"wcf\\system\\listView\\AbstractListView","type":"->","args":[]},{"file":"\/lib\/system\/request\/Request.class.php","line":52,"function":"handle","class":"wcf\\action\\ListViewFilterAction","type":"->","args":["Laminas\\Diactoros\\ServerRequest"]},{"file":"\/lib\/http\/middleware\/HandleValinorMappingErrors.class.php","line":35,"function":"handle","class":"wcf\\system\\request\\Request","type":"->","args":["Laminas\\Diactoros\\ServerRequest"]},{"file":"\/lib\/system\/request\/RequestHandler.class.php","line":168,"function":"process","class":"wcf\\http\\Pipeline","type":"->","args":["Laminas\\Diactoros\\ServerRequest","wcf\\http\\RequestHandlerMiddleware"]},{"file":"\/index.php","line":10,"function":"handle","class":"wcf\\system\\request\\RequestHandler","type":"->","args":["wcf"]}]
<<<<
```

This change/PR:

- adds `Helper::mapQueryParametersToClass()` to map query parameters against a class constructor signature;
- uses constructor argument mapping without attempting to map the complete object;
- applies the helper to `ListViewFilterAction`, `GetItem`, and `GetItems`;
- declares `TaggedArticleListView::$tagIDs` as a `non-empty-list<positive-int>`.

Invalid parameters now result in the existing HTTP 400 mapping error instead of reaching the list view or its downstream services with invalid types.